### PR TITLE
fix(ci): resolve lint errors and fix workflow configuration issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           echo "📝 Commit Message Check"
           echo "========================================"
-          git log --oneline origin/main..${{ github.head_ref }} | head -10
+          git log --oneline origin/main..HEAD | head -10
 
       - name: Verify test coverage for changed files
         run: |

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -6,7 +6,7 @@ import { synth } from '../audio';
 
 // Mock child components to isolate App logic
 vi.mock('../Fretboard', () => ({
-  Fretboard: ({ highlightNotes, rootNote }: any) => (
+  Fretboard: ({ highlightNotes, rootNote }: { highlightNotes: string[]; rootNote: string }) => (
     <div data-testid="fretboard">
       Fretboard: {rootNote} - {highlightNotes.length} notes
     </div>
@@ -14,7 +14,7 @@ vi.mock('../Fretboard', () => ({
 }));
 
 vi.mock('../CircleOfFifths', () => ({
-  CircleOfFifths: ({ rootNote, setRootNote }: any) => (
+  CircleOfFifths: ({ rootNote, setRootNote }: { rootNote: string; setRootNote: (note: string) => void }) => (
     <button data-testid="circle-of-fifths" onClick={() => setRootNote('G')}>
       CoF: {rootNote}
     </button>
@@ -22,9 +22,9 @@ vi.mock('../CircleOfFifths', () => ({
 }));
 
 vi.mock('../DrawerSelector', () => ({
-  DrawerSelector: ({ label, value, onSelect, options }: any) => (
+  DrawerSelector: ({ label, value, onSelect, options }: { label: string; value: string; onSelect: (v: string) => void; options: string[] }) => (
     <div data-testid={`drawer-${label.toLowerCase()}`}>
-      <button onClick={() => onSelect(options.find((o: any) => typeof o === 'string') ?? options[0])}>{label}: {value}</button>
+      <button onClick={() => onSelect(options.find((o: string) => typeof o === 'string') ?? options[0])}>{label}: {value}</button>
     </div>
   ),
 }));

--- a/src/__tests__/audio.test.ts
+++ b/src/__tests__/audio.test.ts
@@ -48,8 +48,11 @@ describe('GuitarSynth', () => {
     vi.clearAllMocks();
 
     // Reset singleton state so each test gets a fresh AudioContext
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (synth as any).ctx = null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (synth as any).masterGain = null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (synth as any).isMuted = false;
 
     // Setup mock returns
@@ -61,6 +64,7 @@ describe('GuitarSynth', () => {
     // Replace window.AudioContext with our mock — must use a regular function,
     // not an arrow function, so it can be called with `new`.
     (window as unknown as { AudioContext: typeof AudioContext }).AudioContext =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       vi.fn(function() { return mockAudioContext; }) as any;
   });
 
@@ -84,9 +88,9 @@ describe('GuitarSynth', () => {
 
     it('does not create context twice', () => {
       synth.init();
-      const callCount1 = (mockAudioContext.createGain as any).mock.calls.length;
+      const callCount1 = mockAudioContext.createGain.mock.calls.length;
       synth.init();
-      const callCount2 = (mockAudioContext.createGain as any).mock.calls.length;
+      const callCount2 = mockAudioContext.createGain.mock.calls.length;
       expect(callCount2).toBe(callCount1);
     });
   });
@@ -167,8 +171,8 @@ describe('GuitarSynth', () => {
 
     it('stops oscillator after envelope duration', () => {
       synth.playNote(440);
-      const stopCall = (mockOscillator.stop as any).mock.calls[0];
-      const startCall = (mockOscillator.start as any).mock.calls[0];
+      const stopCall = mockOscillator.stop.mock.calls[0];
+      const startCall = mockOscillator.start.mock.calls[0];
       const duration = stopCall[0] - startCall[0];
 
       // Attack(0.01) + Decay(1.0) + Release(1.0) + buffer(0.1) ≈ 2.11
@@ -194,13 +198,13 @@ describe('GuitarSynth', () => {
 
     it('plays different frequencies', () => {
       synth.playNote(262); // C4
-      const call1 = (mockOscillator.frequency.setValueAtTime as any).mock.calls[0];
+      const call1 = mockOscillator.frequency.setValueAtTime.mock.calls[0];
 
       vi.clearAllMocks();
       mockAudioContext.createOscillator.mockReturnValue(mockOscillator as unknown as OscillatorNode);
 
       synth.playNote(440); // A4
-      const call2 = (mockOscillator.frequency.setValueAtTime as any).mock.calls[0];
+      const call2 = mockOscillator.frequency.setValueAtTime.mock.calls[0];
 
       expect(call1[0]).toBe(262);
       expect(call2[0]).toBe(440);

--- a/src/__tests__/integration.test.tsx
+++ b/src/__tests__/integration.test.tsx
@@ -124,7 +124,7 @@ describe('Integration Tests - User Workflows', () => {
       localStorage.setItem('chordType', 'Major Triad');
       localStorage.setItem('hideNonChordNotes', 'false');
 
-      let { rerender } = render(<App />);
+      const { rerender } = render(<App />);
       expect(localStorage.getItem('hideNonChordNotes')).toBe('false');
 
       // User enables filter
@@ -141,7 +141,7 @@ describe('Integration Tests - User Workflows', () => {
       localStorage.setItem('chordType', 'Minor 7th');
       localStorage.setItem('linkChordRoot', 'true');
 
-      let { rerender } = render(<App />);
+      const { rerender } = render(<App />);
 
       // Change scale root
       localStorage.setItem('rootNote', 'D');
@@ -161,7 +161,7 @@ describe('Integration Tests - User Workflows', () => {
       localStorage.setItem('linkChordRoot', 'false');
       localStorage.setItem('chordRoot', 'G');
 
-      let { rerender } = render(<App />);
+      const { rerender } = render(<App />);
       rerender(<App />);
 
       // Change scale root
@@ -640,7 +640,7 @@ describe('Integration Tests - User Workflows', () => {
 
       // Step 1: Select key
       localStorage.setItem('rootNote', 'A');
-      let { rerender } = render(<App />);
+      const { rerender } = render(<App />);
       rerender(<App />);
       expect(localStorage.getItem('rootNote')).toBe('A');
 


### PR DESCRIPTION
Fix 18 ESLint errors that were failing CI lint checks:
- Replace `any` types with proper types in mock component props (App.test.tsx)
- Remove unnecessary `as any` casts on vi.fn() mocks (audio.test.ts)
- Add eslint-disable for required `any` casts on private property access (audio.test.ts)
- Change `let` to `const` for non-reassigned destructured variables (integration.test.tsx)

Fix workflow YAML issues:
- pr-checks.yml: use HEAD instead of github.head_ref as git ref (branch name
  doesn't exist as local ref after actions/checkout)
- ci.yml: add permissions for PR comment posting in quality-gate job
- coverage.yml: add permissions for PR coverage comment posting

https://claude.ai/code/session_01MVKmd5B5MeRDZXD8hW2rGu