### PR TITLE
feat(caged): long press to multi-select shapes on touch devices

### DIFF
--- a/src/components/FingeringPatternControls.css
+++ b/src/components/FingeringPatternControls.css
@@ -1,3 +1,10 @@
 /* FingeringPatternControls component styles */
 /* Layout styles (.control-section, .toggle-group, .toggle-btn) are in shared.module.css */
-/* Add component-specific overrides here if needed */
+
+/* Visual "charging" feedback while a long press is building up */
+[data-pressing] {
+  box-shadow:
+    0 0 0 2px rgb(77 228 255 / 0.55),
+    0 0 10px rgb(77 228 255 / 0.22) !important;
+  transition: box-shadow 0.45s ease !important;
+}

--- a/src/components/FingeringPatternControls.tsx
+++ b/src/components/FingeringPatternControls.tsx
@@ -1,4 +1,4 @@
-import { useId } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 import clsx from "clsx";
 import { CAGED_SHAPES, type CagedShape } from "../shapes";
 import { type FingeringPattern } from "../store/atoms";
@@ -23,6 +23,24 @@ interface FingeringPatternControlsProps {
   onShapeClick?: (shape: CagedShape) => void;
 }
 
+const LONG_PRESS_MS = 500;
+const MOVE_CANCEL_PX = 8;
+
+/** True when the primary pointer is coarse (touch/pen). Evaluated once at load. */
+const isTouchPrimary =
+  typeof window !== "undefined" &&
+  window.matchMedia("(pointer: coarse)").matches;
+
+function toggleShape(prev: Set<CagedShape>, shape: CagedShape): Set<CagedShape> {
+  const next = new Set(prev);
+  if (next.has(shape)) {
+    if (next.size > 1) next.delete(shape);
+  } else {
+    next.add(shape);
+  }
+  return next;
+}
+
 export function FingeringPatternControls({
   fingeringPattern,
   setFingeringPattern,
@@ -38,6 +56,22 @@ export function FingeringPatternControls({
 }: FingeringPatternControlsProps) {
   const shapeLabelId = useId();
   const shapeHelpId = useId();
+
+  // Long-press tracking refs — shared across all shape buttons
+  const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pressStartRef = useRef<{ x: number; y: number } | null>(null);
+  const longPressedShapeRef = useRef<CagedShape | null>(null);
+  const [pressingShape, setPressingShape] = useState<CagedShape | null>(null);
+
+  const cancelPress = useCallback(() => {
+    if (pressTimerRef.current !== null) {
+      clearTimeout(pressTimerRef.current);
+      pressTimerRef.current = null;
+    }
+    pressStartRef.current = null;
+    setPressingShape(null);
+  }, []);
+
   return (
     <>
       <div className={shared["control-section"]}>
@@ -57,12 +91,14 @@ export function FingeringPatternControls({
       {fingeringPattern === "caged" && (
         <>
           <div className={shared["control-section"]}>
-            {/* TODO: Shape selector is kept inline because it supports Shift+click
+            {/* TODO: Shape selector is kept inline because it supports Shift+click / long-press
                 multi-select, which ToggleBar does not support (single-select only).
                 Refactor once ToggleBar gains a multi-select variant. */}
             <span className={shared["section-label"]} id={shapeLabelId}>Shape</span>
             <span id={shapeHelpId} className={shared["sr-only"]}>
-              Click to select a shape. Shift+click to toggle multiple shapes.
+              {isTouchPrimary
+                ? "Tap to select a shape. Long press to toggle multiple shapes."
+                : "Click to select a shape. Shift+click to toggle multiple shapes."}
             </span>
             <div
               className={shared["toggle-group"]}
@@ -90,20 +126,50 @@ export function FingeringPatternControls({
                     cagedShapes.has(s) && shared.active,
                   )}
                   aria-pressed={cagedShapes.has(s)}
-                  title="Click to select; Shift+click to toggle multiple"
+                  title={
+                    isTouchPrimary
+                      ? "Tap to select; long press to add/remove"
+                      : "Click to select; Shift+click to toggle multiple"
+                  }
+                  data-pressing={pressingShape === s ? true : undefined}
+                  onPointerDown={(e) => {
+                    // Long press only applies to touch/pen — desktop uses Shift+click
+                    if (e.pointerType !== "touch" && e.pointerType !== "pen") return;
+                    cancelPress();
+                    longPressedShapeRef.current = null;
+                    pressStartRef.current = { x: e.clientX, y: e.clientY };
+                    setPressingShape(s);
+                    pressTimerRef.current = setTimeout(() => {
+                      longPressedShapeRef.current = s;
+                      pressTimerRef.current = null;
+                      pressStartRef.current = null;
+                      setPressingShape(null);
+                      setCagedShapes((prev) => toggleShape(prev, s));
+                      navigator.vibrate?.(30);
+                    }, LONG_PRESS_MS);
+                  }}
+                  onPointerMove={(e) => {
+                    if (!pressStartRef.current) return;
+                    const dx = e.clientX - pressStartRef.current.x;
+                    const dy = e.clientY - pressStartRef.current.y;
+                    if (Math.hypot(dx, dy) > MOVE_CANCEL_PX) cancelPress();
+                  }}
+                  onPointerUp={cancelPress}
+                  onPointerCancel={cancelPress}
+                  onPointerLeave={cancelPress}
+                  onContextMenu={(e) => {
+                    // Suppress context menu that browsers show on long press
+                    if (longPressedShapeRef.current !== null) e.preventDefault();
+                  }}
                   onClick={(e) => {
-                    // Always notify parent that shape was clicked (for recentering)
+                    // If this click followed a long press, skip single-select
+                    if (longPressedShapeRef.current !== null) {
+                      longPressedShapeRef.current = null;
+                      return;
+                    }
                     onShapeClick?.(s);
                     if (e.shiftKey) {
-                      setCagedShapes((prev) => {
-                        const next = new Set(prev);
-                        if (next.has(s)) {
-                          if (next.size > 1) next.delete(s);
-                        } else {
-                          next.add(s);
-                        }
-                        return next;
-                      });
+                      setCagedShapes((prev) => toggleShape(prev, s));
                     } else {
                       setCagedShapes(new Set([s]));
                     }
@@ -113,6 +179,9 @@ export function FingeringPatternControls({
                 </button>
               ))}
             </div>
+            <p className={shared["shape-hint"]}>
+              {isTouchPrimary ? "Long press to add shapes" : "Shift+click to add shapes"}
+            </p>
           </div>
           <div className={shared["control-section"]}>
             <span className={shared["section-label"]}>Shape Labels</span>

--- a/src/components/shared.module.css
+++ b/src/components/shared.module.css
@@ -196,6 +196,15 @@
 }
 /* stylelint-enable selector-pseudo-class-no-unknown */
 
+.shape-hint {
+  font-size: 0.68rem;
+  color: rgb(188 200 214 / 0.45);
+  text-align: center;
+  line-height: 1.3;
+  margin-top: 0.05rem;
+  user-select: none;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
## Summary

- Adds a **500 ms long press** gesture on CAGED shape buttons (touch/pen only) that toggles multi-select — the same behaviour as Shift+click on desktop
- Shows a per-device hint below the shape selector: **"Long press to add shapes"** on touch, **"Shift+click to add shapes"** on desktop
- Cyan glow animation on the button while the hold builds up, so users get visual feedback that something is happening
- Haptic feedback via `navigator.vibrate(30)` on supported devices
- Browser long-press context menu suppressed after a successful long press
- Screen-reader description updated to match the device interaction model

## Changed files

| File | What changed |
|---|---|
| `src/components/FingeringPatternControls.tsx` | Pointer event handlers + hint text + sr-only update |
| `src/components/shared.module.css` | `.shape-hint` style (small muted text below shape row) |
| `src/components/FingeringPatternControls.css` | `[data-pressing]` glow animation |

## Implementation notes

- Long press is **touch/pen only** (`e.pointerType !== "touch" && e.pointerType !== "pen"` guard in `onPointerDown`) — desktop users still use Shift+click unchanged
- Movement > 8 px cancels the timer (scroll-safe)
- `longPressedShapeRef` flag is checked in `onClick` to skip single-select when a long press already fired, preventing double-action on pointer-up → click sequence
- `isTouchPrimary` is evaluated once at module load via `window.matchMedia("(pointer: coarse)")` — stable for a session

## Test plan

- [ ] On a touch device (or DevTools touch simulation): long press a shape — it should toggle without triggering single-select
- [ ] Tapping a shape normally still single-selects
- [ ] Scrolling over the button does not accidentally trigger long press
- [ ] On desktop: Shift+click still works; no long-press behaviour on mouse hold
- [ ] "Long press to add shapes" hint visible on touch layout; "Shift+click to add shapes" on desktop
- [ ] All tests pass (`npm run test`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)