### PR TITLE
test(atoms): add atoms test coverage

### DIFF
--- a/src/__tests__/atoms.test.ts
+++ b/src/__tests__/atoms.test.ts
@@ -123,6 +123,17 @@ describe("atoms", () => {
       expect(localStorage.getItem(k("isMuted"))).toBe("false");
       unsub();
     });
+
+    it("returns initialValue when localStorage.getItem throws", () => {
+      const spy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+        throw new Error("storage blocked");
+      });
+      const store = makeStore();
+      const unsub = mount(store, isMutedAtom);
+      expect(store.get(isMutedAtom)).toBe(false);
+      spy.mockRestore();
+      unsub();
+    });
   });
 
   describe("numberStorage (via fretZoomAtom)", () => {
@@ -169,6 +180,35 @@ describe("atoms", () => {
       const unsub = mount(store, fretZoomAtom);
       expect(store.get(fretZoomAtom)).toBe(100);
       expect(localStorage.getItem(k("fretZoom"))).toBe("100");
+      unsub();
+    });
+
+    it("self-heals non-integer float values to default", () => {
+      localStorage.setItem(k("fretZoom"), "75.5");
+      const store = makeStore();
+      const unsub = mount(store, fretZoomAtom);
+      expect(store.get(fretZoomAtom)).toBe(100);
+      expect(localStorage.getItem(k("fretZoom"))).toBe("100");
+      unsub();
+    });
+
+    it("self-heals below-min values to default", () => {
+      localStorage.setItem(k("fretZoom"), "10"); // fretZoom min is 50
+      const store = makeStore();
+      const unsub = mount(store, fretZoomAtom);
+      expect(store.get(fretZoomAtom)).toBe(100);
+      expect(localStorage.getItem(k("fretZoom"))).toBe("100");
+      unsub();
+    });
+
+    it("returns initialValue when localStorage.getItem throws", () => {
+      const spy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+        throw new Error("storage blocked");
+      });
+      const store = makeStore();
+      const unsub = mount(store, fretZoomAtom);
+      expect(store.get(fretZoomAtom)).toBe(100);
+      spy.mockRestore();
       unsub();
     });
   });
@@ -395,6 +435,18 @@ describe("atoms", () => {
       expect(localStorage.getItem("rootNote")).toBeNull();
       expect(localStorage.getItem(k("rootNote"))).toBe("G");
       unsub();
+    });
+
+    it("removes legacy key without overwriting existing prefixed key", async () => {
+      // When the prefixed key already exists, migration must skip the copy
+      // but still remove the stale legacy key (the continue branch in migrateLegacyKeys).
+      localStorage.setItem(k("rootNote"), "D");
+      localStorage.setItem("rootNote", "G");
+      vi.resetModules();
+      await import("../store/atoms");
+
+      expect(localStorage.getItem(k("rootNote"))).toBe("D");
+      expect(localStorage.getItem("rootNote")).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Add targeted tests for the error-handling and constraint paths added
in the previous commit that were missing coverage:

- booleanStorage.getItem catch branch (localStorage throws → initialValue)
- constrainedNumberStorage.getItem integer guard (non-integer float → default)
- constrainedNumberStorage.getItem min guard (below-min value → default)
- constrainedNumberStorage.getItem catch branch (localStorage throws → initialValue)
- migrateLegacyKeys early-exit branch (prefixed key exists → remove legacy, skip copy)

Patch line coverage for atoms.ts: 89% → 100%.

https://claude.ai/code/session_0177VoiCVsy5CSeypt9btQ9h