### PR TITLE
fix(ci): make release tags explicitly annotated

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -28,14 +28,34 @@ jobs:
           node-version: 24
           cache: npm
 
-      - name: Bump version and push tag
+      - name: Calculate next release
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: patch
           tag_prefix: v
-          create_annotated_tag: true
+          dry_run: true
+
+      - name: Create and push annotated tag
+        if: steps.tag.outputs.new_tag
+        run: |
+          TAG_NAME="${{ steps.tag.outputs.new_tag }}"
+          CHANGELOG="${{ steps.tag.outputs.changelog }}"
+          TAG_MESSAGE_FILE=$(mktemp)
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          {
+            printf '%s\n' "$TAG_NAME"
+            if [ -n "$CHANGELOG" ]; then
+              printf '\n%s\n' "$CHANGELOG"
+            fi
+          } > "$TAG_MESSAGE_FILE"
+
+          git tag -a "$TAG_NAME" -F "$TAG_MESSAGE_FILE"
+          git push origin "refs/tags/$TAG_NAME"
 
       - name: Trigger deploy workflow
         if: steps.tag.outputs.new_tag

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -39,9 +39,10 @@ jobs:
 
       - name: Create and push annotated tag
         if: steps.tag.outputs.new_tag
+        env:
+          TAG_NAME: ${{ steps.tag.outputs.new_tag }}
+          CHANGELOG: ${{ steps.tag.outputs.changelog }}
         run: |
-          TAG_NAME="${{ steps.tag.outputs.new_tag }}"
-          CHANGELOG="${{ steps.tag.outputs.changelog }}"
           TAG_MESSAGE_FILE=$(mktemp)
 
           git config user.name "github-actions[bot]"

--- a/scripts/retag-release-annotations.sh
+++ b/scripts/retag-release-annotations.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Rewrite existing semver release tags as annotated tags while preserving
+their target commits.
+
+By default this is a dry run. Use --execute to rewrite local tags, and
+--push to force-push the updated tags to the remote.
+
+Usage:
+  scripts/retag-release-annotations.sh [options]
+
+Options:
+  --execute          Rewrite local tags in place.
+  --push             Force-push rewritten tags to the remote. Requires --execute.
+  --remote <name>    Remote to push to. Default: origin
+  --tag <tag>        Retag a specific release tag. Repeatable.
+  --help             Show this help.
+
+Examples:
+  scripts/retag-release-annotations.sh
+  scripts/retag-release-annotations.sh --tag v1.3.0
+  scripts/retag-release-annotations.sh --execute --tag v1.3.0
+  scripts/retag-release-annotations.sh --execute --push
+
+Notes:
+  - Only tags matching v*.*.* are considered.
+  - The annotation body is generated from the tagged commit message:
+    first line is the tag name, followed by the full commit message.
+  - Force-pushing release tags may retrigger workflows that listen for tag pushes.
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$1" >&2
+  exit 1
+}
+
+require_repo() {
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git repository"
+}
+
+ensure_tag_exists() {
+  local tag="$1"
+  git rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1 || die "tag not found: $tag"
+}
+
+ensure_semver_tag() {
+  local tag="$1"
+  [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "tag is not a semver release tag: $tag"
+}
+
+build_message_file() {
+  local tag="$1"
+  local target="$2"
+  local message_file="$3"
+  local commit_message
+
+  commit_message="$(git log -1 --format=%B "$target")"
+
+  {
+    printf '%s\n' "$tag"
+    if [[ -n "$commit_message" ]]; then
+      printf '\n%s\n' "$commit_message"
+    fi
+  } > "$message_file"
+}
+
+main() {
+  require_repo
+
+  local execute=false
+  local push=false
+  local remote=origin
+  local -a requested_tags=()
+  local -a tags=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --execute)
+        execute=true
+        shift
+        ;;
+      --push)
+        push=true
+        shift
+        ;;
+      --remote)
+        [[ $# -ge 2 ]] || die "--remote requires a value"
+        remote="$2"
+        shift 2
+        ;;
+      --tag)
+        [[ $# -ge 2 ]] || die "--tag requires a value"
+        requested_tags+=("$2")
+        shift 2
+        ;;
+      --help|-h)
+        usage
+        exit 0
+        ;;
+      *)
+        die "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  if [[ "$push" == true && "$execute" != true ]]; then
+    die "--push requires --execute"
+  fi
+
+  if [[ ${#requested_tags[@]} -gt 0 ]]; then
+    tags=("${requested_tags[@]}")
+  else
+    while IFS= read -r tag; do
+      [[ -n "$tag" ]] && tags+=("$tag")
+    done < <(git tag --list 'v*.*.*' --sort=version:refname)
+  fi
+
+  [[ ${#tags[@]} -gt 0 ]] || die "no semver release tags found"
+
+  if [[ "$push" == true ]]; then
+    git remote get-url "$remote" >/dev/null 2>&1 || die "remote not found: $remote"
+  fi
+
+  printf 'Mode: %s\n' "$([[ "$execute" == true ]] && printf 'execute' || printf 'dry-run')"
+  printf 'Push: %s\n' "$([[ "$push" == true ]] && printf 'yes (%s)' "$remote" || printf 'no')"
+  printf 'Tags: %s\n' "${tags[*]}"
+
+  local tag
+  for tag in "${tags[@]}"; do
+    ensure_semver_tag "$tag"
+    ensure_tag_exists "$tag"
+
+    local target
+    local target_subject
+    local message_file
+
+    target="$(git rev-list -n 1 "$tag")"
+    target_subject="$(git log -1 --format=%s "$target")"
+    message_file="$(mktemp)"
+    build_message_file "$tag" "$target" "$message_file"
+
+    printf '\n== %s ==\n' "$tag"
+    printf 'target: %s\n' "$target"
+    printf 'subject: %s\n' "$target_subject"
+    printf 'annotation preview:\n'
+    sed -n '1,12p' "$message_file"
+
+    if [[ "$execute" == true ]]; then
+      git tag -a -f "$tag" "$target" -F "$message_file"
+      printf 'local tag rewritten: %s\n' "$tag"
+
+      if [[ "$push" == true ]]; then
+        git push "$remote" "refs/tags/$tag" --force
+        printf 'remote tag force-pushed: %s/%s\n' "$remote" "$tag"
+      fi
+    fi
+
+    rm -f "$message_file"
+  done
+
+  if [[ "$execute" != true ]]; then
+    printf '\nDry run only. Re-run with --execute to rewrite local tags.\n'
+    printf 'Add --push after disabling the tag protection rule to update the remote.\n'
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- stop relying on github-tag-action to create the tag object and create release tags explicitly with git tag -a using the generated changelog
- add a portable retag helper for rewriting existing semver tags with proper annotation bodies while preserving their target commits
- keep the script dry-run by default and require explicit execute/push flags for safety

## Verification
- git diff --check
- bash -n scripts/retag-release-annotations.sh
- bash scripts/retag-release-annotations.sh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Split release tagging so the pipeline calculates the next version tag separately and then explicitly creates and pushes an annotated tag when present, improving reliability of tag creation.
  * Added a new command-line utility to rewrite lightweight semver tags into annotated tags (dry-run, execute, and optional push modes), with previews and configurable tag selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->