### PR TITLE
style(theory): Pass 2 — mode browser compound + fret range dashboard

### DIFF
--- a/src/components/ExpandedControlsPanel.tsx
+++ b/src/components/ExpandedControlsPanel.tsx
@@ -66,8 +66,7 @@ export function BaseControlsSection() {
           onStartChange={setFretStart}
           onEndChange={setFretEnd}
           maxFret={END_FRET}
-          layout="mobile"
-          showLabels
+          layout="dashboard"
         />
       </div>
     </Card>

--- a/src/components/FretRangeControl.css
+++ b/src/components/FretRangeControl.css
@@ -76,3 +76,29 @@
   align-items: center;
   justify-content: center;
 }
+
+/* Dashboard: compact, no wrap, labels visible — fits card context on tablet/desktop */
+.fret-range-control.dashboard {
+  flex-wrap: nowrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.fret-range-control.dashboard .fret-group {
+  gap: 0.3rem;
+}
+
+.fret-range-control.dashboard .fret-btn {
+  min-width: 2.15rem;
+  min-height: 2.15rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.45rem;
+  font-size: 0.84rem;
+}
+
+.fret-range-control.dashboard .fret-label {
+  min-width: auto;
+  font-size: 0.7rem;
+}

--- a/src/components/FretRangeControl.test.tsx
+++ b/src/components/FretRangeControl.test.tsx
@@ -171,6 +171,27 @@ describe("FretRangeControl", () => {
     });
   });
 
