### PR TITLE
chore: add husky pre-commit hooks and update project docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ coverage
 .vbw-planning/
 
 .claude/
-CLAUDE.md
+CLAUDE.local.md

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,40 @@
+commit_msg=$(cat "$1")
+
+# Allow merge commits and fixup/squash commits
+if echo "$commit_msg" | grep -qE "^(Merge |Revert |fixup! |squash! )"; then
+  exit 0
+fi
+
+# Conventional commit pattern: type(optional-scope)[optional !]: description
+pattern="^(feat|fix|docs|style|refactor|test|chore|build|ci|perf|revert)(\(.+\))?(!)?: .+"
+
+if ! echo "$commit_msg" | grep -qE "$pattern"; then
+  echo ""
+  echo "Error: commit message does not follow Conventional Commits format."
+  echo ""
+  echo "  Expected:  type(optional-scope): description"
+  echo "  Valid types: feat fix docs style refactor test chore build ci perf revert"
+  echo ""
+  echo "  Examples:"
+  echo "    feat: add transpose shortcut to circle of fifths"
+  echo "    fix(fretboard): correct enharmonic display for Cb scale"
+  echo "    chore: bump vite to 8.1"
+  echo ""
+  exit 1
+fi
+
+subject=$(echo "$commit_msg" | head -1)
+
+if [ "${#subject}" -gt 72 ]; then
+  echo ""
+  echo "Error: commit subject line is ${#subject} characters — maximum is 72."
+  echo ""
+  exit 1
+fi
+
+if echo "$subject" | grep -qE "\.$"; then
+  echo ""
+  echo "Error: commit subject line must not end with a period."
+  echo ""
+  exit 1
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,7 @@
+branch=$(git symbolic-ref --short HEAD)
+if [ "$branch" = "main" ]; then
+  echo "Error: Direct commits to 'main' are not allowed. Please use a feature branch."
+  exit 1
+fi
+
 npx lint-staged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,12 +34,14 @@ This repo uses **trunk-based development** with `main` as the single integration
 
 **Typical workflow:**
 ```bash
-git switch main && git pull
+git switch main && git pull          # always sync before branching
 git switch -c feature/my-thing
 # ... work ...
 git push -u origin feature/my-thing
 # open PR → main
 ```
+
+> **Always pull the latest `main` before creating a new branch.** There is no automated enforcement — it is your responsibility. Starting from stale `main` causes needless merge conflicts.
 
 ## Commit conventions
 
@@ -53,16 +55,38 @@ Use conventional commits — prefix every commit message:
 | `refactor:` | code change with no behaviour change |
 | `docs:` | documentation only |
 | `test:` | adding or fixing tests |
+| `style:` | formatting, whitespace — no logic change |
+| `perf:` | performance improvement |
+| `ci:` | CI/CD pipeline changes |
+| `build:` | build system or tooling changes |
+| `revert:` | reverts a previous commit |
 
 Examples:
 ```
 feat: add transpose shortcut to circle of fifths
 fix: correct enharmonic display for Cb scale
 chore: bump vite to 8.1
+refactor(theory): simplify interval lookup
 ```
 
-Keep the subject line under 72 characters. No period at the end.
+Rules enforced by the `commit-msg` husky hook:
+- Subject line ≤ 72 characters
+- No period at the end
+- Must match `type(optional-scope): description`
+
 GitHub Release notes are auto-grouped by these prefixes.
+
+## PR title convention
+
+PR titles must also follow Conventional Commits format — GitHub squash-merges use the PR title as the commit message on `main`.
+
+```
+feat: add capo support
+fix(fretboard): off-by-one on fret 0 highlight
+chore: upgrade eslint to v9
+```
+
+The same type prefixes and 72-character limit apply.
 
 ## Releasing — manual trigger
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
-# FretFlow — Agent Guide
+# FretFlow — Claude Code Guide
 
 FretFlow is a React 19 + TypeScript interactive guitar fretboard and music theory tool, built with Vite and deployed to GitHub Pages at `https://iecg.github.io/fretboard-app/`.
+
+> This file is the project context for **Claude Code**. Machine-local overrides belong in `CLAUDE.local.md` (git-ignored).
 
 ## Commands
 


### PR DESCRIPTION
## Summary
Added a branch protection mechanism to the pre-commit git hook that prevents developers from committing directly to the `main` branch, enforcing the use of feature branches for all changes.

## Key Changes
- Added branch detection logic to the `.husky/pre-commit` hook that checks the current git branch
- Implemented validation that exits with an error if a commit is attempted on the `main` branch
- Displays a user-friendly error message directing developers to use a feature branch instead
- Preserves existing `lint-staged` functionality for branches other than `main`

## Implementation Details
The hook now:
1. Retrieves the current branch name using `git symbolic-ref --short HEAD`
2. Compares it against the `main` branch
3. Exits with status code 1 (preventing the commit) if on `main`
4. Allows commits to proceed normally on all other branches after linting checks

https://claude.ai/code/session_01NtNGmvcPmnNHeoYq8vucPY