### PR TITLE
feat(a11y): add full keyboard navigation to DrawerSelector

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1242,6 +1242,11 @@
   font-weight: 500;
 }
 
+.drawer-option.focused {
+  background: var(--surface-raised);
+  color: white;
+}
+
 .drawer-divider {
   padding: var(--space-1) var(--space-3);
   font-size: 10px;

--- a/src/DrawerSelector.tsx
+++ b/src/DrawerSelector.tsx
@@ -37,6 +37,27 @@ export function DrawerSelector(props: DrawerSelectorProps) {
   const [open, setOpen] = useState(false);
   const [dropUp, setDropUp] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const listboxRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  // Build flat options list for keyboard navigation (null option + string options)
+  const flatOptions = [
+    ...(nullable ? [null as string | null] : []),
+    ...options.filter((o): o is string => typeof o === "string"),
+  ];
+
+  // Find index of currently selected value
+  const selectedIndex = flatOptions.findIndex((opt) => opt === value);
+
+  // Track active index for keyboard navigation (starts at selected value)
+  const [activeIndex, setActiveIndex] = useState(selectedIndex >= 0 ? selectedIndex : 0);
+
+  // Reset activeIndex when opening to match current selection
+  useEffect(() => {
+    if (open) {
+      setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
+    }
+  }, [open, selectedIndex]);
 
   useEffect(() => {
     if (!open || !containerRef.current) return;
@@ -59,52 +80,137 @@ export function DrawerSelector(props: DrawerSelectorProps) {
     return () => document.removeEventListener("mousedown", handleClick);
   }, [open]);
 
+  const listboxId = `${label.toLowerCase().replace(/\s+/g, '-')}-listbox`;
+  const triggerId = `${label.toLowerCase().replace(/\s+/g, '-')}-trigger`;
+
   return (
     <div className="drawer-selector" ref={containerRef}>
-      <button className="drawer-trigger" onClick={() => setOpen((o) => !o)}>
+      <button
+        id={triggerId}
+        ref={triggerRef}
+        className="drawer-trigger"
+        onClick={() => setOpen((o) => !o)}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === " ") {
+            if (!open) {
+              setOpen(true);
+            }
+          }
+        }}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-controls={listboxId}
+        aria-label={`${label}: ${value ?? "None"}`}
+      >
         <span className="drawer-label">{label}</span>
         <span className="drawer-value">{value ?? "None"}</span>
         <ChevronDown className={`drawer-chevron ${open ? "open" : ""}`} />
       </button>
       {open && (
         <div
+          ref={listboxRef}
+          id={listboxId}
+          role="listbox"
+          aria-label={label}
+          tabIndex={0}
+          autoFocus
+          aria-activedescendant={flatOptions[activeIndex] === null ? `${listboxId}-none` : `${listboxId}-${flatOptions[activeIndex]}`}
           className={clsx(
             "drawer-options",
             "custom-scrollbar",
             dropUp && "drawer-options--above",
           )}
+          onKeyDown={(e) => {
+            switch (e.key) {
+              case "ArrowDown":
+                e.preventDefault();
+                setActiveIndex((prev) => Math.min(prev + 1, flatOptions.length - 1));
+                break;
+              case "ArrowUp":
+                e.preventDefault();
+                setActiveIndex((prev) => Math.max(prev - 1, 0));
+                break;
+              case "Home":
+                e.preventDefault();
+                setActiveIndex(0);
+                break;
+              case "End":
+                e.preventDefault();
+                setActiveIndex(flatOptions.length - 1);
+                break;
+              case "Enter":
+              case " ":
+                {
+                  e.preventDefault();
+                  const selected = flatOptions[activeIndex];
+                  if (selected !== undefined) {
+                    if (selected === null) {
+                      if (nullable) props.onSelect(null);
+                    } else {
+                      props.onSelect(selected);
+                    }
+                  }
+                  setOpen(false);
+                  triggerRef.current?.focus();
+                  break;
+                }
+              case "Escape":
+                e.preventDefault();
+                setOpen(false);
+                triggerRef.current?.focus();
+                break;
+              case "Tab":
+                setOpen(false);
+                break;
+            }
+          }}
         >
           {nullable && (
             <button
               type="button"
-              className={`drawer-option ${value === null ? "active" : ""}`}
+              id={`${listboxId}-none`}
+              data-index={0}
+              className={`drawer-option ${value === null ? "active" : ""} ${activeIndex === 0 ? "focused" : ""}`}
               onClick={() => {
                 props.onSelect(null);
                 setOpen(false);
+                triggerRef.current?.focus();
               }}
+              role="option"
+              aria-selected={value === null}
+              tabIndex={-1}
             >
               None
             </button>
           )}
-          {options.map((opt, i) =>
-            typeof opt === "string" ? (
-              <button
-                type="button"
-                key={opt}
-                className={`drawer-option ${value === opt ? "active" : ""}`}
-                onClick={() => {
-                  props.onSelect(opt);
-                  setOpen(false);
-                }}
-              >
-                {opt}
-              </button>
-            ) : (
-              <div key={`div-${i}`} className="drawer-divider">
-                {opt.divider}
-              </div>
-            ),
-          )}
+          {(() => {
+            let flatIndex = nullable ? 1 : 0;
+            return options.map((opt, i) =>
+              typeof opt === "string" ? (
+                <button
+                  type="button"
+                  key={opt}
+                  id={`${listboxId}-${opt}`}
+                  data-index={flatIndex}
+                  className={`drawer-option ${value === opt ? "active" : ""} ${activeIndex === flatIndex++ ? "focused" : ""}`}
+                  onClick={() => {
+                    props.onSelect(opt);
+                    setOpen(false);
+                    triggerRef.current?.focus();
+                  }}
+                  role="option"
+                  aria-selected={value === opt}
+                  tabIndex={-1}
+                >
+                  {opt}
+                </button>
+              ) : (
+                <div key={`div-${i}`} className="drawer-divider" role="separator">
+                  {opt.divider}
+                </div>
+              ),
+            );
+          })()}
         </div>
       )}
     </div>

--- a/src/DrawerSelector.tsx
+++ b/src/DrawerSelector.tsx
@@ -97,7 +97,6 @@ export function DrawerSelector(props: DrawerSelectorProps) {
             }
           }
         }}
