### PR TITLE
chore: fix drawer keyboard nav

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1298,6 +1298,10 @@
   transition: opacity var(--transition-slow);
 }
 
+.drawer-options:focus-visible {
+  outline: none;
+}
+
 .drawer-options--above {
   top: auto;
   bottom: calc(100% + 4px);

--- a/src/DrawerSelector.tsx
+++ b/src/DrawerSelector.tsx
@@ -59,6 +59,20 @@ export function DrawerSelector(props: DrawerSelectorProps) {
     }
   }, [open, selectedIndex]);
 
+  // Reliably move focus to the listbox when it opens (autoFocus on div is not reliable)
+  useEffect(() => {
+    if (open && listboxRef.current) {
+      listboxRef.current.focus();
+    }
+  }, [open]);
+
+  // Scroll the focused option into view when activeIndex changes
+  useEffect(() => {
+    if (!open || !listboxRef.current) return;
+    const focused = listboxRef.current.querySelector<HTMLElement>(".drawer-option.focused");
+    focused?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, open]);
+
   useEffect(() => {
     if (!open || !containerRef.current) return;
     const rect = containerRef.current.getBoundingClientRect();
@@ -95,6 +109,7 @@ export function DrawerSelector(props: DrawerSelectorProps) {
         onClick={() => setOpen((o) => !o)}
         onKeyDown={(e) => {
           if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+            e.preventDefault();
             if (!open) {
               setOpen(true);
             }
@@ -116,7 +131,6 @@ export function DrawerSelector(props: DrawerSelectorProps) {
           role="listbox"
           aria-label={label}
           tabIndex={0}
-          autoFocus
           aria-activedescendant={flatOptions[activeIndex] === null ? `${listboxId}-none` : `${listboxId}-${sanitizeId(flatOptions[activeIndex] as string)}`}
           className={clsx(
             "drawer-options",


### PR DESCRIPTION
- Replace unreliable autoFocus on listbox div with explicit .focus() in
  useEffect so arrow keys always work after opening via keyboard
- Add scrollIntoView effect so the focused option stays visible when
  navigating long lists
- Add e.preventDefault() on trigger arrow keys to prevent page scroll
- Suppress default browser focus ring on listbox container via
  .drawer-options:focus-visible; .focused class on options handles visuals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Updated focus outline styling for drawer options container.

## Bug Fixes
* Enhanced keyboard navigation in drawer selector with automatic focus management when opening and improved scrolling behavior to keep focused items visible when using arrow key navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->