+  describe("Dashboard layout", () => {
+    it("renders with Start/End labels", () => {
+      render(<FretRangeControl {...defaultProps} layout="dashboard" />);
+      expect(screen.getByText("Start")).toBeTruthy();
+      expect(screen.getByText("End")).toBeTruthy();
+    });
+
+    it('shows "—" separator', () => {
+      render(<FretRangeControl {...defaultProps} layout="dashboard" />);
+      expect(screen.getByText("—")).toBeTruthy();
+    });
+
+    it("uses −/+ symbols by default", () => {
+      render(<FretRangeControl {...defaultProps} layout="dashboard" />);
+      const buttons = screen.getAllByRole("button");
+      const symbols = buttons.map((b) => b.textContent);
+      expect(symbols.filter((s) => s === "−").length).toBe(2);
+      expect(symbols.filter((s) => s === "+").length).toBe(2);
+    });
+  });
+
   describe("Custom symbols", () => {
     it("overrides decrement and increment symbols via props", () => {
       render(

--- a/src/components/FretRangeControl.tsx
+++ b/src/components/FretRangeControl.tsx
@@ -7,7 +7,7 @@ export interface FretRangeControlProps {
   onStartChange: (fret: number) => void;
   onEndChange: (fret: number) => void;
   maxFret: number;
-  layout?: "toolbar" | "mobile";
+  layout?: "toolbar" | "mobile" | "dashboard";
   showSeparator?: boolean;
   showLabels?: boolean;
   decrementSymbol?: string;
@@ -26,8 +26,9 @@ export function FretRangeControl({
   decrementSymbol,
   incrementSymbol,
 }: FretRangeControlProps) {
-  const isToolbar = (layout ?? "toolbar") === "toolbar";
-  const sep = showSeparator ?? isToolbar;
+  const isToolbar = layout === "toolbar" || layout === undefined;
+  const isMobile = layout === "mobile";
+  const sep = showSeparator ?? !isMobile;
   const labels = showLabels ?? !isToolbar;
   const dec = decrementSymbol ?? (isToolbar ? "◀" : "−");
   const inc = incrementSymbol ?? (isToolbar ? "▶" : "+");

--- a/src/components/TheoryControls.css
+++ b/src/components/TheoryControls.css
@@ -4,62 +4,110 @@
   gap: 0.95rem;
 }
 
-.theory-browser-row {
-  display: flex;
-  align-items: center;
-  gap: 0.7rem;
-}
+/* ── Mode browser panel ─────────────────────────────────────────────────── */
 
-.theory-browser-main {
-  flex: 1 1 auto;
-  min-width: 0;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  align-items: center;
+.theory-mode-browser {
+  display: flex;
+  flex-direction: column;
   gap: 0.65rem;
 }
 
+/* Compound nav strip: left-btn | select | right-btn as one connected widget */
+.theory-browser-main {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: stretch;
+  gap: 0;
+  border: 1px solid rgb(255 255 255 / 0.1);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.035), rgb(255 255 255 / 0.018)),
+    rgb(12 16 24 / 0.95);
+  overflow: hidden;
+}
+
+/* Selector cell stretches to fill compound height */
 .theory-browser-selector {
+  display: flex;
+  align-items: stretch;
   min-width: 0;
 }
 
+/* Cascade LabeledSelect internals to fill height within compound */
+.theory-browser-main .labeled-select,
+.theory-browser-main .labeled-select-label {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+}
+
+.theory-browser-main .labeled-select-label {
+  flex-direction: row;
+  gap: 0;
+  align-items: stretch;
+}
+
+.theory-browser-main .labeled-select-field {
+  flex: 1;
+}
+
+/* Strip native select of its own chrome — inherits compound surface */
+.theory-browser-main .labeled-select-native {
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  min-height: unset;
+  padding-left: 0.85rem;
+  padding-right: 2.4rem;
+}
+
+.theory-browser-main .labeled-select-native:hover {
+  border-color: transparent;
+}
+
+/* Inset focus ring — avoids overflow:hidden clipping */
+.theory-browser-main .labeled-select-native:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--neon-cyan);
+}
+
+/* Nav buttons — no individual border/bg; inner dividers via border-right/left */
 .theory-nav-btn {
-  width: 3rem;
+  width: 2.75rem;
   height: 3rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid rgb(255 255 255 / 0.1);
-  border-radius: 0.95rem;
-  background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.04), rgb(255 255 255 / 0.02)),
-    rgb(15 20 29 / 0.95);
+  border: none;
+  border-right: 1px solid rgb(255 255 255 / 0.08);
+  border-radius: 0;
+  background: transparent;
   color: rgb(228 238 248 / 0.92);
   cursor: pointer;
-  transition: var(--transition-surface), transform var(--transition-fast);
+  transition: background-color var(--transition-fast) ease, color var(--transition-fast) ease;
+  flex-shrink: 0;
+}
+
+.theory-browser-main > .theory-nav-btn:last-child {
+  border-right: none;
+  border-left: 1px solid rgb(255 255 255 / 0.08);
 }
 
 .theory-nav-btn:hover {
-  border-color: rgb(77 228 255 / 0.48);
+  background: rgb(77 228 255 / 0.09);
   color: white;
-  transform: translateY(-1px);
 }
 
-.theory-nav-btn:focus-visible,
+/* Inset focus for nav buttons — same reason as select */
+.theory-nav-btn:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--neon-cyan);
+}
+
 .theory-disclosure-btn:focus-visible {
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
-}
-
-.theory-browse-mode {
-  gap: 0.55rem;
-}
-
-.theory-inline-label-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
 }
 
 .theory-chord-section,
@@ -119,13 +167,9 @@
 }
 
 @media (max-width: 767px) {
-  .theory-browser-main {
-    gap: 0.5rem;
-  }
-
   .theory-nav-btn {
     width: 2.7rem;
-    height: 2.7rem;
+    /* height stays 3rem — matches select min-height on mobile */
   }
 }
 
@@ -140,7 +184,8 @@
   gap: 0.58rem;
 }
 
+/* Desktop: shrink compound nav to match the desktop select height (2.65rem) */
 .app-container[data-layout-tier="desktop"] .theory-nav-btn {
-  width: 2.6rem;
-  height: 2.6rem;
+  width: 2.5rem;
+  height: 2.65rem;
 }

