### PR TITLE
Refactor: Extract SummaryNote component to reduce duplication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,9 @@
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.4",
         "vitest": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=20.12.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,37 @@ import {
 import { DrawerSelector } from "./DrawerSelector";
 import "./App.css";
 
+function SummaryNote({
+  note,
+  rootNote,
+  scaleName,
+  displayName,
+  isChord,
+}: {
+  note: string;
+  rootNote: string;
+  scaleName: string;
+  displayName: string;
+  isChord?: boolean;
+}) {
+  const rootIdx = NOTES.indexOf(rootNote);
+  const noteIdx = NOTES.indexOf(note);
+  const chromaticInterval = rootIdx !== -1 && noteIdx !== -1 ? (noteIdx - rootIdx + 12) % 12 : -1;
+  const degree = chromaticInterval !== -1 ? INTERVAL_NAMES[chromaticInterval] : null;
+  const romanNumeral = chromaticInterval !== -1 ? getDegreesForScale(scaleName)[chromaticInterval] : undefined;
+  const degreeColor = romanNumeral ? DEGREE_COLORS[romanNumeral] : undefined;
+  return (
+    <span
+      className={`summary-note${isChord ? " summary-note--chord" : ""}`}
+      style={degreeColor ? { outline: `2px solid ${degreeColor}`, outlineOffset: "-2px" } : undefined}
+    >
+      <span className="summary-note-name">{formatAccidental(displayName)}</span>
+      {degree && (
+        <span className="summary-note-degree" style={{ color: degreeColor }}>{formatAccidental(degree)}</span>
+      )}
+    </span>
+  );
+}
 
 type FingeringPattern = "all" | "caged" | "3nps";
 
@@ -380,50 +411,31 @@ function App() {
       <div className="summary-row">
         <div className="summary-row-label">{scaleLabel}</div>
         <div className="summary-notes">
-          {summaryNotes.map((n, i) => {
-            const rootIdx = NOTES.indexOf(rootNote);
-            const noteIdx = NOTES.indexOf(n);
-            const chromaticInterval = rootIdx !== -1 && noteIdx !== -1 ? (noteIdx - rootIdx + 12) % 12 : -1;
-            const degree = chromaticInterval !== -1 ? INTERVAL_NAMES[chromaticInterval] : null;
-            const degreeMap = getDegreesForScale(scaleName);
-            const romanNumeral = chromaticInterval !== -1 ? degreeMap[chromaticInterval] : undefined;
-            const degreeColor = romanNumeral ? DEGREE_COLORS[romanNumeral] : undefined;
-            return (
-              <span key={i} className="summary-note" style={degreeColor ? { outline: `2px solid ${degreeColor}`, outlineOffset: '-2px' } : undefined}>
-                <span className="summary-note-name">
-                  {formatAccidental(getNoteDisplayInScale(n, rootNote, SCALES[scaleName] || [], useFlats))}
-                </span>
-                {degree && (
-                  <span className="summary-note-degree" style={{ color: degreeColor }}>{formatAccidental(degree)}</span>
-                )}
-              </span>
-            );
-          })}
+          {summaryNotes.map((n, i) => (
+            <SummaryNote
+              key={i}
+              note={n}
+              rootNote={rootNote}
+              scaleName={scaleName}
+              displayName={getNoteDisplayInScale(n, rootNote, SCALES[scaleName] || [], useFlats)}
+            />
+          ))}
         </div>
       </div>
       {chordLabel && (
         <div className="summary-row summary-row--chord">
           <div className="summary-row-label">{chordLabel}</div>
           <div className="summary-notes">
-            {chordSummaryNotes.map((n, i) => {
-              const rootIdx = NOTES.indexOf(chordRoot);
-              const noteIdx = NOTES.indexOf(n);
-              const chromaticInterval = rootIdx !== -1 && noteIdx !== -1 ? (noteIdx - rootIdx + 12) % 12 : -1;
-              const degree = chromaticInterval !== -1 ? INTERVAL_NAMES[chromaticInterval] : null;
-              const degreeMap = getDegreesForScale(scaleName);
-              const romanNumeral = chromaticInterval !== -1 ? degreeMap[chromaticInterval] : undefined;
-              const degreeColor = romanNumeral ? DEGREE_COLORS[romanNumeral] : undefined;
-              return (
-                <span key={i} className="summary-note summary-note--chord" style={degreeColor ? { outline: `2px solid ${degreeColor}`, outlineOffset: '-2px' } : undefined}>
-                  <span className="summary-note-name">
-                    {formatAccidental(getNoteDisplay(n, chordRoot, useFlats))}
-                  </span>
-                  {degree && (
-                    <span className="summary-note-degree" style={{ color: degreeColor }}>{formatAccidental(degree)}</span>
-                  )}
-                </span>
-              );
-            })}
+            {chordSummaryNotes.map((n, i) => (
+              <SummaryNote
+                key={i}
+                note={n}
+                rootNote={chordRoot}
+                scaleName={scaleName}
+                displayName={getNoteDisplay(n, chordRoot, useFlats)}
+                isChord
+              />
+            ))}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
Extracted the `SummaryNote` component to eliminate duplicate code in the scale and chord summary rendering logic. This improves maintainability and reduces code duplication.

## Key Changes
- Created a new `SummaryNote` component that encapsulates the logic for rendering individual note summaries with degree information and styling
- Refactored the scale summary notes rendering to use the new `SummaryNote` component
- Refactored the chord summary notes rendering to use the new `SummaryNote` component
- Added an optional `isChord` prop to the `SummaryNote` component to apply chord-specific styling when needed

## Implementation Details
- The `SummaryNote` component accepts `note`, `rootNote`, `scaleName`, `displayName`, and an optional `isChord` prop
- Moved the chromatic interval calculation, degree lookup, and color styling logic into the component
- The component handles both scale and chord note rendering by conditionally applying the `summary-note--chord` CSS class based on the `isChord` prop
- Reduced the main App component's render logic by ~40 lines while maintaining identical functionality

https://claude.ai/code/session_01Qejpft9X5mjQwHhKa8oaqt