### PR TITLE
feat(caged): auto-select E shape when switching scales in CAGED mode

### DIFF
--- a/src/hooks/useDisplayState.ts
+++ b/src/hooks/useDisplayState.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import {
   rootNoteAtom,
@@ -105,6 +105,16 @@ export default function useDisplayState() {
   // Internalized local state
   const [clickedShape, setClickedShape] = useState<CagedShape | null>(null);
   const [recenterKey, setRecenterKey] = useState(0);
+
+  // When in CAGED mode, reset to E shape whenever the scale changes
+  const prevScaleNameRef = useRef<string | null>(null);
+  useEffect(() => {
+    const prev = prevScaleNameRef.current;
+    prevScaleNameRef.current = scaleName;
+    if (prev === null || prev === scaleName) return;
+    if (fingeringPattern !== "caged") return;
+    setCagedShapes(new Set<CagedShape>(["E"]));
+  }, [scaleName, fingeringPattern, setCagedShapes]);
 
   // Callbacks
   const onShapeClick = (shape: CagedShape | null) => {

--- a/src/shapes/index.ts
+++ b/src/shapes/index.ts
@@ -1,6 +1,6 @@
 // From templates
 export type { CagedShape } from "./templates";
-export { CAGED_SHAPES, CAGED_SHAPE_COLORS } from "./templates";
+export { CAGED_SHAPES, CAGED_SHAPE_COLORS, isMajorScale } from "./templates";
 
 // From polygons
 export type { ShapeVertex, ShapePolygon, ShapeResult } from "./polygons";


### PR DESCRIPTION
## Summary

- When the fingering pattern is set to CAGED, switching to any scale now automatically resets the active shape to **E** (displayed as "E Shape" for major-quality scales, "Em Shape" for minor-quality)
- Applies to all scale types and modes — major, minor, pentatonic, blues, all modal variations (Dorian, Phrygian, Lydian, Mixolydian, etc.)
- Also exports `isMajorScale` from `shapes/index.ts` for future consumers

## Why E shape

The E shape is the correct default for any scale because:
- `rootStringFocus: 5` — root anchors on the low E string (lowest possible string)
- `fretOffsetMin: -1` — pattern starts at the root, so you begin playing from the root note

The previous implementation only reset the shape when scale *quality* changed (major ↔ minor). This PR extends that to every scale change.

## Implementation

Added a `useEffect` in `useDisplayState.ts` that tracks the previous `scaleName`. When the name changes and `fingeringPattern === "caged"`, it calls `setCagedShapes(new Set(["E"]))`. The initial mount is skipped so persisted user preferences are respected on page load.

## Test plan

- [ ] Switch to CAGED mode, select a non-E shape, then change scale → shape resets to E
- [ ] Switch between major scales (e.g. Major → Major Pentatonic) → resets to E
- [ ] Switch between minor scales (e.g. Natural Minor → Minor Pentatonic) → resets to Em (E)
- [ ] Switch between modes (e.g. Ionian → Dorian → Phrygian) → resets to E/Em each time
- [ ] Change scale while in All or 3NPS mode → shape selection unchanged
- [ ] Page reload in CAGED mode → persisted shape selection respected (no reset on mount)

🤖 Generated with [Claude Code](https://claude.com/claude-code)