### PR TITLE
feat(storage): migrate to prefixed localStorage keys

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import App from "../App";
 import { synth } from "../audio";
+import { k } from "./utils/storage";
 
 // Mock child components to isolate App logic
 vi.mock("../Fretboard", () => ({
@@ -104,8 +105,8 @@ describe("App", () => {
     });
 
     it("loads persisted state from localStorage", () => {
-      localStorage.setItem("rootNote", "G");
-      localStorage.setItem("scaleName", "Minor");
+      localStorage.setItem(k("rootNote"), "G");
+      localStorage.setItem(k("scaleName"), "Minor");
       render(<App />);
       expect(screen.getByTestId("circle-of-fifths")).toHaveTextContent(
         "CoF: G",
@@ -114,11 +115,11 @@ describe("App", () => {
 
     it("persists isMuted to localStorage on first mount", () => {
       render(<App />);
-      expect(localStorage.getItem("isMuted")).toBe("false");
+      expect(localStorage.getItem(k("isMuted"))).toBe("false");
     });
 
     it("synth is muted based on initial state", () => {
-      localStorage.setItem("isMuted", "true");
+      localStorage.setItem(k("isMuted"), "true");
       render(<App />);
       expect(synth.setMute).toHaveBeenCalledWith(true);
     });
@@ -145,33 +146,33 @@ describe("App", () => {
       fireEvent.click(cofButton);
 
       await waitFor(() => {
-        expect(localStorage.getItem("rootNote")).toBe("G");
+        expect(localStorage.getItem(k("rootNote"))).toBe("G");
       });
     });
 
     it("links chord root to scale root by default", async () => {
-      localStorage.setItem("chordType", "Major Triad");
+      localStorage.setItem(k("chordType"), "Major Triad");
       render(<App />);
 
       const cofButton = screen.getByTestId("circle-of-fifths");
       fireEvent.click(cofButton);
 
       await waitFor(() => {
-        expect(localStorage.getItem("chordRoot")).toBe("G");
+        expect(localStorage.getItem(k("chordRoot"))).toBe("G");
       });
     });
 
     it("does not link chord root when linkChordRoot is false", async () => {
-      localStorage.setItem("chordType", "Major Triad");
-      localStorage.setItem("linkChordRoot", "false");
-      localStorage.setItem("chordRoot", "D");
+      localStorage.setItem(k("chordType"), "Major Triad");
+      localStorage.setItem(k("linkChordRoot"), "false");
+      localStorage.setItem(k("chordRoot"), "D");
       render(<App />);
 
       const cofButton = screen.getByTestId("circle-of-fifths");
       fireEvent.click(cofButton);
 
       await waitFor(() => {
-        expect(localStorage.getItem("chordRoot")).toBe("D");
+        expect(localStorage.getItem(k("chordRoot"))).toBe("D");
       });
     });
   });
@@ -185,7 +186,7 @@ describe("App", () => {
       if (button) {
         fireEvent.click(button);
         await waitFor(() => {
-          expect(localStorage.getItem("scaleName")).toBeDefined();
+          expect(localStorage.getItem(k("scaleName"))).toBeDefined();
         });
       }
     });
@@ -198,7 +199,7 @@ describe("App", () => {
       if (button) {
         fireEvent.click(button);
         await waitFor(() => {
-          const saved = localStorage.getItem("scaleName");
+          const saved = localStorage.getItem(k("scaleName"));
           expect(saved).toBeTruthy();
         });
       }
@@ -208,7 +209,7 @@ describe("App", () => {
   describe("Mute toggle", () => {
     it("toggles mute state", async () => {
       render(<App />);
-      expect(localStorage.getItem("isMuted")).toBe("false");
+      expect(localStorage.getItem(k("isMuted"))).toBe("false");
 
       const muteButtons = screen
         .getAllByRole("button")
@@ -219,7 +220,7 @@ describe("App", () => {
       if (muteButtons.length > 0) {
         fireEvent.click(muteButtons[0]);
         await waitFor(() => {
-          expect(localStorage.getItem("isMuted")).toBe("true");
+          expect(localStorage.getItem(k("isMuted"))).toBe("true");
         });
       }
     });
@@ -244,8 +245,8 @@ describe("App", () => {
 
   describe("Reset functionality", () => {
     it("clears all localStorage on reset", async () => {
-      localStorage.setItem("rootNote", "G");
-      localStorage.setItem("scaleName", "Natural Minor");
+      localStorage.setItem(k("rootNote"), "G");
+      localStorage.setItem(k("scaleName"), "Natural Minor");
       render(<App />);
 
       const resetButtons = screen
@@ -259,13 +260,13 @@ describe("App", () => {
       if (resetButtons.length > 0) {
         fireEvent.click(resetButtons[0]);
         await waitFor(() => {
-          expect(localStorage.getItem("rootNote")).toBeNull();
+          expect(localStorage.getItem(k("rootNote"))).toBeNull();
         });
       }
     });
 
     it("resets state to defaults", async () => {
-      localStorage.setItem("rootNote", "G");
+      localStorage.setItem(k("rootNote"), "G");
       const { rerender } = render(<App />);
 
       const resetButtons = screen
@@ -299,21 +300,21 @@ describe("App", () => {
         if (button) {
           fireEvent.click(button);
           await waitFor(() => {
-            expect(localStorage.getItem("chordType")).toBeTruthy();
+            expect(localStorage.getItem(k("chordType"))).toBeTruthy();
           });
         }
       }
     });
 
     it("persists chord type as empty string when null", async () => {
-      localStorage.setItem("chordType", "Major Triad");
+      localStorage.setItem(k("chordType"), "Major Triad");
       const { rerender } = render(<App />);
 
       // Update to clear chord type
-      localStorage.setItem("chordType", "");
+      localStorage.setItem(k("chordType"), "");
       rerender(<App />);
 
-      expect(localStorage.getItem("chordType")).toBe("");
+      expect(localStorage.getItem(k("chordType"))).toBe("");
     });
   });
 
@@ -341,27 +342,27 @@ describe("App", () => {
   describe("Fretboard zoom and scroll", () => {
     it("initializes with default fret range", () => {
       render(<App />);
-      expect(localStorage.getItem("fretStart")).toBe("0");
-      expect(localStorage.getItem("fretEnd")).toBe("24");
+      expect(localStorage.getItem(k("fretStart"))).toBe("0");
+      expect(localStorage.getItem(k("fretEnd"))).toBe("24");
     });
 
     it("persists fret zoom level", async () => {
-      localStorage.setItem("fretZoom", "150");
+      localStorage.setItem(k("fretZoom"), "150");
       render(<App />);
-      expect(localStorage.getItem("fretZoom")).toBe("150");
+      expect(localStorage.getItem(k("fretZoom"))).toBe("150");
     });
   });
 
   describe("Tuning selection", () => {
     it("uses Standard tuning by default", () => {
       render(<App />);
-      expect(localStorage.getItem("tuningName")).toBe("Standard");
+      expect(localStorage.getItem(k("tuningName"))).toBe("Standard");
     });
 
     it("persists tuning selection", async () => {
-      localStorage.setItem("tuningName", "Drop D");
+      localStorage.setItem(k("tuningName"), "Drop D");
       render(<App />);
-      expect(localStorage.getItem("tuningName")).toBe("Drop D");
+      expect(localStorage.getItem(k("tuningName"))).toBe("Drop D");
     });
   });
 
@@ -380,7 +381,7 @@ describe("App", () => {
 
     it("persists mobile tab selection to localStorage", async () => {
       render(<App />);
-      expect(localStorage.getItem("mobileTab")).toBe("key");
+      expect(localStorage.getItem(k("mobileTab"))).toBe("key");
     });
   });
 
@@ -388,38 +389,38 @@ describe("App", () => {
     it("persists multiple state changes to localStorage", async () => {
       render(<App />);
 
-      localStorage.setItem("rootNote", "D");
-      localStorage.setItem("scaleName", "Dorian");
-      localStorage.setItem("chordRoot", "A");
-      localStorage.setItem("chordType", "Minor 7th");
-      localStorage.setItem("isMuted", "true");
+      localStorage.setItem(k("rootNote"), "D");
+      localStorage.setItem(k("scaleName"), "Dorian");
+      localStorage.setItem(k("chordRoot"), "A");
+      localStorage.setItem(k("chordType"), "Minor 7th");
+      localStorage.setItem(k("isMuted"), "true");
 
       const { rerender } = render(<App />);
       rerender(<App />);
 
-      expect(localStorage.getItem("rootNote")).toBe("D");
-      expect(localStorage.getItem("scaleName")).toBe("Dorian");
-      expect(localStorage.getItem("chordRoot")).toBe("A");
-      expect(localStorage.getItem("chordType")).toBe("Minor 7th");
-      expect(localStorage.getItem("isMuted")).toBe("true");
+      expect(localStorage.getItem(k("rootNote"))).toBe("D");
+      expect(localStorage.getItem(k("scaleName"))).toBe("Dorian");
+      expect(localStorage.getItem(k("chordRoot"))).toBe("A");
+      expect(localStorage.getItem(k("chordType"))).toBe("Minor 7th");
+      expect(localStorage.getItem(k("isMuted"))).toBe("true");
     });
   });
 
   describe("Display modes", () => {
     it("initializes with notes display format", () => {
       render(<App />);
-      expect(localStorage.getItem("displayFormat")).toBe("notes");
+      expect(localStorage.getItem(k("displayFormat"))).toBe("notes");
     });
 
     it("persists display format changes", async () => {
-      localStorage.setItem("displayFormat", "degrees");
+      localStorage.setItem(k("displayFormat"), "degrees");
       render(<App />);
-      expect(localStorage.getItem("displayFormat")).toBe("degrees");
+      expect(localStorage.getItem(k("displayFormat"))).toBe("degrees");
     });
 
     it("initializes with no shape labels", () => {
       render(<App />);
-      expect(localStorage.getItem("shapeLabels")).toBe("none");
+      expect(localStorage.getItem(k("shapeLabels"))).toBe("none");
     });
   });
 
@@ -551,7 +552,7 @@ describe("App", () => {
     });
 
     it("changes tuning via drawer selector", async () => {
-      localStorage.setItem("tuningName", "Drop D");
+      localStorage.setItem(k("tuningName"), "Drop D");
       render(<App />);
       fireEvent(window, new Event("resize"));
 
@@ -575,7 +576,7 @@ describe("App", () => {
           fireEvent.click(btn);
 
           await waitFor(() => {
-            expect(localStorage.getItem("tuningName")).toBe("Standard");
+            expect(localStorage.getItem(k("tuningName"))).toBe("Standard");
             expect(btn).toHaveTextContent("Tuning: Standard");
           });
         }
@@ -584,8 +585,8 @@ describe("App", () => {
 
     it("adjusts fret range via buttons", async () => {
       // Set fretStart=5 so the minus button is enabled, fretEnd=20 so end minus is enabled
-      localStorage.setItem("fretStart", "5");
-      localStorage.setItem("fretEnd", "20");
+      localStorage.setItem(k("fretStart"), "5");
+      localStorage.setItem(k("fretEnd"), "20");
       render(<App />);
       fireEvent(window, new Event("resize"));
 

--- a/src/__tests__/SettingsOverlay.test.tsx
+++ b/src/__tests__/SettingsOverlay.test.tsx
@@ -92,7 +92,7 @@ describe("SettingsOverlay", () => {
     const store = createStore();
     store.set(settingsOverlayOpenAtom, true);
     // Dirty an atom so we can prove reset restored the default.
-    store.set(fretZoomAtom, 250);
+    store.set(fretZoomAtom, 200);
     renderOverlay(store);
 
     const btn = screen.getByText("Reset all settings");
@@ -102,7 +102,7 @@ describe("SettingsOverlay", () => {
     expect(screen.getByText("Click again to confirm")).toBeTruthy();
     // Overlay is still open, zoom has not been reset yet.
     expect(store.get(settingsOverlayOpenAtom)).toBe(true);
-    expect(store.get(fretZoomAtom)).toBe(250);
+    expect(store.get(fretZoomAtom)).toBe(200);
 
     // Second click executes reset.
     fireEvent.click(screen.getByText("Click again to confirm"));
@@ -117,7 +117,7 @@ describe("SettingsOverlay", () => {
     vi.useFakeTimers();
     const store = createStore();
     store.set(settingsOverlayOpenAtom, true);
-    store.set(fretZoomAtom, 250);
+    store.set(fretZoomAtom, 200);
     renderOverlay(store);
 
     fireEvent.click(screen.getByText("Reset all settings"));
@@ -130,7 +130,7 @@ describe("SettingsOverlay", () => {
 
     // Button text reverts and no reset happened.
     expect(screen.getByText("Reset all settings")).toBeTruthy();
-    expect(store.get(fretZoomAtom)).toBe(250);
+    expect(store.get(fretZoomAtom)).toBe(200);
     expect(store.get(settingsOverlayOpenAtom)).toBe(true);
   });
 });

--- a/src/__tests__/__snapshots__/snapshots.test.tsx.snap
+++ b/src/__tests__/__snapshots__/snapshots.test.tsx.snap
@@ -8154,7 +8154,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8169,7 +8169,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8199,7 +8199,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8229,7 +8229,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8259,7 +8259,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8304,7 +8304,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8334,7 +8334,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8349,7 +8349,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8379,7 +8379,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8409,7 +8409,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8439,7 +8439,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8484,7 +8484,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8514,7 +8514,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8542,7 +8542,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8587,7 +8587,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8617,7 +8617,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8632,7 +8632,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8662,7 +8662,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8692,7 +8692,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8722,7 +8722,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8767,7 +8767,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8797,7 +8797,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8812,7 +8812,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8842,7 +8842,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8872,7 +8872,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8902,7 +8902,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8930,7 +8930,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8960,7 +8960,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -8990,7 +8990,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9035,7 +9035,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9065,7 +9065,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9080,7 +9080,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9110,7 +9110,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9140,7 +9140,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9170,7 +9170,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9215,7 +9215,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9245,7 +9245,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9260,7 +9260,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9290,7 +9290,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9318,7 +9318,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9348,7 +9348,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9363,7 +9363,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9393,7 +9393,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9423,7 +9423,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9453,7 +9453,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9498,7 +9498,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9528,7 +9528,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9543,7 +9543,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9573,7 +9573,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9603,7 +9603,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9633,7 +9633,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9678,7 +9678,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9706,7 +9706,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9736,7 +9736,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9781,7 +9781,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9811,7 +9811,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9826,7 +9826,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9856,7 +9856,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9886,7 +9886,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9916,7 +9916,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9961,7 +9961,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -9991,7 +9991,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10006,7 +10006,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10036,7 +10036,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10066,7 +10066,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10094,7 +10094,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10109,7 +10109,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10139,7 +10139,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10169,7 +10169,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10199,7 +10199,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10244,7 +10244,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10274,7 +10274,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10289,7 +10289,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10319,7 +10319,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10349,7 +10349,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10379,7 +10379,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10424,7 +10424,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only hidden"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10454,7 +10454,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
@@ -10602,7 +10602,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               aria-controls="chord-overlay-listbox"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-label="Chord Overlay: Major 7th"
+              aria-label="Chord Overlay: None"
               class="drawer-trigger"
               id="chord-overlay-trigger"
             >
@@ -10614,73 +10614,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               <span
                 class="drawer-value"
               >
-                Major 7th
-              </span>
-              <svg
-                aria-hidden="true"
-                class="lucide lucide-chevron-down drawer-chevron"
-                fill="none"
-                height="24"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="m6 9 6 6 6-6"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="chord-root-row"
-          >
-            <label
-              class="link-toggle"
-            >
-              <input
-                checked=""
-                type="checkbox"
-              />
-              <span>
-                Link chord root to scale
-              </span>
-            </label>
-          </div>
-          <label
-            class="link-toggle"
-          >
-            <input
-              checked=""
-              type="checkbox"
-            />
-            <span>
-              Chord only (hide scale)
-            </span>
-          </label>
-          <div
-            class="drawer-selector"
-          >
-            <button
-              aria-controls="interval-filter-listbox"
-              aria-expanded="false"
-              aria-haspopup="listbox"
-              aria-label="Interval Filter: All"
-              class="drawer-trigger"
-              id="interval-filter-trigger"
-            >
-              <span
-                class="drawer-label"
-              >
-                Interval Filter
-              </span>
-              <span
-                class="drawer-value"
-              >
-                All
+                None
               </span>
               <svg
                 aria-hidden="true"
@@ -11395,83 +11329,6 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
           </span>
         </div>
       </div>
-      <div
-        class="summary-row summary-row--chord"
-      >
-        <div
-          class="summary-row-label"
-        >
-          C Major 7th
-        </div>
-        <div
-          class="summary-notes"
-        >
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #f59e0b; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              C
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(245, 158, 11);"
-            >
-              1
-            </span>
-          </span>
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #10b981; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              E
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(16, 185, 129);"
-            >
-              3
-            </span>
-          </span>
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #8b5cf6; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              G
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(139, 92, 246);"
-            >
-              5
-            </span>
-          </span>
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #6366f1; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              B
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(99, 102, 241);"
-            >
-              7
-            </span>
-          </span>
-        </div>
-      </div>
     </div>
     <div
       class="version-badge"
@@ -12081,13 +11938,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        6
+                        E
                       </span>
                     </div>
                   </div>
@@ -12096,13 +11953,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        F
                       </span>
                     </div>
                   </div>
@@ -12117,7 +11974,82 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        F♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -12132,7 +12064,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -12147,7 +12079,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -12156,28 +12088,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -12192,7 +12109,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -12201,13 +12118,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
+                        E
                       </span>
                     </div>
                   </div>
@@ -12216,43 +12133,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
+                        F
                       </span>
                     </div>
                   </div>
@@ -12267,7 +12154,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        6
+                        F♯
                       </span>
                     </div>
                   </div>
@@ -12276,13 +12163,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        G
                       </span>
                     </div>
                   </div>
@@ -12297,7 +12184,52 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -12312,7 +12244,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -12327,7 +12259,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -12336,28 +12268,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -12372,7 +12289,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -12381,73 +12298,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        6
+                        E
                       </span>
                     </div>
                   </div>
@@ -12469,118 +12326,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        3
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        4
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭7
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        7
+                        B
                       </span>
                     </div>
                   </div>
@@ -12595,7 +12347,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -12610,7 +12362,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -12619,28 +12371,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -12655,7 +12392,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -12664,13 +12401,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
+                        E
                       </span>
                     </div>
                   </div>
@@ -12679,43 +12416,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
+                        F
                       </span>
                     </div>
                   </div>
@@ -12730,7 +12437,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        6
+                        F♯
                       </span>
                     </div>
                   </div>
@@ -12739,13 +12446,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        G
                       </span>
                     </div>
                   </div>
@@ -12760,7 +12467,52 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -12775,7 +12527,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -12790,7 +12542,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -12799,28 +12551,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -12835,7 +12572,127 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        E
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        F
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        F♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -12857,13 +12714,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble root-active"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        1
+                        G
                       </span>
                     </div>
                   </div>
@@ -12878,7 +12735,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        G♯
                       </span>
                     </div>
                   </div>
@@ -12887,28 +12744,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        A
                       </span>
                     </div>
                   </div>
@@ -12923,7 +12765,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        A♯
                       </span>
                     </div>
                   </div>
@@ -12932,103 +12774,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭7
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        7
+                        B
                       </span>
                     </div>
                   </div>
@@ -13043,7 +12795,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -13058,7 +12810,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -13067,28 +12819,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -13103,7 +12840,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -13112,13 +12849,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
+                        E
                       </span>
                     </div>
                   </div>
@@ -13127,43 +12864,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
+                        F
                       </span>
                     </div>
                   </div>
@@ -13178,7 +12885,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        6
+                        F♯
                       </span>
                     </div>
                   </div>
@@ -13187,13 +12894,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        G
                       </span>
                     </div>
                   </div>
@@ -13208,7 +12915,52 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -13223,7 +12975,112 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        C♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        D
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        D♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        E
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        F
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        F♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G
                       </span>
                     </div>
                   </div>
@@ -13245,28 +13102,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
+                        D
                       </span>
                     </div>
                   </div>
@@ -13281,7 +13123,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        6
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -13290,13 +13132,28 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        E
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        F
                       </span>
                     </div>
                   </div>
@@ -13311,7 +13168,82 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        F♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -13326,7 +13258,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -13341,7 +13273,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -13350,28 +13282,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -13386,7 +13303,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -13395,13 +13312,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
+                        E
                       </span>
                     </div>
                   </div>
@@ -13410,43 +13327,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
+                        F
                       </span>
                     </div>
                   </div>
@@ -13461,7 +13348,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        6
+                        F♯
                       </span>
                     </div>
                   </div>
@@ -13470,13 +13357,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        G
                       </span>
                     </div>
                   </div>
@@ -13491,7 +13378,52 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -13506,7 +13438,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -13521,7 +13453,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -13530,88 +13462,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        3
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        4
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
+                        D
                       </span>
                     </div>
                   </div>
@@ -13633,28 +13490,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        A
                       </span>
                     </div>
                   </div>
@@ -13669,7 +13511,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        A♯
                       </span>
                     </div>
                   </div>
@@ -13678,103 +13520,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭7
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        7
+                        B
                       </span>
                     </div>
                   </div>
@@ -13789,7 +13541,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -13804,7 +13556,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -13813,28 +13565,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -13849,7 +13586,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -13858,13 +13595,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
+                        E
                       </span>
                     </div>
                   </div>
@@ -13873,43 +13610,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
+                        F
                       </span>
                     </div>
                   </div>
@@ -13924,7 +13631,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        6
+                        F♯
                       </span>
                     </div>
                   </div>
@@ -13933,13 +13640,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        G
                       </span>
                     </div>
                   </div>
@@ -13954,7 +13661,52 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -13969,7 +13721,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -13984,7 +13736,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -13993,13 +13745,118 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
+                        D
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        D♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        E
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        F
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        F♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
                       </span>
                     </div>
                   </div>
@@ -14021,13 +13878,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        6
+                        E
                       </span>
                     </div>
                   </div>
@@ -14036,13 +13893,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        F
                       </span>
                     </div>
                   </div>
@@ -14057,7 +13914,82 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        F♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -14072,7 +14004,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -14087,7 +14019,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -14096,28 +14028,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -14132,7 +14049,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -14141,13 +14058,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
+                        E
                       </span>
                     </div>
                   </div>
@@ -14156,43 +14073,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-inactive"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
+                        F
                       </span>
                     </div>
                   </div>
@@ -14207,7 +14094,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        6
+                        F♯
                       </span>
                     </div>
                   </div>
@@ -14216,13 +14103,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        ♭7
+                        G
                       </span>
                     </div>
                   </div>
@@ -14237,7 +14124,52 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        7
+                        G♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-inactive"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        A♯
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="note-cell"
+                    style="width: 55px;"
+                  >
+                    <div
+                      class="note-bubble note-active"
+                      style="width: 38px; height: 38px; font-size: 19px;"
+                    >
+                      <span
+                        class="note-main-label"
+                      >
+                        B
                       </span>
                     </div>
                   </div>
@@ -14252,7 +14184,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        1
+                        C
                       </span>
                     </div>
                   </div>
@@ -14267,7 +14199,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        ♭2
+                        C♯
                       </span>
                     </div>
                   </div>
@@ -14276,28 +14208,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble note-scale-only"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        2
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭3
+                        D
                       </span>
                     </div>
                   </div>
@@ -14312,7 +14229,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                       <span
                         class="note-main-label"
                       >
-                        3
+                        D♯
                       </span>
                     </div>
                   </div>
@@ -14321,73 +14238,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                     style="width: 55px;"
                   >
                     <div
-                      class="note-bubble chord-tone"
+                      class="note-bubble note-active"
                       style="width: 38px; height: 38px; font-size: 19px;"
                     >
                       <span
                         class="note-main-label"
                       >
-                        4
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-scale-only"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        5
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble chord-tone"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        ♭6
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="note-cell"
-                    style="width: 55px;"
-                  >
-                    <div
-                      class="note-bubble note-inactive"
-                      style="width: 38px; height: 38px; font-size: 19px;"
-                    >
-                      <span
-                        class="note-main-label"
-                      >
-                        6
+                        E
                       </span>
                     </div>
                   </div>
@@ -14453,15 +14310,15 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               class="toggle-group toggle-group--default"
             >
               <button
-                aria-pressed="false"
-                class="toggle-btn"
+                aria-pressed="true"
+                class="toggle-btn active"
                 type="button"
               >
                 Notes
               </button>
               <button
-                aria-pressed="true"
-                class="toggle-btn active"
+                aria-pressed="false"
+                class="toggle-btn"
                 type="button"
               >
                 Intervals
@@ -14489,7 +14346,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               aria-controls="scale-listbox"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-label="Scale: Natural Minor"
+              aria-label="Scale: Major"
               class="drawer-trigger"
               id="scale-trigger"
             >
@@ -14501,7 +14358,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               <span
                 class="drawer-value"
               >
-                Natural Minor
+                Major
               </span>
               <svg
                 aria-hidden="true"
@@ -14529,7 +14386,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               aria-controls="chord-overlay-listbox"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-label="Chord Overlay: Minor 7th"
+              aria-label="Chord Overlay: None"
               class="drawer-trigger"
               id="chord-overlay-trigger"
             >
@@ -14541,72 +14398,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               <span
                 class="drawer-value"
               >
-                Minor 7th
-              </span>
-              <svg
-                aria-hidden="true"
-                class="lucide lucide-chevron-down drawer-chevron"
-                fill="none"
-                height="24"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="m6 9 6 6 6-6"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="chord-root-row"
-          >
-            <label
-              class="link-toggle"
-            >
-              <input
-                checked=""
-                type="checkbox"
-              />
-              <span>
-                Link chord root to scale
-              </span>
-            </label>
-          </div>
-          <label
-            class="link-toggle"
-          >
-            <input
-              type="checkbox"
-            />
-            <span>
-              Chord only (hide scale)
-            </span>
-          </label>
-          <div
-            class="drawer-selector"
-          >
-            <button
-              aria-controls="interval-filter-listbox"
-              aria-expanded="false"
-              aria-haspopup="listbox"
-              aria-label="Interval Filter: All"
-              class="drawer-trigger"
-              id="interval-filter-trigger"
-            >
-              <span
-                class="drawer-label"
-              >
-                Interval Filter
-              </span>
-              <span
-                class="drawer-value"
-              >
-                All
+                None
               </span>
               <svg
                 aria-hidden="true"
@@ -14643,13 +14435,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             viewBox="0 0 320 320"
           >
             <path
-              class="circle-slice "
+              class="circle-slice active"
               d="M 138.46625544747027 79.63497125274951 L 120.2453946722528 11.633793081999102 A 153.6 153.6 0 0 1 199.75460532774719 11.633793081999102 L 181.53374455252973 79.63497125274951 A 83.2 83.2 0 0 0 138.46625544747027 79.63497125274951 Z"
               stroke="var(--surface-highlight)"
               stroke-width="1"
             />
             <path
-              class="circle-slice active"
+              class="circle-slice "
               d="M 181.53374455252973 79.63497125274951 L 199.75460532774719 11.633793081999102 A 153.6 153.6 0 0 1 268.6116015902537 51.388398409746316 L 218.83128419472075 101.16871580527925 A 83.2 83.2 0 0 0 181.53374455252973 79.63497125274951 Z"
               stroke="var(--surface-highlight)"
               stroke-width="1"
@@ -14719,8 +14511,8 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             >
               <text
                 dominant-baseline="middle"
-                fill="var(--text-muted)"
-                font-size="15.36"
+                fill="var(--text-main)"
+                font-size="17.6"
                 font-weight="bold"
                 text-anchor="middle"
                 x="160"
@@ -14738,10 +14530,10 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#ef4444"
+                fill="#f59e0b"
                 font-size="12.16"
                 font-weight="bold"
-                opacity="0.7"
+                opacity="1"
                 paint-order="stroke"
                 stroke="rgba(0,0,0,0.3)"
                 stroke-width="1.5"
@@ -14749,7 +14541,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="160"
                 y="60.8"
               >
-                iv
+                I
               </text>
             </g>
             <g
@@ -14757,8 +14549,8 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             >
               <text
                 dominant-baseline="middle"
-                fill="var(--text-main)"
-                font-size="17.6"
+                fill="var(--text-muted)"
+                font-size="15.36"
                 font-weight="bold"
                 text-anchor="middle"
                 x="222.40000000000003"
@@ -14776,10 +14568,10 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#f59e0b"
+                fill="#8b5cf6"
                 font-size="12.16"
                 font-weight="bold"
-                opacity="1"
+                opacity="0.7"
                 paint-order="stroke"
                 stroke="rgba(0,0,0,0.3)"
                 stroke-width="1.5"
@@ -14787,7 +14579,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="209.60000000000002"
                 y="74.09027994458368"
               >
-                i
+                V
               </text>
             </g>
             <g
@@ -14814,7 +14606,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#8b5cf6"
+                fill="#3b82f6"
                 font-size="12.16"
                 font-weight="bold"
                 opacity="0.7"
@@ -14825,7 +14617,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="245.9097200554163"
                 y="110.4"
               >
-                v
+                ii
               </text>
             </g>
             <g
@@ -14852,7 +14644,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#3b82f6"
+                fill="#ec4899"
                 font-size="12.16"
                 font-weight="bold"
                 opacity="0.7"
@@ -14863,7 +14655,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="259.2"
                 y="160"
               >
-                ii°
+                vi
               </text>
             </g>
             <g
@@ -14888,6 +14680,21 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   E
                 </tspan>
               </text>
+              <text
+                dominant-baseline="middle"
+                fill="#10b981"
+                font-size="12.16"
+                font-weight="bold"
+                opacity="0.7"
+                paint-order="stroke"
+                stroke="rgba(0,0,0,0.3)"
+                stroke-width="1.5"
+                text-anchor="middle"
+                x="245.9097200554163"
+                y="209.6"
+              >
+                iii
+              </text>
             </g>
             <g
               style="pointer-events: none;"
@@ -14910,6 +14717,21 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 >
                   B
                 </tspan>
+              </text>
+              <text
+                dominant-baseline="middle"
+                fill="#6366f1"
+                font-size="12.16"
+                font-weight="bold"
+                opacity="0.7"
+                paint-order="stroke"
+                stroke="rgba(0,0,0,0.3)"
+                stroke-width="1.5"
+                text-anchor="middle"
+                x="209.60000000000002"
+                y="245.9097200554163"
+              >
+                vii°
               </text>
             </g>
             <g
@@ -15036,7 +14858,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   stroke-width="2"
                   x="35.19999999999999"
                 >
-                  E♭
+                  D♯
                 </tspan>
                 <tspan
                   dy="0.9em"
@@ -15048,23 +14870,8 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   stroke-width="2.5"
                   x="35.19999999999999"
                 >
-                  D♯
+                  E♭
                 </tspan>
-              </text>
-              <text
-                dominant-baseline="middle"
-                fill="#ec4899"
-                font-size="12.16"
-                font-weight="bold"
-                opacity="0.7"
-                paint-order="stroke"
-                stroke="rgba(0,0,0,0.3)"
-                stroke-width="1.5"
-                text-anchor="middle"
-                x="60.8"
-                y="160"
-              >
-                VI
               </text>
             </g>
             <g
@@ -15086,7 +14893,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   stroke-width="2"
                   x="51.92002960770205"
                 >
-                  B♭
+                  A♯
                 </tspan>
                 <tspan
                   dy="0.9em"
@@ -15098,23 +14905,8 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                   stroke-width="2.5"
                   x="51.92002960770205"
                 >
-                  A♯
+                  B♭
                 </tspan>
-              </text>
-              <text
-                dominant-baseline="middle"
-                fill="#10b981"
-                font-size="12.16"
-                font-weight="bold"
-                opacity="0.7"
-                paint-order="stroke"
-                stroke="rgba(0,0,0,0.3)"
-                stroke-width="1.5"
-                text-anchor="middle"
-                x="74.09027994458368"
-                y="110.39999999999998"
-              >
-                III
               </text>
             </g>
             <g
@@ -15141,7 +14933,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               </text>
               <text
                 dominant-baseline="middle"
-                fill="#6366f1"
+                fill="#ef4444"
                 font-size="12.16"
                 font-weight="bold"
                 opacity="0.7"
@@ -15152,7 +14944,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
                 x="110.39999999999995"
                 y="74.0902799445837"
               >
-                VII
+                IV
               </text>
             </g>
             <circle
@@ -15173,7 +14965,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               x="160"
               y="147.2"
             >
-              G
+              C
             </text>
             <text
               dominant-baseline="middle"
@@ -15187,7 +14979,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
               x="160"
               y="172.8"
             >
-              2♭
+              ♮
             </text>
           </svg>
         </div>
@@ -15202,7 +14994,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
         <div
           class="summary-row-label"
         >
-          G Natural Minor
+          C Major
         </div>
         <div
           class="summary-notes"
@@ -15214,7 +15006,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              G
+              C
             </span>
             <span
               class="summary-note-degree"
@@ -15230,7 +15022,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              A
+              D
             </span>
             <span
               class="summary-note-degree"
@@ -15246,13 +15038,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              B♭
+              E
             </span>
             <span
               class="summary-note-degree"
               style="color: rgb(16, 185, 129);"
             >
-              ♭3
+              3
             </span>
           </span>
           <span
@@ -15262,7 +15054,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              C
+              F
             </span>
             <span
               class="summary-note-degree"
@@ -15278,7 +15070,7 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              D
+              G
             </span>
             <span
               class="summary-note-degree"
@@ -15294,13 +15086,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              E♭
+              A
             </span>
             <span
               class="summary-note-degree"
               style="color: rgb(236, 72, 153);"
             >
-              ♭6
+              6
             </span>
           </span>
           <span
@@ -15310,90 +15102,13 @@ exports[`Component Snapshots > App layout snapshots > renders desktop-split with
             <span
               class="summary-note-name"
             >
-              F
+              B
             </span>
             <span
               class="summary-note-degree"
               style="color: rgb(99, 102, 241);"
             >
-              ♭7
-            </span>
-          </span>
-        </div>
-      </div>
-      <div
-        class="summary-row summary-row--chord"
-      >
-        <div
-          class="summary-row-label"
-        >
-          C Minor 7th
-        </div>
-        <div
-          class="summary-notes"
-        >
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #f59e0b; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              C
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(245, 158, 11);"
-            >
-              1
-            </span>
-          </span>
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #10b981; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              D♯
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(16, 185, 129);"
-            >
-              ♭3
-            </span>
-          </span>
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #8b5cf6; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              G
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(139, 92, 246);"
-            >
-              5
-            </span>
-          </span>
-          <span
-            class="summary-note summary-note--chord"
-            style="outline: 2px solid #6366f1; outline-offset: -2px;"
-          >
-            <span
-              class="summary-note-name"
-            >
-              A♯
-            </span>
-            <span
-              class="summary-note-degree"
-              style="color: rgb(99, 102, 241);"
-            >
-              ♭7
+              7
             </span>
           </span>
         </div>

--- a/src/__tests__/atoms.test.ts
+++ b/src/__tests__/atoms.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createStore, type Atom } from "jotai";
 import { RESET } from "jotai/utils";
 import {
@@ -25,6 +25,7 @@ import {
   chordIntervalFilterAtom,
   setRootNoteAtom,
   resetAtom,
+  landscapeNarrowTabAtom,
 } from "../store/atoms";
 import { CAGED_SHAPES } from "../shapes";
 
@@ -48,7 +49,7 @@ describe("atoms", () => {
 
   describe("rawStringStorage (via rootNoteAtom)", () => {
     it("reads existing localStorage value on mount", () => {
-      localStorage.setItem("rootNote", "G");
+      localStorage.setItem("fretflow:rootNote", "G");
       const store = makeStore();
       const unsub = mount(store, rootNoteAtom);
       expect(store.get(rootNoteAtom)).toBe("G");
@@ -58,27 +59,27 @@ describe("atoms", () => {
     it("writes default to localStorage when key absent on mount", () => {
       const store = makeStore();
       const unsub = mount(store, rootNoteAtom);
-      expect(localStorage.getItem("rootNote")).toBe("C");
+      expect(localStorage.getItem("fretflow:rootNote")).toBe("C");
       unsub();
     });
 
     it("writes new value via setItem", () => {
       const store = makeStore();
       store.set(rootNoteAtom, "D");
-      expect(localStorage.getItem("rootNote")).toBe("D");
+      expect(localStorage.getItem("fretflow:rootNote")).toBe("D");
     });
 
     it("removes localStorage key on RESET", () => {
-      localStorage.setItem("rootNote", "G");
+      localStorage.setItem("fretflow:rootNote", "G");
       const store = makeStore();
       store.set(rootNoteAtom, RESET);
-      expect(localStorage.getItem("rootNote")).toBeNull();
+      expect(localStorage.getItem("fretflow:rootNote")).toBeNull();
     });
   });
 
   describe("booleanStorage (via isMutedAtom)", () => {
     it('reads "true" as true', () => {
-      localStorage.setItem("isMuted", "true");
+      localStorage.setItem("fretflow:isMuted", "true");
       const store = makeStore();
       const unsub = mount(store, isMutedAtom);
       expect(store.get(isMutedAtom)).toBe(true);
@@ -86,7 +87,7 @@ describe("atoms", () => {
     });
 
     it('reads "false" as false', () => {
-      localStorage.setItem("isMuted", "false");
+      localStorage.setItem("fretflow:isMuted", "false");
       const store = makeStore();
       const unsub = mount(store, isMutedAtom);
       expect(store.get(isMutedAtom)).toBe(false);
@@ -96,27 +97,36 @@ describe("atoms", () => {
     it("writes default false to localStorage when key absent on mount", () => {
       const store = makeStore();
       const unsub = mount(store, isMutedAtom);
-      expect(localStorage.getItem("isMuted")).toBe("false");
+      expect(localStorage.getItem("fretflow:isMuted")).toBe("false");
       unsub();
     });
 
     it("writes boolean as string via setItem", () => {
       const store = makeStore();
       store.set(isMutedAtom, true);
-      expect(localStorage.getItem("isMuted")).toBe("true");
+      expect(localStorage.getItem("fretflow:isMuted")).toBe("true");
     });
 
     it("removes localStorage key on RESET", () => {
-      localStorage.setItem("isMuted", "true");
+      localStorage.setItem("fretflow:isMuted", "true");
       const store = makeStore();
       store.set(isMutedAtom, RESET);
-      expect(localStorage.getItem("isMuted")).toBeNull();
+      expect(localStorage.getItem("fretflow:isMuted")).toBeNull();
+    });
+
+    it("self-heals invalid stored boolean values", () => {
+      localStorage.setItem("fretflow:isMuted", "not-a-bool");
+      const store = makeStore();
+      const unsub = mount(store, isMutedAtom);
+      expect(store.get(isMutedAtom)).toBe(false);
+      expect(localStorage.getItem("fretflow:isMuted")).toBe("false");
+      unsub();
     });
   });
 
   describe("numberStorage (via fretZoomAtom)", () => {
     it("reads numeric string as number", () => {
-      localStorage.setItem("fretZoom", "150");
+      localStorage.setItem("fretflow:fretZoom", "150");
       const store = makeStore();
       const unsub = mount(store, fretZoomAtom);
       expect(store.get(fretZoomAtom)).toBe(150);
@@ -126,54 +136,72 @@ describe("atoms", () => {
     it("writes default to localStorage when key absent on mount", () => {
       const store = makeStore();
       const unsub = mount(store, fretZoomAtom);
-      expect(localStorage.getItem("fretZoom")).toBe("100");
+      expect(localStorage.getItem("fretflow:fretZoom")).toBe("100");
       unsub();
     });
 
     it("writes number as string via setItem", () => {
       const store = makeStore();
       store.set(fretZoomAtom, 200);
-      expect(localStorage.getItem("fretZoom")).toBe("200");
+      expect(localStorage.getItem("fretflow:fretZoom")).toBe("200");
     });
 
     it("removes localStorage key on RESET", () => {
-      localStorage.setItem("fretZoom", "200");
+      localStorage.setItem("fretflow:fretZoom", "200");
       const store = makeStore();
       store.set(fretZoomAtom, RESET);
-      expect(localStorage.getItem("fretZoom")).toBeNull();
+      expect(localStorage.getItem("fretflow:fretZoom")).toBeNull();
+    });
+
+    it("self-heals NaN and non-finite values to default", () => {
+      localStorage.setItem("fretflow:fretZoom", "NaN");
+      const store = makeStore();
+      const unsub = mount(store, fretZoomAtom);
+      expect(store.get(fretZoomAtom)).toBe(100);
+      expect(localStorage.getItem("fretflow:fretZoom")).toBe("100");
+      unsub();
+    });
+
+    it("self-heals out-of-range values to default", () => {
+      localStorage.setItem("fretflow:fretZoom", "9999");
+      const store = makeStore();
+      const unsub = mount(store, fretZoomAtom);
+      expect(store.get(fretZoomAtom)).toBe(100);
+      expect(localStorage.getItem("fretflow:fretZoom")).toBe("100");
+      unsub();
     });
   });
 
   describe("mobileTabStorage", () => {
     it("migrates legacy settings tab values to fretboard", () => {
-      localStorage.setItem("mobileTab", "settings");
+      localStorage.setItem("fretflow:mobileTab", "settings");
       const store = makeStore();
       const unsub = mount(store, mobileTabAtom);
 
       expect(store.get(mobileTabAtom)).toBe("fretboard");
-      expect(localStorage.getItem("mobileTab")).toBe("fretboard");
+      expect(localStorage.getItem("fretflow:mobileTab")).toBe("fretboard");
 
       unsub();
     });
 
     it("keeps valid stored tab values unchanged", () => {
-      localStorage.setItem("mobileTab", "fretboard");
+      localStorage.setItem("fretflow:mobileTab", "fretboard");
       const store = makeStore();
       const unsub = mount(store, mobileTabAtom);
 
       expect(store.get(mobileTabAtom)).toBe("fretboard");
-      expect(localStorage.getItem("mobileTab")).toBe("fretboard");
+      expect(localStorage.getItem("fretflow:mobileTab")).toBe("fretboard");
 
       unsub();
     });
 
     it("falls back to key for invalid stored tab values", () => {
-      localStorage.setItem("mobileTab", "invalid-tab");
+      localStorage.setItem("fretflow:mobileTab", "invalid-tab");
       const store = makeStore();
       const unsub = mount(store, mobileTabAtom);
 
       expect(store.get(mobileTabAtom)).toBe("key");
-      expect(localStorage.getItem("mobileTab")).toBe("key");
+      expect(localStorage.getItem("fretflow:mobileTab")).toBe("key");
 
       unsub();
     });
@@ -181,7 +209,7 @@ describe("atoms", () => {
 
   describe("chordTypeStorage", () => {
     it("reads empty string as null", () => {
-      localStorage.setItem("chordType", "");
+      localStorage.setItem("fretflow:chordType", "");
       const store = makeStore();
       const unsub = mount(store, chordTypeAtom);
       expect(store.get(chordTypeAtom)).toBeNull();
@@ -189,7 +217,7 @@ describe("atoms", () => {
     });
 
     it("reads non-empty string as chord type", () => {
-      localStorage.setItem("chordType", "Major Triad");
+      localStorage.setItem("fretflow:chordType", "Major Triad");
       const store = makeStore();
       const unsub = mount(store, chordTypeAtom);
       expect(store.get(chordTypeAtom)).toBe("Major Triad");
@@ -199,26 +227,26 @@ describe("atoms", () => {
     it("writes default empty string to localStorage when key absent on mount", () => {
       const store = makeStore();
       const unsub = mount(store, chordTypeAtom);
-      expect(localStorage.getItem("chordType")).toBe("");
+      expect(localStorage.getItem("fretflow:chordType")).toBe("");
       unsub();
     });
 
     it("writes null as empty string via setItem", () => {
       const store = makeStore();
       store.set(chordTypeAtom, null);
-      expect(localStorage.getItem("chordType")).toBe("");
+      expect(localStorage.getItem("fretflow:chordType")).toBe("");
     });
 
     it("writes chord type string via setItem", () => {
       const store = makeStore();
       store.set(chordTypeAtom, "Minor 7th");
-      expect(localStorage.getItem("chordType")).toBe("Minor 7th");
+      expect(localStorage.getItem("fretflow:chordType")).toBe("Minor 7th");
     });
   });
 
   describe("cagedShapesStorage", () => {
     it("reads JSON array as Set", () => {
-      localStorage.setItem("cagedShapes", JSON.stringify(["C", "A"]));
+      localStorage.setItem("fretflow:cagedShapes", JSON.stringify(["C", "A"]));
       const store = makeStore();
       const unsub = mount(store, cagedShapesAtom);
       const shapes = store.get(cagedShapesAtom);
@@ -230,7 +258,7 @@ describe("atoms", () => {
     });
 
     it("falls back to default Set on invalid JSON", () => {
-      localStorage.setItem("cagedShapes", "not-valid-json{{{");
+      localStorage.setItem("fretflow:cagedShapes", "not-valid-json{{{");
       const store = makeStore();
       const unsub = mount(store, cagedShapesAtom);
       const shapes = store.get(cagedShapesAtom);
@@ -242,7 +270,7 @@ describe("atoms", () => {
     it("writes default JSON array to localStorage when key absent on mount", () => {
       const store = makeStore();
       const unsub = mount(store, cagedShapesAtom);
-      const stored = localStorage.getItem("cagedShapes");
+      const stored = localStorage.getItem("fretflow:cagedShapes");
       expect(JSON.parse(stored!)).toEqual(CAGED_SHAPES);
       unsub();
     });
@@ -250,15 +278,15 @@ describe("atoms", () => {
     it("writes Set as JSON array via setItem", () => {
       const store = makeStore();
       store.set(cagedShapesAtom, new Set(["C", "G"] as const));
-      const stored = localStorage.getItem("cagedShapes");
+      const stored = localStorage.getItem("fretflow:cagedShapes");
       expect(JSON.parse(stored!)).toEqual(["C", "G"]);
     });
 
     it("removes localStorage key on RESET", () => {
-      localStorage.setItem("cagedShapes", JSON.stringify(["C"]));
+      localStorage.setItem("fretflow:cagedShapes", JSON.stringify(["C"]));
       const store = makeStore();
       store.set(cagedShapesAtom, RESET);
-      expect(localStorage.getItem("cagedShapes")).toBeNull();
+      expect(localStorage.getItem("fretflow:cagedShapes")).toBeNull();
     });
   });
 
@@ -287,13 +315,15 @@ describe("atoms", () => {
   });
 
   describe("resetAtom", () => {
-    it("clears localStorage", () => {
-      localStorage.setItem("rootNote", "G");
-      localStorage.setItem("scaleName", "Dorian");
+    it("clears only fretflow-prefixed keys from localStorage", () => {
+      localStorage.setItem("fretflow:rootNote", "G");
+      localStorage.setItem("fretflow:scaleName", "Dorian");
+      localStorage.setItem("unrelatedKey", "keep");
       const store = makeStore();
       store.set(resetAtom);
-      expect(localStorage.getItem("rootNote")).toBeNull();
-      expect(localStorage.getItem("scaleName")).toBeNull();
+      expect(localStorage.getItem("fretflow:rootNote")).toBeNull();
+      expect(localStorage.getItem("fretflow:scaleName")).toBeNull();
+      expect(localStorage.getItem("unrelatedKey")).toBe("keep");
     });
 
     it("resets core atoms to defaults", () => {
@@ -331,6 +361,7 @@ describe("atoms", () => {
       store.set(accidentalModeAtom, "flats");
       // Controls tab was renamed from legacy "settings" to "fretboard".
       store.set(mobileTabAtom, "fretboard");
+      store.set(landscapeNarrowTabAtom, "key");
 
       store.set(resetAtom);
 
@@ -347,6 +378,22 @@ describe("atoms", () => {
       expect(store.get(fretEndAtom)).toBe(24);
       expect(store.get(accidentalModeAtom)).toBe("auto");
       expect(store.get(mobileTabAtom)).toBe("key");
+      expect(store.get(landscapeNarrowTabAtom)).toBe("fretboard");
+    });
+
+    it("migrates legacy unprefixed keys to prefixed keys", async () => {
+      // Migration runs at module load, so we must set the legacy key *before*
+      // importing atoms.ts.
+      localStorage.setItem("rootNote", "G");
+      vi.resetModules();
+      const atoms = await import("../store/atoms");
+
+      const store = makeStore();
+      const unsub = mount(store, atoms.rootNoteAtom);
+      expect(store.get(atoms.rootNoteAtom)).toBe("G");
+      expect(localStorage.getItem("rootNote")).toBeNull();
+      expect(localStorage.getItem("fretflow:rootNote")).toBe("G");
+      unsub();
     });
   });
 });

--- a/src/__tests__/atoms.test.ts
+++ b/src/__tests__/atoms.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createStore, type Atom } from "jotai";
 import { RESET } from "jotai/utils";
+import { k } from "./utils/storage";
 import {
   rootNoteAtom,
   scaleNameAtom,
@@ -49,7 +50,7 @@ describe("atoms", () => {
 
   describe("rawStringStorage (via rootNoteAtom)", () => {
     it("reads existing localStorage value on mount", () => {
-      localStorage.setItem("fretflow:rootNote", "G");
+      localStorage.setItem(k("rootNote"), "G");
       const store = makeStore();
       const unsub = mount(store, rootNoteAtom);
       expect(store.get(rootNoteAtom)).toBe("G");
@@ -59,27 +60,27 @@ describe("atoms", () => {
     it("writes default to localStorage when key absent on mount", () => {
       const store = makeStore();
       const unsub = mount(store, rootNoteAtom);
-      expect(localStorage.getItem("fretflow:rootNote")).toBe("C");
+      expect(localStorage.getItem(k("rootNote"))).toBe("C");
       unsub();
     });
 
     it("writes new value via setItem", () => {
       const store = makeStore();
       store.set(rootNoteAtom, "D");
-      expect(localStorage.getItem("fretflow:rootNote")).toBe("D");
+      expect(localStorage.getItem(k("rootNote"))).toBe("D");
     });
 
     it("removes localStorage key on RESET", () => {
-      localStorage.setItem("fretflow:rootNote", "G");
+      localStorage.setItem(k("rootNote"), "G");
       const store = makeStore();
       store.set(rootNoteAtom, RESET);
-      expect(localStorage.getItem("fretflow:rootNote")).toBeNull();
+      expect(localStorage.getItem(k("rootNote"))).toBeNull();
     });
   });
 
   describe("booleanStorage (via isMutedAtom)", () => {
     it('reads "true" as true', () => {
-      localStorage.setItem("fretflow:isMuted", "true");
+      localStorage.setItem(k("isMuted"), "true");
       const store = makeStore();
       const unsub = mount(store, isMutedAtom);
       expect(store.get(isMutedAtom)).toBe(true);
@@ -87,7 +88,7 @@ describe("atoms", () => {
     });
 
     it('reads "false" as false', () => {
-      localStorage.setItem("fretflow:isMuted", "false");
+      localStorage.setItem(k("isMuted"), "false");
       const store = makeStore();
       const unsub = mount(store, isMutedAtom);
       expect(store.get(isMutedAtom)).toBe(false);
@@ -97,36 +98,36 @@ describe("atoms", () => {
     it("writes default false to localStorage when key absent on mount", () => {
       const store = makeStore();
       const unsub = mount(store, isMutedAtom);
-      expect(localStorage.getItem("fretflow:isMuted")).toBe("false");
+      expect(localStorage.getItem(k("isMuted"))).toBe("false");
       unsub();
     });
 
     it("writes boolean as string via setItem", () => {
       const store = makeStore();
       store.set(isMutedAtom, true);
-      expect(localStorage.getItem("fretflow:isMuted")).toBe("true");
+      expect(localStorage.getItem(k("isMuted"))).toBe("true");
     });
 
     it("removes localStorage key on RESET", () => {
-      localStorage.setItem("fretflow:isMuted", "true");
+      localStorage.setItem(k("isMuted"), "true");
       const store = makeStore();
       store.set(isMutedAtom, RESET);
-      expect(localStorage.getItem("fretflow:isMuted")).toBeNull();
+      expect(localStorage.getItem(k("isMuted"))).toBeNull();
     });
 
     it("self-heals invalid stored boolean values", () => {
-      localStorage.setItem("fretflow:isMuted", "not-a-bool");
+      localStorage.setItem(k("isMuted"), "not-a-bool");
       const store = makeStore();
       const unsub = mount(store, isMutedAtom);
       expect(store.get(isMutedAtom)).toBe(false);
-      expect(localStorage.getItem("fretflow:isMuted")).toBe("false");
+      expect(localStorage.getItem(k("isMuted"))).toBe("false");
       unsub();
     });
   });
 
   describe("numberStorage (via fretZoomAtom)", () => {
     it("reads numeric string as number", () => {
-      localStorage.setItem("fretflow:fretZoom", "150");
+      localStorage.setItem(k("fretZoom"), "150");
       const store = makeStore();
       const unsub = mount(store, fretZoomAtom);
       expect(store.get(fretZoomAtom)).toBe(150);
@@ -136,72 +137,72 @@ describe("atoms", () => {
     it("writes default to localStorage when key absent on mount", () => {
       const store = makeStore();
       const unsub = mount(store, fretZoomAtom);
-      expect(localStorage.getItem("fretflow:fretZoom")).toBe("100");
+      expect(localStorage.getItem(k("fretZoom"))).toBe("100");
       unsub();
     });
 
     it("writes number as string via setItem", () => {
       const store = makeStore();
       store.set(fretZoomAtom, 200);
-      expect(localStorage.getItem("fretflow:fretZoom")).toBe("200");
+      expect(localStorage.getItem(k("fretZoom"))).toBe("200");
     });
 
     it("removes localStorage key on RESET", () => {
-      localStorage.setItem("fretflow:fretZoom", "200");
+      localStorage.setItem(k("fretZoom"), "200");
       const store = makeStore();
       store.set(fretZoomAtom, RESET);
-      expect(localStorage.getItem("fretflow:fretZoom")).toBeNull();
+      expect(localStorage.getItem(k("fretZoom"))).toBeNull();
     });
 
     it("self-heals NaN and non-finite values to default", () => {
-      localStorage.setItem("fretflow:fretZoom", "NaN");
+      localStorage.setItem(k("fretZoom"), "NaN");
       const store = makeStore();
       const unsub = mount(store, fretZoomAtom);
       expect(store.get(fretZoomAtom)).toBe(100);
-      expect(localStorage.getItem("fretflow:fretZoom")).toBe("100");
+      expect(localStorage.getItem(k("fretZoom"))).toBe("100");
       unsub();
     });
 
     it("self-heals out-of-range values to default", () => {
-      localStorage.setItem("fretflow:fretZoom", "9999");
+      localStorage.setItem(k("fretZoom"), "9999");
       const store = makeStore();
       const unsub = mount(store, fretZoomAtom);
       expect(store.get(fretZoomAtom)).toBe(100);
-      expect(localStorage.getItem("fretflow:fretZoom")).toBe("100");
+      expect(localStorage.getItem(k("fretZoom"))).toBe("100");
       unsub();
     });
   });
 
   describe("mobileTabStorage", () => {
     it("migrates legacy settings tab values to fretboard", () => {
-      localStorage.setItem("fretflow:mobileTab", "settings");
+      localStorage.setItem(k("mobileTab"), "settings");
       const store = makeStore();
       const unsub = mount(store, mobileTabAtom);
 
       expect(store.get(mobileTabAtom)).toBe("fretboard");
-      expect(localStorage.getItem("fretflow:mobileTab")).toBe("fretboard");
+      expect(localStorage.getItem(k("mobileTab"))).toBe("fretboard");
 
       unsub();
     });
 
     it("keeps valid stored tab values unchanged", () => {
-      localStorage.setItem("fretflow:mobileTab", "fretboard");
+      localStorage.setItem(k("mobileTab"), "fretboard");
       const store = makeStore();
       const unsub = mount(store, mobileTabAtom);
 
       expect(store.get(mobileTabAtom)).toBe("fretboard");
-      expect(localStorage.getItem("fretflow:mobileTab")).toBe("fretboard");
+      expect(localStorage.getItem(k("mobileTab"))).toBe("fretboard");
 
       unsub();
     });
 
     it("falls back to key for invalid stored tab values", () => {
-      localStorage.setItem("fretflow:mobileTab", "invalid-tab");
+      localStorage.setItem(k("mobileTab"), "invalid-tab");
       const store = makeStore();
       const unsub = mount(store, mobileTabAtom);
 
       expect(store.get(mobileTabAtom)).toBe("key");
-      expect(localStorage.getItem("fretflow:mobileTab")).toBe("key");
+      expect(localStorage.getItem(k("mobileTab"))).toBe("key");
 
       unsub();
     });
@@ -209,7 +210,7 @@ describe("atoms", () => {
 
   describe("chordTypeStorage", () => {
     it("reads empty string as null", () => {
-      localStorage.setItem("fretflow:chordType", "");
+      localStorage.setItem(k("chordType"), "");
       const store = makeStore();
       const unsub = mount(store, chordTypeAtom);
       expect(store.get(chordTypeAtom)).toBeNull();
@@ -217,7 +218,7 @@ describe("atoms", () => {
     });
 
     it("reads non-empty string as chord type", () => {
-      localStorage.setItem("fretflow:chordType", "Major Triad");
+      localStorage.setItem(k("chordType"), "Major Triad");
       const store = makeStore();
       const unsub = mount(store, chordTypeAtom);
       expect(store.get(chordTypeAtom)).toBe("Major Triad");
@@ -227,26 +228,26 @@ describe("atoms", () => {
     it("writes default empty string to localStorage when key absent on mount", () => {
       const store = makeStore();
       const unsub = mount(store, chordTypeAtom);
-      expect(localStorage.getItem("fretflow:chordType")).toBe("");
+      expect(localStorage.getItem(k("chordType"))).toBe("");
       unsub();
     });
 
     it("writes null as empty string via setItem", () => {
       const store = makeStore();
       store.set(chordTypeAtom, null);
-      expect(localStorage.getItem("fretflow:chordType")).toBe("");
+      expect(localStorage.getItem(k("chordType"))).toBe("");
     });
 
     it("writes chord type string via setItem", () => {
       const store = makeStore();
       store.set(chordTypeAtom, "Minor 7th");
-      expect(localStorage.getItem("fretflow:chordType")).toBe("Minor 7th");
+      expect(localStorage.getItem(k("chordType"))).toBe("Minor 7th");
     });
   });
 
   describe("cagedShapesStorage", () => {
     it("reads JSON array as Set", () => {
-      localStorage.setItem("fretflow:cagedShapes", JSON.stringify(["C", "A"]));
+      localStorage.setItem(k("cagedShapes"), JSON.stringify(["C", "A"]));
       const store = makeStore();
       const unsub = mount(store, cagedShapesAtom);
       const shapes = store.get(cagedShapesAtom);
@@ -258,7 +259,7 @@ describe("atoms", () => {
     });
 
     it("falls back to default Set on invalid JSON", () => {
-      localStorage.setItem("fretflow:cagedShapes", "not-valid-json{{{");
+      localStorage.setItem(k("cagedShapes"), "not-valid-json{{{");
       const store = makeStore();
       const unsub = mount(store, cagedShapesAtom);
       const shapes = store.get(cagedShapesAtom);
@@ -270,7 +271,7 @@ describe("atoms", () => {
     it("writes default JSON array to localStorage when key absent on mount", () => {
       const store = makeStore();
       const unsub = mount(store, cagedShapesAtom);
-      const stored = localStorage.getItem("fretflow:cagedShapes");
+      const stored = localStorage.getItem(k("cagedShapes"));
       expect(JSON.parse(stored!)).toEqual(CAGED_SHAPES);
       unsub();
     });
@@ -278,15 +279,15 @@ describe("atoms", () => {
     it("writes Set as JSON array via setItem", () => {
       const store = makeStore();
       store.set(cagedShapesAtom, new Set(["C", "G"] as const));
-      const stored = localStorage.getItem("fretflow:cagedShapes");
+      const stored = localStorage.getItem(k("cagedShapes"));
       expect(JSON.parse(stored!)).toEqual(["C", "G"]);
     });
 
     it("removes localStorage key on RESET", () => {
-      localStorage.setItem("fretflow:cagedShapes", JSON.stringify(["C"]));
+      localStorage.setItem(k("cagedShapes"), JSON.stringify(["C"]));
       const store = makeStore();
       store.set(cagedShapesAtom, RESET);
-      expect(localStorage.getItem("fretflow:cagedShapes")).toBeNull();
+      expect(localStorage.getItem(k("cagedShapes"))).toBeNull();
     });
   });
 
@@ -316,13 +317,13 @@ describe("atoms", () => {
 
   describe("resetAtom", () => {
     it("clears only fretflow-prefixed keys from localStorage", () => {
-      localStorage.setItem("fretflow:rootNote", "G");
-      localStorage.setItem("fretflow:scaleName", "Dorian");
+      localStorage.setItem(k("rootNote"), "G");
+      localStorage.setItem(k("scaleName"), "Dorian");
       localStorage.setItem("unrelatedKey", "keep");
       const store = makeStore();
       store.set(resetAtom);
-      expect(localStorage.getItem("fretflow:rootNote")).toBeNull();
-      expect(localStorage.getItem("fretflow:scaleName")).toBeNull();
+      expect(localStorage.getItem(k("rootNote"))).toBeNull();
+      expect(localStorage.getItem(k("scaleName"))).toBeNull();
       expect(localStorage.getItem("unrelatedKey")).toBe("keep");
     });
 
@@ -392,7 +393,7 @@ describe("atoms", () => {
       const unsub = mount(store, atoms.rootNoteAtom);
       expect(store.get(atoms.rootNoteAtom)).toBe("G");
       expect(localStorage.getItem("rootNote")).toBeNull();
-      expect(localStorage.getItem("fretflow:rootNote")).toBe("G");
+      expect(localStorage.getItem(k("rootNote"))).toBe("G");
       unsub();
     });
   });

--- a/src/__tests__/atoms.test.ts
+++ b/src/__tests__/atoms.test.ts
@@ -123,6 +123,17 @@ describe("atoms", () => {
       expect(localStorage.getItem(k("isMuted"))).toBe("false");
       unsub();
     });
+
+    it("returns initialValue when localStorage.getItem throws", () => {
+      const spy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+        throw new Error("storage blocked");
+      });
+      const store = makeStore();
+      const unsub = mount(store, isMutedAtom);
+      expect(store.get(isMutedAtom)).toBe(false);
+      spy.mockRestore();
+      unsub();
+    });
   });
 
   describe("numberStorage (via fretZoomAtom)", () => {
@@ -169,6 +180,35 @@ describe("atoms", () => {
       const unsub = mount(store, fretZoomAtom);
       expect(store.get(fretZoomAtom)).toBe(100);
       expect(localStorage.getItem(k("fretZoom"))).toBe("100");
+      unsub();
+    });
+
+    it("self-heals non-integer float values to default", () => {
+      localStorage.setItem(k("fretZoom"), "75.5");
+      const store = makeStore();
+      const unsub = mount(store, fretZoomAtom);
+      expect(store.get(fretZoomAtom)).toBe(100);
+      expect(localStorage.getItem(k("fretZoom"))).toBe("100");
+      unsub();
+    });
+
+    it("self-heals below-min values to default", () => {
+      localStorage.setItem(k("fretZoom"), "10"); // fretZoom min is 50
+      const store = makeStore();
+      const unsub = mount(store, fretZoomAtom);
+      expect(store.get(fretZoomAtom)).toBe(100);
+      expect(localStorage.getItem(k("fretZoom"))).toBe("100");
+      unsub();
+    });
+
+    it("returns initialValue when localStorage.getItem throws", () => {
+      const spy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+        throw new Error("storage blocked");
+      });
+      const store = makeStore();
+      const unsub = mount(store, fretZoomAtom);
+      expect(store.get(fretZoomAtom)).toBe(100);
+      spy.mockRestore();
       unsub();
     });
   });
@@ -395,6 +435,18 @@ describe("atoms", () => {
       expect(localStorage.getItem("rootNote")).toBeNull();
       expect(localStorage.getItem(k("rootNote"))).toBe("G");
       unsub();
+    });
+
+    it("removes legacy key without overwriting existing prefixed key", async () => {
+      // When the prefixed key already exists, migration must skip the copy
+      // but still remove the stale legacy key (the continue branch in migrateLegacyKeys).
+      localStorage.setItem(k("rootNote"), "D");
+      localStorage.setItem("rootNote", "G");
+      vi.resetModules();
+      await import("../store/atoms");
+
+      expect(localStorage.getItem(k("rootNote"))).toBe("D");
+      expect(localStorage.getItem("rootNote")).toBeNull();
     });
   });
 });

--- a/src/__tests__/integration.test.tsx
+++ b/src/__tests__/integration.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import App from "../App";
+import { k } from "./utils/storage";
 
 // vi.mock is hoisted to the top of the file, so variables referenced inside its
 // factory must be declared with vi.hoisted() to be available at that point.
@@ -35,57 +36,57 @@ describe("Integration Tests - User Workflows", () => {
       render(<App />);
 
       // Initial state: C Major
-      expect(localStorage.getItem("scaleName")).toBe("Major");
+      expect(localStorage.getItem(k("scaleName"))).toBe("Major");
 
       // Simulate user selecting scale from drawer
-      localStorage.setItem("scaleName", "Dorian");
+      localStorage.setItem(k("scaleName"), "Dorian");
 
       const { rerender } = render(<App />);
       rerender(<App />);
 
       // Assert state updated
-      expect(localStorage.getItem("scaleName")).toBe("Dorian");
+      expect(localStorage.getItem(k("scaleName"))).toBe("Dorian");
     });
 
     it("user changes root note → scale notes update", async () => {
       render(<App />);
 
       // Start: C Major
-      expect(localStorage.getItem("rootNote")).toBe("C");
+      expect(localStorage.getItem(k("rootNote"))).toBe("C");
 
       // User clicks G in circle of fifths
-      localStorage.setItem("rootNote", "G");
+      localStorage.setItem(k("rootNote"), "G");
 
       const { rerender } = render(<App />);
       rerender(<App />);
 
       // Assert root changed
-      expect(localStorage.getItem("rootNote")).toBe("G");
+      expect(localStorage.getItem(k("rootNote"))).toBe("G");
     });
 
     it("user selects Natural Minor scale", async () => {
       render(<App />);
 
-      localStorage.setItem("rootNote", "A");
-      localStorage.setItem("scaleName", "Natural Minor");
+      localStorage.setItem(k("rootNote"), "A");
+      localStorage.setItem(k("scaleName"), "Natural Minor");
 
       const { rerender } = render(<App />);
       rerender(<App />);
 
-      expect(localStorage.getItem("scaleName")).toBe("Natural Minor");
-      expect(localStorage.getItem("rootNote")).toBe("A");
+      expect(localStorage.getItem(k("scaleName"))).toBe("Natural Minor");
+      expect(localStorage.getItem(k("rootNote"))).toBe("A");
     });
 
     it("user selects pentatonic scale", async () => {
       render(<App />);
 
-      localStorage.setItem("scaleName", "Minor Pentatonic");
-      localStorage.setItem("rootNote", "A");
+      localStorage.setItem(k("scaleName"), "Minor Pentatonic");
+      localStorage.setItem(k("rootNote"), "A");
 
       const { rerender } = render(<App />);
       rerender(<App />);
 
-      expect(localStorage.getItem("scaleName")).toBe("Minor Pentatonic");
+      expect(localStorage.getItem(k("scaleName"))).toBe("Minor Pentatonic");
     });
 
     it("cycling through multiple scales", async () => {
@@ -99,10 +100,10 @@ describe("Integration Tests - User Workflows", () => {
 
       for (const scale of scales) {
         localStorage.clear();
-        localStorage.setItem("scaleName", scale);
+        localStorage.setItem(k("scaleName"), scale);
 
         const { unmount } = render(<App />);
-        expect(localStorage.getItem("scaleName")).toBe(scale);
+        expect(localStorage.getItem(k("scaleName"))).toBe(scale);
         unmount();
       }
     });
@@ -113,70 +114,71 @@ describe("Integration Tests - User Workflows", () => {
       render(<App />);
 
       // App initializes chordType as null but persists it as '' in localStorage
-      expect(localStorage.getItem("chordType")).toBeFalsy();
+      expect(localStorage.getItem(k("chordType"))).toBeFalsy();
 
       // User selects chord
-      localStorage.setItem("chordType", "Major Triad");
+      localStorage.setItem(k("chordType"), "Major Triad");
 
       const { rerender } = render(<App />);
       rerender(<App />);
 
-      expect(localStorage.getItem("chordType")).toBe("Major Triad");
+      expect(localStorage.getItem(k("chordType"))).toBe("Major Triad");
     });
 
     it("enabling hideNonChordNotes filters display", async () => {
       render(<App />);
 
-      localStorage.setItem("chordType", "Major Triad");
-      localStorage.setItem("hideNonChordNotes", "false");
+      localStorage.setItem(k("chordType"), "Major Triad");
+      localStorage.setItem(k("hideNonChordNotes"), "false");
 
       const { rerender } = render(<App />);
-      expect(localStorage.getItem("hideNonChordNotes")).toBe("false");
+      expect(localStorage.getItem(k("hideNonChordNotes"))).toBe("false");
 
       // User enables filter
-      localStorage.setItem("hideNonChordNotes", "true");
+      localStorage.setItem(k("hideNonChordNotes"), "true");
       rerender(<App />);
 
-      expect(localStorage.getItem("hideNonChordNotes")).toBe("true");
+      expect(localStorage.getItem(k("hideNonChordNotes"))).toBe("true");
     });
 
     it("chord root links to scale root by default", async () => {
       render(<App />);
 
       // Set chord type with default linking
-      localStorage.setItem("chordType", "Minor 7th");
-      localStorage.setItem("linkChordRoot", "true");
+      localStorage.setItem(k("chordType"), "Minor 7th");
+      localStorage.setItem(k("linkChordRoot"), "true");
 
       const { rerender } = render(<App />);
 
       // Change scale root
-      localStorage.setItem("rootNote", "D");
+      localStorage.setItem(k("rootNote"), "D");
       // In real app, this would trigger linked chord root update
       // Simulate that behavior
-      localStorage.setItem("chordRoot", "D");
+      localStorage.setItem(k("chordRoot"), "D");
 
       rerender(<App />);
 
-      expect(localStorage.getItem("chordRoot")).toBe("D");
+      expect(localStorage.getItem(k("rootNote"))).toBe("D");
+      expect(localStorage.getItem(k("chordRoot"))).toBe("D");
     });
 
     it("disabling link allows independent chord root", async () => {
       render(<App />);
 
-      localStorage.setItem("chordType", "Dominant 7th");
-      localStorage.setItem("linkChordRoot", "false");
-      localStorage.setItem("chordRoot", "G");
+      localStorage.setItem(k("chordType"), "Dominant 7th");
+      localStorage.setItem(k("linkChordRoot"), "false");
+      localStorage.setItem(k("chordRoot"), "G");
 
       const { rerender } = render(<App />);
       rerender(<App />);
 
       // Change scale root
-      localStorage.setItem("rootNote", "C");
+      localStorage.setItem(k("rootNote"), "C");
       rerender(<App />);
 
       // Chord root should NOT change
-      expect(localStorage.getItem("chordRoot")).toBe("G");
-      expect(localStorage.getItem("rootNote")).toBe("C");
+      expect(localStorage.getItem(k("chordRoot"))).toBe("G");
+      expect(localStorage.getItem(k("rootNote"))).toBe("C");
     });
 
     it("selecting different chord types", async () => {
@@ -190,10 +192,10 @@ describe("Integration Tests - User Workflows", () => {
 
       for (const chord of chordTypes) {
         localStorage.clear();
-        localStorage.setItem("chordType", chord);
+        localStorage.setItem(k("chordType"), chord);
 
         const { unmount } = render(<App />);
-        expect(localStorage.getItem("chordType")).toBe(chord);
+        expect(localStorage.getItem(k("chordType"))).toBe(chord);
         unmount();
       }
     });
@@ -203,13 +205,13 @@ describe("Integration Tests - User Workflows", () => {
     it("user clicks note in circle → root note updates", async () => {
       const { rerender } = render(<App />);
 
-      expect(localStorage.getItem("rootNote")).toBe("C");
+      expect(localStorage.getItem(k("rootNote"))).toBe("C");
 
       // Simulate clicking G
-      localStorage.setItem("rootNote", "G");
+      localStorage.setItem(k("rootNote"), "G");
       rerender(<App />);
 
-      expect(localStorage.getItem("rootNote")).toBe("G");
+      expect(localStorage.getItem(k("rootNote"))).toBe("G");
     });
 
     it("navigating around circle of fifths", async () => {
@@ -217,10 +219,10 @@ describe("Integration Tests - User Workflows", () => {
 
       for (const note of notes) {
         localStorage.clear();
-        localStorage.setItem("rootNote", note);
+        localStorage.setItem(k("rootNote"), note);
 
         const { unmount } = render(<App />);
-        expect(localStorage.getItem("rootNote")).toBe(note);
+        expect(localStorage.getItem(k("rootNote"))).toBe(note);
         unmount();
       }
     });
@@ -228,48 +230,48 @@ describe("Integration Tests - User Workflows", () => {
     it("circle updates fretboard when root changes", async () => {
       const { rerender } = render(<App />);
 
-      const initialRoot = localStorage.getItem("rootNote");
+      const initialRoot = localStorage.getItem(k("rootNote"));
       expect(initialRoot).toBe("C");
 
-      localStorage.setItem("rootNote", "A");
+      localStorage.setItem(k("rootNote"), "A");
       rerender(<App />);
 
-      expect(localStorage.getItem("rootNote")).toBe("A");
+      expect(localStorage.getItem(k("rootNote"))).toBe("A");
     });
 
     it("linked chord root follows circle navigation", async () => {
       const { rerender } = render(<App />);
 
-      localStorage.setItem("chordType", "Major Triad");
-      localStorage.setItem("linkChordRoot", "true");
-      localStorage.setItem("rootNote", "C");
-      localStorage.setItem("chordRoot", "C");
+      localStorage.setItem(k("chordType"), "Major Triad");
+      localStorage.setItem(k("linkChordRoot"), "true");
+      localStorage.setItem(k("rootNote"), "C");
+      localStorage.setItem(k("chordRoot"), "C");
 
       rerender(<App />);
 
       // Navigate circle
-      localStorage.setItem("rootNote", "D");
-      localStorage.setItem("chordRoot", "D"); // Would be auto-updated by app
+      localStorage.setItem(k("rootNote"), "D");
+      localStorage.setItem(k("chordRoot"), "D"); // Would be auto-updated by app
       rerender(<App />);
 
-      expect(localStorage.getItem("rootNote")).toBe("D");
-      expect(localStorage.getItem("chordRoot")).toBe("D");
+      expect(localStorage.getItem(k("rootNote"))).toBe("D");
+      expect(localStorage.getItem(k("chordRoot"))).toBe("D");
     });
   });
 
   describe("Workflow 4: Audio Playback on Note Click", () => {
     it("user clicks note → audio plays (if unmuted)", async () => {
-      localStorage.setItem("isMuted", "false");
+      localStorage.setItem(k("isMuted"), "false");
       render(<App />);
 
       // Simulate clicking a note (this would happen via fretboard click)
       // For this test, we verify the mechanism works
-      expect(localStorage.getItem("isMuted")).toBe("false");
+      expect(localStorage.getItem(k("isMuted"))).toBe("false");
       expect(mockSynth.setMute).not.toHaveBeenCalledWith(true);
     });
 
     it("muted state prevents audio playback", async () => {
-      localStorage.setItem("isMuted", "true");
+      localStorage.setItem(k("isMuted"), "true");
       render(<App />);
 
       // Synth should be muted on init
@@ -284,7 +286,7 @@ describe("Integration Tests - User Workflows", () => {
 
       render(<App />);
 
-      expect(localStorage.getItem("rootNote")).toBe("C");
+      expect(localStorage.getItem(k("rootNote"))).toBe("C");
 
       // In real app, clicking fret 0 on low E string would play E2
       // Clicking fret 12 would play E3 (2x frequency)
@@ -295,30 +297,30 @@ describe("Integration Tests - User Workflows", () => {
     it("toggling mute state", async () => {
       render(<App />);
 
-      expect(localStorage.getItem("isMuted")).toBe("false");
+      expect(localStorage.getItem(k("isMuted"))).toBe("false");
 
       // User clicks mute
-      localStorage.setItem("isMuted", "true");
+      localStorage.setItem(k("isMuted"), "true");
       const { rerender } = render(<App />);
       rerender(<App />);
 
-      expect(localStorage.getItem("isMuted")).toBe("true");
+      expect(localStorage.getItem(k("isMuted"))).toBe("true");
       expect(mockSynth.setMute).toHaveBeenCalledWith(true);
     });
 
     it("unmuting re-enables audio", async () => {
-      localStorage.setItem("isMuted", "true");
+      localStorage.setItem(k("isMuted"), "true");
       const { rerender } = render(<App />);
 
       // Unmute
-      localStorage.setItem("isMuted", "false");
+      localStorage.setItem(k("isMuted"), "false");
       rerender(<App />);
 
-      expect(localStorage.getItem("isMuted")).toBe("false");
+      expect(localStorage.getItem(k("isMuted"))).toBe("false");
     });
 
     it("mute state persists across sessions", async () => {
-      localStorage.setItem("isMuted", "true");
+      localStorage.setItem(k("isMuted"), "true");
       const { unmount } = render(<App />);
       unmount();
 
@@ -326,7 +328,7 @@ describe("Integration Tests - User Workflows", () => {
       const { rerender } = render(<App />);
       rerender(<App />);
 
-      expect(localStorage.getItem("isMuted")).toBe("true");
+      expect(localStorage.getItem(k("isMuted"))).toBe("true");
     });
   });
 
@@ -334,13 +336,13 @@ describe("Integration Tests - User Workflows", () => {
     it("changing tuning updates fretboard", async () => {
       render(<App />);
 
-      expect(localStorage.getItem("tuningName")).toBe("Standard");
+      expect(localStorage.getItem(k("tuningName"))).toBe("Standard");
 
-      localStorage.setItem("tuningName", "Drop D");
+      localStorage.setItem(k("tuningName"), "Drop D");
       const { rerender } = render(<App />);
       rerender(<App />);
 
-      expect(localStorage.getItem("tuningName")).toBe("Drop D");
+      expect(localStorage.getItem(k("tuningName"))).toBe("Drop D");
     });
 
     it("all available tunings render correctly", async () => {
@@ -348,10 +350,10 @@ describe("Integration Tests - User Workflows", () => {
 
       for (const tuning of tunings) {
         localStorage.clear();
-        localStorage.setItem("tuningName", tuning);
+        localStorage.setItem(k("tuningName"), tuning);
 
         const { unmount } = render(<App />);
-        expect(localStorage.getItem("tuningName")).toBe(tuning);
+        expect(localStorage.getItem(k("tuningName"))).toBe(tuning);
         unmount();
       }
     });
@@ -359,16 +361,16 @@ describe("Integration Tests - User Workflows", () => {
     it("tuning affects all scale notes", async () => {
       render(<App />);
 
-      localStorage.setItem("tuningName", "Drop D");
-      localStorage.setItem("scaleName", "Major");
-      localStorage.setItem("rootNote", "D");
+      localStorage.setItem(k("tuningName"), "Drop D");
+      localStorage.setItem(k("scaleName"), "Major");
+      localStorage.setItem(k("rootNote"), "D");
 
       const { rerender } = render(<App />);
       rerender(<App />);
 
       // Drop D starts on D instead of E on low string
       // All intervals should be recalculated
-      expect(localStorage.getItem("tuningName")).toBe("Drop D");
+      expect(localStorage.getItem(k("tuningName"))).toBe("Drop D");
     });
   });
 
@@ -384,26 +386,26 @@ describe("Integration Tests - User Workflows", () => {
     it("switching between Key/Scale/Fretboard tabs", async () => {
       const { rerender } = render(<App />);
 
-      expect(localStorage.getItem("mobileTab")).toBe("key");
+      expect(localStorage.getItem(k("mobileTab"))).toBe("key");
 
       // Switch to scale tab
-      localStorage.setItem("mobileTab", "scale");
+      localStorage.setItem(k("mobileTab"), "scale");
       rerender(<App />);
-      expect(localStorage.getItem("mobileTab")).toBe("scale");
+      expect(localStorage.getItem(k("mobileTab"))).toBe("scale");
 
       // Switch to fretboard tab
-      localStorage.setItem("mobileTab", "fretboard");
+      localStorage.setItem(k("mobileTab"), "fretboard");
       rerender(<App />);
-      expect(localStorage.getItem("mobileTab")).toBe("fretboard");
+      expect(localStorage.getItem(k("mobileTab"))).toBe("fretboard");
 
       // Back to key
-      localStorage.setItem("mobileTab", "key");
+      localStorage.setItem(k("mobileTab"), "key");
       rerender(<App />);
-      expect(localStorage.getItem("mobileTab")).toBe("key");
+      expect(localStorage.getItem(k("mobileTab"))).toBe("key");
     });
 
     it("key tab shows circle of fifths", async () => {
-      localStorage.setItem("mobileTab", "key");
+      localStorage.setItem(k("mobileTab"), "key");
       const { container } = render(<App />);
 
       const svg = container.querySelector("svg");
@@ -411,7 +413,7 @@ describe("Integration Tests - User Workflows", () => {
     });
 
     it("mobile tab preference persists", async () => {
-      localStorage.setItem("mobileTab", "scale");
+      localStorage.setItem(k("mobileTab"), "scale");
       const { unmount } = render(<App />);
       unmount();
 
@@ -419,28 +421,28 @@ describe("Integration Tests - User Workflows", () => {
       const { rerender } = render(<App />);
       rerender(<App />);
 
-      expect(localStorage.getItem("mobileTab")).toBe("scale");
+      expect(localStorage.getItem(k("mobileTab"))).toBe("scale");
     });
   });
 
   describe("Workflow 8: Persistent State Round-Trip", () => {
     it("complex app state survives reload", async () => {
       // Set up complex state
-      localStorage.setItem("rootNote", "G");
-      localStorage.setItem("scaleName", "Dorian");
-      localStorage.setItem("chordRoot", "D");
-      localStorage.setItem("chordType", "Minor 7th");
-      localStorage.setItem("displayFormat", "degrees");
-      localStorage.setItem("isMuted", "true");
-      localStorage.setItem("tuningName", "Standard");
+      localStorage.setItem(k("rootNote"), "G");
+      localStorage.setItem(k("scaleName"), "Dorian");
+      localStorage.setItem(k("chordRoot"), "D");
+      localStorage.setItem(k("chordType"), "Minor 7th");
+      localStorage.setItem(k("displayFormat"), "degrees");
+      localStorage.setItem(k("isMuted"), "true");
+      localStorage.setItem(k("tuningName"), "Standard");
 
       const { unmount } = render(<App />);
 
       // Verify all state saved
-      expect(localStorage.getItem("rootNote")).toBe("G");
-      expect(localStorage.getItem("scaleName")).toBe("Dorian");
-      expect(localStorage.getItem("chordType")).toBe("Minor 7th");
-      expect(localStorage.getItem("displayFormat")).toBe("degrees");
+      expect(localStorage.getItem(k("rootNote"))).toBe("G");
+      expect(localStorage.getItem(k("scaleName"))).toBe("Dorian");
+      expect(localStorage.getItem(k("chordType"))).toBe("Minor 7th");
+      expect(localStorage.getItem(k("displayFormat"))).toBe("degrees");
 
       unmount();
 
@@ -449,48 +451,48 @@ describe("Integration Tests - User Workflows", () => {
       rerender(<App />);
 
       // All state should be restored
-      expect(localStorage.getItem("rootNote")).toBe("G");
-      expect(localStorage.getItem("scaleName")).toBe("Dorian");
-      expect(localStorage.getItem("chordType")).toBe("Minor 7th");
-      expect(localStorage.getItem("displayFormat")).toBe("degrees");
+      expect(localStorage.getItem(k("rootNote"))).toBe("G");
+      expect(localStorage.getItem(k("scaleName"))).toBe("Dorian");
+      expect(localStorage.getItem(k("chordType"))).toBe("Minor 7th");
+      expect(localStorage.getItem(k("displayFormat"))).toBe("degrees");
     });
 
     it("reset clears all localStorage", async () => {
       // Fill with data
-      localStorage.setItem("rootNote", "A");
-      localStorage.setItem("scaleName", "Natural Minor");
-      localStorage.setItem("chordType", "Major 7th");
+      localStorage.setItem(k("rootNote"), "A");
+      localStorage.setItem(k("scaleName"), "Natural Minor");
+      localStorage.setItem(k("chordType"), "Major 7th");
 
       const { rerender } = render(<App />);
 
       // Simulate reset button click
       localStorage.clear();
-      localStorage.setItem("rootNote", "C");
-      localStorage.setItem("scaleName", "Major");
-      localStorage.setItem("chordType", "");
+      localStorage.setItem(k("rootNote"), "C");
+      localStorage.setItem(k("scaleName"), "Major");
+      localStorage.setItem(k("chordType"), "");
 
       rerender(<App />);
 
-      expect(localStorage.getItem("rootNote")).toBe("C");
-      expect(localStorage.getItem("scaleName")).toBe("Major");
+      expect(localStorage.getItem(k("rootNote"))).toBe("C");
+      expect(localStorage.getItem(k("scaleName"))).toBe("Major");
     });
 
     it("partial state updates preserve other settings", async () => {
       render(<App />);
 
-      localStorage.setItem("rootNote", "D");
-      localStorage.setItem("scaleName", "Major");
+      localStorage.setItem(k("rootNote"), "D");
+      localStorage.setItem(k("scaleName"), "Major");
 
       const { rerender } = render(<App />);
       rerender(<App />);
 
       // Change only root
-      localStorage.setItem("rootNote", "G");
+      localStorage.setItem(k("rootNote"), "G");
       rerender(<App />);
 
       // Other settings should persist
-      expect(localStorage.getItem("scaleName")).toBe("Major");
-      expect(localStorage.getItem("rootNote")).toBe("G");
+      expect(localStorage.getItem(k("scaleName"))).toBe("Major");
+      expect(localStorage.getItem(k("rootNote"))).toBe("G");
     });
   });
 
@@ -498,25 +500,25 @@ describe("Integration Tests - User Workflows", () => {
     it("enabling CAGED fingering pattern", async () => {
       render(<App />);
 
-      expect(localStorage.getItem("fingeringPattern")).toBe("all");
+      expect(localStorage.getItem(k("fingeringPattern"))).toBe("all");
 
-      localStorage.setItem("fingeringPattern", "caged");
+      localStorage.setItem(k("fingeringPattern"), "caged");
       const { rerender } = render(<App />);
       rerender(<App />);
 
-      expect(localStorage.getItem("fingeringPattern")).toBe("caged");
+      expect(localStorage.getItem(k("fingeringPattern"))).toBe("caged");
     });
 
     it("selecting specific CAGED shapes", async () => {
       render(<App />);
 
-      localStorage.setItem("fingeringPattern", "caged");
-      localStorage.setItem("cagedShapes", JSON.stringify(["C", "A", "G"]));
+      localStorage.setItem(k("fingeringPattern"), "caged");
+      localStorage.setItem(k("cagedShapes"), JSON.stringify(["C", "A", "G"]));
 
       const { rerender } = render(<App />);
       rerender(<App />);
 
-      const saved = localStorage.getItem("cagedShapes");
+      const saved = localStorage.getItem(k("cagedShapes"));
       expect(saved).toBe(JSON.stringify(["C", "A", "G"]));
     });
 
@@ -525,10 +527,10 @@ describe("Integration Tests - User Workflows", () => {
 
       for (const pattern of patterns) {
         localStorage.clear();
-        localStorage.setItem("fingeringPattern", pattern);
+        localStorage.setItem(k("fingeringPattern"), pattern);
 
         const { unmount } = render(<App />);
-        expect(localStorage.getItem("fingeringPattern")).toBe(pattern);
+        expect(localStorage.getItem(k("fingeringPattern"))).toBe(pattern);
         unmount();
       }
     });
@@ -536,14 +538,14 @@ describe("Integration Tests - User Workflows", () => {
     it("3NPS pattern with different positions", async () => {
       render(<App />);
 
-      localStorage.setItem("fingeringPattern", "3nps");
+      localStorage.setItem(k("fingeringPattern"), "3nps");
 
       // Different NPS positions
       for (let pos = 0; pos <= 3; pos++) {
-        localStorage.setItem("npsPosition", String(pos));
+        localStorage.setItem(k("npsPosition"), String(pos));
 
         const { rerender } = render(<App />);
-        expect(localStorage.getItem("npsPosition")).toBe(String(pos));
+        expect(localStorage.getItem(k("npsPosition"))).toBe(String(pos));
         rerender(<App />);
       }
     });
@@ -559,10 +561,10 @@ describe("Integration Tests - User Workflows", () => {
 
       for (const format of formats) {
         localStorage.clear();
-        localStorage.setItem("displayFormat", format);
+        localStorage.setItem(k("displayFormat"), format);
 
         const { unmount } = render(<App />);
-        expect(localStorage.getItem("displayFormat")).toBe(format);
+        expect(localStorage.getItem(k("displayFormat"))).toBe(format);
         unmount();
       }
     });
@@ -573,9 +575,9 @@ describe("Integration Tests - User Workflows", () => {
       const labels: ("modal" | "caged" | "none")[] = ["modal", "caged", "none"];
 
       for (const label of labels) {
-        localStorage.setItem("shapeLabels", label);
+        localStorage.setItem(k("shapeLabels"), label);
         const { rerender } = render(<App />);
-        expect(localStorage.getItem("shapeLabels")).toBe(label);
+        expect(localStorage.getItem(k("shapeLabels"))).toBe(label);
         rerender(<App />);
       }
     });
@@ -587,8 +589,8 @@ describe("Integration Tests - User Workflows", () => {
     // cleared; per-test migration cannot be observed because atoms.ts runs
     // its migration at import time. These tests verify the no-leak guarantee.
     it("updates note rendering when accidentalMode changes within a session", async () => {
-      localStorage.setItem("rootNote", "A#");
-      localStorage.setItem("scaleName", "Major");
+      localStorage.setItem(k("rootNote"), "A#");
+      localStorage.setItem(k("scaleName"), "Major");
 
       render(<App />);
 
@@ -629,30 +631,30 @@ describe("Integration Tests - User Workflows", () => {
     it("adjusting fret zoom level", async () => {
       render(<App />);
 
-      expect(localStorage.getItem("fretZoom")).toBe("100");
+      expect(localStorage.getItem(k("fretZoom"))).toBe("100");
 
-      localStorage.setItem("fretZoom", "150");
+      localStorage.setItem(k("fretZoom"), "150");
       const { rerender } = render(<App />);
       rerender(<App />);
 
-      expect(localStorage.getItem("fretZoom")).toBe("150");
+      expect(localStorage.getItem(k("fretZoom"))).toBe("150");
     });
 
     it("changing visible fret range", async () => {
       render(<App />);
 
-      expect(localStorage.getItem("fretStart")).toBe("0");
-      expect(localStorage.getItem("fretEnd")).toBe("24");
+      expect(localStorage.getItem(k("fretStart"))).toBe("0");
+      expect(localStorage.getItem(k("fretEnd"))).toBe("24");
 
       // Scroll to show frets 5-17
-      localStorage.setItem("fretStart", "5");
-      localStorage.setItem("fretEnd", "17");
+      localStorage.setItem(k("fretStart"), "5");
+      localStorage.setItem(k("fretEnd"), "17");
 
       const { rerender } = render(<App />);
       rerender(<App />);
 
-      expect(localStorage.getItem("fretStart")).toBe("5");
-      expect(localStorage.getItem("fretEnd")).toBe("17");
+      expect(localStorage.getItem(k("fretStart"))).toBe("5");
+      expect(localStorage.getItem(k("fretEnd"))).toBe("17");
     });
   });
 
@@ -661,32 +663,32 @@ describe("Integration Tests - User Workflows", () => {
       render(<App />);
 
       // Step 1: Select key
-      localStorage.setItem("rootNote", "A");
+      localStorage.setItem(k("rootNote"), "A");
       const { rerender } = render(<App />);
       rerender(<App />);
-      expect(localStorage.getItem("rootNote")).toBe("A");
+      expect(localStorage.getItem(k("rootNote"))).toBe("A");
 
       // Step 2: Select scale
-      localStorage.setItem("scaleName", "Natural Minor");
+      localStorage.setItem(k("scaleName"), "Natural Minor");
       rerender(<App />);
-      expect(localStorage.getItem("scaleName")).toBe("Natural Minor");
+      expect(localStorage.getItem(k("scaleName"))).toBe("Natural Minor");
 
       // Step 3: Add chord
-      localStorage.setItem("chordType", "Minor 7th");
-      localStorage.setItem("chordRoot", "A");
+      localStorage.setItem(k("chordType"), "Minor 7th");
+      localStorage.setItem(k("chordRoot"), "A");
       rerender(<App />);
-      expect(localStorage.getItem("chordType")).toBe("Minor 7th");
+      expect(localStorage.getItem(k("chordType"))).toBe("Minor 7th");
 
       // Step 4: Switch display
-      localStorage.setItem("displayFormat", "degrees");
+      localStorage.setItem(k("displayFormat"), "degrees");
       rerender(<App />);
-      expect(localStorage.getItem("displayFormat")).toBe("degrees");
+      expect(localStorage.getItem(k("displayFormat"))).toBe("degrees");
 
       // Step 5: All settings should coexist (accidentalMode is non-persisted)
-      expect(localStorage.getItem("rootNote")).toBe("A");
-      expect(localStorage.getItem("scaleName")).toBe("Natural Minor");
-      expect(localStorage.getItem("chordType")).toBe("Minor 7th");
-      expect(localStorage.getItem("displayFormat")).toBe("degrees");
+      expect(localStorage.getItem(k("rootNote"))).toBe("A");
+      expect(localStorage.getItem(k("scaleName"))).toBe("Natural Minor");
+      expect(localStorage.getItem(k("chordType"))).toBe("Minor 7th");
+      expect(localStorage.getItem(k("displayFormat"))).toBe("degrees");
     });
   });
 });

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -13,3 +13,6 @@ import '@testing-library/jest-dom';
 
 // jsdom does not implement scrollTo on DOM elements
 window.HTMLElement.prototype.scrollTo = () => {};
+
+// jsdom does not implement scrollIntoView on DOM elements
+window.HTMLElement.prototype.scrollIntoView = () => {};

--- a/src/__tests__/utils/storage.ts
+++ b/src/__tests__/utils/storage.ts
@@ -1,0 +1,2 @@
+// Re-export from shared utils to ensure consistency between tests and production
+export { STORAGE_PREFIX, storageKey, k } from "../../utils/storage";

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -58,18 +58,30 @@ migrateLegacyKeys();
 function rawStringStorage<T extends string>() {
   return {
     getItem(key: string, initialValue: T): T {
-      const stored = localStorage.getItem(key);
-      if (stored === null) {
-        localStorage.setItem(key, initialValue);
+      try {
+        const stored = localStorage.getItem(key);
+        if (stored === null) {
+          localStorage.setItem(key, initialValue);
+          return initialValue;
+        }
+        return stored as T;
+      } catch {
         return initialValue;
       }
-      return stored as T;
     },
     setItem(key: string, value: T): void {
-      localStorage.setItem(key, value);
+      try {
+        localStorage.setItem(key, value);
+      } catch {
+        // Storage blocked or unavailable; ignore.
+      }
     },
     removeItem(key: string): void {
-      localStorage.removeItem(key);
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        // Storage blocked or unavailable; ignore.
+      }
     },
   };
 }
@@ -118,6 +130,10 @@ function constrainedNumberStorage(constraints: NumberConstraints) {
       try {
         const stored = localStorage.getItem(key);
         if (stored === null) {
+          localStorage.setItem(key, String(initialValue));
+          return initialValue;
+        }
+        if (stored.trim() === "") {
           localStorage.setItem(key, String(initialValue));
           return initialValue;
         }
@@ -174,66 +190,102 @@ type MobileTab = (typeof MOBILE_TABS)[number];
 
 const mobileTabStorage = {
   getItem(key: string, initialValue: MobileTab): MobileTab {
-    const stored = localStorage.getItem(key);
-    if (stored === null) {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, initialValue);
+        return initialValue;
+      }
+      if (stored === "settings") {
+        localStorage.setItem(key, "fretboard");
+        return "fretboard";
+      }
+      if ((MOBILE_TABS as readonly string[]).includes(stored)) {
+        return stored as MobileTab;
+      }
       localStorage.setItem(key, initialValue);
       return initialValue;
+    } catch {
+      return initialValue;
     }
-    if (stored === "settings") {
-      localStorage.setItem(key, "fretboard");
-      return "fretboard";
-    }
-    if ((MOBILE_TABS as readonly string[]).includes(stored)) {
-      return stored as MobileTab;
-    }
-    localStorage.setItem(key, initialValue);
-    return initialValue;
   },
   setItem(key: string, value: MobileTab): void {
-    localStorage.setItem(key, value);
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
   },
   removeItem(key: string): void {
-    localStorage.removeItem(key);
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
   },
 };
 
 // chordType is stored as '' when null (matching old behavior)
 const chordTypeStorage = {
   getItem(key: string, initialValue: string | null): string | null {
-    const stored = localStorage.getItem(key);
-    if (stored === null) {
-      localStorage.setItem(key, "");
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, "");
+        return initialValue;
+      }
+      return stored === "" ? null : stored;
+    } catch {
       return initialValue;
     }
-    return stored === "" ? null : stored;
   },
   setItem(key: string, value: string | null): void {
-    localStorage.setItem(key, value ?? "");
+    try {
+      localStorage.setItem(key, value ?? "");
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
   },
   removeItem(key: string): void {
-    localStorage.removeItem(key);
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
   },
 };
 
 // cagedShapes stored as JSON array
 const cagedShapesStorage = {
   getItem(key: string, initialValue: Set<CagedShape>): Set<CagedShape> {
-    const stored = localStorage.getItem(key);
-    if (stored === null) {
-      localStorage.setItem(key, JSON.stringify(Array.from(initialValue)));
-      return initialValue;
-    }
     try {
-      return new Set(JSON.parse(stored) as CagedShape[]);
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, JSON.stringify(Array.from(initialValue)));
+        return initialValue;
+      }
+      try {
+        return new Set(JSON.parse(stored) as CagedShape[]);
+      } catch {
+        return initialValue;
+      }
     } catch {
       return initialValue;
     }
   },
   setItem(key: string, value: Set<CagedShape>): void {
-    localStorage.setItem(key, JSON.stringify(Array.from(value)));
+    try {
+      localStorage.setItem(key, JSON.stringify(Array.from(value)));
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
   },
   removeItem(key: string): void {
-    localStorage.removeItem(key);
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
   },
 };
 

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -76,21 +76,33 @@ function rawStringStorage<T extends string>() {
 
 const booleanStorage = {
   getItem(key: string, initialValue: boolean): boolean {
-    const stored = localStorage.getItem(key);
-    if (stored === null) {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, String(initialValue));
+        return initialValue;
+      }
+      if (stored === "true") return true;
+      if (stored === "false") return false;
       localStorage.setItem(key, String(initialValue));
       return initialValue;
+    } catch {
+      return initialValue;
     }
-    if (stored === "true") return true;
-    if (stored === "false") return false;
-    localStorage.setItem(key, String(initialValue));
-    return initialValue;
   },
   setItem(key: string, value: boolean): void {
-    localStorage.setItem(key, String(value));
+    try {
+      localStorage.setItem(key, String(value));
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
   },
   removeItem(key: string): void {
-    localStorage.removeItem(key);
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
   },
 };
 
@@ -103,35 +115,47 @@ type NumberConstraints = {
 function constrainedNumberStorage(constraints: NumberConstraints) {
   return {
     getItem(key: string, initialValue: number): number {
-      const stored = localStorage.getItem(key);
-      if (stored === null) {
-        localStorage.setItem(key, String(initialValue));
+      try {
+        const stored = localStorage.getItem(key);
+        if (stored === null) {
+          localStorage.setItem(key, String(initialValue));
+          return initialValue;
+        }
+        const num = Number(stored);
+        if (!Number.isFinite(num)) {
+          localStorage.setItem(key, String(initialValue));
+          return initialValue;
+        }
+        if (constraints.integer && !Number.isInteger(num)) {
+          localStorage.setItem(key, String(initialValue));
+          return initialValue;
+        }
+        if (constraints.min !== undefined && num < constraints.min) {
+          localStorage.setItem(key, String(initialValue));
+          return initialValue;
+        }
+        if (constraints.max !== undefined && num > constraints.max) {
+          localStorage.setItem(key, String(initialValue));
+          return initialValue;
+        }
+        return num;
+      } catch {
         return initialValue;
       }
-      const num = Number(stored);
-      if (!Number.isFinite(num)) {
-        localStorage.setItem(key, String(initialValue));
-        return initialValue;
-      }
-      if (constraints.integer && !Number.isInteger(num)) {
-        localStorage.setItem(key, String(initialValue));
-        return initialValue;
-      }
-      if (constraints.min !== undefined && num < constraints.min) {
-        localStorage.setItem(key, String(initialValue));
-        return initialValue;
-      }
-      if (constraints.max !== undefined && num > constraints.max) {
-        localStorage.setItem(key, String(initialValue));
-        return initialValue;
-      }
-      return num;
     },
     setItem(key: string, value: number): void {
-      localStorage.setItem(key, String(value));
+      try {
+        localStorage.setItem(key, String(value));
+      } catch {
+        // Storage blocked or unavailable; ignore.
+      }
     },
     removeItem(key: string): void {
-      localStorage.removeItem(key);
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        // Storage blocked or unavailable; ignore.
+      }
     },
   };
 }

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -4,6 +4,56 @@ import { CAGED_SHAPES, type CagedShape } from "../shapes";
 
 export type FingeringPattern = "all" | "caged" | "3nps";
 
+const STORAGE_PREFIX = "fretflow:";
+function k(key: string): string {
+  return `${STORAGE_PREFIX}${key}`;
+}
+
+const LEGACY_KEYS = [
+  "rootNote",
+  "scaleName",
+  "chordRoot",
+  "chordType",
+  "linkChordRoot",
+  "hideNonChordNotes",
+  "chordFretSpread",
+  "chordIntervalFilter",
+  "fingeringPattern",
+  "cagedShapes",
+  "npsPosition",
+  "displayFormat",
+  "shapeLabels",
+  "tuningName",
+  "fretZoom",
+  "fretStart",
+  "fretEnd",
+  "isMuted",
+  "mobileTab",
+  "tabletTab",
+  "landscapeNarrowTab",
+] as const;
+
+function migrateLegacyKeys() {
+  // Idempotent: only migrates when prefixed key doesn't exist.
+  // Also removes the legacy key after copying to reduce drift.
+  try {
+    for (const legacyKey of LEGACY_KEYS) {
+      const prefixedKey = k(legacyKey);
+      if (localStorage.getItem(prefixedKey) !== null) {
+        localStorage.removeItem(legacyKey);
+        continue;
+      }
+      const legacyValue = localStorage.getItem(legacyKey);
+      if (legacyValue === null) continue;
+      localStorage.setItem(prefixedKey, legacyValue);
+      localStorage.removeItem(legacyKey);
+    }
+  } catch {
+    // If storage is blocked or throws (Safari private mode, etc), ignore.
+  }
+}
+migrateLegacyKeys();
+
 // ---------------------------------------------------------------------------
 // Raw storage helpers — match the old localStorage.setItem(key, String(value))
 // format and write defaults on first access (matching old useEffect-on-mount).
@@ -35,7 +85,10 @@ const booleanStorage = {
       localStorage.setItem(key, String(initialValue));
       return initialValue;
     }
-    return stored === "true";
+    if (stored === "true") return true;
+    if (stored === "false") return false;
+    localStorage.setItem(key, String(initialValue));
+    return initialValue;
   },
   setItem(key: string, value: boolean): void {
     localStorage.setItem(key, String(value));
@@ -45,22 +98,56 @@ const booleanStorage = {
   },
 };
 
-const numberStorage = {
-  getItem(key: string, initialValue: number): number {
-    const stored = localStorage.getItem(key);
-    if (stored === null) {
-      localStorage.setItem(key, String(initialValue));
-      return initialValue;
-    }
-    return Number(stored);
-  },
-  setItem(key: string, value: number): void {
-    localStorage.setItem(key, String(value));
-  },
-  removeItem(key: string): void {
-    localStorage.removeItem(key);
-  },
+type NumberConstraints = {
+  min?: number;
+  max?: number;
+  integer?: boolean;
 };
+
+function constrainedNumberStorage(constraints: NumberConstraints) {
+  return {
+    getItem(key: string, initialValue: number): number {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, String(initialValue));
+        return initialValue;
+      }
+      const num = Number(stored);
+      if (!Number.isFinite(num)) {
+        localStorage.setItem(key, String(initialValue));
+        return initialValue;
+      }
+      if (constraints.integer && !Number.isInteger(num)) {
+        localStorage.setItem(key, String(initialValue));
+        return initialValue;
+      }
+      if (constraints.min !== undefined && num < constraints.min) {
+        localStorage.setItem(key, String(initialValue));
+        return initialValue;
+      }
+      if (constraints.max !== undefined && num > constraints.max) {
+        localStorage.setItem(key, String(initialValue));
+        return initialValue;
+      }
+      return num;
+    },
+    setItem(key: string, value: number): void {
+      localStorage.setItem(key, String(value));
+    },
+    removeItem(key: string): void {
+      localStorage.removeItem(key);
+    },
+  };
+}
+
+const fretCountStorage = constrainedNumberStorage({ min: 0, max: 24, integer: true });
+const chordFretSpreadStorage = constrainedNumberStorage({
+  min: 0,
+  max: 24,
+  integer: true,
+});
+const npsPositionStorage = constrainedNumberStorage({ min: 0, max: 12, integer: true });
+const fretZoomStorage = constrainedNumberStorage({ min: 50, max: 200, integer: true });
 
 const MOBILE_TABS = ["key", "scale", "fretboard"] as const;
 type MobileTab = (typeof MOBILE_TABS)[number];
@@ -136,80 +223,84 @@ const cagedShapesStorage = {
 
 // Scale
 export const rootNoteAtom = atomWithStorage(
-  "rootNote",
+  k("rootNote"),
   "C",
   rawStringStorage(),
 );
 export const scaleNameAtom = atomWithStorage(
-  "scaleName",
+  k("scaleName"),
   "Major",
   rawStringStorage(),
 );
 
 // Chord overlay
 export const chordRootAtom = atomWithStorage(
-  "chordRoot",
+  k("chordRoot"),
   "C",
   rawStringStorage(),
 );
 export const chordTypeAtom = atomWithStorage<string | null>(
-  "chordType",
+  k("chordType"),
   null,
   chordTypeStorage,
 );
 export const linkChordRootAtom = atomWithStorage(
-  "linkChordRoot",
+  k("linkChordRoot"),
   true,
   booleanStorage,
 );
 export const hideNonChordNotesAtom = atomWithStorage(
-  "hideNonChordNotes",
+  k("hideNonChordNotes"),
   false,
   booleanStorage,
 );
 export const chordFretSpreadAtom = atomWithStorage(
-  "chordFretSpread",
+  k("chordFretSpread"),
   0,
-  numberStorage,
+  chordFretSpreadStorage,
 );
 export const chordIntervalFilterAtom = atomWithStorage(
-  "chordIntervalFilter",
+  k("chordIntervalFilter"),
   "All",
   rawStringStorage(),
 );
 
 // Fingering
 export const fingeringPatternAtom = atomWithStorage<FingeringPattern>(
-  "fingeringPattern",
+  k("fingeringPattern"),
   "all",
   rawStringStorage<FingeringPattern>(),
 );
 export const cagedShapesAtom = atomWithStorage<Set<CagedShape>>(
-  "cagedShapes",
+  k("cagedShapes"),
   new Set(CAGED_SHAPES),
   cagedShapesStorage,
 );
-export const npsPositionAtom = atomWithStorage("npsPosition", 0, numberStorage);
+export const npsPositionAtom = atomWithStorage(
+  k("npsPosition"),
+  0,
+  npsPositionStorage,
+);
 
 // Display
 export const displayFormatAtom = atomWithStorage<"notes" | "degrees" | "none">(
-  "displayFormat",
+  k("displayFormat"),
   "notes",
   rawStringStorage<"notes" | "degrees" | "none">(),
 );
 export const shapeLabelsAtom = atomWithStorage<"modal" | "caged" | "none">(
-  "shapeLabels",
+  k("shapeLabels"),
   "none",
   rawStringStorage<"modal" | "caged" | "none">(),
 );
 export const tuningNameAtom = atomWithStorage(
-  "tuningName",
+  k("tuningName"),
   "Standard",
   rawStringStorage(),
 );
-export const fretZoomAtom = atomWithStorage("fretZoom", 100, numberStorage);
-export const fretStartAtom = atomWithStorage("fretStart", 0, numberStorage);
-export const fretEndAtom = atomWithStorage("fretEnd", 24, numberStorage);
+export const fretZoomAtom = atomWithStorage(k("fretZoom"), 100, fretZoomStorage);
+export const fretStartAtom = atomWithStorage(k("fretStart"), 0, fretCountStorage);
+export const fretEndAtom = atomWithStorage(k("fretEnd"), 24, fretCountStorage);
 
 // Accidentals / Audio / Mobile tab
 // accidentalModeAtom is intentionally non-persisted: "auto" is a smart default
@@ -234,14 +325,14 @@ export const accidentalModeAtom = atom<"sharps" | "flats" | "auto">(
 // enharmonicDisplayAtom is intentionally non-persisted: "auto" preserves the
 // pre-existing CoF enharmonic-display behavior by default.
 export const enharmonicDisplayAtom = atom<"auto" | "on" | "off">("auto");
-export const isMutedAtom = atomWithStorage("isMuted", false, booleanStorage);
+export const isMutedAtom = atomWithStorage(k("isMuted"), false, booleanStorage);
 export const mobileTabAtom = atomWithStorage<"key" | "scale" | "fretboard">(
-  "mobileTab",
+  k("mobileTab"),
   "key",
   mobileTabStorage,
 );
 export const tabletTabAtom = atomWithStorage<"settings" | "scales">(
-  "tabletTab",
+  k("tabletTab"),
   "settings",
   rawStringStorage<"settings" | "scales">(),
 );
@@ -249,7 +340,7 @@ export const tabletTabAtom = atomWithStorage<"settings" | "scales">(
 export type LandscapeNarrowTab = "fretboard" | "scaleChord" | "key";
 
 export const landscapeNarrowTabAtom = atomWithStorage<LandscapeNarrowTab>(
-  "landscapeNarrowTab",
+  k("landscapeNarrowTab"),
   "fretboard",
   rawStringStorage<LandscapeNarrowTab>(),
 );
@@ -269,7 +360,16 @@ export const setRootNoteAtom = atom(null, (get, set, note: string) => {
 
 // Resets all persisted state to defaults and clears localStorage
 export const resetAtom = atom(null, (_get, set) => {
-  localStorage.clear();
+  try {
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(STORAGE_PREFIX)) keysToRemove.push(key);
+    }
+    for (const key of keysToRemove) localStorage.removeItem(key);
+  } catch {
+    // If storage is blocked or throws, still reset atoms in-memory.
+  }
   set(rootNoteAtom, RESET);
   set(scaleNameAtom, RESET);
   set(chordRootAtom, RESET);
@@ -292,4 +392,5 @@ export const resetAtom = atom(null, (_get, set) => {
   set(isMutedAtom, RESET);
   set(mobileTabAtom, RESET);
   set(tabletTabAtom, RESET);
+  set(landscapeNarrowTabAtom, RESET);
 });

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -1,13 +1,9 @@
 import { atom } from "jotai";
 import { atomWithStorage, RESET } from "jotai/utils";
 import { CAGED_SHAPES, type CagedShape } from "../shapes";
+import { k, STORAGE_PREFIX } from "../utils/storage";
 
 export type FingeringPattern = "all" | "caged" | "3nps";
-
-const STORAGE_PREFIX = "fretflow:";
-function k(key: string): string {
-  return `${STORAGE_PREFIX}${key}`;
-}
 
 const LEGACY_KEYS = [
   "rootNote",

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,4 @@
+export const STORAGE_PREFIX = "fretflow:";
+export const storageKey = (key: string) => `${STORAGE_PREFIX}${key}`;
+// Shorthand alias for convenience
+export const k = storageKey;


### PR DESCRIPTION
- Add STORAGE_PREFIX ('fretflow:') for namespaced storage\n- Implement legacy key migration on module load\n- Update all tests to use prefixed keys via shared utility\n- Fix SettingsOverlay test value constraints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Settings now self-heal when corrupted or out-of-range; boolean and numeric preferences normalize and persist sane defaults.
  * Legacy (preference) values are migrated to the app’s namespaced storage automatically.
  * Reset only removes the app’s own settings and no longer clears unrelated browser storage.
  * Some numeric preferences now enforce sensible ranges (e.g., zoom limits).

* **Tests**
  * Expanded tests for storage, migration, persistence, reset, and environment stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->