### PR TITLE
claude/update-favicon-logo-MOAP0

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,16 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
-  <rect width="40" height="40" rx="9" fill="#18110d"/>
-  <rect x="2" y="4" width="36" height="32" rx="6" fill="#5b3a29" stroke="#f5e7d0" stroke-width="1.5"/>
-  <g stroke="#f5e7d0" stroke-linecap="round" stroke-width="1.5">
-    <line x1="2" y1="12" x2="38" y2="12"/>
-    <line x1="2" y1="20" x2="38" y2="20"/>
-    <line x1="2" y1="28" x2="38" y2="28"/>
+  <defs>
+    <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0a84ff"/>
+      <stop offset="100%" stop-color="#ff9f0a"/>
+    </linearGradient>
+  </defs>
+  <rect width="40" height="40" rx="10" fill="url(#logoGradient)"/>
+  <g transform="translate(10 10) scale(0.8333)" fill="none" stroke="#ffffff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M9 18V5l12-2v13"/>
+    <circle cx="6" cy="18" r="3"/>
+    <circle cx="18" cy="16" r="3"/>
   </g>
-  <g stroke="#f5e7d0" stroke-width="1.5">
-    <line x1="12" y1="4" x2="12" y2="36"/>
-    <line x1="22" y1="4" x2="22" y2="36"/>
-    <line x1="32" y1="4" x2="32" y2="36"/>
-  </g>
-  <circle cx="17" cy="20" r="4.5" fill="#22c55e"/>
-  <circle cx="15.2" cy="18.2" r="1.3" fill="#bbf7d0" opacity="0.9"/>
 </svg>


### PR DESCRIPTION
Replace the previous fretboard-themed favicon with one that mirrors
the in-app .logo-icon: a rounded square with the accent-primary →
accent-secondary 135° gradient and a white Lucide Music icon, so the
browser tab matches the app header.