### PR TITLE
fix: harden audio and guitar utilities against edge cases

### DIFF
--- a/src/Fretboard.tsx
+++ b/src/Fretboard.tsx
@@ -397,7 +397,10 @@ export function Fretboard({
                       if (rootIdx !== -1 && noteIdx !== -1) {
                         displayValue = INTERVAL_NAMES[(noteIdx - rootIdx + 12) % 12];
                       }
-                    } else if (fretIndex === 0 && parseNote(openString).noteName === noteName) {
+                    } else if (
+                      fretIndex === 0 &&
+                      parseNote(openString)?.noteName === noteName
+                    ) {
                       displayValue = getNoteDisplayInScale(noteName, rootNote, SCALES[scaleName] || [], useFlats);
                     }
 

--- a/src/__tests__/audio.test.ts
+++ b/src/__tests__/audio.test.ts
@@ -105,6 +105,28 @@ describe('GuitarSynth', () => {
 
       await expect(synth.playNote(440)).resolves.toBeUndefined();
     });
+
+    it('marks the synth unsupported when AudioContext construction fails', async () => {
+      const throwingCtor = vi.fn(function() {
+        throw new Error('AudioContext blocked');
+      });
+      (window as unknown as { AudioContext: typeof AudioContext }).AudioContext =
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        throwingCtor as any;
+
+      await expect(synth.playNote(440)).resolves.toBeUndefined();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((synth as any).unsupported).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((synth as any).ctx).toBeNull();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((synth as any).masterGain).toBeNull();
+
+      await synth.playNote(440);
+      expect(throwingCtor).toHaveBeenCalledTimes(1);
+      expect(mockAudioContext.createOscillator).not.toHaveBeenCalled();
+    });
   });
 
   describe('setMute', () => {

--- a/src/__tests__/audio.test.ts
+++ b/src/__tests__/audio.test.ts
@@ -54,6 +54,8 @@ describe('GuitarSynth', () => {
     (synth as any).masterGain = null;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (synth as any).isMuted = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (synth as any).unsupported = false;
 
     // Setup mock returns
     mockAudioContext.createGain.mockReturnValue(mockGainNode as unknown as GainNode);
@@ -92,6 +94,16 @@ describe('GuitarSynth', () => {
       synth.init();
       const callCount2 = mockAudioContext.createGain.mock.calls.length;
       expect(callCount2).toBe(callCount1);
+    });
+
+    it('no-ops safely when WebAudio is unsupported', async () => {
+      // Simulate an environment without AudioContext.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (window as any).AudioContext;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (window as any).webkitAudioContext;
+
+      await expect(synth.playNote(440)).resolves.toBeUndefined();
     });
   });
 

--- a/src/__tests__/guitar.test.ts
+++ b/src/__tests__/guitar.test.ts
@@ -15,8 +15,10 @@ describe('parseNote', () => {
     expect(parseNote('C#3')).toEqual({ noteName: 'C#', octave: 3 });
   });
 
-  it('falls back for non-standard input', () => {
-    expect(parseNote('X')).toEqual({ noteName: 'X', octave: 4 });
+  it('returns null for non-standard input', () => {
+    expect(parseNote('X')).toBeNull();
+    expect(parseNote('E')).toBeNull();
+    expect(parseNote('H4')).toBeNull();
   });
 });
 

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -2,13 +2,36 @@ class GuitarSynth {
   private ctx: AudioContext | null = null;
   private isMuted: boolean = false;
   private masterGain: GainNode | null = null;
+  private unsupported: boolean = false;
+
+  private getAudioContextConstructor():
+    | (new () => AudioContext)
+    | undefined {
+    const w = window as Window & {
+      AudioContext?: new () => AudioContext;
+      webkitAudioContext?: new () => AudioContext;
+    };
+    return w.AudioContext ?? w.webkitAudioContext;
+  }
 
   init() {
-    if (!this.ctx) {
-      this.ctx = new (window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext)();
+    if (this.unsupported || this.ctx) return;
+
+    const AudioContextCtor = this.getAudioContextConstructor();
+    if (!AudioContextCtor) {
+      this.unsupported = true;
+      return;
+    }
+
+    try {
+      this.ctx = new AudioContextCtor();
       this.masterGain = this.ctx.createGain();
       this.masterGain.connect(this.ctx.destination);
       this.masterGain.gain.value = 0.5; // Slightly louder clean signal
+    } catch {
+      this.unsupported = true;
+      this.ctx = null;
+      this.masterGain = null;
     }
   }
 

--- a/src/guitar.ts
+++ b/src/guitar.ts
@@ -5,12 +5,14 @@ export interface NoteWithOctave {
   octave: number;
 }
 
-export function parseNote(noteString: string): NoteWithOctave {
+export function parseNote(noteString: string): NoteWithOctave | null {
   const match = noteString.match(/^([A-G]#?)(\d)$/);
-  if (match) {
-    return { noteName: match[1], octave: parseInt(match[2], 10) };
-  }
-  return { noteName: noteString, octave: 4 }; // fallback
+  if (!match) return null;
+  const noteName = match[1];
+  const octave = parseInt(match[2], 10);
+  if (!NOTES.includes(noteName)) return null;
+  if (!Number.isFinite(octave)) return null;
+  return { noteName, octave };
 }
 
 // Standard Tuning from highest string (1st, thinnest) to lowest string (6th, thickest)
@@ -24,14 +26,14 @@ export const TUNINGS: Record<string, string[]> = {
 };
 
 export function getFretNote(openStringNote: string, fretNumber: number): string {
-  const parsed = parseNote(openStringNote);
+  const parsed = parseNote(openStringNote) ?? { noteName: "E", octave: 4 };
   const openIndex = NOTES.indexOf(parsed.noteName);
   const noteIndex = (openIndex + fretNumber) % 12;
   return NOTES[noteIndex];
 }
 
 export function getFretNoteWithOctave(openStringNote: string, fretNumber: number): string {
-  const parsed = parseNote(openStringNote);
+  const parsed = parseNote(openStringNote) ?? { noteName: "E", octave: 4 };
   const openIndex = NOTES.indexOf(parsed.noteName);
   const totalSemi = parsed.octave * 12 + openIndex + fretNumber;
   const newOctave = Math.floor(totalSemi / 12);
@@ -40,7 +42,7 @@ export function getFretNoteWithOctave(openStringNote: string, fretNumber: number
 }
 
 export function getNoteFrequency(noteStringWithOctave: string): number {
-  const parsed = parseNote(noteStringWithOctave);
+  const parsed = parseNote(noteStringWithOctave) ?? { noteName: "A", octave: 4 };
   const noteIndex = NOTES.indexOf(parsed.noteName);
   // C0 is 0. C4 is 48. A4 is 57 (since A is index 9).
   const absoluteDistance = (parsed.octave * 12) + noteIndex;


### PR DESCRIPTION
## Summary
- add AudioContext fallback detection and error handling
- make parseNote return null for invalid input instead of fallback values
- update the fretboard path and tests to cover invalid-note edge cases

## Testing
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential runtime error when displaying open-string notes in scale mode with null-safe comparison.
  * Improved graceful degradation when Web Audio API is unavailable—the app now safely handles environments without audio support instead of crashing.
  * Enhanced note parsing validation to properly reject invalid inputs.

* **Tests**
  * Added comprehensive test coverage for Web Audio API unavailability scenarios.
  * Updated test expectations for invalid note parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->