### PR TITLE
style: remove mobile tab styling

### DIFF
--- a/src/__tests__/__snapshots__/snapshots.test.tsx.snap
+++ b/src/__tests__/__snapshots__/snapshots.test.tsx.snap
@@ -21893,7 +21893,7 @@ exports[`Component Snapshots > App layout snapshots > renders iPhone 12 Pro port
       </button>
     </div>
     <div
-      class="mobile-tab-content panel-surface"
+      class="mobile-tab-content"
     >
       <div
         class="mobile-tab-panel mobile-key-tab"
@@ -25548,7 +25548,7 @@ exports[`Component Snapshots > App layout snapshots > renders iPhone SE portrait
       </button>
     </div>
     <div
-      class="mobile-tab-content panel-surface"
+      class="mobile-tab-content"
     >
       <div
         class="mobile-tab-panel mobile-key-tab"
@@ -29203,7 +29203,7 @@ exports[`Component Snapshots > App layout snapshots > renders mobile layout snap
       </button>
     </div>
     <div
-      class="mobile-tab-content panel-surface"
+      class="mobile-tab-content"
     >
       <div
         class="mobile-tab-panel mobile-key-tab"

--- a/src/components/MobileTabPanel.css
+++ b/src/components/MobileTabPanel.css
@@ -1,3 +1,0 @@
-.mobile-tab-content {
-  padding: 0 var(--space-3);
-}

--- a/src/components/MobileTabPanel.tsx
+++ b/src/components/MobileTabPanel.tsx
@@ -1,6 +1,5 @@
 import type React from "react";
 import { ToggleBar } from "./ToggleBar";
-import "./MobileTabPanel.css";
 
 const MOBILE_TAB_OPTIONS = [
   { value: "key", label: "Key" },

--- a/src/components/MobileTabPanel.tsx
+++ b/src/components/MobileTabPanel.tsx
@@ -33,7 +33,7 @@ export function MobileTabPanel({
         onChange={setMobileTab}
         variant="tabs"
       />
-      <div className="mobile-tab-content panel-surface">
+      <div className="mobile-tab-content">
         {mobileTab === "key" && keyTabContent}
         {mobileTab === "scale" && scaleChordTabContent}
         {mobileTab === "fretboard" && settingsTabContent}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated mobile tab panel styling by removing applied padding properties and simplifying the component's styling structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->