--- a/src/components/TheoryControls.tsx
+++ b/src/components/TheoryControls.tsx
@@ -198,9 +198,13 @@ export function TheoryControls({
       </div>
 
       <div className={shared["control-section"]}>
-        <span className={shared["section-label"]}>{memberTerm}</span>
-        <div className="theory-browser-row">
-          <div className="theory-browser-main">
+        <div className="theory-mode-browser panel-surface panel-surface--compact">
+          <span className={shared["section-label"]}>{memberTerm}</span>
+          <div
+            className="theory-browser-main"
+            role="group"
+            aria-label={`Browse ${memberTerm}`}
+          >
             <button
               type="button"
               className="theory-nav-btn"
@@ -227,24 +231,18 @@ export function TheoryControls({
               <ChevronRight size={16} />
             </button>
           </div>
+          {supportsRelativeBrowse ? (
+            <ToggleBar
+              options={[
+                { value: "parallel", label: "Parallel" },
+                { value: "relative", label: "Relative" },
+              ]}
+              value={effectiveBrowseMode}
+              onChange={(value) => setScaleBrowseMode(value as ScaleBrowseMode)}
+            />
+          ) : null}
         </div>
       </div>
-
-      {supportsRelativeBrowse ? (
-        <div className={clsx(shared["control-section"], "theory-browse-mode")}>
-          <div className="theory-inline-label-row">
-            <span className={shared["section-label"]}>Parallel / Relative</span>
-          </div>
-          <ToggleBar
-            options={[
-              { value: "parallel", label: "Parallel" },
-              { value: "relative", label: "Relative" },
-            ]}
-            value={effectiveBrowseMode}
-            onChange={(value) => setScaleBrowseMode(value as ScaleBrowseMode)}
-          />
-        </div>
-      ) : null}
 
       {keyExplorer ? (
         <div className="theory-inline-key panel-surface panel-surface--compact">


### PR DESCRIPTION
## Summary

- **Mode browser** — the `[◀] [select▾] [▶]` nav row is now a single connected compound widget (`gap:0`, shared border + background, `overflow:hidden`, inner dividers between elements). The Parallel/Relative ToggleBar moves inside the same `panel-surface` panel, so the entire browsing control reads as one intentional unit.
- **Fret range** — adds a `dashboard` layout variant to `FretRangeControl`. Fixes the root-cause mismatch: `ExpandedControlsPanel` was passing `layout="mobile"` (large touch targets, `flex-wrap:wrap`) on tablet/desktop. The new `dashboard` variant is compact (2.15rem buttons), labelled, non-wrapping, and appropriate for the Configuration card context. Settings overlay keeps `layout="mobile"` unchanged.
- **Focus rings** — compound nav buttons and the select use inset `box-shadow` focus rings to avoid clipping by `overflow:hidden` on the compound container.

## Root cause of fret range mismatch

`ExpandedControlsPanel.tsx` passed `layout="mobile"` to `FretRangeControl` in the dashboard card. No `dashboard` variant existed, so the mobile treatment (with touch-target-sized buttons and `flex-wrap`) was the only labelled option.

## Files changed

| File | Change |
|---|---|
| `TheoryControls.tsx` | Mode browser restructured into `.theory-mode-browser panel-surface` panel; ToggleBar moved inside |
| `TheoryControls.css` | Compound nav strip; inset focus rings |
| `FretRangeControl.tsx` | `"dashboard"` added to layout union; separator/label defaults updated |
| `FretRangeControl.css` | `.fret-range-control.dashboard` compact styles |
| `ExpandedControlsPanel.tsx` | `layout="dashboard"`, dropped redundant `showLabels` |
| `FretRangeControl.test.tsx` | Dashboard layout coverage added |
| `snapshots.test.tsx.snap` | 9 snapshots updated |

## Test plan

- [x] 673 tests pass, build clean
- [x] 1440×900 (desktop-3col): compound mode browser + dashboard fret range
- [x] 768×1024 (tablet): compound mode browser + dashboard fret range
- [x] 375×667 mobile: Theory tab compound browser works; View tab unaffected
- [x] 390×844 mobile regression clean
- [x] 1024×1366 (iPad Pro, desktop-split): both controls verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard layout variant for fret range control, providing compact spacing and adjusted button/label sizing for dashboard displays.

* **UI Updates**
  * Reorganized theory controls interface by integrating the mode selection toggle into the main browser panel.
  * Enhanced mode browser styling with improved layout, borders, rounded corners, and visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->