### PR TITLE
Migrate state management from useState to Jotai atoms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "clsx": "^2.1.1",
+        "jotai": "^2.19.1",
         "lucide-react": "^1.7.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
@@ -87,7 +88,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -102,7 +103,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -112,7 +113,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -143,7 +144,7 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -160,7 +161,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -177,7 +178,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -187,7 +188,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -201,7 +202,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -219,7 +220,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -229,7 +230,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -239,7 +240,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -249,7 +250,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -263,7 +264,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -289,7 +290,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -304,7 +305,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -323,7 +324,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -764,7 +765,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -775,7 +776,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -786,7 +787,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -796,14 +797,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1263,7 +1264,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1868,7 +1869,7 @@
       "version": "2.10.15",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.15.tgz",
       "integrity": "sha512-1nfKCq9wuAZFTkA2ey/3OXXx7GzFjLdkTiFVNwlJ9WqdI706CZRIhEqjuwanjMIja+84jDLa9rcyZDPDiVkASQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -1902,7 +1903,7 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -1946,7 +1947,7 @@
       "version": "1.0.30001786",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001786.tgz",
       "integrity": "sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2030,7 +2031,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -2073,7 +2074,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -2094,7 +2095,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2154,7 +2155,7 @@
       "version": "1.5.331",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
       "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/entities": {
@@ -2181,7 +2182,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2513,7 +2514,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2715,11 +2716,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/jotai": {
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.19.1.tgz",
+      "integrity": "sha512-sqm9lVZiqBHZH8aSRk32DSiZDHY3yUIlulXYn9GQj7/LvoUdYXSMti7ZPJGo+6zjzKFt5a25k/I6iBCi43PJcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0",
+        "@babel/template": ">=7.0.0",
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@babel/template": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2790,7 +2820,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -2824,7 +2854,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -3145,7 +3175,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -3256,7 +3286,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3289,7 +3319,7 @@
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/obug": {
@@ -3410,7 +3440,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -3632,7 +3662,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3921,7 +3951,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4238,7 +4268,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "jotai": "^2.19.1",
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
@@ -30,6 +31,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.3",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
@@ -38,7 +40,6 @@
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.4",
-    "vitest": "^4.1.3",
-    "@vitest/coverage-v8": "^4.1.3"
+    "vitest": "^4.1.3"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
+import { useAtom, useAtomValue, useSetAtom, createStore, Provider } from "jotai";
 import { Fretboard } from "./Fretboard";
 import {
   SCALES,
@@ -28,11 +29,37 @@ import {
   CAGED_SHAPES,
   getCagedCoordinates,
   get3NPSCoordinates,
-  type CagedShape,
   type ShapePolygon,
 } from "./shapes";
 import { DrawerSelector } from "./DrawerSelector";
+import {
+  type FingeringPattern,
+  rootNoteAtom,
+  scaleNameAtom,
+  chordRootAtom,
+  chordTypeAtom,
+  linkChordRootAtom,
+  hideNonChordNotesAtom,
+  chordFretSpreadAtom,
+  chordIntervalFilterAtom,
+  fingeringPatternAtom,
+  cagedShapesAtom,
+  npsPositionAtom,
+  displayFormatAtom,
+  shapeLabelsAtom,
+  tuningNameAtom,
+  fretZoomAtom,
+  fretStartAtom,
+  fretEndAtom,
+  useFlatsAtom,
+  isMutedAtom,
+  mobileTabAtom,
+  setRootNoteAtom,
+  resetAtom,
+} from "./store/atoms";
 import "./App.css";
+
+const END_FRET = 24;
 
 function SummaryNote({
   note,
@@ -65,8 +92,6 @@ function SummaryNote({
     </span>
   );
 }
-
-type FingeringPattern = "all" | "caged" | "3nps";
 
 // Chord interval filter presets — sets of allowed semitone intervals from chord root
 const CHORD_INTERVAL_FILTERS: Record<string, Set<number>> = {
@@ -117,90 +142,38 @@ const CHORD_OPTIONS: (string | { divider: string })[] = [
   "Power Chord (5)",
 ];
 
-function App() {
-  const END_FRET = 24;
-
+function AppContent() {
   // Scale
-  const [rootNote, setRootNote] = useState<string>(() => localStorage.getItem('rootNote') ?? 'C');
-  const [scaleName, setScaleName] = useState<string>(() => localStorage.getItem('scaleName') ?? 'Major');
+  const rootNote = useAtomValue(rootNoteAtom);
+  const [scaleName, setScaleName] = useAtom(scaleNameAtom);
 
-  // Chord overlay — fully independent
-  const [chordRoot, setChordRoot] = useState<string>(() => localStorage.getItem('chordRoot') ?? 'C');
-  const [chordType, setChordType] = useState<string | null>(() => {
-    const saved = localStorage.getItem('chordType');
-    return saved !== null ? (saved === '' ? null : saved) : null;
-  });
-  const [linkChordRoot, setLinkChordRoot] = useState<boolean>(() => {
-    const saved = localStorage.getItem('linkChordRoot');
-    return saved !== null ? saved === 'true' : true;
-  });
-  const [hideNonChordNotes, setHideNonChordNotes] = useState<boolean>(() => {
-    const saved = localStorage.getItem('hideNonChordNotes');
-    return saved !== null ? saved === 'true' : false;
-  });
-  const [chordFretSpread, setChordFretSpread] = useState<number>(() => {
-    const saved = localStorage.getItem('chordFretSpread');
-    return saved !== null ? Number(saved) : 0;
-  });
-  const [chordIntervalFilter, setChordIntervalFilter] = useState<string>(() => localStorage.getItem('chordIntervalFilter') ?? 'All');
+  // Chord overlay
+  const [chordRoot, setChordRoot] = useAtom(chordRootAtom);
+  const [chordType, setChordType] = useAtom(chordTypeAtom);
+  const [linkChordRoot, setLinkChordRoot] = useAtom(linkChordRootAtom);
+  const [hideNonChordNotes, setHideNonChordNotes] = useAtom(hideNonChordNotesAtom);
+  const [chordFretSpread, setChordFretSpread] = useAtom(chordFretSpreadAtom);
+  const [chordIntervalFilter, setChordIntervalFilter] = useAtom(chordIntervalFilterAtom);
 
   // Fingering
-  const [fingeringPattern, setFingeringPattern] = useState<FingeringPattern>(() => {
-    const saved = localStorage.getItem('fingeringPattern');
-    return (saved as FingeringPattern) ?? 'all';
-  });
-  const [cagedShapes, setCagedShapes] = useState<Set<CagedShape>>(() => {
-    const saved = localStorage.getItem('cagedShapes');
-    if (saved !== null) {
-      try {
-        return new Set(JSON.parse(saved) as CagedShape[]);
-      } catch {
-        // fall through to default
-      }
-    }
-    return new Set(CAGED_SHAPES);
-  });
-  const [npsPosition, setNpsPosition] = useState<number>(() => {
-    const saved = localStorage.getItem('npsPosition');
-    return saved !== null ? Number(saved) : 0;
-  });
+  const [fingeringPattern, setFingeringPattern] = useAtom(fingeringPatternAtom);
+  const [cagedShapes, setCagedShapes] = useAtom(cagedShapesAtom);
+  const [npsPosition, setNpsPosition] = useAtom(npsPositionAtom);
 
   // Display
-  const [displayFormat, setDisplayFormat] = useState<"notes" | "degrees" | "none">(() => {
-    const saved = localStorage.getItem('displayFormat');
-    return (saved as "notes" | "degrees" | "none") ?? 'notes';
-  });
-  const [shapeLabels, setShapeLabels] = useState<"modal" | "caged" | "none">(() => {
-    const saved = localStorage.getItem('shapeLabels');
-    return (saved as "modal" | "caged" | "none") ?? 'none';
-  });
-  const [tuningName, setTuningName] = useState<string>(() => localStorage.getItem('tuningName') ?? 'Standard');
-  const [fretZoom, setFretZoom] = useState<number>(() => {
-    const saved = localStorage.getItem('fretZoom');
-    return saved !== null ? Number(saved) : 100;
-  });
-  const [fretStart, setFretStart] = useState<number>(() => {
-    const saved = localStorage.getItem('fretStart');
-    return saved !== null ? Number(saved) : 0;
-  });
-  const [fretEnd, setFretEnd] = useState<number>(() => {
-    const saved = localStorage.getItem('fretEnd');
-    return saved !== null ? Number(saved) : END_FRET;
-  });
+  const [displayFormat, setDisplayFormat] = useAtom(displayFormatAtom);
+  const [shapeLabels, setShapeLabels] = useAtom(shapeLabelsAtom);
+  const [tuningName, setTuningName] = useAtom(tuningNameAtom);
+  const [fretZoom, setFretZoom] = useAtom(fretZoomAtom);
+  const [fretStart, setFretStart] = useAtom(fretStartAtom);
+  const [fretEnd, setFretEnd] = useAtom(fretEndAtom);
 
-  // Accidentals
-  const [useFlats, setUseFlats] = useState<boolean>(() => {
-    const saved = localStorage.getItem('useFlats');
-    return saved !== null ? saved === 'true' : false;
-  });
+  // Accidentals / Audio / Mobile tab
+  const [useFlats, setUseFlats] = useAtom(useFlatsAtom);
+  const [isMuted, setIsMuted] = useAtom(isMutedAtom);
+  const [mobileTab, setMobileTab] = useAtom(mobileTabAtom);
 
-  // Audio
-  const [isMuted, setIsMuted] = useState<boolean>(() => {
-    const saved = localStorage.getItem('isMuted');
-    return saved !== null ? saved === 'true' : false;
-  });
-
-  // Viewport / mobile detection
+  // Viewport / mobile detection (not persisted)
   const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
   useEffect(() => {
     const handler = () => setViewportWidth(window.innerWidth);
@@ -209,51 +182,15 @@ function App() {
   }, []);
   const isMobile = viewportWidth < 768;
 
-  // Mobile tab state
-  const [mobileTab, setMobileTab] = useState<'key' | 'scale' | 'settings'>(() => {
-    const saved = localStorage.getItem('mobileTab');
-    return (saved as 'key' | 'scale' | 'settings') ?? 'key';
-  });
-
-  // Persist all user state to localStorage
-  useEffect(() => {
-    localStorage.setItem('rootNote', rootNote);
-    localStorage.setItem('scaleName', scaleName);
-    localStorage.setItem('chordRoot', chordRoot);
-    localStorage.setItem('chordType', chordType ?? '');
-    localStorage.setItem('linkChordRoot', String(linkChordRoot));
-    localStorage.setItem('hideNonChordNotes', String(hideNonChordNotes));
-    localStorage.setItem('chordFretSpread', String(chordFretSpread));
-    localStorage.setItem('chordIntervalFilter', chordIntervalFilter);
-    localStorage.setItem('fingeringPattern', fingeringPattern);
-    localStorage.setItem('cagedShapes', JSON.stringify(Array.from(cagedShapes)));
-    localStorage.setItem('npsPosition', String(npsPosition));
-    localStorage.setItem('displayFormat', displayFormat);
-    localStorage.setItem('shapeLabels', shapeLabels);
-    localStorage.setItem('tuningName', tuningName);
-    localStorage.setItem('fretZoom', String(fretZoom));
-    localStorage.setItem('fretStart', String(fretStart));
-    localStorage.setItem('fretEnd', String(fretEnd));
-    localStorage.setItem('useFlats', String(useFlats));
-    localStorage.setItem('isMuted', String(isMuted));
-    localStorage.setItem('mobileTab', mobileTab);
-  }, [rootNote, scaleName, chordRoot, chordType, linkChordRoot, hideNonChordNotes,
-      chordFretSpread, chordIntervalFilter, fingeringPattern, cagedShapes, npsPosition,
-      displayFormat, shapeLabels, tuningName, fretZoom, fretStart, fretEnd, useFlats, isMuted, mobileTab]);
-
-  // Sync persisted mute state to audio synth on mount
+  // Sync mute state to audio synth (runs on mount and whenever isMuted changes)
   useEffect(() => {
     synth.setMute(isMuted);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // intentionally only on mount
+  }, [isMuted]);
 
   const currentTuning = TUNINGS[tuningName] || STANDARD_TUNING;
 
-  // When root note changes, keep chord root linked if toggled
-  const handleSetRootNote = (note: string) => {
-    setRootNote(note);
-    if (linkChordRoot) setChordRoot(note);
-  };
+  // Linked root note setter — syncs chordRoot when linkChordRoot is enabled
+  const handleSetRootNote = useSetAtom(setRootNoteAtom);
 
   const toggleMute = () => {
     const nextMute = !isMuted;
@@ -261,29 +198,10 @@ function App() {
     synth.setMute(nextMute);
   };
 
+  const dispatchReset = useSetAtom(resetAtom);
   const handleReset = () => {
-    localStorage.clear();
-    setRootNote("C");
-    setScaleName("Major");
-    setChordRoot("C");
-    setChordType(null);
-    setLinkChordRoot(true);
-    setHideNonChordNotes(false);
-    setChordFretSpread(0);
-    setChordIntervalFilter("All");
-    setFingeringPattern("all");
-    setCagedShapes(new Set(CAGED_SHAPES));
-    setNpsPosition(0);
-    setDisplayFormat("notes");
-    setShapeLabels("none");
-    setTuningName("Standard");
-    setFretZoom(100);
-    setFretStart(0);
-    setFretEnd(END_FRET);
-    setUseFlats(false);
-    setIsMuted(false);
+    dispatchReset();
     synth.setMute(false);
-    setMobileTab('key');
   };
 
   // Compute active chord tones (independent of scale)
@@ -1029,6 +947,18 @@ function App() {
       </div>
 
     </div>
+  );
+}
+
+// Wraps AppContent with a fresh Jotai store per mount.
+// useState lazy initializer ensures one store per component instance:
+// stable across re-renders, isolated between mounts (e.g. in tests).
+function App() {
+  const [store] = useState(() => createStore());
+  return (
+    <Provider store={store}>
+      <AppContent />
+    </Provider>
   );
 }
 

--- a/src/__tests__/atoms.test.ts
+++ b/src/__tests__/atoms.test.ts
@@ -1,0 +1,313 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createStore, type Atom } from 'jotai';
+import { RESET } from 'jotai/utils';
+import {
+  rootNoteAtom,
+  scaleNameAtom,
+  chordRootAtom,
+  chordTypeAtom,
+  linkChordRootAtom,
+  cagedShapesAtom,
+  fingeringPatternAtom,
+  displayFormatAtom,
+  shapeLabelsAtom,
+  isMutedAtom,
+  fretStartAtom,
+  fretEndAtom,
+  fretZoomAtom,
+  tuningNameAtom,
+  useFlatsAtom,
+  mobileTabAtom,
+  npsPositionAtom,
+  hideNonChordNotesAtom,
+  chordFretSpreadAtom,
+  chordIntervalFilterAtom,
+  setRootNoteAtom,
+  resetAtom,
+} from '../store/atoms';
+import { CAGED_SHAPES } from '../shapes';
+
+function makeStore() {
+  return createStore();
+}
+
+// Trigger onMount for an atom so atomWithStorage reads from localStorage.
+// Returns cleanup (unsubscribe) function.
+function mount<T>(store: ReturnType<typeof createStore>, atom: Atom<T>): () => void {
+  return store.sub(atom, () => {});
+}
+
+describe('atoms', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('rawStringStorage (via rootNoteAtom)', () => {
+    it('reads existing localStorage value on mount', () => {
+      localStorage.setItem('rootNote', 'G');
+      const store = makeStore();
+      const unsub = mount(store, rootNoteAtom);
+      expect(store.get(rootNoteAtom)).toBe('G');
+      unsub();
+    });
+
+    it('writes default to localStorage when key absent on mount', () => {
+      const store = makeStore();
+      const unsub = mount(store, rootNoteAtom);
+      expect(localStorage.getItem('rootNote')).toBe('C');
+      unsub();
+    });
+
+    it('writes new value via setItem', () => {
+      const store = makeStore();
+      store.set(rootNoteAtom, 'D');
+      expect(localStorage.getItem('rootNote')).toBe('D');
+    });
+
+    it('removes localStorage key on RESET', () => {
+      localStorage.setItem('rootNote', 'G');
+      const store = makeStore();
+      store.set(rootNoteAtom, RESET);
+      expect(localStorage.getItem('rootNote')).toBeNull();
+    });
+  });
+
+  describe('booleanStorage (via isMutedAtom)', () => {
+    it('reads "true" as true', () => {
+      localStorage.setItem('isMuted', 'true');
+      const store = makeStore();
+      const unsub = mount(store, isMutedAtom);
+      expect(store.get(isMutedAtom)).toBe(true);
+      unsub();
+    });
+
+    it('reads "false" as false', () => {
+      localStorage.setItem('isMuted', 'false');
+      const store = makeStore();
+      const unsub = mount(store, isMutedAtom);
+      expect(store.get(isMutedAtom)).toBe(false);
+      unsub();
+    });
+
+    it('writes default false to localStorage when key absent on mount', () => {
+      const store = makeStore();
+      const unsub = mount(store, isMutedAtom);
+      expect(localStorage.getItem('isMuted')).toBe('false');
+      unsub();
+    });
+
+    it('writes boolean as string via setItem', () => {
+      const store = makeStore();
+      store.set(isMutedAtom, true);
+      expect(localStorage.getItem('isMuted')).toBe('true');
+    });
+
+    it('removes localStorage key on RESET', () => {
+      localStorage.setItem('isMuted', 'true');
+      const store = makeStore();
+      store.set(isMutedAtom, RESET);
+      expect(localStorage.getItem('isMuted')).toBeNull();
+    });
+  });
+
+  describe('numberStorage (via fretZoomAtom)', () => {
+    it('reads numeric string as number', () => {
+      localStorage.setItem('fretZoom', '150');
+      const store = makeStore();
+      const unsub = mount(store, fretZoomAtom);
+      expect(store.get(fretZoomAtom)).toBe(150);
+      unsub();
+    });
+
+    it('writes default to localStorage when key absent on mount', () => {
+      const store = makeStore();
+      const unsub = mount(store, fretZoomAtom);
+      expect(localStorage.getItem('fretZoom')).toBe('100');
+      unsub();
+    });
+
+    it('writes number as string via setItem', () => {
+      const store = makeStore();
+      store.set(fretZoomAtom, 200);
+      expect(localStorage.getItem('fretZoom')).toBe('200');
+    });
+
+    it('removes localStorage key on RESET', () => {
+      localStorage.setItem('fretZoom', '200');
+      const store = makeStore();
+      store.set(fretZoomAtom, RESET);
+      expect(localStorage.getItem('fretZoom')).toBeNull();
+    });
+  });
+
+  describe('chordTypeStorage', () => {
+    it('reads empty string as null', () => {
+      localStorage.setItem('chordType', '');
+      const store = makeStore();
+      const unsub = mount(store, chordTypeAtom);
+      expect(store.get(chordTypeAtom)).toBeNull();
+      unsub();
+    });
+
+    it('reads non-empty string as chord type', () => {
+      localStorage.setItem('chordType', 'Major Triad');
+      const store = makeStore();
+      const unsub = mount(store, chordTypeAtom);
+      expect(store.get(chordTypeAtom)).toBe('Major Triad');
+      unsub();
+    });
+
+    it('writes default empty string to localStorage when key absent on mount', () => {
+      const store = makeStore();
+      const unsub = mount(store, chordTypeAtom);
+      expect(localStorage.getItem('chordType')).toBe('');
+      unsub();
+    });
+
+    it('writes null as empty string via setItem', () => {
+      const store = makeStore();
+      store.set(chordTypeAtom, null);
+      expect(localStorage.getItem('chordType')).toBe('');
+    });
+
+    it('writes chord type string via setItem', () => {
+      const store = makeStore();
+      store.set(chordTypeAtom, 'Minor 7th');
+      expect(localStorage.getItem('chordType')).toBe('Minor 7th');
+    });
+  });
+
+  describe('cagedShapesStorage', () => {
+    it('reads JSON array as Set', () => {
+      localStorage.setItem('cagedShapes', JSON.stringify(['C', 'A']));
+      const store = makeStore();
+      const unsub = mount(store, cagedShapesAtom);
+      const shapes = store.get(cagedShapesAtom);
+      expect(shapes).toBeInstanceOf(Set);
+      expect(shapes.has('C')).toBe(true);
+      expect(shapes.has('A')).toBe(true);
+      expect(shapes.has('G')).toBe(false);
+      unsub();
+    });
+
+    it('falls back to default Set on invalid JSON', () => {
+      localStorage.setItem('cagedShapes', 'not-valid-json{{{');
+      const store = makeStore();
+      const unsub = mount(store, cagedShapesAtom);
+      const shapes = store.get(cagedShapesAtom);
+      expect(shapes).toBeInstanceOf(Set);
+      expect(shapes.size).toBe(CAGED_SHAPES.length);
+      unsub();
+    });
+
+    it('writes default JSON array to localStorage when key absent on mount', () => {
+      const store = makeStore();
+      const unsub = mount(store, cagedShapesAtom);
+      const stored = localStorage.getItem('cagedShapes');
+      expect(JSON.parse(stored!)).toEqual(CAGED_SHAPES);
+      unsub();
+    });
+
+    it('writes Set as JSON array via setItem', () => {
+      const store = makeStore();
+      store.set(cagedShapesAtom, new Set(['C', 'G'] as const));
+      const stored = localStorage.getItem('cagedShapes');
+      expect(JSON.parse(stored!)).toEqual(['C', 'G']);
+    });
+
+    it('removes localStorage key on RESET', () => {
+      localStorage.setItem('cagedShapes', JSON.stringify(['C']));
+      const store = makeStore();
+      store.set(cagedShapesAtom, RESET);
+      expect(localStorage.getItem('cagedShapes')).toBeNull();
+    });
+  });
+
+  describe('setRootNoteAtom', () => {
+    it('sets rootNote', () => {
+      const store = makeStore();
+      store.set(setRootNoteAtom, 'G');
+      expect(store.get(rootNoteAtom)).toBe('G');
+    });
+
+    it('syncs chordRoot when linkChordRoot is true', () => {
+      const store = makeStore();
+      store.set(linkChordRootAtom, true);
+      store.set(setRootNoteAtom, 'G');
+      expect(store.get(chordRootAtom)).toBe('G');
+    });
+
+    it('does not sync chordRoot when linkChordRoot is false', () => {
+      const store = makeStore();
+      store.set(chordRootAtom, 'D');
+      store.set(linkChordRootAtom, false);
+      store.set(setRootNoteAtom, 'G');
+      expect(store.get(rootNoteAtom)).toBe('G');
+      expect(store.get(chordRootAtom)).toBe('D');
+    });
+  });
+
+  describe('resetAtom', () => {
+    it('clears localStorage', () => {
+      localStorage.setItem('rootNote', 'G');
+      localStorage.setItem('scaleName', 'Dorian');
+      const store = makeStore();
+      store.set(resetAtom);
+      expect(localStorage.getItem('rootNote')).toBeNull();
+      expect(localStorage.getItem('scaleName')).toBeNull();
+    });
+
+    it('resets core atoms to defaults', () => {
+      const store = makeStore();
+      store.set(rootNoteAtom, 'G');
+      store.set(scaleNameAtom, 'Dorian');
+      store.set(isMutedAtom, true);
+      store.set(fretZoomAtom, 200);
+      store.set(displayFormatAtom, 'degrees');
+      store.set(chordTypeAtom, 'Major Triad');
+
+      store.set(resetAtom);
+
+      expect(store.get(rootNoteAtom)).toBe('C');
+      expect(store.get(scaleNameAtom)).toBe('Major');
+      expect(store.get(isMutedAtom)).toBe(false);
+      expect(store.get(fretZoomAtom)).toBe(100);
+      expect(store.get(displayFormatAtom)).toBe('notes');
+      expect(store.get(chordTypeAtom)).toBeNull();
+    });
+
+    it('resets all remaining atoms to defaults', () => {
+      const store = makeStore();
+      store.set(chordRootAtom, 'G');
+      store.set(linkChordRootAtom, false);
+      store.set(hideNonChordNotesAtom, true);
+      store.set(chordFretSpreadAtom, 5);
+      store.set(chordIntervalFilterAtom, 'Triad');
+      store.set(fingeringPatternAtom, 'caged');
+      store.set(npsPositionAtom, 3);
+      store.set(shapeLabelsAtom, 'caged');
+      store.set(tuningNameAtom, 'Drop D');
+      store.set(fretStartAtom, 3);
+      store.set(fretEndAtom, 12);
+      store.set(useFlatsAtom, true);
+      store.set(mobileTabAtom, 'settings');
+
+      store.set(resetAtom);
+
+      expect(store.get(chordRootAtom)).toBe('C');
+      expect(store.get(linkChordRootAtom)).toBe(true);
+      expect(store.get(hideNonChordNotesAtom)).toBe(false);
+      expect(store.get(chordFretSpreadAtom)).toBe(0);
+      expect(store.get(chordIntervalFilterAtom)).toBe('All');
+      expect(store.get(fingeringPatternAtom)).toBe('all');
+      expect(store.get(npsPositionAtom)).toBe(0);
+      expect(store.get(shapeLabelsAtom)).toBe('none');
+      expect(store.get(tuningNameAtom)).toBe('Standard');
+      expect(store.get(fretStartAtom)).toBe(0);
+      expect(store.get(fretEndAtom)).toBe(24);
+      expect(store.get(useFlatsAtom)).toBe(false);
+      expect(store.get(mobileTabAtom)).toBe('key');
+    });
+  });
+});

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -1,0 +1,195 @@
+import { atom } from "jotai";
+import { atomWithStorage, RESET } from "jotai/utils";
+import { CAGED_SHAPES, type CagedShape } from "../shapes";
+
+export type FingeringPattern = "all" | "caged" | "3nps";
+
+// ---------------------------------------------------------------------------
+// Raw storage helpers — match the old localStorage.setItem(key, String(value))
+// format and write defaults on first access (matching old useEffect-on-mount).
+// ---------------------------------------------------------------------------
+
+function rawStringStorage<T extends string>() {
+  return {
+    getItem(key: string, initialValue: T): T {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, initialValue);
+        return initialValue;
+      }
+      return stored as T;
+    },
+    setItem(key: string, value: T): void {
+      localStorage.setItem(key, value);
+    },
+    removeItem(key: string): void {
+      localStorage.removeItem(key);
+    },
+  };
+}
+
+const booleanStorage = {
+  getItem(key: string, initialValue: boolean): boolean {
+    const stored = localStorage.getItem(key);
+    if (stored === null) {
+      localStorage.setItem(key, String(initialValue));
+      return initialValue;
+    }
+    return stored === "true";
+  },
+  setItem(key: string, value: boolean): void {
+    localStorage.setItem(key, String(value));
+  },
+  removeItem(key: string): void {
+    localStorage.removeItem(key);
+  },
+};
+
+const numberStorage = {
+  getItem(key: string, initialValue: number): number {
+    const stored = localStorage.getItem(key);
+    if (stored === null) {
+      localStorage.setItem(key, String(initialValue));
+      return initialValue;
+    }
+    return Number(stored);
+  },
+  setItem(key: string, value: number): void {
+    localStorage.setItem(key, String(value));
+  },
+  removeItem(key: string): void {
+    localStorage.removeItem(key);
+  },
+};
+
+// chordType is stored as '' when null (matching old behavior)
+const chordTypeStorage = {
+  getItem(key: string, initialValue: string | null): string | null {
+    const stored = localStorage.getItem(key);
+    if (stored === null) {
+      localStorage.setItem(key, "");
+      return initialValue;
+    }
+    return stored === "" ? null : stored;
+  },
+  setItem(key: string, value: string | null): void {
+    localStorage.setItem(key, value ?? "");
+  },
+  removeItem(key: string): void {
+    localStorage.removeItem(key);
+  },
+};
+
+// cagedShapes stored as JSON array
+const cagedShapesStorage = {
+  getItem(key: string, initialValue: Set<CagedShape>): Set<CagedShape> {
+    const stored = localStorage.getItem(key);
+    if (stored === null) {
+      localStorage.setItem(key, JSON.stringify(Array.from(initialValue)));
+      return initialValue;
+    }
+    try {
+      return new Set(JSON.parse(stored) as CagedShape[]);
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: Set<CagedShape>): void {
+    localStorage.setItem(key, JSON.stringify(Array.from(value)));
+  },
+  removeItem(key: string): void {
+    localStorage.removeItem(key);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Atoms
+// ---------------------------------------------------------------------------
+
+// Scale
+export const rootNoteAtom = atomWithStorage("rootNote", "C", rawStringStorage());
+export const scaleNameAtom = atomWithStorage("scaleName", "Major", rawStringStorage());
+
+// Chord overlay
+export const chordRootAtom = atomWithStorage("chordRoot", "C", rawStringStorage());
+export const chordTypeAtom = atomWithStorage<string | null>("chordType", null, chordTypeStorage);
+export const linkChordRootAtom = atomWithStorage("linkChordRoot", true, booleanStorage);
+export const hideNonChordNotesAtom = atomWithStorage("hideNonChordNotes", false, booleanStorage);
+export const chordFretSpreadAtom = atomWithStorage("chordFretSpread", 0, numberStorage);
+export const chordIntervalFilterAtom = atomWithStorage("chordIntervalFilter", "All", rawStringStorage());
+
+// Fingering
+export const fingeringPatternAtom = atomWithStorage<FingeringPattern>(
+  "fingeringPattern",
+  "all",
+  rawStringStorage<FingeringPattern>(),
+);
+export const cagedShapesAtom = atomWithStorage<Set<CagedShape>>(
+  "cagedShapes",
+  new Set(CAGED_SHAPES),
+  cagedShapesStorage,
+);
+export const npsPositionAtom = atomWithStorage("npsPosition", 0, numberStorage);
+
+// Display
+export const displayFormatAtom = atomWithStorage<"notes" | "degrees" | "none">(
+  "displayFormat",
+  "notes",
+  rawStringStorage<"notes" | "degrees" | "none">(),
+);
+export const shapeLabelsAtom = atomWithStorage<"modal" | "caged" | "none">(
+  "shapeLabels",
+  "none",
+  rawStringStorage<"modal" | "caged" | "none">(),
+);
+export const tuningNameAtom = atomWithStorage("tuningName", "Standard", rawStringStorage());
+export const fretZoomAtom = atomWithStorage("fretZoom", 100, numberStorage);
+export const fretStartAtom = atomWithStorage("fretStart", 0, numberStorage);
+export const fretEndAtom = atomWithStorage("fretEnd", 24, numberStorage);
+
+// Accidentals / Audio / Mobile tab
+export const useFlatsAtom = atomWithStorage("useFlats", false, booleanStorage);
+export const isMutedAtom = atomWithStorage("isMuted", false, booleanStorage);
+export const mobileTabAtom = atomWithStorage<"key" | "scale" | "settings">(
+  "mobileTab",
+  "key",
+  rawStringStorage<"key" | "scale" | "settings">(),
+);
+
+// ---------------------------------------------------------------------------
+// Write atoms (actions)
+// ---------------------------------------------------------------------------
+
+// Sets rootNote and syncs chordRoot when linkChordRoot is enabled
+export const setRootNoteAtom = atom(
+  null,
+  (get, set, note: string) => {
+    set(rootNoteAtom, note);
+    if (get(linkChordRootAtom)) set(chordRootAtom, note);
+  },
+);
+
+// Resets all persisted state to defaults and clears localStorage
+export const resetAtom = atom(null, (_get, set) => {
+  localStorage.clear();
+  set(rootNoteAtom, RESET);
+  set(scaleNameAtom, RESET);
+  set(chordRootAtom, RESET);
+  set(chordTypeAtom, RESET);
+  set(linkChordRootAtom, RESET);
+  set(hideNonChordNotesAtom, RESET);
+  set(chordFretSpreadAtom, RESET);
+  set(chordIntervalFilterAtom, RESET);
+  set(fingeringPatternAtom, RESET);
+  set(cagedShapesAtom, RESET);
+  set(npsPositionAtom, RESET);
+  set(displayFormatAtom, RESET);
+  set(shapeLabelsAtom, RESET);
+  set(tuningNameAtom, RESET);
+  set(fretZoomAtom, RESET);
+  set(fretStartAtom, RESET);
+  set(fretEndAtom, RESET);
+  set(useFlatsAtom, RESET);
+  set(isMutedAtom, RESET);
+  set(mobileTabAtom, RESET);
+});


### PR DESCRIPTION
## Summary
Refactored the application's state management from React's `useState` with manual `localStorage` persistence to Jotai atoms with automatic storage synchronization. This improves code maintainability, reduces boilerplate, and provides a cleaner separation of concerns.

## Key Changes

- **Created new `src/store/atoms.ts`**: Centralized atom definitions for all persisted application state (scale, chord, fingering, display, and audio settings) with custom storage adapters that match the previous `localStorage` behavior
  
- **Refactored `App.tsx`**: 
  - Replaced 19 individual `useState` hooks with corresponding `useAtom` and `useAtomValue` hooks
  - Removed ~60 lines of manual `localStorage` persistence logic and the associated `useEffect` dependency array
  - Extracted `AppContent` component and wrapped it with a Jotai `Provider` using a fresh store per mount for isolation
  - Simplified `handleReset()` to dispatch a single `resetAtom` action instead of manually resetting 19 state variables
  - Simplified `handleSetRootNote()` to use a write atom (`setRootNoteAtom`) that handles linked chord root synchronization

- **Custom Storage Adapters**: Implemented `rawStringStorage`, `booleanStorage`, `numberStorage`, `chordTypeStorage`, and `cagedShapesStorage` to maintain exact parity with the previous `localStorage` format and initialization behavior

- **Write Atoms**: Created two action atoms:
  - `setRootNoteAtom`: Syncs `chordRoot` when `linkChordRoot` is enabled
  - `resetAtom`: Atomically resets all state to defaults and clears `localStorage`

## Notable Implementation Details

- The Jotai store is created once per `App` mount using a `useState` lazy initializer, ensuring stability across re-renders and isolation in test environments
- All storage adapters write defaults to `localStorage` on first access, matching the original behavior of the `useState` initializers
- The `chordType` atom uses a custom storage adapter to preserve the original behavior of storing `null` as an empty string
- Removed the `CagedShape` type import from `App.tsx` (now only in `atoms.ts`)
- Removed the `END_FRET` constant from inside the component and moved it to module scope

https://claude.ai/code/session_01QVF9CjMSs63yPLWeqf2VBD