### PR TITLE
style(overlay): Pass 3 — help modal + settings drawer refresh

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -143,24 +143,20 @@
 /* Help Modal */
 .help-modal-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  inset: 0;
+  background: var(--chrome-scrim);
   display: flex;
   align-items: center;
   justify-content: center;
-  /* z-index token — see semantic.css for the full z-index registry */
   z-index: var(--z-help-overlay);
   padding: clamp(0.75rem, 3vw, 1.25rem);
 }
 
 .help-modal {
-  background-color: var(--surface-raised);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--surface-highlight);
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  background: var(--panel-surface-bg);
+  border-radius: var(--radius-xl);
+  border: var(--panel-surface-border);
+  box-shadow: var(--elevation-overlay);
   width: min(42rem, calc(100vw - 2 * clamp(0.75rem, 3vw, 1.25rem)));
   max-width: 100%;
   max-height: min(88dvh, 48rem);
@@ -168,6 +164,7 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  will-change: transform, opacity;
 }
 
 .help-modal--full-width {
@@ -179,38 +176,47 @@
   justify-content: space-between;
   align-items: center;
   gap: var(--space-3);
-  padding: clamp(0.75rem, 2vw, 1rem) clamp(1rem, 3vw, 1.25rem);
-  border-bottom: 1px solid var(--surface-highlight);
+  padding: 12px clamp(1rem, 3vw, 1.25rem);
+  border-bottom: 1px solid var(--chrome-border);
   flex-shrink: 0;
+  background: color-mix(in srgb, var(--panel-surface-bg) 92%, white 8%);
 }
 
 .help-modal-header h2 {
   margin: 0;
-  font-size: var(--text-lg);
+  font-size: 1rem;
   font-weight: 600;
+  color: var(--chrome-fg);
   min-width: 0;
 }
 
 .help-modal-close {
-  background: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
   border: none;
-  font-size: 24px;
-  line-height: 1;
-  color: var(--text-muted);
+  color: var(--chrome-fg-muted);
   cursor: pointer;
-  padding: var(--space-1);
+  padding: 6px;
   border-radius: var(--radius-sm);
-  transition: background-color var(--transition-fast);
+  transition: var(--transition-surface);
+  flex-shrink: 0;
 }
 
 .help-modal-close:hover {
-  background-color: var(--surface-highlight);
-  color: var(--text-primary);
+  color: var(--chrome-fg);
+  background-color: var(--chrome-hover-bg);
 }
 
 .help-modal-close:focus-visible {
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
+}
+
+.help-modal-close .icon {
+  width: 20px;
+  height: 20px;
 }
 
 .help-modal-content {
@@ -224,8 +230,11 @@
 .help-modal-content h3 {
   margin-top: var(--space-4);
   margin-bottom: var(--space-2);
-  font-size: var(--text-base);
-  font-weight: 600;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--chrome-fg-muted);
 }
 
 .help-modal-content h3:first-child {
@@ -234,7 +243,9 @@
 
 .help-modal-content p {
   margin-bottom: var(--space-3);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
+  color: var(--chrome-fg);
+  font-size: 0.9375rem;
 }
 
 .help-modal-content ul {
@@ -244,11 +255,14 @@
 
 .help-modal-content li {
   margin-bottom: var(--space-2);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
+  color: var(--chrome-fg);
+  font-size: 0.9375rem;
 }
 
 .help-modal-content strong {
   font-weight: 600;
+  color: var(--chrome-fg);
 }
 
 /* Main Fretboard */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,8 @@ import {
   getNoteDisplayInScale,
   formatAccidental,
 } from "./theory";
-import { HelpCircle, Settings2, Volume2, VolumeX } from "lucide-react";
+import { HelpCircle, Settings2, Volume2, VolumeX, X } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 import { getFocusableElements } from "./utils/dom";
 import { synth } from "./audio";
 import { CircleOfFifths } from "./CircleOfFifths";
@@ -299,80 +300,111 @@ function AppContent() {
       )}
 
       {/* Help Modal */}
-      {showHelp && (
-        <div className="help-modal-overlay">
-          <div
-            ref={helpModalRef}
-            className={clsx("help-modal", {
-              "help-modal--full-width": layout.fullWidthOverlay,
-            })}
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="help-modal-title"
+      <AnimatePresence>
+        {showHelp ? (
+          <motion.div
+            className="help-modal-overlay"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
           >
-            <div className="help-modal-header">
-              <h2 id="help-modal-title">FretFlow Help</h2>
-              <button
-                type="button"
-                className="help-modal-close"
-                onClick={() => setShowHelp(false)}
-                title="Close help"
-                aria-label="Close help"
-              >
-                ×
-              </button>
-            </div>
-            <div className="help-modal-content">
-              <h3>Getting Started</h3>
-              <p>
-                FretFlow is an interactive guitar fretboard and music theory
-                tool. Use the controls below to explore scales, chords, and
-                fingering patterns.
-              </p>
+            <motion.div
+              ref={helpModalRef}
+              className={clsx("help-modal", {
+                "help-modal--full-width": layout.fullWidthOverlay,
+              })}
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="help-modal-title"
+              tabIndex={-1}
+              onClick={(e) => e.stopPropagation()}
+              initial={{ opacity: 0, scale: 0.96 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.96 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+            >
+              <div className="help-modal-header">
+                <h2 id="help-modal-title">FretFlow Help</h2>
+                <button
+                  type="button"
+                  className="help-modal-close"
+                  onClick={() => setShowHelp(false)}
+                  aria-label="Close help"
+                >
+                  <X className="icon" />
+                </button>
+              </div>
+              <div className="help-modal-content">
+                <h3>Getting Started</h3>
+                <p>
+                  FretFlow is an interactive guitar fretboard and music theory
+                  tool. Choose a root note, scale type, and optional chord to
+                  explore how notes and intervals map across a 6-string guitar
+                  neck.
+                </p>
 
-              <h3>Basic Usage</h3>
-              <ul>
-                <li>
-                  <strong>Scale Selection:</strong> Choose a root note and scale
-                  type to highlight notes on the fretboard
-                </li>
-                <li>
-                  <strong>Chord Overlay:</strong> Select a chord to see which
-                  scale notes are chord tones
-                </li>
-                <li>
-                  <strong>Fret Range:</strong> Adjust which frets are visible
-                </li>
-              </ul>
+                <h3>Basic Usage</h3>
+                <ul>
+                  <li>
+                    <strong>Scale Selection:</strong> Pick a root note and scale
+                    type to highlight the matching notes on the fretboard.
+                  </li>
+                  <li>
+                    <strong>Chord Overlay:</strong> Select a chord to
+                    distinguish chord tones from other scale notes. Use the
+                    interval filter to narrow which chord tones appear.
+                  </li>
+                  <li>
+                    <strong>Fingering Patterns:</strong> Enable CAGED shapes or
+                    3NPS positions to see positional overlays across the neck.
+                  </li>
+                  <li>
+                    <strong>Circle of Fifths:</strong> Tap a key segment to
+                    change the root note. Degree markers show the current
+                    scale's intervals relative to each key.
+                  </li>
+                </ul>
 
-              <h3>Controls</h3>
-              <ul>
-                <li>
-                  <strong>Reset:</strong> Return all settings to defaults
-                </li>
-                <li>
-                  <strong>Mute:</strong> Toggle audio feedback when clicking
-                  notes
-                </li>
-                <li>
-                  <strong>Settings:</strong> Coming soon - additional
-                  preferences
-                </li>
-              </ul>
+                <h3>Controls</h3>
+                <ul>
+                  <li>
+                    <strong>Mute:</strong> Toggle audio feedback on note taps
+                    using the speaker icon in the header.
+                  </li>
+                  <li>
+                    <strong>Settings (gear icon):</strong> Adjust tuning, zoom,
+                    fret range, accidentals, enharmonic display, and chord
+                    spread. Reset all settings to defaults from Settings →
+                    Reset.
+                  </li>
+                </ul>
 
-              <h3>Tips</h3>
-              <ul>
-                <li>Click on fretboard notes to hear them (when unmuted)</li>
-                <li>Use the Circle of Fifths widget for key relationships</li>
-                <li>
-                  Try different fingering patterns to find comfortable positions
-                </li>
-                <li>Chord overlays help identify chord tones within scales</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      )}
+                <h3>Tips</h3>
+                <ul>
+                  <li>Tap any fretboard note to hear it play (when unmuted).</li>
+                  <li>
+                    The fret range control lets you focus on any section of the
+                    neck — useful for position-specific practice.
+                  </li>
+                  <li>
+                    CAGED shapes and 3NPS positions show how the same scale maps
+                    across different hand positions on the neck.
+                  </li>
+                  <li>
+                    The degree strip below the fretboard shows the interval
+                    structure of the selected scale.
+                  </li>
+                  <li>
+                    Enable "Hide non-chord notes" in the chord overlay to focus
+                    on playable chord voicings within the scale.
+                  </li>
+                </ul>
+              </div>
+            </motion.div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
 
       <main className="main-fretboard">
         <Fretboard

--- a/src/components/FretRangeControl.css
+++ b/src/components/FretRangeControl.css
@@ -65,8 +65,26 @@
 }
 
 .fret-range-control.mobile {
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 0.85rem;
+}
+
+.fret-range-control.mobile .fret-group {
+  flex-wrap: wrap;
+  align-content: flex-start;
+  gap: var(--space-1);
+}
+
+.fret-range-control.mobile .fret-label {
+  flex-basis: 100%;
+  min-width: unset;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--chrome-fg-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding-bottom: var(--space-1);
 }
 
 .fret-range-control.mobile .fret-btn {

--- a/src/components/SettingsOverlay.css
+++ b/src/components/SettingsOverlay.css
@@ -26,7 +26,7 @@
   flex-direction: column;
   overflow: hidden;
   will-change: transform;
-  box-shadow: 0 4px 24px color-mix(in srgb, var(--bg-color) 72%, transparent);
+  box-shadow: var(--elevation-overlay);
   border-left: 1px solid var(--chrome-border);
 }
 
@@ -94,8 +94,7 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
-  border: 1px solid color-mix(in srgb, var(--surface-highlight) 78%, transparent);
-  box-shadow: 0 12px 24px color-mix(in srgb, var(--chrome-bg) 84%, transparent);
+  box-shadow: var(--elevation-card);
 }
 
 .overlay-section-card--danger {


### PR DESCRIPTION
## Summary

- **Help modal chrome refresh**: replace Phase 4 raw values with Phase 5 semantic tokens; add `AnimatePresence`/`motion.div` entry animation; swap bare `×` text close for Lucide `X` icon matching the Settings drawer; fix 1.5rem title (`--text-lg` historical bug) → 1rem; `tabIndex={-1}` on modal div for focus-trap consistency
- **Help copy update**: remove stale "Settings: Coming soon" bullet; rewrite Controls section to describe the real Settings drawer; expand Basic Usage with CAGED/3NPS patterns and Circle of Fifths; add degree-strip and hide-non-chord-notes tips
- **Settings > View fret-range layout**: switch `mobile` variant from `flex-wrap` to `display:grid 1fr/1fr` — label stacks above stepper per column, preserves `--size-touch-target` button sizes, feels intentional rather than a utility row
- **Settings drawer shell**: drawer box-shadow → `--elevation-overlay`; section card removes diluted `color-mix` border override (letting `panel-surface` own it) and replaces raw shadow with `--elevation-card`

## Root cause

The Help modal was built before the Phase 5 token system and was never migrated. It used `rgba(0,0,0,0.5)` scrim, `var(--surface-raised)` card surface, a too-light box-shadow, no motion, and a plain text close button. The Settings section cards had a hand-rolled border color-mix that partially undercut the `panel-surface` border, and the drawer shadow referenced raw primitives instead of elevation tokens.

## Test plan

- [ ] Help modal opens/closes with fade+scale animation at 375×667, 768×1024, 1440×900
- [ ] Help modal close button (X icon) dismisses modal; Escape key also closes
- [ ] Focus trapped inside modal while open; focus restored to trigger on close
- [ ] Settings drawer opens; fret range shows two-column grid (Start / End) with labels above steppers
- [ ] Fret range touch targets are ≥ 36px (--size-touch-target) in Settings on mobile
- [ ] No regressions on dashboard fret-range control (layout="dashboard" unchanged)
- [ ] All 673 tests pass; lint clean; production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)