### PR TITLE
fix(theory): render interval accidentals as Unicode in degree chip strip

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -167,7 +167,7 @@ function AppContent() {
             useFlats,
           ),
         ),
-        interval,
+        interval: formatAccidental(interval),
         inScale: true,
         isTonic: note === rootNote,
         inChord: chordToneSet.has(note),

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -177,6 +177,16 @@ describe("App", () => {
       expect(within(summary).getByText("D Dorian (2nd Mode)")).toBeInTheDocument();
     });
 
+    it("renders Unicode flat intervals in the degree chip strip for Natural Minor", () => {
+      localStorage.setItem(k("rootNote"), "A");
+      localStorage.setItem(k("scaleName"), "Natural Minor");
+      render(<App />);
+      const summary = screen.getByRole("group", { name: /scale degrees/i });
+      expect(within(summary).getByText("♭3")).toBeInTheDocument();
+      expect(within(summary).getByText("♭6")).toBeInTheDocument();
+      expect(within(summary).getByText("♭7")).toBeInTheDocument();
+    });
+
     it("defaults the summary collapsed on mobile", () => {
       setViewport(390, 844);
       render(<App />);

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -122,11 +122,6 @@ export function formatAccidental(s: string): string {
     .replace(/b/g, "♭");
 }
 
-// For interval labels like b3, b5, b7 — keep lowercase 'b' which reads better
-// inline with small digits. Only replace # with ♯.
-export function formatIntervalAccidental(s: string): string {
-  return s.replace(/##/g, "𝄪").replace(/#/g, "♯");
-}
 
 const LETTER_NAMES = ["C", "D", "E", "F", "G", "A", "B"];
 const LETTER_PITCHES: Record<string, number> = {


### PR DESCRIPTION
## Summary

- Interval labels in the degree chip strip were rendering raw ASCII (e.g. `b3`, `b7`) while fretboard dots in degrees mode correctly displayed Unicode (e.g. `♭3`, `♭7`) — same data, inconsistent presentation.
- Applied `formatAccidental()` to the `interval` field when assembling `degreeChips` in `App.tsx`, at the data-assembly boundary.
- Removed the dead `formatIntervalAccidental` helper from `theory.ts` (defined but never called anywhere).
- Added a regression test: A Natural Minor chip strip now asserts `♭3`, `♭6`, `♭7` render as Unicode.

## What changed

| File | Change |
|---|---|
| `src/App.tsx` | `interval: formatAccidental(interval)` when building each chip |
| `src/theory.ts` | Remove unused `formatIntervalAccidental` export |
| `src/__tests__/App.test.tsx` | Regression test for Unicode flat intervals in the strip |

## Reviewer notes

- Internal theory constants (`INTERVAL_NAMES`, `NOTES`, `ENHARMONICS`) remain ASCII — no data layer changes.
- `DegreeChipStrip` stays purely presentational; formatting responsibility stays at the assembly boundary in `App.tsx`.
- 674/674 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)