### PR TITLE
chore(ci): upgrade to Node.js 24, auto-bump version, add badges

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -26,12 +26,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Bump version and push tag
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_PAT }}
           default_bump: patch
           tag_prefix: v
           create_annotated_tag: true

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -28,9 +28,21 @@ jobs:
           fetch-depth: 0
 
       - name: Bump version and push tag
+        id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: patch
           tag_prefix: v
           create_annotated_tag: true
+
+      - name: Update package.json version
+        if: steps.tag.outputs.new_tag
+        run: |
+          NEW_VERSION="${{ steps.tag.outputs.new_version }}"
+          npm version "$NEW_VERSION" --no-git-tag-version
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore(release): bump version to v${NEW_VERSION} [skip ci]"
+          git push origin main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -107,7 +107,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -32,12 +30,6 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run test
-      - name: Set version from latest tag
-        run: |
-          TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -n "$TAG" ]; then
-            npm version "${TAG#v}" --no-git-tag-version
-          fi
       - run: npm run build
       - uses: actions/configure-pages@v4
       - uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -30,9 +32,12 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run test
-      - name: Set version from tag
-        if: startsWith(github.ref, 'refs/tags/')
-        run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version
+      - name: Set version from latest tag
+        run: |
+          TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$TAG" ]; then
+            npm version "${TAG#v}" --no-git-tag-version
+          fi
       - run: npm run build
       - uses: actions/configure-pages@v4
       - uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22]
+        node-version: [24]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # FretFlow
 
 [![Live Demo](https://img.shields.io/badge/demo-live-brightgreen)](https://iecg.github.io/fretboard-app/)
+[![Version](https://img.shields.io/github/v/tag/iecg/fretboard-app?label=version&sort=semver)](https://github.com/iecg/fretboard-app/tags)
 [![CI](https://github.com/iecg/fretboard-app/actions/workflows/ci.yml/badge.svg)](https://github.com/iecg/fretboard-app/actions/workflows/ci.yml)
 [![Deploy](https://github.com/iecg/fretboard-app/actions/workflows/deploy.yml/badge.svg)](https://github.com/iecg/fretboard-app/actions/workflows/deploy.yml)
 [![Coverage](https://codecov.io/gh/iecg/fretboard-app/branch/main/graph/badge.svg)](https://codecov.io/gh/iecg/fretboard-app)
-[![Node](https://img.shields.io/badge/node-%3E%3D20.12-brightgreen?logo=node.js)](https://nodejs.org/)
+[![Node](https://img.shields.io/badge/node-%3E%3D24-brightgreen?logo=node.js)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)](https://react.dev/)
 [![Vite](https://img.shields.io/badge/Vite-8-646CFF?logo=vite&logoColor=white)](https://vitejs.dev/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-Support%20FretFlow-FF5E5B?logo=ko-fi&logoColor=white)](https://ko-fi.com/E1E01XFJ0G)
 
 An interactive guitar fretboard learning tool built with React, TypeScript, and Vite.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "type": "module",
   "engines": {
-    "node": ">=20.12.0"
+    "node": ">=24.0.0"
   },
   "scripts": {
     "dev": "vite",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { readFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
 
-const { version } = JSON.parse(readFileSync('./package.json', 'utf-8')) as { version: string }
+const version = (() => {
+  try {
+    return execSync('git describe --tags --abbrev=0', { encoding: 'utf-8' }).trim().replace(/^v/, '')
+  } catch {
+    return JSON.parse(readFileSync('./package.json', 'utf-8')).version as string
+  }
+})()
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,15 +2,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { readFileSync } from 'node:fs'
-import { execSync } from 'node:child_process'
 
-const version = (() => {
-  try {
-    return execSync('git describe --tags --abbrev=0', { encoding: 'utf-8' }).trim().replace(/^v/, '')
-  } catch {
-    return JSON.parse(readFileSync('./package.json', 'utf-8')).version as string
-  }
-})()
+const { version } = JSON.parse(readFileSync('./package.json', 'utf-8')) as { version: string }
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary

- **Node.js 24**: all workflows updated from node-version 20 → 24, test matrix reduced to [24] only, package.json engines bumped to >=24.0.0
- **Auto version bump**: auto-release.yml uses RELEASE_PAT to commit package.json version bump back to main after tagging
- **Deploy fix**: removed dead `git describe` version step, reverted vite.config.ts to read package.json directly
- **README badges**: added version badge (from latest git tag), Ko-fi shields.io badge, updated Node badge to >=24

## Test plan

- [ ] CI passes on Node.js 24
- [ ] PR checks matrix runs on Node 24
- [ ] After merge to main, auto-release creates tag + bumps package.json
- [ ] Version and Ko-fi badges render on README

🤖 Generated with [Claude Code](https://claude.com/claude-code)