### PR TITLE
style(theory): improve Mode browser surface background

### DIFF
--- a/src/components/TheoryControls.css
+++ b/src/components/TheoryControls.css
@@ -10,6 +10,16 @@
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
+  /* Override panel-surface flat token — align with the frosted cool-blue
+     language used by .theory-chord-section and .theory-inline-key */
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.04), rgb(255 255 255 / 0.01)),
+    rgb(12 17 25 / 0.68);
+  border: 1px solid rgb(255 255 255 / 0.1);
+  /* Top-edge gleam + soft outer shadow for nested depth */
+  box-shadow:
+    0 1px 0 rgb(255 255 255 / 0.06) inset,
+    0 2px 10px rgb(0 0 0 / 0.18);
 }
 
 /* Compound nav strip: left-btn | select | right-btn as one connected widget */


### PR DESCRIPTION
## Summary

- Overrides the `panel-surface` flat-token background on `.theory-mode-browser` with the frosted cool-blue treatment already used by `.theory-chord-section` and `.theory-inline-key`
- Adds a top-edge gleam (`inset 0 1px 0`) and soft drop shadow for nested-panel depth
- No logic or layout changes — CSS-only, single file

## Why

`panel-surface` resolves to `--surface-base: #1c1c1e` (flat warm gray), which clashes with the cool-blue `rgba(12,17,25)` language everywhere else in the Theory controls column. This override aligns the Mode browser visually.

## Test plan

- [ ] Verify Mode browser panel matches the frosted look of the Chord and Key sections
- [ ] Verify no regressions on mobile, tablet, or desktop layout tiers
- [ ] `npm run lint && npm run test && npm run build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined the theory mode browser panel with an updated frosted cool-blue aesthetic, improved semi-transparent border styling, and enhanced layered shadow effects for better visual clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->