### PR TITLE
docs(help): update help modal to reflect current app controls and layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -339,65 +339,137 @@ function AppContent() {
                 <h3>Getting Started</h3>
                 <p>
                   FretFlow is an interactive guitar fretboard and music theory
-                  tool. Choose a root note, scale type, and optional chord to
-                  explore how notes and intervals map across a 6-string guitar
-                  neck.
+                  tool. Choose a root note, scale, and optional chord overlay to
+                  visualize notes and intervals across a 6-string guitar neck.
                 </p>
 
-                <h3>Basic Usage</h3>
+                <h3>Layout</h3>
                 <ul>
                   <li>
-                    <strong>Scale Selection:</strong> Pick a root note and scale
-                    type to highlight the matching notes on the fretboard.
+                    <strong>Mobile:</strong> The fretboard fills the center of
+                    the screen. A tab bar below switches between the{" "}
+                    <em>Theory</em> panel (scale, chord, Circle of Fifths) and
+                    the <em>View</em> panel (fingering patterns, note labels).
                   </li>
                   <li>
-                    <strong>Chord Overlay:</strong> Select a chord to
-                    distinguish chord tones from other scale notes. Use the
-                    interval filter to narrow which chord tones appear.
-                  </li>
-                  <li>
-                    <strong>Fingering Patterns:</strong> Enable CAGED shapes or
-                    3NPS positions to see positional overlays across the neck.
-                  </li>
-                  <li>
-                    <strong>Circle of Fifths:</strong> Tap a key segment to
-                    change the root note. Degree markers show the current
-                    scale's intervals relative to each key.
+                    <strong>Tablet &amp; desktop:</strong> Controls appear
+                    alongside the fretboard in three cards — Music Theory,
+                    Configuration, and Key Explorer.
                   </li>
                 </ul>
 
-                <h3>Controls</h3>
+                <h3>Choosing a Scale</h3>
                 <ul>
                   <li>
-                    <strong>Mute:</strong> Toggle audio feedback on note taps
-                    using the speaker icon in the header.
+                    <strong>Root:</strong> Tap a note in the note grid to set
+                    the tonic.
                   </li>
                   <li>
-                    <strong>Settings (gear icon):</strong> Adjust tuning, zoom,
-                    fret range, accidentals, enharmonic display, and chord
-                    spread. Reset all settings to defaults from Settings →
-                    Reset.
+                    <strong>Scale Family:</strong> Choose a broad family
+                    (Pentatonic, Diatonic, etc.) from the dropdown.
+                  </li>
+                  <li>
+                    <strong>Mode / Scale browser:</strong> Use the arrows or
+                    dropdown to step through the modes or keys within that
+                    family. The <em>Parallel</em> / <em>Relative</em> toggle
+                    controls whether browsing stays on the same root or cycles
+                    through relative keys.
+                  </li>
+                </ul>
+
+                <h3>Chord Overlay</h3>
+                <ul>
+                  <li>
+                    Expand <strong>Chord Overlay</strong> and pick a chord type
+                    to highlight chord tones on the fretboard in a distinct
+                    color.
+                  </li>
+                  <li>
+                    <strong>Link chord root to scale</strong> keeps the chord
+                    root in sync with the scale root automatically.
+                  </li>
+                  <li>
+                    <strong>Chord only (hide scale)</strong> dims non-chord
+                    notes so you can focus on playable voicings.
+                  </li>
+                  <li>
+                    <strong>Interval Filter</strong> narrows which chord tones
+                    appear — useful for isolating roots, fifths, or specific
+                    intervals.
+                  </li>
+                </ul>
+
+                <h3>Fingering Patterns</h3>
+                <ul>
+                  <li>
+                    <strong>All:</strong> Highlights every scale note with no
+                    positional shapes.
+                  </li>
+                  <li>
+                    <strong>CAGED:</strong> Shows overlapping position shapes
+                    across the neck. Click a shape (C / A / G / E / D) to
+                    isolate it; Shift-click to toggle multiple shapes. Enable{" "}
+                    <em>Shape Labels</em> to letter each polygon.
+                  </li>
+                  <li>
+                    <strong>3NPS:</strong> Shows 3-notes-per-string positions.
+                    Use the position selector (1–7 or All) to isolate a single
+                    hand position.
+                  </li>
+                </ul>
+
+                <h3>Note Labels &amp; Degree Strip</h3>
+                <ul>
+                  <li>
+                    The <strong>Note Labels</strong> toggle (Notes / Intervals /
+                    None) controls what appears inside each fretboard dot.
+                  </li>
+                  <li>
+                    The <strong>degree strip</strong> between the header and the
+                    fretboard lists the scale's notes with their interval name
+                    below each one. Chord tones are highlighted when a chord is
+                    active.
+                  </li>
+                </ul>
+
+                <h3>Circle of Fifths</h3>
+                <p>
+                  Tap any key segment to change the root note. Degree markers
+                  around the circle show how the current scale's intervals
+                  relate to each key. On mobile, expand it from the{" "}
+                  <em>Theory</em> tab under <em>Circle of Fifths</em>.
+                </p>
+
+                <h3>Header Controls</h3>
+                <ul>
+                  <li>
+                    <strong>Settings (gear icon):</strong> Opens a drawer for
+                    Tuning, Zoom, Fret Range, Accidentals, Enharmonic Display,
+                    and Chord Spread. Use Settings → Reset to restore all
+                    defaults.
+                  </li>
+                  <li>
+                    <strong>Speaker icon:</strong> Toggles audio playback. Tap
+                    any fretboard dot to hear the note when unmuted.
                   </li>
                 </ul>
 
                 <h3>Tips</h3>
                 <ul>
-                  <li>Tap any fretboard note to hear it play (when unmuted).</li>
                   <li>
-                    The fret range control lets you focus on any section of the
-                    neck — useful for position-specific practice.
+                    Drag or scroll the fretboard horizontally when zoomed in.
                   </li>
                   <li>
-                    CAGED shapes and 3NPS positions show how the same scale maps
-                    across different hand positions on the neck.
+                    The fret range control (in Settings or the Configuration
+                    card) lets you focus on a specific section of the neck.
                   </li>
                   <li>
-                    The degree strip below the fretboard shows the interval
-                    structure of the selected scale.
+                    Use CAGED or 3NPS shapes to see how the same scale maps to
+                    different hand positions.
                   </li>
                   <li>
-                    Enable "Hide non-chord notes" in the chord overlay to focus
-                    on playable chord voicings within the scale.
+                    Switch between Parallel and Relative browsing to explore
+                    related modes without leaving the current key.
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
## Summary

- Rewrote the help modal content in `App.tsx` to accurately reflect the current state of the app
- Fixed stale/incorrect labels and control locations
- Added documentation for several features that were entirely missing

## What changed

**Fixed inaccuracies:**
- "Hide non-chord notes" corrected to the actual UI label: **"Chord only (hide scale)"**
- Degree strip location corrected from "below the fretboard" to "between the header and the fretboard"
- Header button order now matches the actual left-to-right order: Settings → Mute → Help

**Added missing content:**
- Layout section explaining mobile (Theory/View tab bar) vs tablet/desktop (three-card panel)
- Scale Family dropdown and mode browser with Parallel/Relative toggle
- "Link chord root to scale" checkbox in chord overlay
- Note Labels toggle (Notes / Intervals / None)
- Shape Labels toggle and Shift-click multi-select for CAGED shapes
- 3NPS position selector (All, 1–7)
- Fretboard horizontal drag/scroll behavior when zoomed in
- Circle of Fifths collapsible disclosure on mobile (Theory tab)

## Test plan

- [ ] Open the app and click the **?** button in the top-right header
- [ ] Read through each section and verify labels match the actual UI controls
- [ ] Confirm mobile layout section matches the Theory/View tab bar
- [ ] Confirm chord overlay section matches actual checkbox labels
- [ ] Close the modal with Escape, backdrop click, and the X button

🤖 Generated with [Claude Code](https://claude.com/claude-code)