### PR TITLE
fix(ci): fix GitHub Pages deploy trigger and version conflict

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -36,6 +36,12 @@ jobs:
           tag_prefix: v
           create_annotated_tag: true
 
+      - name: Trigger deploy workflow
+        if: steps.tag.outputs.new_tag
+        run: gh workflow run deploy.yml --ref ${{ steps.tag.outputs.new_tag }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create version bump PR
         if: steps.tag.outputs.new_tag
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -n "$TAG" ]; then
-            npm version "${TAG#v}" --no-git-tag-version
+            npm version "${TAG#v}" --no-git-tag-version --allow-same-version
           fi
       - run: npm run build
       - uses: actions/configure-pages@v5

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,7 @@ name: PR Checks & Enforcement
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
## Summary

- Add `--allow-same-version` to `npm version` in deploy workflow so it doesn't fail when `package.json` already reflects the tag version
- Explicitly trigger the deploy workflow from auto-release via `gh workflow run` after pushing the tag, since tags pushed with `GITHUB_TOKEN` don't fire `push` events in other workflows

https://claude.ai/code/session_01GwccidrsD6b24ew7oEYF92