### PR TITLE
docs: add worktree setup instruction for .vbw-planning symlink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ Scale degrees on circle use chromatic interval conversion: `(circleIntervalIndex
 When working in a new git worktree that lacks a `.vbw-planning` directory, check the parent repo (`git worktree list` to find the main working tree) for an existing `.vbw-planning`. If found, create a symlink from the worktree to the parent:
 
 ```bash
-MAIN_TREE=$(git worktree list --porcelain | grep -m1 '^worktree ' | cut -d' ' -f2)
+MAIN_TREE=$(git worktree list --porcelain | grep -m1 '^worktree ' | sed 's/^worktree //')
 if [ ! -e .vbw-planning ] && [ -d "$MAIN_TREE/.vbw-planning" ]; then
   ln -s "$MAIN_TREE/.vbw-planning" .vbw-planning
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,19 @@ Scale degrees on circle use chromatic interval conversion: `(circleIntervalIndex
 
 **`DrawerSelector`** = accordion dropdown in `src/DrawerSelector.tsx`. Use for any new selector controls → maintains visual consistency.
 
+## Worktree Setup
+
+When working in a new git worktree that lacks a `.vbw-planning` directory, check the parent repo (`git worktree list` to find the main working tree) for an existing `.vbw-planning`. If found, create a symlink from the worktree to the parent:
+
+```bash
+MAIN_TREE=$(git worktree list --porcelain | grep -m1 '^worktree ' | cut -d' ' -f2)
+if [ ! -e .vbw-planning ] && [ -d "$MAIN_TREE/.vbw-planning" ]; then
+  ln -s "$MAIN_TREE/.vbw-planning" .vbw-planning
+fi
+```
+
+This ensures all worktrees share a single source of truth for VBW planning state.
+
 ## Copyright
 
 © Isaac Cocar. Licensed under AGPLv3.


### PR DESCRIPTION
## Summary
- Adds a "Worktree Setup" section to CLAUDE.md with instructions to symlink `.vbw-planning` from the parent repo when working in a git worktree
- Ensures all worktrees share a single source of truth for VBW planning state instead of each worktree operating without planning context

## Test plan
- [ ] Verify the symlink command in the docs works: create a new worktree, run the snippet, confirm `.vbw-planning` resolves to the parent repo's directory
- [ ] Confirm no other CLAUDE.md sections were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new "Worktree Setup" guide with instructions for initializing and configuring git worktree environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->