### PR TITLE
Change deployment trigger from version tags to main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Updated the GitHub Pages deployment workflow to trigger on pushes to the main branch instead of semantic version tags.

## Key Changes
- Modified the `Deploy to GitHub Pages` workflow trigger condition
- Changed from tag-based deployment (`tags: 'v*.*.*'`) to branch-based deployment (`branches: main`)
- This enables automatic deployment on every push to main rather than only on version releases

## Implementation Details
The workflow will now automatically deploy to GitHub Pages whenever code is pushed to the main branch, providing continuous deployment instead of release-based deployment. The `workflow_dispatch` trigger remains available for manual deployments.

https://claude.ai/code/session_01Xpf2twBSSLmi71f8mhG3n4