### PR TITLE
style(theory): Pass 1 — CoF legibility + mode browser cleanup

### DIFF
--- a/src/CircleOfFifths.tsx
+++ b/src/CircleOfFifths.tsx
@@ -219,10 +219,10 @@ export function CircleOfFifths({
             enharmonicDisplay,
           );
           const noteFontSize = Math.max(
-            15,
-            isActive ? SIZE * 0.055 : SIZE * 0.048,
+            16,
+            isActive ? SIZE * 0.062 : SIZE * 0.054,
           );
-          const degreeFontSize = Math.max(10, SIZE * 0.038);
+          const degreeFontSize = Math.max(11, SIZE * 0.043);
 
           return (
             <g key={`text-group-${note}`} style={{ pointerEvents: "none" }}>
@@ -321,7 +321,7 @@ export function CircleOfFifths({
           textAnchor="middle"
           dominantBaseline="middle"
           fill="var(--neon-orange-bright)"
-          fontSize={Math.max(15, SIZE * 0.05)}
+          fontSize={Math.max(16, SIZE * 0.058)}
           fontWeight="bold"
           fontFamily="var(--font-display)"
           stroke="rgba(0,0,0,0.3)"
@@ -337,7 +337,7 @@ export function CircleOfFifths({
           textAnchor="middle"
           dominantBaseline="middle"
           fill="var(--neon-cyan-bright)"
-          fontSize={Math.max(15, SIZE * 0.055)}
+          fontSize={Math.max(16, SIZE * 0.064)}
           fontWeight="bold"
           fontFamily="var(--font-display)"
           stroke="rgba(0,0,0,0.3)"

--- a/src/components/LabeledSelect.css
+++ b/src/components/LabeledSelect.css
@@ -84,7 +84,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/src/components/LabeledSelect.css
+++ b/src/components/LabeledSelect.css
@@ -72,6 +72,23 @@
   font-size: 0.92rem;
 }
 
+/* Visually-hidden label: accessible to screen readers via <label htmlFor>, invisible visually. */
+.labeled-select--hide-label .labeled-select-label {
+  gap: 0;
+}
+
+.labeled-select--hide-label .labeled-select-label-text {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Desktop: tighter select height — Phase 3 density pass. */
 .app-container[data-layout-tier="desktop"] .labeled-select-native {
   min-height: 2.65rem;

--- a/src/components/LabeledSelect.tsx
+++ b/src/components/LabeledSelect.tsx
@@ -17,6 +17,7 @@ export interface LabeledSelectProps {
   className?: string;
   'aria-describedby'?: string;
   disabled?: boolean;
+  hideLabel?: boolean;
 }
 
 export function LabeledSelect({
@@ -28,12 +29,13 @@ export function LabeledSelect({
   className,
   'aria-describedby': ariaDescribedBy,
   disabled,
+  hideLabel,
 }: LabeledSelectProps) {
   const generatedId = useId();
   const selectId = id ?? generatedId;
 
   return (
-    <div className={clsx('labeled-select', { 'labeled-select--disabled': disabled }, className)}>
+    <div className={clsx('labeled-select', { 'labeled-select--disabled': disabled, 'labeled-select--hide-label': hideLabel }, className)}>
       <label className="labeled-select-label" htmlFor={selectId}>
         <span className="labeled-select-label-text">{label}</span>
         <div className="labeled-select-field">

--- a/src/components/TheoryControls.tsx
+++ b/src/components/TheoryControls.tsx
@@ -212,6 +212,7 @@ export function TheoryControls({
             <div className="theory-browser-selector">
               <LabeledSelect
                 label={memberTerm}
+                hideLabel
                 value={activeBrowseOption.label}
                 options={browseSelectOptions}
                 onChange={handleBrowseSelect}


### PR DESCRIPTION
## Summary

- **Circle of Fifths text legibility**: Increased note label font sizes ~12–13% (inactive `SIZE*0.048→0.054`, active `SIZE*0.055→0.062`), degree labels `0.038→0.043`, center note/key-sig `0.05/0.055→0.058/0.064`. No change to circle diameter, radii, or container sizing.
- **Removed duplicate "Mode" label**: The theory browser row was showing "MODE" twice — once as a `section-label` span above the row and again as the `LabeledSelect` internal label. Added a `hideLabel` prop to `LabeledSelect` that applies an sr-only pattern (visually hidden, accessible to screen readers via `<label htmlFor>`). Passes `hideLabel` on the browse select; section-label above the row remains as the single visible label.
- **Snapshot updates**: 30 CoF snapshots regenerated to reflect new font-size attribute values.

## What changed and why

The CoF labels were rendered small enough (~13–16px effective at desktop-3col's constrained size) that note names required close attention to read. Bumping the multipliers brings them to ~17–20px without touching layout.

The "Mode" duplication was a structural issue: `TheoryControls` passed `memberTerm` both as a bare `section-label` and as the `LabeledSelect` `label` prop, which the component always renders visibly. The fix adds a controlled escape hatch (`hideLabel`) to `LabeledSelect` rather than changing its default behavior.

## Files changed

| File | Change |
|---|---|
| `src/CircleOfFifths.tsx` | Font size multiplier bumps |
| `src/components/LabeledSelect.tsx` | Add `hideLabel?: boolean` prop |
| `src/components/LabeledSelect.css` | Sr-only rules for `--hide-label` modifier |
| `src/components/TheoryControls.tsx` | Pass `hideLabel` to browse select |
| `src/__tests__/__snapshots__/snapshots.test.tsx.snap` | Updated CoF snapshots |

## Test plan

- [x] `npm run lint` — clean (warnings in coverage files only, pre-existing)
- [x] `npm run test` — 670/670 pass after snapshot update
- [x] `npm run build` — clean
- [x] Verified `visibleModeLabels: 0` at all six target viewports (1440×900, 768×1024, 375×667, 390×844, 1024×1366, 1920×1080)
- [x] Confirmed CoF note font sizes 19.84px / 17.28px at desktop and tablet
- [x] Screen reader accessibility preserved — hidden label still associated via `<label htmlFor>`; existing tests find combobox by accessible name "Mode" without change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Increased text sizing across the Circle of Fifths visualization—note labels, degree markers, and center text are more readable.
  * Added an option to visually hide select labels while keeping them accessible to screen readers.
  * Applied hidden-label behavior to the scale browse selector in the controls for a cleaner UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->