### PR TITLE
claude/fix-text-rendering-case-OF1s1

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import {
   formatAccidental,
 } from "./theory";
 import { Music, Settings2, Volume2, VolumeX, HelpCircle } from "lucide-react";
+import { getFocusableElements } from "./utils/dom";
 import { synth } from "./audio";
 import { CircleOfFifths } from "./CircleOfFifths";
 import { DEGREE_COLORS, getDegreesForScale } from "./degrees";
@@ -165,15 +166,6 @@ function AppContent() {
   const helpModalRef = useRef<HTMLDivElement>(null);
   const helpTriggerRef = useRef<HTMLButtonElement>(null);
   const layout = useLayoutMode();
-
-  function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
-    if (!container) return [];
-    return Array.from(
-      container.querySelectorAll<HTMLElement>(
-        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      ),
-    ).filter((el) => el.getAttribute("aria-hidden") !== "true");
-  }
 
   // Focus trap + focus restoration for help modal
   useEffect(() => {

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -25,6 +25,7 @@ import {
   getResponsiveTier,
   type ResponsiveTier,
 } from "../layout/responsive";
+import { getFocusableElements } from "../utils/dom";
 import "./SettingsOverlay.css";
 
 const END_FRET = 24;
@@ -165,15 +166,6 @@ function getViewportSnapshot() {
     width: window.innerWidth,
     height: window.innerHeight,
   };
-}
-
-function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
-  if (!container) return [];
-  return Array.from(
-    container.querySelectorAll<HTMLElement>(
-      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    ),
-  ).filter((element) => element.getAttribute("aria-hidden") !== "true");
 }
 
 function OverlaySection({

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,0 +1,9 @@
+export const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return [];
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter((el) => el.getAttribute("aria-hidden") !== "true");
+}


### PR DESCRIPTION
Removes duplicate focus-trap helper from App.tsx and SettingsOverlay.tsx
and consolidates into a single exported function with a named
FOCUSABLE_SELECTOR constant in src/utils/dom.ts.