### PR TITLE
chore(ci): bump GitHub Actions to Node 24, fix snapshot version coupling

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
         node-version: [24]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -54,7 +54,7 @@ jobs:
 
       - name: Archive test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-results-node-${{ matrix.node-version }}
           path: |
@@ -68,9 +68,9 @@ jobs:
     needs: test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
@@ -82,7 +82,7 @@ jobs:
         run: npm run build
 
       - name: Archive build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist
           path: dist/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
@@ -39,9 +39,9 @@ jobs:
             npm version "${TAG#v}" --no-git-tag-version
           fi
       - run: npm run build
-      - uses: actions/configure-pages@v4
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: dist
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,11 +18,11 @@ jobs:
     name: PR Validation
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
@@ -144,9 +144,9 @@ jobs:
         node-version: [24]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/src/__tests__/__snapshots__/snapshots.test.tsx.snap
+++ b/src/__tests__/__snapshots__/snapshots.test.tsx.snap
@@ -3827,7 +3827,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop layout sna
       class="version-badge"
     >
       v
-      1.0.0
+      0.0.0-test
        · © 
       2026
        Isaac Cocar. Licensed under 
@@ -7796,7 +7796,7 @@ exports[`Component Snapshots > App layout snapshots > renders iPad Pro portrait 
       class="version-badge"
     >
       v
-      1.0.0
+      0.0.0-test
        · © 
       2026
        Isaac Cocar. Licensed under 
@@ -11765,7 +11765,7 @@ exports[`Component Snapshots > App layout snapshots > renders iPad portrait layo
       class="version-badge"
     >
       v
-      1.0.0
+      0.0.0-test
        · © 
       2026
        Isaac Cocar. Licensed under 
@@ -16182,7 +16182,7 @@ exports[`Component Snapshots > App layout snapshots > renders iPhone 12 Pro port
       class="version-badge"
     >
       v
-      1.0.0
+      0.0.0-test
        · © 
       2026
        Isaac Cocar. Licensed under 
@@ -20605,7 +20605,7 @@ exports[`Component Snapshots > App layout snapshots > renders iPhone SE portrait
       class="version-badge"
     >
       v
-      1.0.0
+      0.0.0-test
        · © 
       2026
        Isaac Cocar. Licensed under 
@@ -25022,7 +25022,7 @@ exports[`Component Snapshots > App layout snapshots > renders mobile layout snap
       class="version-badge"
     >
       v
-      1.0.0
+      0.0.0-test
        · © 
       2026
        Isaac Cocar. Licensed under 
@@ -29004,7 +29004,7 @@ exports[`Component Snapshots > App layout snapshots > renders with chord overlay
       class="version-badge"
     >
       v
-      1.0.0
+      0.0.0-test
        · © 
       2026
        Isaac Cocar. Licensed under 
@@ -32985,7 +32985,7 @@ exports[`Component Snapshots > App layout snapshots > renders with custom config
       class="version-badge"
     >
       v
-      1.0.0
+      0.0.0-test
        · © 
       2026
        Isaac Cocar. Licensed under 

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,5 +1,8 @@
 import '@testing-library/jest-dom';
 
+// Fix __APP_VERSION__ to prevent snapshot breakage on version bumps
+(globalThis as Record<string, unknown>).__APP_VERSION__ = '0.0.0-test';
+
 // jsdom does not implement ResizeObserver
 (globalThis as typeof globalThis & { ResizeObserver: unknown }).ResizeObserver =
   class ResizeObserver {


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4→v5, `actions/setup-node` v4→v5, `actions/upload-artifact` v4→v5, and pages actions to latest — fixes Node.js 20 deprecation warnings
- Mock `__APP_VERSION__` in test setup to a fixed value (`0.0.0-test`) so snapshots don't break on version bumps

## Test plan
- [x] All 324 tests pass locally
- [x] Lint passes
- [x] Build passes
- [ ] CI workflows run without Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)