-        }}
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-controls={listboxId}
@@ -171,7 +170,7 @@ export function DrawerSelector(props: DrawerSelectorProps) {
               type="button"
               id={`${listboxId}-none`}
               data-index={0}
-              className={`drawer-option ${value === null ? "active" : ""} ${activeIndex === 0 ? "focused" : ""}`}
+              className={clsx('drawer-option', value === null && 'active', activeIndex === 0 && 'focused')}
               onClick={() => {
                 props.onSelect(null);
                 setOpen(false);
@@ -193,7 +192,7 @@ export function DrawerSelector(props: DrawerSelectorProps) {
                   key={opt}
                   id={`${listboxId}-${opt}`}
                   data-index={flatIndex}
-                  className={`drawer-option ${value === opt ? "active" : ""} ${activeIndex === flatIndex++ ? "focused" : ""}`}
+                  className={clsx('drawer-option', value === opt && 'active', activeIndex === flatIndex++ && 'focused')}
                   onClick={() => {
                     props.onSelect(opt);
                     setOpen(false);

--- a/src/DrawerSelector.tsx
+++ b/src/DrawerSelector.tsx
@@ -156,6 +156,7 @@ export function DrawerSelector(props: DrawerSelectorProps) {
                 }
               case "Escape":
                 e.preventDefault();
+                e.stopPropagation();
                 setOpen(false);
                 triggerRef.current?.focus();
                 break;

--- a/src/DrawerSelector.tsx
+++ b/src/DrawerSelector.tsx
@@ -80,6 +80,9 @@ export function DrawerSelector(props: DrawerSelectorProps) {
     return () => document.removeEventListener("mousedown", handleClick);
   }, [open]);
 
+  const sanitizeId = (s: string) =>
+    s.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+
   const listboxId = `${label.toLowerCase().replace(/\s+/g, '-')}-listbox`;
   const triggerId = `${label.toLowerCase().replace(/\s+/g, '-')}-trigger`;
 
@@ -114,7 +117,7 @@ export function DrawerSelector(props: DrawerSelectorProps) {
           aria-label={label}
           tabIndex={0}
           autoFocus
-          aria-activedescendant={flatOptions[activeIndex] === null ? `${listboxId}-none` : `${listboxId}-${flatOptions[activeIndex]}`}
+          aria-activedescendant={flatOptions[activeIndex] === null ? `${listboxId}-none` : `${listboxId}-${sanitizeId(flatOptions[activeIndex] as string)}`}
           className={clsx(
             "drawer-options",
             "custom-scrollbar",
@@ -191,7 +194,7 @@ export function DrawerSelector(props: DrawerSelectorProps) {
                 <button
                   type="button"
                   key={opt}
-                  id={`${listboxId}-${opt}`}
+                  id={`${listboxId}-${sanitizeId(opt)}`}
                   data-index={flatIndex}
                   className={clsx('drawer-option', value === opt && 'active', activeIndex === flatIndex++ && 'focused')}
                   onClick={() => {

--- a/src/DrawerSelector.tsx
+++ b/src/DrawerSelector.tsx
@@ -91,11 +91,12 @@ export function DrawerSelector(props: DrawerSelectorProps) {
         className="drawer-trigger"
         onClick={() => setOpen((o) => !o)}
         onKeyDown={(e) => {
-          if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === " ") {
+          if (e.key === "ArrowDown" || e.key === "ArrowUp") {
             if (!open) {
               setOpen(true);
             }
           }
+        }}
         }}
         aria-expanded={open}
         aria-haspopup="listbox"

--- a/src/__tests__/DrawerSelector.test.tsx
+++ b/src/__tests__/DrawerSelector.test.tsx
@@ -5,6 +5,11 @@ import { DrawerSelector } from "../DrawerSelector";
 
 const OPTIONS = ["Major", "Minor", "Pentatonic"];
 
+// Helper to open the dropdown
+const openDropdown = () => {
+  fireEvent.click(screen.getByRole("button", { name: /Scale:/i }));
+};
+
 describe("DrawerSelector", () => {
   it("renders the label and is closed by default", () => {
     render(
@@ -19,6 +24,36 @@ describe("DrawerSelector", () => {
     expect(screen.queryByText("Minor")).toBeNull();
   });
 
+  it("has proper ARIA attributes on trigger button", () => {
+    render(
+      <DrawerSelector
+        label="Scale"
+        value="Major"
+        options={OPTIONS}
+        onSelect={() => {}}
+      />,
+    );
+    const trigger = screen.getByRole("button", { name: /Scale:/i });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger).toHaveAttribute("aria-haspopup", "listbox");
+    expect(trigger).toHaveAttribute("aria-controls", "scale-listbox");
+    expect(trigger).toHaveAttribute("aria-label", "Scale: Major");
+  });
+
+  it("updates aria-expanded when opened", () => {
+    render(
+      <DrawerSelector
+        label="Scale"
+        value="Major"
+        options={OPTIONS}
+        onSelect={() => {}}
+      />,
+    );
+    const trigger = screen.getByRole("button", { name: /Scale:/i });
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
+
   it("opens the options list on trigger click", () => {
     render(
       <DrawerSelector
@@ -28,9 +63,40 @@ describe("DrawerSelector", () => {
         onSelect={() => {}}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /Scale/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Scale:/i }));
     expect(screen.getByText("Minor")).toBeTruthy();
     expect(screen.getByText("Pentatonic")).toBeTruthy();
+  });
+
+  it("has listbox role and proper ARIA attributes when opened", () => {
+    render(
+      <DrawerSelector
+        label="Scale"
+        value="Major"
+        options={OPTIONS}
+        onSelect={() => {}}
+      />,
+    );
+    openDropdown();
+    const listbox = screen.getByRole("listbox");
+    expect(listbox).toHaveAttribute("aria-label", "Scale");
+  });
+
+  it("has option roles with aria-selected on items", () => {
+    render(
+      <DrawerSelector
+        label="Scale"
+        value="Major"
+        options={OPTIONS}
+        onSelect={() => {}}
+      />,
+    );
+    openDropdown();
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveAttribute("aria-selected", "true");
+    expect(options[1]).toHaveAttribute("aria-selected", "false");
+    expect(options[2]).toHaveAttribute("aria-selected", "false");
   });
 
   it("calls onSelect with the correct value when an option is clicked", () => {
@@ -43,7 +109,7 @@ describe("DrawerSelector", () => {
         onSelect={onSelect}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /Scale/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Scale:/i }));
     fireEvent.click(screen.getByText("Minor"));
     expect(onSelect).toHaveBeenCalledWith("Minor");
   });
@@ -57,9 +123,25 @@ describe("DrawerSelector", () => {
         onSelect={() => {}}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /Scale/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Scale:/i }));
     fireEvent.click(screen.getByText("Minor"));
     expect(screen.queryByText("Pentatonic")).toBeNull();
+  });
+
+  it("returns focus to trigger button after selection", () => {
+    render(
+      <DrawerSelector
+        label="Scale"
+        value="Major"
+        options={OPTIONS}
+        onSelect={() => {}}
+      />,
+    );
+    const trigger = screen.getByRole("button", { name: /Scale:/i });
+    fireEvent.click(trigger);
+    const minorOption = screen.getByRole("option", { name: "Minor" });
+    fireEvent.click(minorOption);
+    expect(document.activeElement).toBe(trigger);
   });
 
   it("shows None button when nullable=true", () => {
@@ -72,7 +154,7 @@ describe("DrawerSelector", () => {
         nullable
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /Chord/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Chord:/i }));
     const noneButtons = screen.getAllByText("None");
     expect(noneButtons.length).toBeGreaterThanOrEqual(1);
   });
@@ -88,8 +170,153 @@ describe("DrawerSelector", () => {
         nullable
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /Chord/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Chord:/i }));
     fireEvent.click(screen.getByText("None"));
     expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  describe("keyboard navigation", () => {
+    it("opens dropdown with ArrowDown and shows listbox", () => {
+      render(
+        <DrawerSelector
+          label="Scale"
+          value="Major"
+          options={OPTIONS}
+          onSelect={() => {}}
+        />,
+      );
+      const trigger = screen.getByRole("button", { name: /Scale:/i });
+      fireEvent.keyDown(trigger, { key: "ArrowDown" });
+      const listbox = screen.getByRole("listbox");
+      expect(listbox).toBeTruthy();
+    });
+
+    it("opens dropdown with ArrowUp and shows listbox", () => {
+      render(
+        <DrawerSelector
+          label="Scale"
+          value="Major"
+          options={OPTIONS}
+          onSelect={() => {}}
+        />,
+      );
+      const trigger = screen.getByRole("button", { name: /Scale:/i });
+      fireEvent.keyDown(trigger, { key: "ArrowUp" });
+      const listbox = screen.getByRole("listbox");
+      expect(listbox).toBeTruthy();
+    });
+
+    it("navigates options with ArrowDown using aria-activedescendant", () => {
+      render(
+        <DrawerSelector
+          label="Scale"
+          value="Major"
+          options={OPTIONS}
+          onSelect={() => {}}
+        />,
+      );
+      openDropdown();
+      const listbox = screen.getByRole("listbox");
+      fireEvent.keyDown(listbox, { key: "ArrowDown" });
+      fireEvent.keyDown(listbox, { key: "ArrowDown" });
+      expect(listbox).toHaveAttribute("aria-activedescendant", "scale-listbox-Pentatonic");
+    });
+
+    it("navigates options with ArrowUp using aria-activedescendant", () => {
+      render(
+        <DrawerSelector
+          label="Scale"
+          value="Major"
+          options={OPTIONS}
+          onSelect={() => {}}
+        />,
+      );
+      openDropdown();
+      const listbox = screen.getByRole("listbox");
+      fireEvent.keyDown(listbox, { key: "ArrowDown" });
+      fireEvent.keyDown(listbox, { key: "ArrowUp" });
+      expect(listbox).toHaveAttribute("aria-activedescendant", "scale-listbox-Major");
+    });
+
+    it("selects option with Enter key", () => {
+      const onSelect = vi.fn();
+      render(
+        <DrawerSelector
+          label="Scale"
+          value="Major"
+          options={OPTIONS}
+          onSelect={onSelect}
+        />,
+      );
+      openDropdown();
+      const listbox = screen.getByRole("listbox");
+      fireEvent.keyDown(listbox, { key: "ArrowDown" });
+      fireEvent.keyDown(listbox, { key: "Enter" });
+      expect(onSelect).toHaveBeenCalledWith("Minor");
+    });
+
+    it("closes dropdown with Escape key and returns focus to trigger", () => {
+      render(
+        <DrawerSelector
+          label="Scale"
+          value="Major"
+          options={OPTIONS}
+          onSelect={() => {}}
+        />,
+      );
+      const trigger = screen.getByRole("button", { name: /Scale:/i });
+      openDropdown();
+      const listbox = screen.getByRole("listbox");
+      fireEvent.keyDown(listbox, { key: "Escape" });
+      expect(screen.queryByRole("listbox")).toBeNull();
+      expect(document.activeElement).toBe(trigger);
+    });
+
+    it("jumps to first option with Home key", () => {
+      render(
+        <DrawerSelector
+          label="Scale"
+          value="Major"
+          options={OPTIONS}
+          onSelect={() => {}}
+        />,
+      );
+      openDropdown();
+      const listbox = screen.getByRole("listbox");
+      fireEvent.keyDown(listbox, { key: "ArrowDown" });
+      fireEvent.keyDown(listbox, { key: "ArrowDown" });
+      fireEvent.keyDown(listbox, { key: "Home" });
+      expect(listbox).toHaveAttribute("aria-activedescendant", "scale-listbox-Major");
+    });
+
+    it("jumps to last option with End key", () => {
+      render(
+        <DrawerSelector
+          label="Scale"
+          value="Major"
+          options={OPTIONS}
+          onSelect={() => {}}
+        />,
+      );
+      openDropdown();
+      const listbox = screen.getByRole("listbox");
+      fireEvent.keyDown(listbox, { key: "End" });
+      expect(listbox).toHaveAttribute("aria-activedescendant", "scale-listbox-Pentatonic");
+    });
+
+    it("closes dropdown with Tab key", () => {
+      render(
+        <DrawerSelector
+          label="Scale"
+          value="Major"
+          options={OPTIONS}
+          onSelect={() => {}}
+        />,
+      );
+      openDropdown();
+      const listbox = screen.getByRole("listbox");
+      fireEvent.keyDown(listbox, { key: "Tab" });
+      expect(screen.queryByRole("listbox")).toBeNull();
+    });
   });
 });

--- a/src/__tests__/DrawerSelector.test.tsx
+++ b/src/__tests__/DrawerSelector.test.tsx
@@ -219,7 +219,7 @@ describe("DrawerSelector", () => {
       const listbox = screen.getByRole("listbox");
       fireEvent.keyDown(listbox, { key: "ArrowDown" });
       fireEvent.keyDown(listbox, { key: "ArrowDown" });
-      expect(listbox).toHaveAttribute("aria-activedescendant", "scale-listbox-Pentatonic");
+      expect(listbox).toHaveAttribute("aria-activedescendant", "scale-listbox-pentatonic");
     });
 
     it("navigates options with ArrowUp using aria-activedescendant", () => {
@@ -235,7 +235,7 @@ describe("DrawerSelector", () => {
       const listbox = screen.getByRole("listbox");
       fireEvent.keyDown(listbox, { key: "ArrowDown" });
       fireEvent.keyDown(listbox, { key: "ArrowUp" });
-      expect(listbox).toHaveAttribute("aria-activedescendant", "scale-listbox-Major");
+      expect(listbox).toHaveAttribute("aria-activedescendant", "scale-listbox-major");
     });
 
     it("selects option with Enter key", () => {
@@ -286,7 +286,7 @@ describe("DrawerSelector", () => {
       fireEvent.keyDown(listbox, { key: "ArrowDown" });
       fireEvent.keyDown(listbox, { key: "ArrowDown" });
       fireEvent.keyDown(listbox, { key: "Home" });
-      expect(listbox).toHaveAttribute("aria-activedescendant", "scale-listbox-Major");
+      expect(listbox).toHaveAttribute("aria-activedescendant", "scale-listbox-major");
     });
 
     it("jumps to last option with End key", () => {
@@ -301,7 +301,7 @@ describe("DrawerSelector", () => {
       openDropdown();
       const listbox = screen.getByRole("listbox");
       fireEvent.keyDown(listbox, { key: "End" });
-      expect(listbox).toHaveAttribute("aria-activedescendant", "scale-listbox-Pentatonic");
+      expect(listbox).toHaveAttribute("aria-activedescendant", "scale-listbox-pentatonic");
     });
 
     it("closes dropdown with Tab key", () => {

--- a/src/__tests__/__snapshots__/snapshots.test.tsx.snap
+++ b/src/__tests__/__snapshots__/snapshots.test.tsx.snap
@@ -8154,7 +8154,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8169,7 +8169,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8199,7 +8199,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8229,7 +8229,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8259,7 +8259,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8304,7 +8304,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8334,7 +8334,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8349,7 +8349,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8379,7 +8379,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8409,7 +8409,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8439,7 +8439,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8484,7 +8484,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8514,7 +8514,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8542,7 +8542,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8587,7 +8587,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8617,7 +8617,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8632,7 +8632,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8662,7 +8662,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8692,7 +8692,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8722,7 +8722,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8767,7 +8767,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8797,7 +8797,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8812,7 +8812,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8842,7 +8842,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8872,7 +8872,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8902,7 +8902,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8930,7 +8930,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8960,7 +8960,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8990,7 +8990,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9035,7 +9035,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9065,7 +9065,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9080,7 +9080,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9110,7 +9110,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9140,7 +9140,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9170,7 +9170,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9215,7 +9215,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9245,7 +9245,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9260,7 +9260,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9290,7 +9290,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9318,7 +9318,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9348,7 +9348,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9363,7 +9363,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9393,7 +9393,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9423,7 +9423,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9453,7 +9453,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9498,7 +9498,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9528,7 +9528,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9543,7 +9543,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9573,7 +9573,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9603,7 +9603,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9633,7 +9633,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9678,7 +9678,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9706,7 +9706,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9736,7 +9736,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9781,7 +9781,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9811,7 +9811,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9826,7 +9826,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9856,7 +9856,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9886,7 +9886,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9916,7 +9916,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9961,7 +9961,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9991,7 +9991,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10006,7 +10006,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10036,7 +10036,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10066,7 +10066,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10094,7 +10094,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10109,7 +10109,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10139,7 +10139,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10169,7 +10169,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10199,7 +10199,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10244,7 +10244,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10274,7 +10274,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10289,7 +10289,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10319,7 +10319,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10349,7 +10349,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10379,7 +10379,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10424,7 +10424,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only hidden"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10454,7 +10454,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10602,7 +10602,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               aria-controls="chord-overlay-listbox"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-label="Chord Overlay: None"
+              aria-label="Chord Overlay: Major 7th"
               class="drawer-trigger"
               id="chord-overlay-trigger"
             >
@@ -10614,7 +10614,73 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               <span
                 class="drawer-value"
               >
-                None
+                Major 7th
+              </span>
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-down drawer-chevron"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m6 9 6 6 6-6"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="chord-root-row"
+          >
+            <label
+              class="link-toggle"
+            >
+              <input
+                checked=""
+                type="checkbox"
+              />
+              <span>
+                Link chord root to scale
+              </span>
+            </label>
+          </div>
+          <label
+            class="link-toggle"
+          >
+            <input
+              checked=""
+              type="checkbox"
+            />
+            <span>
+              Chord only (hide scale)
+            </span>
+          </label>
+          <div
+            class="drawer-selector"
+          >
+            <button
+              aria-controls="interval-filter-listbox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Interval Filter: All"
+              class="drawer-trigger"
+              id="interval-filter-trigger"
+            >
+              <span
+                class="drawer-label"
+              >
+                Interval Filter
+              </span>
+              <span
+                class="drawer-value"
+              >
+                All
               </span>
               <svg
                 aria-hidden="true"
@@ -11313,6 +11379,83 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
           </span>
           <span
             class="summary-note"
+            style="outline: 2px solid #6366f1; outline-offset: -2px;"
+          >
+            <span
+              class="summary-note-name"
+            >
+              B
+            </span>
+            <span
+              class="summary-note-degree"
+              style="color: rgb(99, 102, 241);"
+            >
+              7
+            </span>
+          </span>
+        </div>
+      </div>
+      <div
+        class="summary-row summary-row--chord"
+      >
+        <div
+          class="summary-row-label"
+        >
+          C Major 7th
+        </div>
+        <div
+          class="summary-notes"
+        >
+          <span
+            class="summary-note summary-note--chord"
+            style="outline: 2px solid #f59e0b; outline-offset: -2px;"
+          >
+            <span
+              class="summary-note-name"
+            >
+              C
+            </span>
+            <span
+              class="summary-note-degree"
+              style="color: rgb(245, 158, 11);"
+            >
+              1
+            </span>
+          </span>
+          <span
+            class="summary-note summary-note--chord"
+            style="outline: 2px solid #10b981; outline-offset: -2px;"
+          >
+            <span
+              class="summary-note-name"
+            >
+              E
+            </span>
+            <span
+              class="summary-note-degree"
+              style="color: rgb(16, 185, 129);"
+            >
+              3
+            </span>
+          </span>
+          <span
+            class="summary-note summary-note--chord"
+            style="outline: 2px solid #8b5cf6; outline-offset: -2px;"
+          >
+            <span
+              class="summary-note-name"
+            >
+              G
+            </span>
+            <span
+              class="summary-note-degree"
+              style="color: rgb(139, 92, 246);"
+            >
+              5
+            </span>
+          </span>
+          <span
+            class="summary-note summary-note--chord"
             style="outline: 2px solid #6366f1; outline-offset: -2px;"
           >
             <span
@@ -11938,13 +12081,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-inactive"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        E
+                        6
                       </span>
                     </div>
                   </div>
@@ -11953,13 +12096,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        F
+                        ♭7
                       </span>
                     </div>
                   </div>
@@ -11974,82 +12117,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        F♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        B
+                        7
                       </span>
                     </div>
                   </div>
@@ -12064,7 +12132,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C
+                        1
                       </span>
                     </div>
                   </div>
@@ -12079,7 +12147,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C♯
+                        ♭2
                       </span>
                     </div>
                   </div>
@@ -12088,13 +12156,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D
+                        2
                       </span>
                     </div>
                   </div>
@@ -12103,43 +12171,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        E
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        F
+                        ♭3
                       </span>
                     </div>
                   </div>
@@ -12154,7 +12192,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        F♯
+                        3
                       </span>
                     </div>
                   </div>
@@ -12163,43 +12201,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        G
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A
+                        4
                       </span>
                     </div>
                   </div>
@@ -12214,7 +12222,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        A♯
+                        ♭5
                       </span>
                     </div>
                   </div>
@@ -12223,13 +12231,73 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        B
+                        5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭7
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        7
                       </span>
                     </div>
                   </div>
@@ -12244,7 +12312,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C
+                        1
                       </span>
                     </div>
                   </div>
@@ -12259,7 +12327,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C♯
+                        ♭2
                       </span>
                     </div>
                   </div>
@@ -12268,13 +12336,28 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D
+                        2
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭3
                       </span>
                     </div>
                   </div>
@@ -12289,7 +12372,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        D♯
+                        3
                       </span>
                     </div>
                   </div>
@@ -12298,13 +12381,73 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        E
+                        4
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        6
                       </span>
                     </div>
                   </div>
@@ -12326,13 +12469,118 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-inactive"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        B
+                        3
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        4
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭7
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        7
                       </span>
                     </div>
                   </div>
@@ -12347,7 +12595,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C
+                        1
                       </span>
                     </div>
                   </div>
@@ -12362,7 +12610,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C♯
+                        ♭2
                       </span>
                     </div>
                   </div>
@@ -12371,13 +12619,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D
+                        2
                       </span>
                     </div>
                   </div>
@@ -12386,43 +12634,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        E
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        F
+                        ♭3
                       </span>
                     </div>
                   </div>
@@ -12437,7 +12655,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        F♯
+                        3
                       </span>
                     </div>
                   </div>
@@ -12446,43 +12664,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        G
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A
+                        4
                       </span>
                     </div>
                   </div>
@@ -12497,7 +12685,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        A♯
+                        ♭5
                       </span>
                     </div>
                   </div>
@@ -12506,13 +12694,73 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        B
+                        5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭7
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        7
                       </span>
                     </div>
                   </div>
@@ -12527,7 +12775,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C
+                        1
                       </span>
                     </div>
                   </div>
@@ -12542,7 +12790,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C♯
+                        ♭2
                       </span>
                     </div>
                   </div>
@@ -12551,13 +12799,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D
+                        2
                       </span>
                     </div>
                   </div>
@@ -12566,43 +12814,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        E
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        F
+                        ♭3
                       </span>
                     </div>
                   </div>
@@ -12617,82 +12835,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        F♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        B
+                        3
                       </span>
                     </div>
                   </div>
@@ -12714,13 +12857,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble root-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        G
+                        1
                       </span>
                     </div>
                   </div>
@@ -12735,7 +12878,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        G♯
+                        ♭2
                       </span>
                     </div>
                   </div>
@@ -12744,13 +12887,28 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        A
+                        2
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭3
                       </span>
                     </div>
                   </div>
@@ -12765,7 +12923,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        A♯
+                        3
                       </span>
                     </div>
                   </div>
@@ -12774,13 +12932,103 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        B
+                        4
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭7
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        7
                       </span>
                     </div>
                   </div>
@@ -12795,7 +13043,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C
+                        1
                       </span>
                     </div>
                   </div>
@@ -12810,7 +13058,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C♯
+                        ♭2
                       </span>
                     </div>
                   </div>
@@ -12819,13 +13067,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D
+                        2
                       </span>
                     </div>
                   </div>
@@ -12834,43 +13082,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        E
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        F
+                        ♭3
                       </span>
                     </div>
                   </div>
@@ -12885,7 +13103,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        F♯
+                        3
                       </span>
                     </div>
                   </div>
@@ -12894,43 +13112,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        G
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A
+                        4
                       </span>
                     </div>
                   </div>
@@ -12945,7 +13133,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        A♯
+                        ♭5
                       </span>
                     </div>
                   </div>
@@ -12954,13 +13142,73 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        B
+                        5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭7
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        7
                       </span>
                     </div>
                   </div>
@@ -12975,112 +13223,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        C♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        D
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        D♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        E
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        F
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        F♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G
+                        1
                       </span>
                     </div>
                   </div>
@@ -13102,13 +13245,28 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D
+                        5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭6
                       </span>
                     </div>
                   </div>
@@ -13123,7 +13281,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        D♯
+                        6
                       </span>
                     </div>
                   </div>
@@ -13132,28 +13290,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        E
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        F
+                        ♭7
                       </span>
                     </div>
                   </div>
@@ -13168,82 +13311,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        F♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        B
+                        7
                       </span>
                     </div>
                   </div>
@@ -13258,7 +13326,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C
+                        1
                       </span>
                     </div>
                   </div>
@@ -13273,7 +13341,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C♯
+                        ♭2
                       </span>
                     </div>
                   </div>
@@ -13282,13 +13350,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D
+                        2
                       </span>
                     </div>
                   </div>
@@ -13297,43 +13365,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        E
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        F
+                        ♭3
                       </span>
                     </div>
                   </div>
@@ -13348,7 +13386,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        F♯
+                        3
                       </span>
                     </div>
                   </div>
@@ -13357,43 +13395,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        G
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A
+                        4
                       </span>
                     </div>
                   </div>
@@ -13408,7 +13416,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        A♯
+                        ♭5
                       </span>
                     </div>
                   </div>
@@ -13417,13 +13425,73 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        B
+                        5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭7
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        7
                       </span>
                     </div>
                   </div>
@@ -13438,7 +13506,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C
+                        1
                       </span>
                     </div>
                   </div>
@@ -13453,7 +13521,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C♯
+                        ♭2
                       </span>
                     </div>
                   </div>
@@ -13462,13 +13530,88 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D
+                        2
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭3
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        3
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        4
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        5
                       </span>
                     </div>
                   </div>
@@ -13490,13 +13633,28 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        A
+                        2
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭3
                       </span>
                     </div>
                   </div>
@@ -13511,7 +13669,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        A♯
+                        3
                       </span>
                     </div>
                   </div>
@@ -13520,13 +13678,103 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        B
+                        4
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭7
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        7
                       </span>
                     </div>
                   </div>
@@ -13541,7 +13789,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C
+                        1
                       </span>
                     </div>
                   </div>
@@ -13556,7 +13804,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C♯
+                        ♭2
                       </span>
                     </div>
                   </div>
@@ -13565,13 +13813,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D
+                        2
                       </span>
                     </div>
                   </div>
@@ -13580,43 +13828,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        E
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        F
+                        ♭3
                       </span>
                     </div>
                   </div>
@@ -13631,7 +13849,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        F♯
+                        3
                       </span>
                     </div>
                   </div>
@@ -13640,43 +13858,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        G
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A
+                        4
                       </span>
                     </div>
                   </div>
@@ -13691,7 +13879,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        A♯
+                        ♭5
                       </span>
                     </div>
                   </div>
@@ -13700,13 +13888,73 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        B
+                        5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭7
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        7
                       </span>
                     </div>
                   </div>
@@ -13721,7 +13969,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C
+                        1
                       </span>
                     </div>
                   </div>
@@ -13736,7 +13984,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C♯
+                        ♭2
                       </span>
                     </div>
                   </div>
@@ -13745,118 +13993,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        D♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        E
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        F
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        F♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A
+                        2
                       </span>
                     </div>
                   </div>
@@ -13878,13 +14021,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-inactive"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        E
+                        6
                       </span>
                     </div>
                   </div>
@@ -13893,13 +14036,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        F
+                        ♭7
                       </span>
                     </div>
                   </div>
@@ -13914,82 +14057,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        F♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        B
+                        7
                       </span>
                     </div>
                   </div>
@@ -14004,7 +14072,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C
+                        1
                       </span>
                     </div>
                   </div>
@@ -14019,7 +14087,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C♯
+                        ♭2
                       </span>
                     </div>
                   </div>
@@ -14028,13 +14096,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D
+                        2
                       </span>
                     </div>
                   </div>
@@ -14043,43 +14111,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        E
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        F
+                        ♭3
                       </span>
                     </div>
                   </div>
@@ -14094,7 +14132,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        F♯
+                        3
                       </span>
                     </div>
                   </div>
@@ -14103,43 +14141,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        G
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        G♯
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-active"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        A
+                        4
                       </span>
                     </div>
                   </div>
@@ -14154,7 +14162,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        A♯
+                        ♭5
                       </span>
                     </div>
                   </div>
@@ -14163,13 +14171,73 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        B
+                        5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭7
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        7
                       </span>
                     </div>
                   </div>
@@ -14184,7 +14252,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C
+                        1
                       </span>
                     </div>
                   </div>
@@ -14199,7 +14267,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        C♯
+                        ♭2
                       </span>
                     </div>
                   </div>
@@ -14208,13 +14276,28 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble note-scale-only"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        D
+                        2
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭3
                       </span>
                     </div>
                   </div>
@@ -14229,7 +14312,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        D♯
+                        3
                       </span>
                     </div>
                   </div>
@@ -14238,13 +14321,73 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-active"
+                      class="note-bubble chord-tone"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        E
+                        4
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-scale-only"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        5
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble chord-tone"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        ♭6
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        6
                       </span>
                     </div>
                   </div>
@@ -14310,15 +14453,15 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               class="toggle-group toggle-group--default"
             >
               <button
-                aria-pressed="true"
-                class="toggle-btn active"
+                aria-pressed="false"
+                class="toggle-btn"
                 type="button"
               >
                 Notes
               </button>
               <button
-                aria-pressed="false"
-                class="toggle-btn"
+                aria-pressed="true"
+                class="toggle-btn active"
                 type="button"
               >
                 Intervals
@@ -14346,7 +14489,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               aria-controls="scale-listbox"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-label="Scale: Major"
+              aria-label="Scale: Natural Minor"
               class="drawer-trigger"
               id="scale-trigger"
             >
@@ -14358,7 +14501,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               <span
                 class="drawer-value"
               >
-                Major
+                Natural Minor
               </span>
               <svg
                 aria-hidden="true"
@@ -14386,7 +14529,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               aria-controls="chord-overlay-listbox"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-label="Chord Overlay: None"
+              aria-label="Chord Overlay: Minor 7th"
               class="drawer-trigger"
               id="chord-overlay-trigger"
             >
@@ -14398,7 +14541,72 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               <span
                 class="drawer-value"
               >
-                None
+                Minor 7th
+              </span>
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-down drawer-chevron"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m6 9 6 6 6-6"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="chord-root-row"
+          >
+            <label
+              class="link-toggle"
+            >
+              <input
+                checked=""
+                type="checkbox"
+              />
+              <span>
+                Link chord root to scale
+              </span>
+            </label>
+          </div>
+          <label
+            class="link-toggle"
+          >
+            <input
+              type="checkbox"
+            />
+            <span>
+              Chord only (hide scale)
+            </span>
+          </label>
+          <div
+            class="drawer-selector"
+          >
+            <button
+              aria-controls="interval-filter-listbox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Interval Filter: All"
+              class="drawer-trigger"
+              id="interval-filter-trigger"
+            >
+              <span
+                class="drawer-label"
+              >
+                Interval Filter
+              </span>
+              <span
+                class="drawer-value"
+              >
+                All
               </span>
               <svg
                 aria-hidden="true"
@@ -14435,13 +14643,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             viewBox="0 0 320 320"
           >
             <path
-              class="circle-slice active"
+              class="circle-slice "
               d="M 138.46625544747027 79.63497125274951 L 120.2453946722528 11.633793081999102 A 153.6 153.6 0 0 1 199.75460532774719 11.633793081999102 L 181.53374455252973 79.63497125274951 A 83.2 83.2 0 0 0 138.46625544747027 79.63497125274951 Z"
               stroke="var(--surface-highlight)"
               stroke-width="1"
             />
             <path
-              class="circle-slice "
+              class="circle-slice active"
               d="M 181.53374455252973 79.63497125274951 L 199.75460532774719 11.633793081999102 A 153.6 153.6 0 0 1 268.6116015902537 51.388398409746316 L 218.83128419472075 101.16871580527925 A 83.2 83.2 0 0 0 181.53374455252973 79.63497125274951 Z"
               stroke="var(--surface-highlight)"
               stroke-width="1"
@@ -14511,8 +14719,8 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             >
               <text
                 dominant-baseline="middle"
-                fill="var(--text-main)"
-                font-size="17.6"
+                fill="var(--text-muted)"
+                font-size="15.36"
                 font-weight="bold"
                 text-anchor="middle"
                 x="160"
@@ -14530,10 +14738,10 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#f59e0b"
+                fill="#ef4444"
                 font-size="12.16"
                 font-weight="bold"
-                opacity="1"
+                opacity="0.7"
                 paint-order="stroke"
                 stroke="rgba(0,0,0,0.3)"
                 stroke-width="1.5"
@@ -14541,7 +14749,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="160"
                 y="60.8"
               >
-                I
+                iv
               </text>
             </g>
             <g
@@ -14549,8 +14757,8 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             >
               <text
                 dominant-baseline="middle"
-                fill="var(--text-muted)"
-                font-size="15.36"
+                fill="var(--text-main)"
+                font-size="17.6"
                 font-weight="bold"
                 text-anchor="middle"
                 x="222.40000000000003"
@@ -14568,10 +14776,10 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#8b5cf6"
+                fill="#f59e0b"
                 font-size="12.16"
                 font-weight="bold"
-                opacity="0.7"
+                opacity="1"
                 paint-order="stroke"
                 stroke="rgba(0,0,0,0.3)"
                 stroke-width="1.5"
@@ -14579,7 +14787,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="209.60000000000002"
                 y="74.09027994458368"
               >
-                V
+                i
               </text>
             </g>
             <g
@@ -14606,7 +14814,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#3b82f6"
+                fill="#8b5cf6"
                 font-size="12.16"
                 font-weight="bold"
                 opacity="0.7"
@@ -14617,7 +14825,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="245.9097200554163"
                 y="110.4"
               >
-                ii
+                v
               </text>
             </g>
             <g
@@ -14644,7 +14852,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#ec4899"
+                fill="#3b82f6"
                 font-size="12.16"
                 font-weight="bold"
                 opacity="0.7"
@@ -14655,7 +14863,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="259.2"
                 y="160"
               >
-                vi
+                ii°
               </text>
             </g>
             <g
@@ -14680,21 +14888,6 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   E
                 </tspan>
               </text>
-              <text
-                dominant-baseline="middle"
-                fill="#10b981"
-                font-size="12.16"
-                font-weight="bold"
-                opacity="0.7"
-                paint-order="stroke"
-                stroke="rgba(0,0,0,0.3)"
-                stroke-width="1.5"
-                text-anchor="middle"
-                x="245.9097200554163"
-                y="209.6"
-              >
-                iii
-              </text>
             </g>
             <g
               style="pointer-events: none;"
@@ -14717,21 +14910,6 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 >
                   B
                 </tspan>
-              </text>
-              <text
-                dominant-baseline="middle"
-                fill="#6366f1"
-                font-size="12.16"
-                font-weight="bold"
-                opacity="0.7"
-                paint-order="stroke"
-                stroke="rgba(0,0,0,0.3)"
-                stroke-width="1.5"
-                text-anchor="middle"
-                x="209.60000000000002"
-                y="245.9097200554163"
-              >
-                vii°
               </text>
             </g>
             <g
@@ -14858,7 +15036,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   stroke-width="2"
                   x="35.19999999999999"
                 >
-                  D♯
+                  E♭
                 </tspan>
                 <tspan
                   dy="0.9em"
@@ -14870,8 +15048,23 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   stroke-width="2.5"
                   x="35.19999999999999"
                 >
-                  E♭
+                  D♯
                 </tspan>
+              </text>
+              <text
+                dominant-baseline="middle"
+                fill="#ec4899"
+                font-size="12.16"
+                font-weight="bold"
+                opacity="0.7"
+                paint-order="stroke"
+                stroke="rgba(0,0,0,0.3)"
+                stroke-width="1.5"
+                text-anchor="middle"
+                x="60.8"
+                y="160"
+              >
+                VI
               </text>
             </g>
             <g
@@ -14893,7 +15086,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   stroke-width="2"
                   x="51.92002960770205"
                 >
-                  A♯
+                  B♭
                 </tspan>
                 <tspan
                   dy="0.9em"
@@ -14905,8 +15098,23 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   stroke-width="2.5"
                   x="51.92002960770205"
                 >
-                  B♭
+                  A♯
                 </tspan>
+              </text>
+              <text
+                dominant-baseline="middle"
+                fill="#10b981"
+                font-size="12.16"
+                font-weight="bold"
+                opacity="0.7"
+                paint-order="stroke"
+                stroke="rgba(0,0,0,0.3)"
+                stroke-width="1.5"
+                text-anchor="middle"
+                x="74.09027994458368"
+                y="110.39999999999998"
+              >
+                III
               </text>
             </g>
             <g
@@ -14933,7 +15141,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#ef4444"
+                fill="#6366f1"
                 font-size="12.16"
                 font-weight="bold"
                 opacity="0.7"
@@ -14944,7 +15152,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="110.39999999999995"
                 y="74.0902799445837"
               >
-                IV
+                VII
               </text>
             </g>
             <circle
@@ -14965,7 +15173,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               x="160"
               y="147.2"
             >
-              C
+              G
             </text>
             <text
               dominant-baseline="middle"
@@ -14979,7 +15187,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               x="160"
               y="172.8"
             >
-              ♮
+              2♭
             </text>
           </svg>
         </div>
@@ -14994,7 +15202,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
         <div
           class="summary-row-label"
         >
-          C Major
+          G Natural Minor
         </div>
         <div
           class="summary-notes"
@@ -15006,7 +15214,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              C
+              G
             </span>
             <span
               class="summary-note-degree"
@@ -15022,7 +15230,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              D
+              A
             </span>
             <span
               class="summary-note-degree"
@@ -15038,13 +15246,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              E
+              B♭
             </span>
             <span
               class="summary-note-degree"
               style="color: rgb(16, 185, 129);"
             >
-              3
+              ♭3
             </span>
           </span>
           <span
@@ -15054,7 +15262,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              F
+              C
             </span>
             <span
               class="summary-note-degree"
@@ -15070,7 +15278,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              G
+              D
             </span>
             <span
               class="summary-note-degree"
@@ -15086,13 +15294,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              A
+              E♭
             </span>
             <span
               class="summary-note-degree"
               style="color: rgb(236, 72, 153);"
             >
-              6
+              ♭6
             </span>
           </span>
           <span
@@ -15102,13 +15310,90 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              B
+              F
             </span>
             <span
               class="summary-note-degree"
               style="color: rgb(99, 102, 241);"
             >
-              7
+              ♭7
+            </span>
+          </span>
+        </div>
+      </div>
+      <div
+        class="summary-row summary-row--chord"
+      >
+        <div
+          class="summary-row-label"
+        >
+          C Minor 7th
+        </div>
+        <div
+          class="summary-notes"
+        >
+          <span
+            class="summary-note summary-note--chord"
+            style="outline: 2px solid #f59e0b; outline-offset: -2px;"
+          >
+            <span
+              class="summary-note-name"
+            >
+              C
+            </span>
+            <span
+              class="summary-note-degree"
+              style="color: rgb(245, 158, 11);"
+            >
+              1
+            </span>
+          </span>
+          <span
+            class="summary-note summary-note--chord"
+            style="outline: 2px solid #10b981; outline-offset: -2px;"
+          >
+            <span
+              class="summary-note-name"
+            >
+              D♯
+            </span>
+            <span
+              class="summary-note-degree"
+              style="color: rgb(16, 185, 129);"
+            >
+              ♭3
+            </span>
+          </span>
+          <span
+            class="summary-note summary-note--chord"
+            style="outline: 2px solid #8b5cf6; outline-offset: -2px;"
+          >
+            <span
+              class="summary-note-name"
+            >
+              G
+            </span>
+            <span
+              class="summary-note-degree"
+              style="color: rgb(139, 92, 246);"
+            >
+              5
+            </span>
+          </span>
+          <span
+            class="summary-note summary-note--chord"
+            style="outline: 2px solid #6366f1; outline-offset: -2px;"
+          >
+            <span
+              class="summary-note-name"
+            >
+              A♯
+            </span>
+            <span
+              class="summary-note-degree"
+              style="color: rgb(99, 102, 241);"
+            >
+              ♭7
             </span>
           </span>
         </div>

--- a/src/__tests__/__snapshots__/snapshots.test.tsx.snap
+++ b/src/__tests__/__snapshots__/snapshots.test.tsx.snap
@@ -2991,7 +2991,12 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split layo
             class="drawer-selector"
           >
             <button
+              aria-controls="scale-listbox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Scale: Major"
               class="drawer-trigger"
+              id="scale-trigger"
             >
               <span
                 class="drawer-label"
@@ -3026,7 +3031,12 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split layo
             class="drawer-selector"
           >
             <button
+              aria-controls="chord-overlay-listbox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Chord Overlay: None"
               class="drawer-trigger"
+              id="chord-overlay-trigger"
             >
               <span
                 class="drawer-label"
@@ -6765,7 +6775,12 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split layo
             class="drawer-selector"
           >
             <button
+              aria-controls="scale-listbox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Scale: Major"
               class="drawer-trigger"
+              id="scale-trigger"
             >
               <span
                 class="drawer-label"
@@ -6800,7 +6815,12 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split layo
             class="drawer-selector"
           >
             <button
+              aria-controls="chord-overlay-listbox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Chord Overlay: None"
               class="drawer-trigger"
+              id="chord-overlay-trigger"
             >
               <span
                 class="drawer-label"
@@ -8134,7 +8154,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8149,7 +8169,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8179,7 +8199,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8209,7 +8229,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8239,7 +8259,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8284,7 +8304,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8314,7 +8334,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8329,7 +8349,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8359,7 +8379,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8389,7 +8409,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8419,7 +8439,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8464,7 +8484,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8494,7 +8514,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8522,7 +8542,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8567,7 +8587,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8597,7 +8617,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8612,7 +8632,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8642,7 +8662,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8672,7 +8692,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8702,7 +8722,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8747,7 +8767,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8777,7 +8797,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8792,7 +8812,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8822,7 +8842,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8852,7 +8872,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8882,7 +8902,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8910,7 +8930,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8940,7 +8960,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8970,7 +8990,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9015,7 +9035,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9045,7 +9065,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9060,7 +9080,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9090,7 +9110,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9120,7 +9140,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9150,7 +9170,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9195,7 +9215,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9225,7 +9245,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9240,7 +9260,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9270,7 +9290,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9298,7 +9318,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9328,7 +9348,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9343,7 +9363,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9373,7 +9393,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9403,7 +9423,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9433,7 +9453,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9478,7 +9498,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9508,7 +9528,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9523,7 +9543,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9553,7 +9573,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9583,7 +9603,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9613,7 +9633,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9658,7 +9678,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9686,7 +9706,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9716,7 +9736,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9761,7 +9781,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9791,7 +9811,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9806,7 +9826,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9836,7 +9856,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9866,7 +9886,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9896,7 +9916,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9941,7 +9961,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9971,7 +9991,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9986,7 +10006,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10016,7 +10036,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10046,7 +10066,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10074,7 +10094,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10089,7 +10109,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10119,7 +10139,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10149,7 +10169,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10179,7 +10199,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10224,7 +10244,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10254,7 +10274,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10269,7 +10289,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10299,7 +10319,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10329,7 +10349,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10359,7 +10379,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10404,7 +10424,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10434,7 +10454,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10539,7 +10559,12 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             class="drawer-selector"
           >
             <button
+              aria-controls="scale-listbox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Scale: Major"
               class="drawer-trigger"
+              id="scale-trigger"
             >
               <span
                 class="drawer-label"
@@ -10574,7 +10599,12 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             class="drawer-selector"
           >
             <button
+              aria-controls="chord-overlay-listbox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Chord Overlay: None"
               class="drawer-trigger"
+              id="chord-overlay-trigger"
             >
               <span
                 class="drawer-label"
@@ -10584,68 +10614,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               <span
                 class="drawer-value"
               >
-                Major 7th
-              </span>
-              <svg
-                aria-hidden="true"
-                class="lucide lucide-chevron-down drawer-chevron"
-                fill="none"
-                height="24"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="m6 9 6 6 6-6"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="chord-root-row"
-          >
-            <label
-              class="link-toggle"
-            >
-              <input
-                checked=""
-                type="checkbox"
-              />
-              <span>
-                Link chord root to scale
-              </span>
-            </label>
-          </div>
-          <label
-            class="link-toggle"
-          >
-            <input
-              checked=""
-              type="checkbox"
-            />
-            <span>
-              Chord only (hide scale)
-            </span>
-          </label>
-          <div
-            class="drawer-selector"
-          >
-            <button
-              class="drawer-trigger"
-            >
-              <span
-                class="drawer-label"
-              >
-                Interval Filter
-              </span>
-              <span
-                class="drawer-value"
-              >
-                All
+                None
               </span>
               <svg
                 aria-hidden="true"
@@ -11360,83 +11329,6 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
           </span>
         </div>
       </div>
-      <div
-        class="summary-row summary-row--chord"
-      >
-        <div
-          class="summary-row-label"
-        >
-          C Major 7th
-        </div>
-        <div
-          class="summary-notes"
-        >
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #f59e0b; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              C
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(245, 158, 11);"
-            >
-              1
-            </span>
-          </span>
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #10b981; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              E
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(16, 185, 129);"
-            >
-              3
-            </span>
-          </span>
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #8b5cf6; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              G
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(139, 92, 246);"
-            >
-              5
-            </span>
-          </span>
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #6366f1; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              B
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(99, 102, 241);"
-            >
-              7
-            </span>
-          </span>
-        </div>
-      </div>
     </div>
     <div
       class="version-badge"
@@ -12046,13 +11938,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        6
+                        E
                       </span>
                     </div>
                   </div>
@@ -12061,13 +11953,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        F
                       </span>
                     </div>
                   </div>
@@ -12082,7 +11974,82 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        F♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -12097,7 +12064,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -12112,7 +12079,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -12121,28 +12088,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -12157,7 +12109,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -12166,13 +12118,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
+                        E
                       </span>
                     </div>
                   </div>
@@ -12181,43 +12133,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
+                        F
                       </span>
                     </div>
                   </div>
@@ -12232,7 +12154,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        6
+                        F♯
                       </span>
                     </div>
                   </div>
@@ -12241,13 +12163,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        G
                       </span>
                     </div>
                   </div>
@@ -12262,7 +12184,52 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -12277,7 +12244,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -12292,7 +12259,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -12301,28 +12268,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -12337,7 +12289,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -12346,73 +12298,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        6
+                        E
                       </span>
                     </div>
                   </div>
@@ -12434,118 +12326,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        3
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        4
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭7
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        7
+                        B
                       </span>
                     </div>
                   </div>
@@ -12560,7 +12347,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -12575,7 +12362,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -12584,28 +12371,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -12620,7 +12392,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -12629,13 +12401,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
+                        E
                       </span>
                     </div>
                   </div>
@@ -12644,43 +12416,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
+                        F
                       </span>
                     </div>
                   </div>
@@ -12695,7 +12437,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        6
+                        F♯
                       </span>
                     </div>
                   </div>
@@ -12704,13 +12446,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        G
                       </span>
                     </div>
                   </div>
@@ -12725,7 +12467,52 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -12740,7 +12527,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -12755,7 +12542,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -12764,28 +12551,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -12800,7 +12572,127 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        E
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        F
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        F♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -12822,13 +12714,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble root-active"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        1
+                        G
                       </span>
                     </div>
                   </div>
@@ -12843,7 +12735,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        G♯
                       </span>
                     </div>
                   </div>
@@ -12852,28 +12744,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        A
                       </span>
                     </div>
                   </div>
@@ -12888,7 +12765,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        A♯
                       </span>
                     </div>
                   </div>
@@ -12897,103 +12774,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭7
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        7
+                        B
                       </span>
                     </div>
                   </div>
@@ -13008,7 +12795,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -13023,7 +12810,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -13032,28 +12819,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -13068,7 +12840,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -13077,13 +12849,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
+                        E
                       </span>
                     </div>
                   </div>
@@ -13092,43 +12864,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
+                        F
                       </span>
                     </div>
                   </div>
@@ -13143,7 +12885,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        6
+                        F♯
                       </span>
                     </div>
                   </div>
@@ -13152,13 +12894,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        G
                       </span>
                     </div>
                   </div>
@@ -13173,7 +12915,52 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -13188,7 +12975,112 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        C♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        D
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        D♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        E
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        F
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        F♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G
                       </span>
                     </div>
                   </div>
@@ -13210,28 +13102,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
+                        D
                       </span>
                     </div>
                   </div>
@@ -13246,7 +13123,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        6
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -13255,13 +13132,28 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        E
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        F
                       </span>
                     </div>
                   </div>
@@ -13276,7 +13168,82 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        F♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -13291,7 +13258,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -13306,7 +13273,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -13315,28 +13282,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -13351,7 +13303,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -13360,13 +13312,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
+                        E
                       </span>
                     </div>
                   </div>
@@ -13375,43 +13327,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
+                        F
                       </span>
                     </div>
                   </div>
@@ -13426,7 +13348,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        6
+                        F♯
                       </span>
                     </div>
                   </div>
@@ -13435,13 +13357,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        G
                       </span>
                     </div>
                   </div>
@@ -13456,7 +13378,52 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -13471,7 +13438,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -13486,7 +13453,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -13495,88 +13462,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        3
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        4
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
+                        D
                       </span>
                     </div>
                   </div>
@@ -13598,28 +13490,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        A
                       </span>
                     </div>
                   </div>
@@ -13634,7 +13511,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        A♯
                       </span>
                     </div>
                   </div>
@@ -13643,103 +13520,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭7
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        7
+                        B
                       </span>
                     </div>
                   </div>
@@ -13754,7 +13541,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -13769,7 +13556,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -13778,28 +13565,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -13814,7 +13586,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -13823,13 +13595,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
+                        E
                       </span>
                     </div>
                   </div>
@@ -13838,43 +13610,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
+                        F
                       </span>
                     </div>
                   </div>
@@ -13889,7 +13631,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        6
+                        F♯
                       </span>
                     </div>
                   </div>
@@ -13898,13 +13640,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        G
                       </span>
                     </div>
                   </div>
@@ -13919,7 +13661,52 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -13934,7 +13721,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -13949,7 +13736,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -13958,13 +13745,118 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
+                        D
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        D♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        E
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        F
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        F♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
                       </span>
                     </div>
                   </div>
@@ -13986,13 +13878,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        6
+                        E
                       </span>
                     </div>
                   </div>
@@ -14001,13 +13893,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        F
                       </span>
                     </div>
                   </div>
@@ -14022,7 +13914,82 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        F♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -14037,7 +14004,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -14052,7 +14019,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -14061,28 +14028,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -14097,7 +14049,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -14106,13 +14058,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
+                        E
                       </span>
                     </div>
                   </div>
@@ -14121,43 +14073,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
+                        F
                       </span>
                     </div>
                   </div>
@@ -14172,7 +14094,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        6
+                        F♯
                       </span>
                     </div>
                   </div>
@@ -14181,13 +14103,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        G
                       </span>
                     </div>
                   </div>
@@ -14202,7 +14124,52 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -14217,7 +14184,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -14232,7 +14199,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -14241,28 +14208,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -14277,7 +14229,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -14286,73 +14238,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        6
+                        E
                       </span>
                     </div>
                   </div>
@@ -14418,15 +14310,15 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               class="toggle-group toggle-group--default"
             >
               <button
-                aria-pressed="false"
-                class="toggle-btn"
+                aria-pressed="true"
+                class="toggle-btn active"
                 type="button"
               >
                 Notes
               </button>
               <button
-                aria-pressed="true"
-                class="toggle-btn active"
+                aria-pressed="false"
+                class="toggle-btn"
                 type="button"
               >
                 Intervals
@@ -14451,7 +14343,12 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             class="drawer-selector"
           >
             <button
+              aria-controls="scale-listbox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Scale: Major"
               class="drawer-trigger"
+              id="scale-trigger"
             >
               <span
                 class="drawer-label"
@@ -14461,7 +14358,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               <span
                 class="drawer-value"
               >
-                Natural Minor
+                Major
               </span>
               <svg
                 aria-hidden="true"
@@ -14486,7 +14383,12 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             class="drawer-selector"
           >
             <button
+              aria-controls="chord-overlay-listbox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Chord Overlay: None"
               class="drawer-trigger"
+              id="chord-overlay-trigger"
             >
               <span
                 class="drawer-label"
@@ -14496,67 +14398,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               <span
                 class="drawer-value"
               >
-                Minor 7th
-              </span>
-              <svg
-                aria-hidden="true"
-                class="lucide lucide-chevron-down drawer-chevron"
-                fill="none"
-                height="24"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="m6 9 6 6 6-6"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="chord-root-row"
-          >
-            <label
-              class="link-toggle"
-            >
-              <input
-                checked=""
-                type="checkbox"
-              />
-              <span>
-                Link chord root to scale
-              </span>
-            </label>
-          </div>
-          <label
-            class="link-toggle"
-          >
-            <input
-              type="checkbox"
-            />
-            <span>
-              Chord only (hide scale)
-            </span>
-          </label>
-          <div
-            class="drawer-selector"
-          >
-            <button
-              class="drawer-trigger"
-            >
-              <span
-                class="drawer-label"
-              >
-                Interval Filter
-              </span>
-              <span
-                class="drawer-value"
-              >
-                All
+                None
               </span>
               <svg
                 aria-hidden="true"
@@ -14593,13 +14435,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             viewBox="0 0 320 320"
           >
             <path
-              class="circle-slice "
+              class="circle-slice active"
               d="M 138.46625544747027 79.63497125274951 L 120.2453946722528 11.633793081999102 A 153.6 153.6 0 0 1 199.75460532774719 11.633793081999102 L 181.53374455252973 79.63497125274951 A 83.2 83.2 0 0 0 138.46625544747027 79.63497125274951 Z"
               stroke="var(--surface-highlight)"
               stroke-width="1"
             />
             <path
-              class="circle-slice active"
+              class="circle-slice "
               d="M 181.53374455252973 79.63497125274951 L 199.75460532774719 11.633793081999102 A 153.6 153.6 0 0 1 268.6116015902537 51.388398409746316 L 218.83128419472075 101.16871580527925 A 83.2 83.2 0 0 0 181.53374455252973 79.63497125274951 Z"
               stroke="var(--surface-highlight)"
               stroke-width="1"
@@ -14669,8 +14511,8 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             >
               <text
                 dominant-baseline="middle"
-                fill="var(--text-muted)"
-                font-size="15.36"
+                fill="var(--text-main)"
+                font-size="17.6"
                 font-weight="bold"
                 text-anchor="middle"
                 x="160"
@@ -14688,10 +14530,10 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#ef4444"
+                fill="#f59e0b"
                 font-size="12.16"
                 font-weight="bold"
-                opacity="0.7"
+                opacity="1"
                 paint-order="stroke"
                 stroke="rgba(0,0,0,0.3)"
                 stroke-width="1.5"
@@ -14699,7 +14541,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="160"
                 y="60.8"
               >
-                iv
+                I
               </text>
             </g>
             <g
@@ -14707,8 +14549,8 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             >
               <text
                 dominant-baseline="middle"
-                fill="var(--text-main)"
-                font-size="17.6"
+                fill="var(--text-muted)"
+                font-size="15.36"
                 font-weight="bold"
                 text-anchor="middle"
                 x="222.40000000000003"
@@ -14726,10 +14568,10 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#f59e0b"
+                fill="#8b5cf6"
                 font-size="12.16"
                 font-weight="bold"
-                opacity="1"
+                opacity="0.7"
                 paint-order="stroke"
                 stroke="rgba(0,0,0,0.3)"
                 stroke-width="1.5"
@@ -14737,7 +14579,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="209.60000000000002"
                 y="74.09027994458368"
               >
-                i
+                V
               </text>
             </g>
             <g
@@ -14764,7 +14606,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#8b5cf6"
+                fill="#3b82f6"
                 font-size="12.16"
                 font-weight="bold"
                 opacity="0.7"
@@ -14775,7 +14617,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="245.9097200554163"
                 y="110.4"
               >
-                v
+                ii
               </text>
             </g>
             <g
@@ -14802,7 +14644,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#3b82f6"
+                fill="#ec4899"
                 font-size="12.16"
                 font-weight="bold"
                 opacity="0.7"
@@ -14813,7 +14655,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="259.2"
                 y="160"
               >
-                ii°
+                vi
               </text>
             </g>
             <g
@@ -14838,6 +14680,21 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   E
                 </tspan>
               </text>
+              <text
+                dominant-baseline="middle"
+                fill="#10b981"
+                font-size="12.16"
+                font-weight="bold"
+                opacity="0.7"
+                paint-order="stroke"
+                stroke="rgba(0,0,0,0.3)"
+                stroke-width="1.5"
+                text-anchor="middle"
+                x="245.9097200554163"
+                y="209.6"
+              >
+                iii
+              </text>
             </g>
             <g
               style="pointer-events: none;"
@@ -14860,6 +14717,21 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 >
                   B
                 </tspan>
+              </text>
+              <text
+                dominant-baseline="middle"
+                fill="#6366f1"
+                font-size="12.16"
+                font-weight="bold"
+                opacity="0.7"
+                paint-order="stroke"
+                stroke="rgba(0,0,0,0.3)"
+                stroke-width="1.5"
+                text-anchor="middle"
+                x="209.60000000000002"
+                y="245.9097200554163"
+              >
+                vii°
               </text>
             </g>
             <g
@@ -14986,7 +14858,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   stroke-width="2"
                   x="35.19999999999999"
                 >
-                  E♭
+                  D♯
                 </tspan>
                 <tspan
                   dy="0.9em"
@@ -14998,23 +14870,8 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   stroke-width="2.5"
                   x="35.19999999999999"
                 >
-                  D♯
+                  E♭
                 </tspan>
-              </text>
-              <text
-                dominant-baseline="middle"
-                fill="#ec4899"
-                font-size="12.16"
-                font-weight="bold"
-                opacity="0.7"
-                paint-order="stroke"
-                stroke="rgba(0,0,0,0.3)"
-                stroke-width="1.5"
-                text-anchor="middle"
-                x="60.8"
-                y="160"
-              >
-                VI
               </text>
             </g>
             <g
@@ -15036,7 +14893,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   stroke-width="2"
                   x="51.92002960770205"
                 >
-                  B♭
+                  A♯
                 </tspan>
                 <tspan
                   dy="0.9em"
@@ -15048,23 +14905,8 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   stroke-width="2.5"
                   x="51.92002960770205"
                 >
-                  A♯
+                  B♭
                 </tspan>
-              </text>
-              <text
-                dominant-baseline="middle"
-                fill="#10b981"
-                font-size="12.16"
-                font-weight="bold"
-                opacity="0.7"
-                paint-order="stroke"
-                stroke="rgba(0,0,0,0.3)"
-                stroke-width="1.5"
-                text-anchor="middle"
-                x="74.09027994458368"
-                y="110.39999999999998"
-              >
-                III
               </text>
             </g>
             <g
@@ -15091,7 +14933,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#6366f1"
+                fill="#ef4444"
                 font-size="12.16"
                 font-weight="bold"
                 opacity="0.7"
@@ -15102,7 +14944,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="110.39999999999995"
                 y="74.0902799445837"
               >
-                VII
+                IV
               </text>
             </g>
             <circle
@@ -15123,7 +14965,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               x="160"
               y="147.2"
             >
-              G
+              C
             </text>
             <text
               dominant-baseline="middle"
@@ -15137,7 +14979,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               x="160"
               y="172.8"
             >
-              2♭
+              ♮
             </text>
           </svg>
         </div>
@@ -15152,7 +14994,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
         <div
           class="summary-row-label"
         >
-          G Natural Minor
+          C Major
         </div>
         <div
           class="summary-notes"
@@ -15164,7 +15006,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              G
+              C
             </span>
             <span
               class="summary-note-degree"
@@ -15180,7 +15022,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              A
+              D
             </span>
             <span
               class="summary-note-degree"
@@ -15196,13 +15038,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              B♭
+              E
             </span>
             <span
               class="summary-note-degree"
               style="color: rgb(16, 185, 129);"
             >
-              ♭3
+              3
             </span>
           </span>
           <span
@@ -15212,7 +15054,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              C
+              F
             </span>
             <span
               class="summary-note-degree"
@@ -15228,7 +15070,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              D
+              G
             </span>
             <span
               class="summary-note-degree"
@@ -15244,13 +15086,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              E♭
+              A
             </span>
             <span
               class="summary-note-degree"
               style="color: rgb(236, 72, 153);"
             >
-              ♭6
+              6
             </span>
           </span>
           <span
@@ -15260,90 +15102,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              F
+              B
             </span>
             <span
               class="summary-note-degree"
               style="color: rgb(99, 102, 241);"
             >
-              ♭7
-            </span>
-          </span>
-        </div>
-      </div>
-      <div
-        class="summary-row summary-row--chord"
-      >
-        <div
-          class="summary-row-label"
-        >
-          C Minor 7th
-        </div>
-        <div
-          class="summary-notes"
-        >
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #f59e0b; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              C
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(245, 158, 11);"
-            >
-              1
-            </span>
-          </span>
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #10b981; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              D♯
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(16, 185, 129);"
-            >
-              ♭3
-            </span>
-          </span>
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #8b5cf6; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              G
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(139, 92, 246);"
-            >
-              5
-            </span>
-          </span>
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #6366f1; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              A♯
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(99, 102, 241);"
-            >
-              ♭7
+              7
             </span>
           </span>
         </div>
@@ -18359,7 +18124,12 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-stacked la
           class="drawer-selector"
         >
           <button
+            aria-controls="scale-listbox"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="Scale: Major"
             class="drawer-trigger"
+            id="scale-trigger"
           >
             <span
               class="drawer-label"
@@ -18394,7 +18164,12 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-stacked la
           class="drawer-selector"
         >
           <button
+            aria-controls="chord-overlay-listbox"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="Chord Overlay: None"
             class="drawer-trigger"
+            id="chord-overlay-trigger"
           >
             <span
               class="drawer-label"
@@ -33067,7 +32842,12 @@ exports[`Component Snapshots > App layout snapshots > renders tablet-split layou
             class="drawer-selector"
           >
             <button
+              aria-controls="scale-listbox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Scale: Major"
               class="drawer-trigger"
+              id="scale-trigger"
             >
               <span
                 class="drawer-label"
@@ -33102,7 +32882,12 @@ exports[`Component Snapshots > App layout snapshots > renders tablet-split layou
             class="drawer-selector"
           >
             <button
+              aria-controls="chord-overlay-listbox"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Chord Overlay: None"
               class="drawer-trigger"
+              id="chord-overlay-trigger"
             >
               <span
                 class="drawer-label"


### PR DESCRIPTION
## Summary

Add complete accessibility support to the `DrawerSelector` dropdown component with ARIA listbox semantics and full keyboard navigation.

## Changes

### ARIA Attributes
- `aria-expanded`, `aria-haspopup="listbox"`, `aria-controls`, `aria-label` on trigger button
- `role="listbox"`, `aria-activedescendant` for screen reader announcements
- `role="option"`, `aria-selected` on each option
- `role="separator"` on dividers

### Keyboard Navigation
- `ArrowUp/ArrowDown` - Navigate between options
- `Home/End` - Jump to first/last option
- `Enter/Space` - Select current option
- `Escape` - Close dropdown, return focus to trigger
- `Tab` - Close dropdown

### Focus Management
- Focus moves to listbox when opened (autoFocus)
- `aria-activedescendant` pattern keeps focus on listbox container
- Focus returns to trigger button after selection or Escape
- `activeIndex` resets to selected value when opening

### Tests
- 20 tests covering ARIA attributes and keyboard behavior

## Checklist
- [x] ARIA attributes follow WAI-ARIA Authoring Practices
- [x] Keyboard navigation matches standard listbox behavior
- [x] All 483 tests pass
- [x] ESLint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full keyboard navigation for the dropdown (Arrow keys, Home/End; Enter/Space to select; Escape/Tab to close)
  * Improved accessibility: listbox/option roles, deterministic IDs, aria-activedescendant, and reliable focus return to the trigger after selection

* **Style**
  * New focused option styling for clearer keyboard focus state

* **Tests**
  * Expanded accessibility and interaction tests covering ARIA states, keyboard navigation, selection, and focus behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->