### PR TITLE
refactor(3nps): remove "All" position option, default to position 1

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -11,7 +11,6 @@ import App from "../App";
 import { synth } from "../audio";
 import { get3NPSCoordinates } from "../shapes";
 import { STANDARD_TUNING } from "../guitar";
-import { getScaleNotes } from "../theory";
 import { k } from "./utils/storage";
 
 // Mock child components to isolate App logic
@@ -603,19 +602,6 @@ describe("App", () => {
       expect(screen.getByTestId("fretboard")).toHaveAttribute(
         "data-color-notes",
         "D#",
-      );
-    });
-
-    it("uses scale notes directly for 3nps position 0", () => {
-      localStorage.setItem(k("rootNote"), "C");
-      localStorage.setItem(k("scaleName"), "Major");
-      localStorage.setItem(k("fingeringPattern"), "3nps");
-      localStorage.setItem(k("npsPosition"), "0");
-
-      render(<App />);
-
-      expect(screen.getByTestId("fretboard")).toHaveTextContent(
-        `Fretboard: C - ${getScaleNotes("C", "Major").length} notes`,
       );
     });
 

--- a/src/__tests__/atoms.test.ts
+++ b/src/__tests__/atoms.test.ts
@@ -487,7 +487,7 @@ describe("atoms", () => {
       expect(store.get(chordFretSpreadAtom)).toBe(0);
       expect(store.get(chordIntervalFilterAtom)).toBe("All");
       expect(store.get(fingeringPatternAtom)).toBe("all");
-      expect(store.get(npsPositionAtom)).toBe(0);
+      expect(store.get(npsPositionAtom)).toBe(1);
       expect(store.get(shapeLabelsAtom)).toBe("none");
       expect(store.get(scaleBrowseModeAtom)).toBe("parallel");
       expect(store.get(tuningNameAtom)).toBe("Standard");

--- a/src/__tests__/integration.test.tsx
+++ b/src/__tests__/integration.test.tsx
@@ -533,7 +533,7 @@ describe("Integration Tests - User Workflows", () => {
       localStorage.setItem(k("fingeringPattern"), "3nps");
 
       // Different NPS positions
-      for (let pos = 0; pos <= 3; pos++) {
+      for (let pos = 1; pos <= 3; pos++) {
         localStorage.setItem(k("npsPosition"), String(pos));
 
         const { rerender } = render(<App />);

--- a/src/components/FingeringPatternControls.test.tsx
+++ b/src/components/FingeringPatternControls.test.tsx
@@ -14,7 +14,7 @@ describe("FingeringPatternControls", () => {
       setFingeringPattern: vi.fn(),
       cagedShapes: new Set<CagedShape>(["C", "A", "G", "E", "D"]),
       setCagedShapes: vi.fn(),
-      npsPosition: 0,
+      npsPosition: 1,
       setNpsPosition: vi.fn(),
       shapeLabels: "none",
       setShapeLabels: vi.fn(),

--- a/src/components/FingeringPatternControls.tsx
+++ b/src/components/FingeringPatternControls.tsx
@@ -132,13 +132,10 @@ export function FingeringPatternControls({
         <div className={shared["control-section"]}>
           <span className={shared["section-label"]}>Position</span>
           <ToggleBar
-            options={[
-              { value: 0, label: "All" },
-              ...[1, 2, 3, 4, 5, 6, 7].map((p) => ({
-                value: p,
-                label: String(p),
-              })),
-            ]}
+            options={[1, 2, 3, 4, 5, 6, 7].map((p) => ({
+              value: p,
+              label: String(p),
+            }))}
             value={npsPosition}
             onChange={(v) => setNpsPosition(v as number)}
           />

--- a/src/hooks/useDisplayState.test.ts
+++ b/src/hooks/useDisplayState.test.ts
@@ -223,21 +223,8 @@ describe("useDisplayState", () => {
     });
   });
 
-  describe("fingering pattern 3nps with npsPosition=0", () => {
-    it("highlightNotes is non-empty when npsPosition is 0 (all positions)", () => {
-      const store = createStore();
-      store.set(rootNoteAtom, "C");
-      store.set(fingeringPatternAtom, "3nps");
-      store.set(npsPositionAtom, 0);
-      const { result } = renderHook(() => useDisplayState(), {
-        wrapper: makeWrapper(store),
-      });
-      expect(result.current.highlightNotes.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe("fingering pattern 3nps with npsPosition > 0", () => {
-    it("highlightNotes is non-empty when npsPosition is 1 (specific position)", () => {
+  describe("fingering pattern 3nps", () => {
+    it("highlightNotes is non-empty when npsPosition is 1", () => {
       const store = createStore();
       store.set(rootNoteAtom, "C");
       store.set(fingeringPatternAtom, "3nps");
@@ -297,19 +284,7 @@ describe("useDisplayState", () => {
   });
 
   describe("3nps autoCenterTarget centering", () => {
-    it("autoCenterTarget is undefined when npsPosition=0 (all positions, no bounds)", () => {
-      const store = createStore();
-      store.set(rootNoteAtom, "C");
-      store.set(fingeringPatternAtom, "3nps");
-      store.set(npsPositionAtom, 0);
-      const { result } = renderHook(() => useDisplayState(), {
-        wrapper: makeWrapper(store),
-      });
-      // npsPosition=0 uses getScaleNotes (no bounds), so no centering target
-      expect(result.current.autoCenterTarget).toBeUndefined();
-    });
-
-    it("autoCenterTarget equals the lowest minFret in boxBounds when npsPosition > 0", () => {
+    it("autoCenterTarget equals the lowest minFret in boxBounds", () => {
       const store = createStore();
       store.set(rootNoteAtom, "A");
       store.set(fingeringPatternAtom, "3nps");

--- a/src/hooks/useDisplayState.ts
+++ b/src/hooks/useDisplayState.ts
@@ -187,19 +187,15 @@ export default function useDisplayState() {
       bounds = allBounds;
       polygons = allPolygons;
     } else if (fingeringPattern === "3nps") {
-      if (npsPosition === 0) {
-        coords = getScaleNotes(rootNote, scaleName);
-      } else {
-        const res = get3NPSCoordinates(
-          rootNote,
-          scaleName,
-          currentTuning,
-          24,
-          npsPosition,
-        );
-        coords = res.coordinates;
-        bounds = res.bounds;
-      }
+      const res = get3NPSCoordinates(
+        rootNote,
+        scaleName,
+        currentTuning,
+        24,
+        npsPosition,
+      );
+      coords = res.coordinates;
+      bounds = res.bounds;
     } else {
       coords = getScaleNotes(rootNote, scaleName);
     }

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -221,7 +221,7 @@ const chordFretSpreadStorage = constrainedNumberStorage({
   integer: true,
 });
 const npsPositionStorage = constrainedNumberStorage({
-  min: 0,
+  min: 1,
   max: 12,
   integer: true,
 });
@@ -507,7 +507,7 @@ export const cagedShapesAtom = atomWithStorage<Set<CagedShape>>(
 );
 export const npsPositionAtom = atomWithStorage(
   k("npsPosition"),
-  0,
+  1,
   npsPositionStorage,
   GET_ON_INIT,
 );


### PR DESCRIPTION
## Summary

- Removes the **All** option (position 0) from the 3NPS Position selector — it showed every scale note with no fingering pattern, duplicating what the plain scale view already provides
- Defaults `npsPosition` to **1** (first real position) instead of 0
- Simplifies `useDisplayState` by eliminating the `npsPosition === 0` special-case branch

## What changed

| File | Change |
|---|---|
| `FingeringPatternControls.tsx` | Removed `{value: 0, label: "All"}` from Position `ToggleBar` |
| `store/atoms.ts` | Default and storage `min` for `npsPositionAtom`: `0 → 1` |
| `hooks/useDisplayState.ts` | Removed `npsPosition === 0` branch; 3NPS always calls `get3NPSCoordinates` |
| Tests | Updated/removed tests that relied on `npsPosition=0` behaviour |

## Test plan

- [x] `npm run test` — 685 tests pass
- [x] `npm run lint` — clean
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)