### PR TITLE
ci: audit ci cd pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,51 +3,27 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.husky/**'
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, edited, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.husky/**'
 
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
-  validate-pr:
-    name: PR Title
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Validate PR title (conventional commit format)
-        env:
-          TITLE: ${{ github.event.pull_request.title }}
-          IS_DRAFT: ${{ github.event.pull_request.draft }}
-        run: |
-          if [[ "$IS_DRAFT" == "true" ]]; then
-            echo "ℹ️ Draft PR — skipping title validation until ready for review"
-            exit 0
-          fi
-          if [[ ! "$TITLE" =~ ^(feat|fix|chore|refactor|docs|test|style|perf|ci|build|revert)(\([^()]+\))?\!?:\ .+ ]]; then
-            echo "❌ PR title must follow conventional commits: type(scope): description"
-            echo "   Examples: feat: add capo support"
-            echo "             fix(fretboard): off-by-one on fret 0 highlight"
-            echo "   Tip: draft PRs may keep a temporary title until ready for review"
-            exit 1
-          fi
-          description="${TITLE#*: }"
-          if [ ${#description} -gt 72 ]; then
-            echo "❌ PR subject must be ≤ 72 chars (got ${#description})"
-            exit 1
-          fi
-          if [[ "${description: -1}" == "." ]]; then
-            echo "❌ PR subject must not end with a period"
-            exit 1
-          fi
-          echo "✅ PR title OK"
-
   test:
     name: Tests
     runs-on: ubuntu-latest
@@ -79,6 +55,12 @@ jobs:
           cache: npm
 
       - run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,46 @@
+name: PR Title
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-title-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-pr:
+    name: PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title (conventional commit format)
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          if [[ "$IS_DRAFT" == "true" ]]; then
+            echo "ℹ️ Draft PR — skipping title validation until ready for review"
+            exit 0
+          fi
+          if [[ ! "$TITLE" =~ ^(feat|fix|chore|refactor|docs|test|style|perf|ci|build|revert)(\([^()]+\))?\!?:\ .+ ]]; then
+            echo "❌ PR title must follow conventional commits: type(scope): description"
+            echo "   Examples: feat: add capo support"
+            echo "             fix(fretboard): off-by-one on fret 0 highlight"
+            echo "   Tip: draft PRs may keep a temporary title until ready for review"
+            exit 1
+          fi
+          description="${TITLE#*: }"
+          if [ ${#description} -gt 72 ]; then
+            echo "❌ PR subject must be ≤ 72 chars (got ${#description})"
+            exit 1
+          fi
+          if [[ "${description: -1}" == "." ]]; then
+            echo "❌ PR subject must not end with a period"
+            exit 1
+          fi
+          echo "✅ PR title OK"


### PR DESCRIPTION
Split PR title validation into its own workflow (pr-title.yml) so that
editing a PR title no longer re-triggers the full lint/test/e2e/build
chain in ci.yml. The `edited` pull_request type is dropped from ci.yml
and moved to the dedicated title validator.

Also cleans up related inefficiencies surfaced during the audit:
- Add paths-ignore for **.md, LICENSE, and .husky/** so doc-only
  changes skip CI.
- Widen the ci.yml concurrency key to include github.event_name so
  push and pull_request events on the same ref stop cancelling each
  other unnecessarily.
- Cache ~/.cache/ms-playwright in the e2e job to avoid re-downloading
  Chromium on every run.

After this change:
- Editing a PR title runs only pr-title.yml (fast, no checkout).
- Pushing a commit runs ci.yml as before.
- Doc-only pushes/PRs skip ci.yml.