### PR TITLE
feat: redesign settings drawer

### DIFF
--- a/src/__tests__/SettingsOverlay.test.tsx
+++ b/src/__tests__/SettingsOverlay.test.tsx
@@ -23,6 +23,15 @@ function renderOverlay(store: ReturnType<typeof createStore>) {
   );
 }
 
+function renderOpenOverlay() {
+  const store = createStore();
+  store.set(settingsOverlayOpenAtom, true);
+  return {
+    store,
+    ...renderOverlay(store),
+  };
+}
+
 function setViewport(width: number, height: number) {
   Object.defineProperty(window, "innerWidth", {
     writable: true,
@@ -56,12 +65,120 @@ describe("SettingsOverlay", () => {
   });
 
   it("renders drawer with Settings heading when open", () => {
-    const store = createStore();
-    store.set(settingsOverlayOpenAtom, true);
-    renderOverlay(store);
+    renderOpenOverlay();
     const drawer = document.querySelector(".settings-overlay-drawer");
     expect(drawer).toBeTruthy();
     expect(screen.getByText("Settings")).toBeTruthy();
+  });
+
+  it("renders sections in the expected order", () => {
+    renderOpenOverlay();
+
+    const headings = Array.from(
+      document.querySelectorAll(".overlay-section-title"),
+    ).map((node) => node.textContent?.trim());
+
+    expect(headings).toEqual([
+      "View",
+      "Instrument",
+      "Notation",
+      "Chord Layout",
+      "Reset",
+    ]);
+  });
+
+  it("renders all settings controls in the redesigned drawer", () => {
+    renderOpenOverlay();
+
+    expect(screen.getByText("Zoom")).toBeTruthy();
+    expect(screen.getByText("Fret Range")).toBeTruthy();
+    expect(screen.getAllByText("Tuning")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Tuning: Standard" })).toBeTruthy();
+    expect(screen.getByText("Accidentals")).toBeTruthy();
+    expect(screen.getByText("Enharmonic Display")).toBeTruthy();
+    expect(screen.getByText("Chord Spread")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Reset all settings" })).toBeTruthy();
+  });
+
+  it("shows help buttons only for the less-obvious settings", () => {
+    renderOpenOverlay();
+
+    expect(screen.getByLabelText("Show help for Chord Spread")).toBeTruthy();
+    expect(screen.getByLabelText("Show help for Accidentals")).toBeTruthy();
+    expect(screen.getByLabelText("Show help for Enharmonic Display")).toBeTruthy();
+    expect(screen.queryByLabelText("Show help for Zoom")).toBeNull();
+    expect(screen.queryByLabelText("Show help for Fret Range")).toBeNull();
+    expect(screen.queryByLabelText("Show help for Tuning")).toBeNull();
+  });
+
+  it("toggles help popovers on click and keeps only one open at a time", () => {
+    renderOpenOverlay();
+
+    fireEvent.click(screen.getByLabelText("Show help for Chord Spread"));
+    expect(
+      screen.getByText(
+        "Limits how far the visible chord tones can span across frets on the fretboard.",
+      ),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText("Show help for Accidentals"));
+    expect(
+      screen.queryByText(
+        "Limits how far the visible chord tones can span across frets on the fretboard.",
+      ),
+    ).toBeNull();
+    expect(
+      screen.getByText(
+        "Auto chooses sharps or flats based on the current musical context.",
+      ),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText("Hide help for Accidentals"));
+    expect(
+      screen.queryByText(
+        "Auto chooses sharps or flats based on the current musical context.",
+      ),
+    ).toBeNull();
+  });
+
+  it("closes a help popover on escape before closing the drawer", () => {
+    const { store } = renderOpenOverlay();
+
+    fireEvent.click(screen.getByLabelText("Show help for Enharmonic Display"));
+    expect(
+      screen.getByText(
+        "Controls whether equivalent note spellings appear when they clarify the theory view.",
+      ),
+    ).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(
+      screen.queryByText(
+        "Controls whether equivalent note spellings appear when they clarify the theory view.",
+      ),
+    ).toBeNull();
+    expect(store.get(settingsOverlayOpenAtom)).toBe(true);
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(store.get(settingsOverlayOpenAtom)).toBe(false);
+  });
+
+  it("closes an open help popover when clicking outside it", () => {
+    renderOpenOverlay();
+
+    fireEvent.click(screen.getByLabelText("Show help for Chord Spread"));
+    expect(
+      screen.getByText(
+        "Limits how far the visible chord tones can span across frets on the fretboard.",
+      ),
+    ).toBeTruthy();
+
+    fireEvent.mouseDown(screen.getByText("Notation"));
+    expect(
+      screen.queryByText(
+        "Limits how far the visible chord tones can span across frets on the fretboard.",
+      ),
+    ).toBeNull();
   });
 
   it("marks the drawer as full-width on mobile layouts", () => {
@@ -75,19 +192,15 @@ describe("SettingsOverlay", () => {
     expect(drawer?.getAttribute("data-full-width")).toBe("true");
   });
 
-  it("closes overlay when ESC is pressed", () => {
-    const store = createStore();
-    store.set(settingsOverlayOpenAtom, true);
-    renderOverlay(store);
+  it("closes overlay when ESC is pressed with no help popover open", () => {
+    const { store } = renderOpenOverlay();
     expect(store.get(settingsOverlayOpenAtom)).toBe(true);
     fireEvent.keyDown(window, { key: "Escape" });
     expect(store.get(settingsOverlayOpenAtom)).toBe(false);
   });
 
   it("closes overlay when backdrop is clicked", () => {
-    const store = createStore();
-    store.set(settingsOverlayOpenAtom, true);
-    renderOverlay(store);
+    const { store } = renderOpenOverlay();
     const backdrop = document.querySelector(".settings-overlay-backdrop");
     expect(backdrop).toBeTruthy();
     fireEvent.click(backdrop!);
@@ -95,18 +208,14 @@ describe("SettingsOverlay", () => {
   });
 
   it("closes overlay when X button is clicked", () => {
-    const store = createStore();
-    store.set(settingsOverlayOpenAtom, true);
-    renderOverlay(store);
+    const { store } = renderOpenOverlay();
     const closeBtn = screen.getByLabelText("Close settings");
     fireEvent.click(closeBtn);
     expect(store.get(settingsOverlayOpenAtom)).toBe(false);
   });
 
   it("stays open when resized within the same layout tier", () => {
-    const store = createStore();
-    store.set(settingsOverlayOpenAtom, true);
-    renderOverlay(store);
+    const { store } = renderOpenOverlay();
 
     setViewport(1280, 900);
     fireEvent(window, new Event("resize"));
@@ -115,9 +224,7 @@ describe("SettingsOverlay", () => {
   });
 
   it("closes when resized across layout tiers", () => {
-    const store = createStore();
-    store.set(settingsOverlayOpenAtom, true);
-    renderOverlay(store);
+    const { store } = renderOpenOverlay();
 
     setViewport(390, 844);
     fireEvent(window, new Event("resize"));
@@ -172,9 +279,7 @@ describe("SettingsOverlay", () => {
   });
 
   it("traps focus when tabbing forward from the last control", () => {
-    const store = createStore();
-    store.set(settingsOverlayOpenAtom, true);
-    renderOverlay(store);
+    renderOpenOverlay();
 
     const closeButton = screen.getByLabelText("Close settings");
     const resetButton = screen.getByRole("button", {
@@ -187,10 +292,23 @@ describe("SettingsOverlay", () => {
     expect(document.activeElement).toBe(closeButton);
   });
 
+  it("keeps focus trapping intact when a help popover is open", () => {
+    renderOpenOverlay();
+
+    fireEvent.click(screen.getByLabelText("Show help for Chord Spread"));
+    const closeButton = screen.getByLabelText("Close settings");
+    const resetButton = screen.getByRole("button", {
+      name: "Reset all settings",
+    });
+
+    resetButton.focus();
+    fireEvent.keyDown(window, { key: "Tab" });
+
+    expect(document.activeElement).toBe(closeButton);
+  });
+
   it("traps focus when shift-tabbing backward from the first control", () => {
-    const store = createStore();
-    store.set(settingsOverlayOpenAtom, true);
-    renderOverlay(store);
+    renderOpenOverlay();
 
     const closeButton = screen.getByLabelText("Close settings");
     const resetButton = screen.getByRole("button", {

--- a/src/components/SettingsOverlay.css
+++ b/src/components/SettingsOverlay.css
@@ -15,7 +15,12 @@
   inline-size: min(100vw, clamp(20rem, 32vw, 24rem));
   max-inline-size: 100vw;
   z-index: var(--z-overlay-drawer);
-  background: var(--chrome-bg);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--chrome-bg) 92%, white 8%) 0%,
+      var(--chrome-bg) 100%
+    );
   color: var(--chrome-fg);
   display: flex;
   flex-direction: column;
@@ -38,6 +43,7 @@
   padding: 12px 16px;
   border-bottom: 1px solid var(--chrome-border);
   flex-shrink: 0;
+  background: color-mix(in srgb, var(--chrome-bg) 92%, white 8%);
 }
 
 .settings-overlay-title {
@@ -78,15 +84,159 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  gap: 14px;
   overflow-y: auto;
   padding: 16px 16px max(32px, env(safe-area-inset-bottom, 0px));
   overscroll-behavior: contain;
 }
 
-.overlay-reset-section {
+.overlay-section-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  border: 1px solid color-mix(in srgb, var(--surface-highlight) 78%, transparent);
+  box-shadow: 0 12px 24px color-mix(in srgb, var(--chrome-bg) 84%, transparent);
+}
+
+.overlay-section-card--danger {
   margin-top: auto;
-  padding-top: 24px;
-  border-top: 1px solid var(--chrome-border);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--panel-surface-bg) 88%, var(--accent-secondary) 12%) 0%,
+      var(--panel-surface-bg) 100%
+    );
+}
+
+.overlay-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.overlay-section-title {
+  margin: 0;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--chrome-fg-muted);
+}
+
+.overlay-section-body {
+  display: flex;
+  flex-direction: column;
+}
+
+.overlay-field {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.overlay-field--divided {
+  padding-bottom: 14px;
+  border-bottom: 1px solid color-mix(in srgb, var(--chrome-border) 74%, transparent);
+  margin-bottom: 14px;
+}
+
+.overlay-field-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  position: relative;
+}
+
+.overlay-field-label {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--chrome-fg);
+}
+
+.overlay-field-control {
+  min-width: 0;
+}
+
+.overlay-field-help {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.overlay-help-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.875rem;
+  height: 1.875rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--chrome-border) 82%, transparent);
+  background: color-mix(in srgb, var(--surface-raised) 90%, transparent);
+  color: var(--chrome-fg-muted);
+  cursor: pointer;
+  transition: var(--transition-surface);
+}
+
+.overlay-help-trigger:hover,
+.overlay-help-trigger[aria-expanded="true"] {
+  color: var(--chrome-fg);
+  border-color: color-mix(in srgb, var(--accent-primary) 42%, var(--chrome-border));
+  background: color-mix(in srgb, var(--accent-primary) 12%, var(--surface-raised));
+}
+
+.overlay-help-trigger:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+}
+
+.overlay-help-trigger .icon {
+  width: 16px;
+  height: 16px;
+}
+
+.overlay-help-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 1;
+  width: min(17rem, calc(100vw - 64px));
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--accent-primary) 22%, var(--chrome-border));
+  background: color-mix(in srgb, var(--surface-base) 94%, white 6%);
+  color: var(--chrome-fg);
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  box-shadow: 0 12px 32px color-mix(in srgb, var(--chrome-bg) 82%, transparent);
+}
+
+.overlay-field--selector .drawer-label {
+  display: none;
+}
+
+.overlay-field--selector .drawer-trigger {
+  width: 100%;
+}
+
+.overlay-field--selector .drawer-value {
+  margin-left: 0;
+}
+
+.overlay-field--accidentals .toggle-btn {
+  font-size: var(--text-sm, 0.875rem);
+}
+
+.overlay-reset-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.overlay-reset-copy {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: var(--chrome-fg-muted);
 }
 
 .overlay-reset-btn {
@@ -116,27 +266,17 @@
   outline-offset: var(--focus-ring-offset);
 }
 
-.overlay-control-group {
-  margin-bottom: 20px;
-}
-
-.overlay-control-label {
-  display: block;
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--chrome-fg-muted);
-  margin-bottom: 8px;
-}
-
-/* Enlarge ♯/♭ unicode symbols which render small at default text-xs */
-.overlay-control-group--accidentals .toggle-btn {
-  font-size: var(--text-sm, 0.875rem);
+@media (max-width: 480px) {
+  .overlay-help-popover {
+    position: static;
+    width: 100%;
+    margin-top: 10px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .settings-overlay-close,
+  .overlay-help-trigger,
   .overlay-reset-btn {
     transition: none;
     animation: none;
@@ -149,10 +289,15 @@
   }
 
   .settings-overlay-content {
+    gap: 12px;
     padding: 12px 14px max(20px, env(safe-area-inset-bottom, 0px));
   }
 
-  .overlay-control-group {
-    margin-bottom: 16px;
+  .overlay-section-card {
+    gap: 12px;
+  }
+
+  .overlay-field {
+    gap: 8px;
   }
 }

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode, type Ref } from "react";
-import { useAtom, useSetAtom } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import clsx from "clsx";
 import { AnimatePresence, motion } from "motion/react";
 import { HelpCircle, X } from "lucide-react";
@@ -555,6 +555,13 @@ export default function SettingsOverlay() {
   const [viewport, setViewport] = useState(getViewportSnapshot);
   const openTierRef = useRef<ResponsiveTier | null>(null);
   const layout = getResponsiveLayout(viewport.width, viewport.height);
+
+  // Preserve atomWithStorage initialization behavior even while the drawer is closed.
+  useAtomValue(fretZoomAtom);
+  useAtomValue(fretStartAtom);
+  useAtomValue(fretEndAtom);
+  useAtomValue(tuningNameAtom);
+  useAtomValue(chordFretSpreadAtom);
 
   // Track layout tier at the moment the overlay opens.
   useEffect(() => {

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode, type Ref } from "react";
 import { useAtom, useSetAtom } from "jotai";
 import clsx from "clsx";
 import { AnimatePresence, motion } from "motion/react";
-import { X } from "lucide-react";
+import { HelpCircle, X } from "lucide-react";
 import {
   settingsOverlayOpenAtom,
   fretZoomAtom,
@@ -34,6 +34,33 @@ const ZOOM_STEP = 10;
 
 type AccidentalOptionValue = "auto" | "sharps" | "flats";
 type EnharmonicDisplayValue = "auto" | "on" | "off";
+type HelpFieldId = "chordSpread" | "accidentals" | "enharmonicDisplay";
+type SettingFieldKey =
+  | "zoom"
+  | "fretRange"
+  | "tuning"
+  | "accidentals"
+  | "enharmonicDisplay"
+  | "chordSpread";
+
+type FieldHelp = {
+  id: HelpFieldId;
+  content: string;
+};
+
+type SettingFieldConfig = {
+  key: SettingFieldKey;
+  label: string;
+  help?: FieldHelp;
+  className?: string;
+};
+
+type SettingsSectionConfig = {
+  id: string;
+  title: string;
+  tone?: "default" | "danger";
+  fields: SettingFieldKey[];
+};
 
 const ACCIDENTAL_OPTIONS = [
   { label: "Auto", value: "auto" },
@@ -52,6 +79,76 @@ const ENHARMONIC_DISPLAY_OPTIONS = [
   label: string;
   value: EnharmonicDisplayValue;
 }[];
+
+const SETTING_FIELDS: Record<SettingFieldKey, SettingFieldConfig> = {
+  zoom: {
+    key: "zoom",
+    label: "Zoom",
+  },
+  fretRange: {
+    key: "fretRange",
+    label: "Fret Range",
+  },
+  tuning: {
+    key: "tuning",
+    label: "Tuning",
+    className: "overlay-field--selector",
+  },
+  accidentals: {
+    key: "accidentals",
+    label: "Accidentals",
+    className: "overlay-field--accidentals",
+    help: {
+      id: "accidentals",
+      content: "Auto chooses sharps or flats based on the current musical context.",
+    },
+  },
+  enharmonicDisplay: {
+    key: "enharmonicDisplay",
+    label: "Enharmonic Display",
+    help: {
+      id: "enharmonicDisplay",
+      content: "Controls whether equivalent note spellings appear when they clarify the theory view.",
+    },
+  },
+  chordSpread: {
+    key: "chordSpread",
+    label: "Chord Spread",
+    help: {
+      id: "chordSpread",
+      content: "Limits how far the visible chord tones can span across frets on the fretboard.",
+    },
+  },
+};
+
+const SETTINGS_SECTIONS: readonly SettingsSectionConfig[] = [
+  {
+    id: "view",
+    title: "View",
+    fields: ["zoom", "fretRange"],
+  },
+  {
+    id: "instrument",
+    title: "Instrument",
+    fields: ["tuning"],
+  },
+  {
+    id: "notation",
+    title: "Notation",
+    fields: ["accidentals", "enharmonicDisplay"],
+  },
+  {
+    id: "chord-layout",
+    title: "Chord Layout",
+    fields: ["chordSpread"],
+  },
+  {
+    id: "reset",
+    title: "Reset",
+    tone: "danger",
+    fields: [],
+  },
+] as const;
 
 // Retained for: auto-close overlay on layout-tier change (resize/rotate detection).
 const getLayoutTier = (): ResponsiveTier => {
@@ -79,8 +176,83 @@ function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
   ).filter((element) => element.getAttribute("aria-hidden") !== "true");
 }
 
-export default function SettingsOverlay() {
-  const [isOpen, setIsOpen] = useAtom(settingsOverlayOpenAtom);
+function OverlaySection({
+  id,
+  title,
+  tone = "default",
+  children,
+}: {
+  id: string;
+  title: string;
+  tone?: "default" | "danger";
+  children: ReactNode;
+}) {
+  return (
+    <section
+      className={clsx(
+        "panel-surface",
+        "panel-surface--compact",
+        "overlay-section-card",
+        tone === "danger" && "overlay-section-card--danger",
+      )}
+      aria-labelledby={`settings-section-${id}`}
+    >
+      <div className="overlay-section-heading">
+        <h2 id={`settings-section-${id}`} className="overlay-section-title">
+          {title}
+        </h2>
+      </div>
+      <div className="overlay-section-body">{children}</div>
+    </section>
+  );
+}
+
+function OverlayFieldHeader({
+  label,
+  help,
+  isHelpOpen,
+  onToggleHelp,
+  helpContainerRef,
+}: {
+  label: string;
+  help?: FieldHelp;
+  isHelpOpen: boolean;
+  onToggleHelp: () => void;
+  helpContainerRef?: Ref<HTMLDivElement>;
+}) {
+  return (
+    <div className="overlay-field-header">
+      <span className="overlay-field-label">{label}</span>
+      {help ? (
+        <div className="overlay-field-help" ref={helpContainerRef}>
+          <button
+            type="button"
+            className="overlay-help-trigger"
+            aria-label={isHelpOpen ? `Hide help for ${label}` : `Show help for ${label}`}
+            aria-expanded={isHelpOpen}
+            aria-controls={`settings-help-${help.id}`}
+            onClick={onToggleHelp}
+          >
+            <HelpCircle className="icon" />
+          </button>
+          {isHelpOpen ? (
+            <div id={`settings-help-${help.id}`} className="overlay-help-popover">
+              {help.content}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SettingsOverlaySurface({
+  layout,
+  setIsOpen,
+}: {
+  layout: ReturnType<typeof getResponsiveLayout>;
+  setIsOpen: (value: boolean) => void;
+}) {
   const [fretZoom, setFretZoom] = useAtom(fretZoomAtom);
   const [fretStart, setFretStart] = useAtom(fretStartAtom);
   const [fretEnd, setFretEnd] = useAtom(fretEndAtom);
@@ -91,28 +263,35 @@ export default function SettingsOverlay() {
   );
   const [chordFretSpread, setChordFretSpread] = useAtom(chordFretSpreadAtom);
   const dispatchReset = useSetAtom(resetAtom);
-  const [viewport, setViewport] = useState(getViewportSnapshot);
   const [resetConfirming, setResetConfirming] = useState(false);
-  const openTierRef = useRef<ResponsiveTier | null>(null);
+  const [activeHelpField, setActiveHelpField] = useState<HelpFieldId | null>(
+    null,
+  );
   const drawerRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const triggerRef = useRef<HTMLElement | null>(null);
-  const layout = getResponsiveLayout(viewport.width, viewport.height);
+  const helpContainerRefs = useRef<Record<HelpFieldId, HTMLDivElement | null>>({
+    chordSpread: null,
+    accidentals: null,
+    enharmonicDisplay: null,
+  });
 
   const close = () => {
     setIsOpen(false);
-    setResetConfirming(false);
   };
 
   const handleResetClick = () => {
     if (resetConfirming) {
       dispatchReset();
       synth.setMute(false);
-      setResetConfirming(false);
       setIsOpen(false);
     } else {
       setResetConfirming(true);
     }
+  };
+
+  const handleHelpToggle = (fieldId: HelpFieldId) => {
+    setActiveHelpField((current) => (current === fieldId ? null : fieldId));
   };
 
   // Auto-clear confirming state after 3 seconds
@@ -122,31 +301,21 @@ export default function SettingsOverlay() {
     return () => clearTimeout(t);
   }, [resetConfirming]);
 
-  // Track layout tier at the moment the overlay opens.
   useEffect(() => {
-    const onResize = () => setViewport(getViewportSnapshot());
-    window.addEventListener("resize", onResize);
+    if (!activeHelpField) return;
 
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
+    const handlePointerDown = (event: MouseEvent) => {
+      const helpContainer = helpContainerRefs.current[activeHelpField];
+      if (helpContainer?.contains(event.target as Node)) return;
+      setActiveHelpField(null);
+    };
 
-  useEffect(() => {
-    openTierRef.current = isOpen ? getLayoutTier() : null;
-  }, [isOpen]);
-
-  // Auto-close the overlay when the layout tier changes (e.g., rotate,
-  // desktop → mobile resize). Resizes within the same tier keep the drawer
-  // open and allow CSS to adapt the surface.
-  useEffect(() => {
-    if (!isOpen || !openTierRef.current) return;
-    if (layout.tier !== openTierRef.current) {
-      setIsOpen(false);
-    }
-  }, [isOpen, layout.tier, setIsOpen]);
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [activeHelpField]);
 
   // Trap focus inside the drawer while open and restore focus on close.
   useEffect(() => {
-    if (!isOpen) return;
     triggerRef.current =
       document.activeElement instanceof HTMLElement
         ? document.activeElement
@@ -161,7 +330,11 @@ export default function SettingsOverlay() {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.stopPropagation();
-        setIsOpen(false);
+        if (activeHelpField) {
+          setActiveHelpField(null);
+        } else {
+          setIsOpen(false);
+        }
         return;
       }
 
@@ -195,131 +368,220 @@ export default function SettingsOverlay() {
       triggerRef.current?.focus();
       triggerRef.current = null;
     };
-  }, [isOpen, setIsOpen]);
+  }, [activeHelpField, setIsOpen]);
+
+  const renderField = (fieldKey: SettingFieldKey, index: number, total: number) => {
+    const field = SETTING_FIELDS[fieldKey];
+    const isHelpOpen = field.help?.id === activeHelpField;
+    const helpId = field.help?.id;
+    const helpContainerRef = helpId
+      ? (node: HTMLDivElement | null) => {
+          helpContainerRefs.current[helpId] = node;
+        }
+      : undefined;
+
+    let control: ReactNode = null;
+
+    switch (field.key) {
+      case "zoom":
+        control = (
+          <StepperControl
+            value={fretZoom}
+            onChange={setFretZoom}
+            min={ZOOM_MIN}
+            max={ZOOM_MAX}
+            step={ZOOM_STEP}
+            formatValue={(zoom) => (zoom <= 100 ? "Auto" : `${zoom}%`)}
+            buttonVariant="mobile"
+          />
+        );
+        break;
+      case "fretRange":
+        control = (
+          <FretRangeControl
+            startFret={fretStart}
+            endFret={fretEnd}
+            onStartChange={setFretStart}
+            onEndChange={setFretEnd}
+            maxFret={END_FRET}
+            layout="mobile"
+          />
+        );
+        break;
+      case "tuning":
+        control = (
+          <DrawerSelector
+            label={field.label}
+            value={tuningName}
+            options={Object.keys(TUNINGS)}
+            onSelect={setTuningName}
+          />
+        );
+        break;
+      case "accidentals":
+        control = (
+          <ToggleBar
+            options={ACCIDENTAL_OPTIONS}
+            value={accidentalMode}
+            onChange={(value) => setAccidentalMode(value as AccidentalOptionValue)}
+          />
+        );
+        break;
+      case "enharmonicDisplay":
+        control = (
+          <ToggleBar
+            options={ENHARMONIC_DISPLAY_OPTIONS}
+            value={enharmonicDisplay}
+            onChange={(value) =>
+              setEnharmonicDisplay(value as EnharmonicDisplayValue)
+            }
+          />
+        );
+        break;
+      case "chordSpread":
+        control = (
+          <StepperControl
+            value={chordFretSpread}
+            onChange={setChordFretSpread}
+            min={0}
+            max={4}
+            step={1}
+            buttonVariant="mobile"
+          />
+        );
+        break;
+    }
+
+    return (
+      <div
+        key={field.key}
+        className={clsx(
+          "overlay-field",
+          field.className,
+          isHelpOpen && "overlay-field--help-open",
+          index < total - 1 && "overlay-field--divided",
+        )}
+      >
+        <OverlayFieldHeader
+          label={field.label}
+          help={field.help}
+          isHelpOpen={Boolean(isHelpOpen)}
+          onToggleHelp={() => field.help && handleHelpToggle(field.help.id)}
+          helpContainerRef={helpContainerRef}
+        />
+        <div className="overlay-field-control">{control}</div>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <motion.div
+        className="settings-overlay-backdrop"
+        onClick={close}
+        aria-hidden="true"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.24, ease: "easeOut" }}
+      />
+      <motion.div
+        className="settings-overlay-drawer"
+        ref={drawerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Settings"
+        data-layout-tier={layout.tier}
+        data-full-width={layout.fullWidthOverlay ? "true" : "false"}
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+        initial={{ x: "100%" }}
+        animate={{ x: 0 }}
+        exit={{ x: "100%" }}
+        transition={{ duration: 0.24, ease: "easeOut" }}
+      >
+        <div className="settings-overlay-header">
+          <span className="settings-overlay-title">Settings</span>
+          <button
+            type="button"
+            ref={closeButtonRef}
+            className="settings-overlay-close"
+            onClick={close}
+            aria-label="Close settings"
+          >
+            <X className="icon" />
+          </button>
+        </div>
+        <div className="settings-overlay-content custom-scrollbar">
+          {SETTINGS_SECTIONS.map((section) => (
+            <OverlaySection
+              key={section.id}
+              id={section.id}
+              title={section.title}
+              tone={section.tone}
+            >
+              {section.id === "reset" ? (
+                <div className="overlay-reset-section">
+                  <p className="overlay-reset-copy">
+                    Restore every setting in the app back to its default value.
+                  </p>
+                  <button
+                    type="button"
+                    className={clsx("overlay-reset-btn", {
+                      "overlay-reset-confirming": resetConfirming,
+                    })}
+                    onClick={handleResetClick}
+                  >
+                    {resetConfirming
+                      ? "Click again to confirm"
+                      : "Reset all settings"}
+                  </button>
+                </div>
+              ) : (
+                section.fields.map((fieldKey, index) =>
+                  renderField(fieldKey, index, section.fields.length),
+                )
+              )}
+            </OverlaySection>
+          ))}
+        </div>
+      </motion.div>
+    </>
+  );
+}
+
+export default function SettingsOverlay() {
+  const [isOpen, setIsOpen] = useAtom(settingsOverlayOpenAtom);
+  const [viewport, setViewport] = useState(getViewportSnapshot);
+  const openTierRef = useRef<ResponsiveTier | null>(null);
+  const layout = getResponsiveLayout(viewport.width, viewport.height);
+
+  // Track layout tier at the moment the overlay opens.
+  useEffect(() => {
+    const onResize = () => setViewport(getViewportSnapshot());
+    window.addEventListener("resize", onResize);
+
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  useEffect(() => {
+    openTierRef.current = isOpen ? getLayoutTier() : null;
+  }, [isOpen]);
+
+  // Auto-close the overlay when the layout tier changes (e.g., rotate,
+  // desktop → mobile resize). Resizes within the same tier keep the drawer
+  // open and allow CSS to adapt the surface.
+  useEffect(() => {
+    if (!isOpen || !openTierRef.current) return;
+    if (layout.tier !== openTierRef.current) {
+      setIsOpen(false);
+    }
+  }, [isOpen, layout.tier, setIsOpen]);
 
   return (
     <AnimatePresence>
       {isOpen ? (
-        <>
-          <motion.div
-            className="settings-overlay-backdrop"
-            onClick={close}
-            aria-hidden="true"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.24, ease: "easeOut" }}
-          />
-          <motion.div
-            className="settings-overlay-drawer"
-            ref={drawerRef}
-            role="dialog"
-            aria-modal="true"
-            aria-label="Settings"
-            data-layout-tier={layout.tier}
-            data-full-width={layout.fullWidthOverlay ? "true" : "false"}
-            tabIndex={-1}
-            onClick={(e) => e.stopPropagation()}
-            initial={{ x: "100%" }}
-            animate={{ x: 0 }}
-            exit={{ x: "100%" }}
-            transition={{ duration: 0.24, ease: "easeOut" }}
-          >
-            <div className="settings-overlay-header">
-              <span className="settings-overlay-title">Settings</span>
-              <button
-                type="button"
-                ref={closeButtonRef}
-                className="settings-overlay-close"
-                onClick={close}
-                aria-label="Close settings"
-              >
-                <X className="icon" />
-              </button>
-            </div>
-            <div className="settings-overlay-content">
-              <div className="overlay-control-group">
-                <StepperControl
-                  label="Zoom"
-                  value={fretZoom}
-                  onChange={setFretZoom}
-                  min={ZOOM_MIN}
-                  max={ZOOM_MAX}
-                  step={ZOOM_STEP}
-                  formatValue={(z) => (z <= 100 ? "Auto" : `${z}%`)}
-                  buttonVariant="mobile"
-                />
-              </div>
-
-              <div className="overlay-control-group">
-                <span className="overlay-control-label">Fret Range</span>
-                <FretRangeControl
-                  startFret={fretStart}
-                  endFret={fretEnd}
-                  onStartChange={setFretStart}
-                  onEndChange={setFretEnd}
-                  maxFret={END_FRET}
-                  layout="mobile"
-                />
-              </div>
-
-              <div className="overlay-control-group">
-                <DrawerSelector
-                  label="Tuning"
-                  value={tuningName}
-                  options={Object.keys(TUNINGS)}
-                  onSelect={setTuningName}
-                />
-              </div>
-
-              <div className="overlay-control-group">
-                <StepperControl
-                  label="Chord Spread"
-                  value={chordFretSpread}
-                  onChange={setChordFretSpread}
-                  min={0}
-                  max={4}
-                  step={1}
-                  buttonVariant="mobile"
-                />
-              </div>
-
-              <div className="overlay-control-group overlay-control-group--accidentals">
-                <span className="overlay-control-label">Accidentals</span>
-                <ToggleBar
-                  options={ACCIDENTAL_OPTIONS}
-                  value={accidentalMode}
-                  onChange={(v) => setAccidentalMode(v as AccidentalOptionValue)}
-                />
-              </div>
-
-              <div className="overlay-control-group">
-                <span className="overlay-control-label">
-                  Enharmonic Display
-                </span>
-                <ToggleBar
-                  options={ENHARMONIC_DISPLAY_OPTIONS}
-                  value={enharmonicDisplay}
-                  onChange={(v) => setEnharmonicDisplay(v as EnharmonicDisplayValue)}
-                />
-              </div>
-
-              <div className="overlay-reset-section">
-                <button
-                  type="button"
-                  className={clsx("overlay-reset-btn", {
-                    "overlay-reset-confirming": resetConfirming,
-                  })}
-                  onClick={handleResetClick}
-                >
-                  {resetConfirming
-                    ? "Click again to confirm"
-                    : "Reset all settings"}
-                </button>
-              </div>
-            </div>
-          </motion.div>
-        </>
+        <SettingsOverlaySurface layout={layout} setIsOpen={setIsOpen} />
       ) : null}
     </AnimatePresence>
   );


### PR DESCRIPTION
## Summary
- redesign the settings drawer into ordered section cards for view, instrument, notation, chord layout, and reset
- add click/tap help popovers for chord spread, accidentals, and enharmonic display
- preserve existing settings behavior and expand overlay tests for ordering, help interactions, and focus handling

## Validation
- npm test -- App.test.tsx SettingsOverlay.test.tsx
- npm run lint -- src/components/SettingsOverlay.tsx src/__tests__/SettingsOverlay.test.tsx src/__tests__/App.test.tsx
- git push -u origin codex/settings-drawer-redesign (pre-push hook ran full test suite and production build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added contextual help popovers for specific settings (Accidentals, Enharmonic Display, Chord Spread).

* **Style**
  * Redesigned settings drawer with improved visual hierarchy, spacing, and subtle gradient background.
  * Reorganized settings into card-based sections for better clarity.

* **Tests**
  * Expanded test coverage for help popover interactions and drawer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->