### PR TITLE
fix(tablet): enable native touch scroll on fretboard

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -979,6 +979,12 @@
   margin: 0 auto;
 }
 
+/* Tablet: enable native touch scroll on the fretboard (same as mobile). */
+.app-container[data-layout-tier="tablet"] .fretboard-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 /* Landscape mobile: fretboard hero, minimal chrome */
 .app-container[data-layout-variant="landscape-mobile"] {
   padding: 0.5rem;


### PR DESCRIPTION
## Summary

- Tablet layout was missing `overflow-x: auto` on `.fretboard-wrapper`, leaving the default `overflow-x: hidden`
- Native touch scroll was silently blocked on tablet; only the JS pointer-drag handler worked
- Added `[data-layout-tier="tablet"] .fretboard-wrapper { overflow-x: auto; -webkit-overflow-scrolling: touch; }` — mirrors the equivalent rule already present in the `@media (max-width: 767px)` mobile block

## Test plan

- [ ] On iPad (or browser DevTools tablet emulation), verify the fretboard scrolls with a native swipe gesture
- [ ] Confirm drag-to-scroll still works (pointer drag handler is unchanged)
- [ ] Confirm mobile scroll still works (untouched)
- [ ] `npm run lint` + `npm run test` pass (673 tests ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling functionality for tablet devices. Horizontal scrolling with native touch support is now available on tablets for the fretboard interface, ensuring a seamless and consistent experience across all device sizes. Users on tablets can now scroll through the fretboard smoothly using touch gestures, matching the mobile experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->