### PR TITLE
feat(chord): chord-member overlay replaces interval-filter model

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,10 +50,16 @@ function AppContent() {
     linkChordRoot,
     setLinkChordRoot,
     hideNonChordNotes,
-    setHideNonChordNotes,
     chordFretSpread,
-    chordIntervalFilter,
-    setChordIntervalFilter,
+    viewMode,
+    setViewMode,
+    focusPreset,
+    setFocusPreset,
+    customMembers,
+    setCustomMembers,
+    availableFocusPresets,
+    chordMembers,
+    hasOutsideChordMembers,
     fingeringPattern,
     setFingeringPattern,
     cagedShapes,
@@ -66,7 +72,7 @@ function AppContent() {
     setShapeLabels,
     enharmonicDisplay,
     setRootNote,
-    filteredChordTones,
+    activeChordTones,
     highlightNotes,
     boxBounds,
     shapePolygons,
@@ -247,10 +253,15 @@ function AppContent() {
         setChordRoot={setChordRoot}
         linkChordRoot={linkChordRoot}
         setLinkChordRoot={setLinkChordRoot}
-        hideNonChordNotes={hideNonChordNotes}
-        setHideNonChordNotes={setHideNonChordNotes}
-        chordIntervalFilter={chordIntervalFilter}
-        setChordIntervalFilter={setChordIntervalFilter}
+        viewMode={viewMode}
+        setViewMode={setViewMode}
+        focusPreset={focusPreset}
+        setFocusPreset={setFocusPreset}
+        customMembers={customMembers}
+        setCustomMembers={setCustomMembers}
+        availableFocusPresets={availableFocusPresets}
+        chordMembers={chordMembers}
+        hasOutsideChordMembers={hasOutsideChordMembers}
         useFlats={useFlats}
         keyExplorer={mobileKeyExplorer}
       />
@@ -519,7 +530,7 @@ function AppContent() {
           highlightNotes={highlightNotes}
           rootNote={rootNote}
           boxBounds={boxBounds}
-          chordTones={filteredChordTones}
+          chordTones={activeChordTones}
           chordFretSpread={chordFretSpread}
           hideNonChordNotes={hideNonChordNotes}
           colorNotes={colorNotes}

--- a/src/__tests__/atoms.test.ts
+++ b/src/__tests__/atoms.test.ts
@@ -24,7 +24,9 @@ import {
   npsPositionAtom,
   hideNonChordNotesAtom,
   chordFretSpreadAtom,
-  chordIntervalFilterAtom,
+  viewModeAtom,
+  focusPresetAtom,
+  customMembersAtom,
   setRootNoteAtom,
   resetAtom,
   landscapeNarrowTabAtom,
@@ -467,7 +469,9 @@ describe("atoms", () => {
       store.set(linkChordRootAtom, false);
       store.set(hideNonChordNotesAtom, true);
       store.set(chordFretSpreadAtom, 5);
-      store.set(chordIntervalFilterAtom, "Triad");
+      store.set(viewModeAtom, "chord");
+      store.set(focusPresetAtom, "triad");
+      store.set(customMembersAtom, ["root", "3"]);
       store.set(fingeringPatternAtom, "caged");
       store.set(npsPositionAtom, 3);
       store.set(shapeLabelsAtom, "caged");
@@ -485,7 +489,9 @@ describe("atoms", () => {
       expect(store.get(linkChordRootAtom)).toBe(true);
       expect(store.get(hideNonChordNotesAtom)).toBe(false);
       expect(store.get(chordFretSpreadAtom)).toBe(0);
-      expect(store.get(chordIntervalFilterAtom)).toBe("All");
+      expect(store.get(viewModeAtom)).toBe("compare");
+      expect(store.get(focusPresetAtom)).toBe("all");
+      expect(store.get(customMembersAtom)).toEqual([]);
       expect(store.get(fingeringPatternAtom)).toBe("all");
       expect(store.get(npsPositionAtom)).toBe(1);
       expect(store.get(shapeLabelsAtom)).toBe("none");

--- a/src/__tests__/theory.test.ts
+++ b/src/__tests__/theory.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   SCALES,
+  CHORDS,
+  CHORD_DEFINITIONS,
   getScaleNotes,
   getChordNotes,
   getNoteIndex,
@@ -10,6 +12,8 @@ import {
   getKeySignature,
   getKeySignatureForDisplay,
   resolveAccidentalMode,
+  getAvailableFocusPresets,
+  applyFocusPreset,
 } from "../theory";
 
 describe("getNoteIndex", () => {
@@ -284,6 +288,107 @@ describe("resolver + key signature integration", () => {
     const useFlats = resolveAccidentalMode("E", "Dorian", "auto");
     expect(useFlats).toBe(false);
     expect(getKeySignatureForDisplay("E", "Dorian", useFlats)).toBe(2);
+  });
+});
+
+describe("CHORD_DEFINITIONS", () => {
+  it("every chord in CHORD_DEFINITIONS has a quality and members", () => {
+    for (const [name, def] of Object.entries(CHORD_DEFINITIONS)) {
+      expect(def.quality).toMatch(/^(triad|seventh|power)$/);
+      expect(def.members.length).toBeGreaterThan(0);
+      expect(def.members[0].name).toBe("root");
+      void name;
+    }
+  });
+
+  it("CHORDS derived from CHORD_DEFINITIONS preserves intervals", () => {
+    expect(CHORDS["Major Triad"]).toEqual([0, 4, 7]);
+    expect(CHORDS["Minor 7th"]).toEqual([0, 3, 7, 10]);
+    expect(CHORDS["Power Chord (5)"]).toEqual([0, 7]);
+  });
+
+  it("Major Triad has triad quality with root, 3, 5 members", () => {
+    const def = CHORD_DEFINITIONS["Major Triad"];
+    expect(def.quality).toBe("triad");
+    expect(def.members.map((m) => m.name)).toEqual(["root", "3", "5"]);
+  });
+
+  it("Minor 7th has seventh quality with root, b3, 5, b7 members", () => {
+    const def = CHORD_DEFINITIONS["Minor 7th"];
+    expect(def.quality).toBe("seventh");
+    expect(def.members.map((m) => m.name)).toEqual(["root", "b3", "5", "b7"]);
+  });
+
+  it("Power Chord has power quality with root and 5 only", () => {
+    const def = CHORD_DEFINITIONS["Power Chord (5)"];
+    expect(def.quality).toBe("power");
+    expect(def.members.map((m) => m.name)).toEqual(["root", "5"]);
+  });
+});
+
+describe("getAvailableFocusPresets", () => {
+  it("triad chord returns all, rootless, custom", () => {
+    expect(getAvailableFocusPresets("Major Triad")).toEqual(["all", "rootless", "custom"]);
+    expect(getAvailableFocusPresets("Minor Triad")).toEqual(["all", "rootless", "custom"]);
+  });
+
+  it("seventh chord returns all six presets", () => {
+    const presets = getAvailableFocusPresets("Dominant 7th");
+    expect(presets).toEqual(["all", "triad", "shell", "guide-tones", "rootless", "custom"]);
+  });
+
+  it("power chord returns only all and custom", () => {
+    expect(getAvailableFocusPresets("Power Chord (5)")).toEqual(["all", "custom"]);
+  });
+
+  it("unknown chord returns all and custom as fallback", () => {
+    expect(getAvailableFocusPresets("Unknown Chord")).toEqual(["all", "custom"]);
+  });
+});
+
+describe("applyFocusPreset", () => {
+  const dom7Def = CHORD_DEFINITIONS["Dominant 7th"];
+  const triadDef = CHORD_DEFINITIONS["Major Triad"];
+
+  it("all returns all members unchanged", () => {
+    expect(applyFocusPreset(dom7Def, "all", [])).toEqual(dom7Def.members);
+  });
+
+  it("triad preset returns root + 3rd + 5th for Dominant 7th", () => {
+    const result = applyFocusPreset(dom7Def, "triad", []);
+    expect(result.map((m) => m.name)).toEqual(["root", "3", "5"]);
+  });
+
+  it("shell preset returns root + 3rd + 7th for Dominant 7th", () => {
+    const result = applyFocusPreset(dom7Def, "shell", []);
+    expect(result.map((m) => m.name)).toEqual(["root", "3", "b7"]);
+  });
+
+  it("guide-tones preset returns 3rd + b7 only (no root)", () => {
+    const result = applyFocusPreset(dom7Def, "guide-tones", []);
+    expect(result.map((m) => m.name)).toEqual(["3", "b7"]);
+    expect(result.some((m) => m.name === "root")).toBe(false);
+  });
+
+  it("rootless preset excludes only the root", () => {
+    const result = applyFocusPreset(dom7Def, "rootless", []);
+    expect(result.map((m) => m.name)).toEqual(["3", "5", "b7"]);
+  });
+
+  it("custom with selections filters to those members", () => {
+    const result = applyFocusPreset(triadDef, "custom", ["root", "5"]);
+    expect(result.map((m) => m.name)).toEqual(["root", "5"]);
+  });
+
+  it("custom with empty selection falls back to all members", () => {
+    const result = applyFocusPreset(triadDef, "custom", []);
+    expect(result).toEqual(triadDef.members);
+  });
+
+  it("guide-tones on Major 7th returns 3 and 7 (maj7)", () => {
+    const maj7Def = CHORD_DEFINITIONS["Major 7th"];
+    const result = applyFocusPreset(maj7Def, "guide-tones", []);
+    expect(result.map((m) => m.name)).toEqual(["3", "7"]);
   });
 });
 

--- a/src/components/ExpandedControlsPanel.tsx
+++ b/src/components/ExpandedControlsPanel.tsx
@@ -15,14 +15,25 @@ import {
   chordRootAtom,
   chordTypeAtom,
   linkChordRootAtom,
-  hideNonChordNotesAtom,
-  chordIntervalFilterAtom,
+  viewModeAtom,
+  focusPresetAtom,
+  customMembersAtom,
   accidentalModeAtom,
   enharmonicDisplayAtom,
   fretStartAtom,
   fretEndAtom,
 } from "../store/atoms";
-import { resolveAccidentalMode } from "../theory";
+import {
+  NOTES,
+  CHORD_DEFINITIONS,
+  resolveAccidentalMode,
+  getScaleNotes,
+  getChordNotes,
+  getAvailableFocusPresets,
+  type ViewMode,
+  type FocusPreset,
+  type ResolvedChordMember,
+} from "../theory";
 import { FingeringPatternControls } from "./FingeringPatternControls";
 import { FretRangeControl } from "./FretRangeControl";
 import { TheoryControls } from "./TheoryControls";
@@ -86,12 +97,9 @@ export function ScaleChordSection() {
   const [chordRoot, setChordRoot] = useAtom(chordRootAtom);
   const [chordType, setChordType] = useAtom(chordTypeAtom);
   const [linkChordRoot, setLinkChordRoot] = useAtom(linkChordRootAtom);
-  const [hideNonChordNotes, setHideNonChordNotes] = useAtom(
-    hideNonChordNotesAtom,
-  );
-  const [chordIntervalFilter, setChordIntervalFilter] = useAtom(
-    chordIntervalFilterAtom,
-  );
+  const [viewMode, setViewMode] = useAtom(viewModeAtom);
+  const [focusPreset, setFocusPreset] = useAtom(focusPresetAtom);
+  const [customMembers, setCustomMembers] = useAtom(customMembersAtom);
   const rootNote = useAtomValue(rootNoteAtom);
   const setRootNote = useSetAtom(setRootNoteAtom);
   const accidentalMode = useAtomValue(accidentalModeAtom);
@@ -99,6 +107,31 @@ export function ScaleChordSection() {
     () => resolveAccidentalMode(rootNote, scaleName, accidentalMode),
     [rootNote, scaleName, accidentalMode],
   );
+
+  const availableFocusPresets = useMemo((): FocusPreset[] => {
+    if (!chordType) return ["all", "custom"];
+    return getAvailableFocusPresets(chordType);
+  }, [chordType]);
+
+  const chordMembers = useMemo((): ResolvedChordMember[] => {
+    if (!chordType) return [];
+    const def = CHORD_DEFINITIONS[chordType];
+    if (!def) return [];
+    const rootIndex = NOTES.indexOf(chordRoot);
+    if (rootIndex === -1) return [];
+    return def.members.map((m) => ({
+      ...m,
+      note: NOTES[(rootIndex + m.semitone) % 12],
+    }));
+  }, [chordRoot, chordType]);
+
+  const hasOutsideChordMembers = useMemo(() => {
+    if (!chordType) return false;
+    const chordTones = getChordNotes(chordRoot, chordType);
+    if (chordTones.length === 0) return false;
+    const scaleNoteSet = new Set(getScaleNotes(rootNote, scaleName));
+    return chordTones.some((note) => !scaleNoteSet.has(note));
+  }, [chordType, chordRoot, rootNote, scaleName]);
 
   return (
     <Card
@@ -118,10 +151,15 @@ export function ScaleChordSection() {
         setChordRoot={setChordRoot}
         linkChordRoot={linkChordRoot}
         setLinkChordRoot={setLinkChordRoot}
-        hideNonChordNotes={hideNonChordNotes}
-        setHideNonChordNotes={setHideNonChordNotes}
-        chordIntervalFilter={chordIntervalFilter}
-        setChordIntervalFilter={setChordIntervalFilter}
+        viewMode={viewMode as ViewMode}
+        setViewMode={setViewMode}
+        focusPreset={focusPreset as FocusPreset}
+        setFocusPreset={setFocusPreset}
+        customMembers={customMembers}
+        setCustomMembers={setCustomMembers}
+        availableFocusPresets={availableFocusPresets}
+        chordMembers={chordMembers}
+        hasOutsideChordMembers={hasOutsideChordMembers}
         useFlats={useFlats}
       />
     </Card>

--- a/src/components/TheoryControls.test.tsx
+++ b/src/components/TheoryControls.test.tsx
@@ -18,10 +18,15 @@ function makeProps(): ComponentProps<typeof TheoryControls> {
     setChordRoot: vi.fn(),
     linkChordRoot: true,
     setLinkChordRoot: vi.fn(),
-    hideNonChordNotes: false,
-    setHideNonChordNotes: vi.fn(),
-    chordIntervalFilter: "All",
-    setChordIntervalFilter: vi.fn(),
+    viewMode: "compare",
+    setViewMode: vi.fn(),
+    focusPreset: "all",
+    setFocusPreset: vi.fn(),
+    customMembers: [],
+    setCustomMembers: vi.fn(),
+    availableFocusPresets: ["all", "rootless", "custom"],
+    chordMembers: [],
+    hasOutsideChordMembers: false,
     useFlats: false,
   };
 }
@@ -124,5 +129,109 @@ describe("TheoryControls", () => {
     expect(screen.queryByText("Key Wheel")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /Circle of Fifths/i }));
     expect(screen.getByText("Key Wheel")).toBeInTheDocument();
+  });
+
+  it("shows View and Focus controls when a chord type is selected", () => {
+    const props = makeProps();
+    render(
+      <TheoryControls
+        {...props}
+        chordType="Major Triad"
+        availableFocusPresets={["all", "rootless", "custom"]}
+        chordMembers={[
+          { name: "root", semitone: 0, note: "C" },
+          { name: "3", semitone: 4, note: "E" },
+          { name: "5", semitone: 7, note: "G" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("View")).toBeInTheDocument();
+    expect(screen.getByText("Focus")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Scale + Chord" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Chord Only" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Rootless" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Custom" })).toBeInTheDocument();
+  });
+
+  it("calls setViewMode when a view option is clicked", () => {
+    const props = makeProps();
+    render(
+      <TheoryControls
+        {...props}
+        chordType="Major Triad"
+        availableFocusPresets={["all", "rootless", "custom"]}
+        chordMembers={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Chord Only" }));
+    expect(props.setViewMode).toHaveBeenCalledWith("chord");
+  });
+
+  it("calls setFocusPreset when a focus option is clicked", () => {
+    const props = makeProps();
+    render(
+      <TheoryControls
+        {...props}
+        chordType="Major Triad"
+        availableFocusPresets={["all", "rootless", "custom"]}
+        chordMembers={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Rootless" }));
+    expect(props.setFocusPreset).toHaveBeenCalledWith("rootless");
+  });
+
+  it("shows custom member toggles when focusPreset is custom", () => {
+    const props = makeProps();
+    render(
+      <TheoryControls
+        {...props}
+        chordType="Major Triad"
+        focusPreset="custom"
+        availableFocusPresets={["all", "rootless", "custom"]}
+        chordMembers={[
+          { name: "root", semitone: 0, note: "C" },
+          { name: "3", semitone: 4, note: "E" },
+          { name: "5", semitone: 7, note: "G" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Members")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Root" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "3" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "5" })).toBeInTheDocument();
+  });
+
+  it("Outside view option is disabled when hasOutsideChordMembers is false", () => {
+    render(
+      <TheoryControls
+        {...makeProps()}
+        chordType="Major Triad"
+        availableFocusPresets={["all", "rootless", "custom"]}
+        chordMembers={[]}
+        hasOutsideChordMembers={false}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Outside" })).toBeDisabled();
+  });
+
+  it("Outside view option is enabled when hasOutsideChordMembers is true", () => {
+    render(
+      <TheoryControls
+        {...makeProps()}
+        chordType="Major Triad"
+        availableFocusPresets={["all", "rootless", "custom"]}
+        chordMembers={[]}
+        hasOutsideChordMembers={true}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Outside" })).not.toBeDisabled();
   });
 });

--- a/src/components/TheoryControls.tsx
+++ b/src/components/TheoryControls.tsx
@@ -1,8 +1,13 @@
 import { startTransition, useId, useState, type ReactNode } from "react";
 import clsx from "clsx";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import { NOTES } from "../theory";
-import { CHORD_FILTER_OPTIONS } from "../hooks/useDisplayState";
+import {
+  NOTES,
+  type ViewMode,
+  type FocusPreset,
+  type ChordMemberName,
+  type ResolvedChordMember,
+} from "../theory";
 import {
   getActiveScaleBrowseOption,
   getAdjacentScaleBrowseOption,
@@ -36,6 +41,26 @@ const CHORD_OPTIONS: (string | { divider: string })[] = [
 
 const CHORD_NONE_VALUE = "__none__";
 
+const VIEW_MODE_OPTIONS: { value: ViewMode; label: string }[] = [
+  { value: "compare", label: "Scale + Chord" },
+  { value: "chord", label: "Chord Only" },
+  { value: "outside", label: "Outside" },
+];
+
+const FOCUS_PRESET_LABELS: Record<FocusPreset, string> = {
+  all: "All",
+  triad: "Triad",
+  shell: "Shell",
+  "guide-tones": "Guide Tones",
+  rootless: "Rootless",
+  custom: "Custom",
+};
+
+function formatMemberName(name: ChordMemberName): string {
+  if (name === "root") return "Root";
+  return name.replace("b", "♭");
+}
+
 interface TheoryControlsProps {
   rootNote: string;
   setRootNote: (note: string) => void;
@@ -49,10 +74,15 @@ interface TheoryControlsProps {
   setChordRoot: (note: string) => void;
   linkChordRoot: boolean;
   setLinkChordRoot: (linked: boolean) => void;
-  hideNonChordNotes: boolean;
-  setHideNonChordNotes: (hide: boolean) => void;
-  chordIntervalFilter: string;
-  setChordIntervalFilter: (filter: string) => void;
+  viewMode: ViewMode;
+  setViewMode: (mode: ViewMode) => void;
+  focusPreset: FocusPreset;
+  setFocusPreset: (preset: FocusPreset) => void;
+  customMembers: ChordMemberName[];
+  setCustomMembers: (members: ChordMemberName[]) => void;
+  availableFocusPresets: FocusPreset[];
+  chordMembers: ResolvedChordMember[];
+  hasOutsideChordMembers: boolean;
   useFlats: boolean;
   keyExplorer?: ReactNode;
 }
@@ -70,17 +100,21 @@ export function TheoryControls({
   setChordRoot,
   linkChordRoot,
   setLinkChordRoot,
-  hideNonChordNotes,
-  setHideNonChordNotes,
-  chordIntervalFilter,
-  setChordIntervalFilter,
+  viewMode,
+  setViewMode,
+  focusPreset,
+  setFocusPreset,
+  customMembers,
+  setCustomMembers,
+  availableFocusPresets,
+  chordMembers,
+  hasOutsideChordMembers,
   useFlats,
   keyExplorer,
 }: TheoryControlsProps) {
   const [isChordOverlayOpen, setChordOverlayOpen] = useState(Boolean(chordType));
   const [isKeyExplorerOpen, setKeyExplorerOpen] = useState(false);
   const linkChordRootId = useId();
-  const hideNonChordNotesId = useId();
 
   const scaleEntry = resolveScaleCatalogEntry(scaleName);
   const familyOptions = getScaleFamilyOptions();
@@ -120,10 +154,20 @@ export function TheoryControls({
       label: option,
     })),
   ];
-  const chordFilterOptions: LabeledSelectOption[] = CHORD_FILTER_OPTIONS.map((option) => ({
-    value: option,
-    label: option,
+
+  const viewModeOptions = VIEW_MODE_OPTIONS.map((opt) => ({
+    ...opt,
+    disabled: opt.value === "outside" && !hasOutsideChordMembers,
   }));
+
+  const focusPresetOptions = availableFocusPresets.map((preset) => ({
+    value: preset,
+    label: FOCUS_PRESET_LABELS[preset],
+  }));
+
+  const effectiveFocusPreset = availableFocusPresets.includes(focusPreset)
+    ? focusPreset
+    : "all";
   const applyRootNote = (note: string) => {
     startTransition(() => {
       setRootNote(note);
@@ -323,26 +367,60 @@ export function TheoryControls({
                   </div>
                 ) : null}
 
-                <label className={shared["link-toggle"]} htmlFor={hideNonChordNotesId}>
-                  <input
-                    id={hideNonChordNotesId}
-                    type="checkbox"
-                    checked={hideNonChordNotes}
-                    onChange={(event) =>
-                      setHideNonChordNotes(event.target.checked)
-                    }
+                <div className={shared["control-section"]}>
+                  <span className={shared["section-label"]}>View</span>
+                  <ToggleBar
+                    options={viewModeOptions}
+                    value={viewMode}
+                    onChange={setViewMode}
+                    label="View mode"
                   />
-                  <span>
-                    Chord only (hide scale)
-                  </span>
-                </label>
+                </div>
 
-                <LabeledSelect
-                  label="Interval Filter"
-                  value={chordIntervalFilter}
-                  options={chordFilterOptions}
-                  onChange={setChordIntervalFilter}
-                />
+                <div className={shared["control-section"]}>
+                  <span className={shared["section-label"]}>Focus</span>
+                  <ToggleBar
+                    options={focusPresetOptions}
+                    value={effectiveFocusPreset}
+                    onChange={setFocusPreset}
+                    label="Focus preset"
+                  />
+                </div>
+
+                {effectiveFocusPreset === "custom" ? (
+                  <div className={shared["control-section"]}>
+                    <span className={shared["section-label"]}>Members</span>
+                    <div
+                      className={clsx(shared["toggle-group"], shared["toggle-group--default"])}
+                      role="group"
+                      aria-label="Custom chord members"
+                    >
+                      {chordMembers.map((m) => {
+                        const isActive = customMembers.includes(m.name);
+                        return (
+                          <button
+                            key={m.name}
+                            type="button"
+                            aria-pressed={isActive}
+                            className={clsx(
+                              shared["toggle-btn"],
+                              isActive && shared.active,
+                            )}
+                            onClick={() =>
+                              setCustomMembers(
+                                isActive
+                                  ? customMembers.filter((n) => n !== m.name)
+                                  : [...customMembers, m.name],
+                              )
+                            }
+                          >
+                            {formatMemberName(m.name)}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ) : null}
               </>
             ) : null}
           </div>

--- a/src/components/ToggleBar.tsx
+++ b/src/components/ToggleBar.tsx
@@ -34,6 +34,7 @@ const toggleButtonVariants = cva("", {
 type ToggleBarOption<Value extends string | number> = {
   value: Value;
   label: string;
+  disabled?: boolean;
 };
 
 interface ToggleBarProps<Value extends string | number> extends VariantProps<
@@ -71,6 +72,7 @@ export function ToggleBar<Value extends string | number>({
               : { "aria-pressed": isActive })}
             className={toggleButtonVariants({ variant, isActive })}
             onClick={() => onChange(option.value)}
+            disabled={option.disabled}
           >
             {option.label}
           </button>

--- a/src/hooks/useDisplayState.test.ts
+++ b/src/hooks/useDisplayState.test.ts
@@ -7,7 +7,9 @@ import {
   rootNoteAtom,
   chordRootAtom,
   chordTypeAtom,
-  chordIntervalFilterAtom,
+  focusPresetAtom,
+  viewModeAtom,
+  customMembersAtom,
   linkChordRootAtom,
   fingeringPatternAtom,
   npsPositionAtom,
@@ -135,36 +137,86 @@ describe("useDisplayState", () => {
     });
   });
 
-  describe("filteredChordTones with chordIntervalFilter = 'All'", () => {
-    it("filteredChordTones equals chordTones when filter is All", () => {
+  describe("activeChordTones with focusPreset = 'all'", () => {
+    it("activeChordTones contains all chord members when preset is all", () => {
       const store = createStore();
       store.set(chordRootAtom, "C");
       store.set(chordTypeAtom, "Major Triad");
-      store.set(chordIntervalFilterAtom, "All");
+      store.set(focusPresetAtom, "all");
       const { result } = renderHook(() => useDisplayState(), {
         wrapper: makeWrapper(store),
       });
-      // With 'All' filter, filteredChordTones is the same reference as chordTones
-      expect(result.current.filteredChordTones).toEqual(result.current.chordTones);
-      expect(result.current.filteredChordTones).toContain("C");
-      expect(result.current.filteredChordTones).toContain("E");
-      expect(result.current.filteredChordTones).toContain("G");
+      expect(result.current.activeChordTones).toContain("C");
+      expect(result.current.activeChordTones).toContain("E");
+      expect(result.current.activeChordTones).toContain("G");
+      expect(result.current.activeChordTones).toEqual(result.current.chordTones);
     });
   });
 
-  describe("filteredChordTones with non-All interval filter", () => {
-    it("filteredChordTones returns only triad tones when filter is Triad", () => {
+  describe("activeChordTones with focusPreset = 'triad'", () => {
+    it("activeChordTones excludes 7th when preset is triad on a Dominant 7th", () => {
       const store = createStore();
       store.set(chordRootAtom, "C");
       store.set(chordTypeAtom, "Dominant 7th");
-      store.set(chordIntervalFilterAtom, "Triad");
+      store.set(focusPresetAtom, "triad");
       const { result } = renderHook(() => useDisplayState(), {
         wrapper: makeWrapper(store),
       });
-      // Triad filter excludes 7th (interval 10), so Bb should not be in result
-      expect(result.current.filteredChordTones).not.toContain("A#");
-      // Root should always be included
-      expect(result.current.filteredChordTones).toContain("C");
+      // Triad preset excludes b7 (Bb/A#)
+      expect(result.current.activeChordTones).not.toContain("A#");
+      expect(result.current.activeChordTones).toContain("C");
+      expect(result.current.activeChordTones).toContain("E");
+      expect(result.current.activeChordTones).toContain("G");
+    });
+  });
+
+  describe("activeChordTones with focusPreset = 'guide-tones'", () => {
+    it("guide-tones excludes root and fifth", () => {
+      const store = createStore();
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Dominant 7th");
+      store.set(focusPresetAtom, "guide-tones");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      // Guide tones = 3rd + 7th only
+      expect(result.current.activeChordTones).not.toContain("C"); // root
+      expect(result.current.activeChordTones).not.toContain("G"); // 5th
+      expect(result.current.activeChordTones).toContain("E"); // 3rd
+      expect(result.current.activeChordTones).toContain("A#"); // b7
+    });
+  });
+
+  describe("activeChordTones with focusPreset = 'rootless'", () => {
+    it("rootless excludes only the root note", () => {
+      const store = createStore();
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major 7th");
+      store.set(focusPresetAtom, "rootless");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.activeChordTones).not.toContain("C");
+      expect(result.current.activeChordTones).toContain("E");
+      expect(result.current.activeChordTones).toContain("G");
+      expect(result.current.activeChordTones).toContain("B");
+    });
+  });
+
+  describe("focusPreset fallback when preset unavailable for chord quality", () => {
+    it("falls back to all when guide-tones is set but chord is a triad", () => {
+      const store = createStore();
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      store.set(focusPresetAtom, "guide-tones");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      // guide-tones not available for triads → falls back to all 3 tones
+      expect(result.current.activeChordTones).toContain("C");
+      expect(result.current.activeChordTones).toContain("E");
+      expect(result.current.activeChordTones).toContain("G");
+      expect(result.current.activeChordTones).toHaveLength(3);
     });
   });
 
@@ -347,6 +399,150 @@ describe("useDisplayState", () => {
 
       // Non-CAGED, non-3NPS mode → no centering target
       expect(result.current.autoCenterTarget).toBeUndefined();
+    });
+  });
+
+  describe("chordMembers resolved with note names", () => {
+    it("chordMembers contains root, 3rd, 5th with notes for C Major Triad", () => {
+      const store = createStore();
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.chordMembers).toHaveLength(3);
+      expect(result.current.chordMembers[0]).toMatchObject({ name: "root", note: "C" });
+      expect(result.current.chordMembers[1]).toMatchObject({ name: "3", note: "E" });
+      expect(result.current.chordMembers[2]).toMatchObject({ name: "5", note: "G" });
+    });
+
+    it("chordMembers is empty when chordType is null", () => {
+      const store = createStore();
+      store.set(chordTypeAtom, null);
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.chordMembers).toEqual([]);
+    });
+  });
+
+  describe("availableFocusPresets by chord quality", () => {
+    it("triad chord exposes all, rootless, custom presets", () => {
+      const store = createStore();
+      store.set(chordTypeAtom, "Major Triad");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.availableFocusPresets).toContain("all");
+      expect(result.current.availableFocusPresets).toContain("rootless");
+      expect(result.current.availableFocusPresets).toContain("custom");
+      expect(result.current.availableFocusPresets).not.toContain("guide-tones");
+      expect(result.current.availableFocusPresets).not.toContain("shell");
+    });
+
+    it("seventh chord exposes all six presets", () => {
+      const store = createStore();
+      store.set(chordTypeAtom, "Dominant 7th");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.availableFocusPresets).toContain("all");
+      expect(result.current.availableFocusPresets).toContain("triad");
+      expect(result.current.availableFocusPresets).toContain("shell");
+      expect(result.current.availableFocusPresets).toContain("guide-tones");
+      expect(result.current.availableFocusPresets).toContain("rootless");
+      expect(result.current.availableFocusPresets).toContain("custom");
+    });
+
+    it("power chord exposes only all and custom", () => {
+      const store = createStore();
+      store.set(chordTypeAtom, "Power Chord (5)");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.availableFocusPresets).toEqual(["all", "custom"]);
+    });
+  });
+
+  describe("hasOutsideChordMembers", () => {
+    it("is false when all chord tones are in the scale", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C"); // C Major scale
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad"); // C E G — all in C Major
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.hasOutsideChordMembers).toBe(false);
+    });
+
+    it("is true when a chord tone is outside the scale", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C"); // C Major scale
+      store.set(chordRootAtom, "G");
+      store.set(chordTypeAtom, "Dominant 7th"); // G B D F — F is in C Major, B is too, but let's check
+      // G Dominant 7th = G B D F; all in C Major scale actually
+      // Use D Dominant 7th = D F# A C — F# is not in C Major
+      const { result: result2 } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(createStore()),
+      });
+      const store2 = createStore();
+      store2.set(rootNoteAtom, "C");
+      store2.set(chordRootAtom, "D");
+      store2.set(chordTypeAtom, "Dominant 7th");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store2),
+      });
+      expect(result.current.hasOutsideChordMembers).toBe(true);
+      void result2; // suppress unused var
+    });
+  });
+
+  describe("hideNonChordNotes derived from viewMode", () => {
+    it("is false when viewMode is compare", () => {
+      const store = createStore();
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.hideNonChordNotes).toBe(false);
+    });
+
+    it("is true when viewMode is chord", () => {
+      const store = createStore();
+      store.set(viewModeAtom, "chord");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.hideNonChordNotes).toBe(true);
+    });
+  });
+
+  describe("customMembers applied in custom preset", () => {
+    it("activeChordTones shows only selected members in custom mode", () => {
+      const store = createStore();
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      store.set(focusPresetAtom, "custom");
+      store.set(customMembersAtom, ["root", "5"]);
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.activeChordTones).toContain("C");
+      expect(result.current.activeChordTones).toContain("G");
+      expect(result.current.activeChordTones).not.toContain("E");
+    });
+
+    it("custom with empty customMembers falls back to all members", () => {
+      const store = createStore();
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      store.set(focusPresetAtom, "custom");
+      store.set(customMembersAtom, []);
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.activeChordTones).toHaveLength(3);
     });
   });
 });

--- a/src/hooks/useDisplayState.ts
+++ b/src/hooks/useDisplayState.ts
@@ -6,9 +6,10 @@ import {
   chordRootAtom,
   chordTypeAtom,
   linkChordRootAtom,
-  hideNonChordNotesAtom,
   chordFretSpreadAtom,
-  chordIntervalFilterAtom,
+  viewModeAtom,
+  focusPresetAtom,
+  customMembersAtom,
   fingeringPatternAtom,
   cagedShapesAtom,
   npsPositionAtom,
@@ -25,14 +26,19 @@ import {
 import {
   SCALES,
   NOTES,
-  CHORDS,
+  CHORD_DEFINITIONS,
   getScaleNotes,
   getChordNotes,
-  getIntervalNotes,
   getNoteDisplay,
   getDivergentNotes,
   formatAccidental,
   resolveAccidentalMode,
+  getAvailableFocusPresets,
+  applyFocusPreset,
+  type ViewMode,
+  type FocusPreset,
+  type ChordMemberName,
+  type ResolvedChordMember,
 } from "../theory";
 import { getActiveScaleBrowseOption } from "../theoryCatalog";
 import { STANDARD_TUNING, TUNINGS } from "../guitar";
@@ -46,22 +52,7 @@ import {
   type CagedShape,
 } from "../shapes";
 
-// Chord interval filter presets — sets of allowed semitone intervals from chord root
-export const CHORD_INTERVAL_FILTERS: Record<string, Set<number>> = {
-  All: new Set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
-  Triad: new Set([0, 3, 4, 6, 7, 8]),
-  "7th Chord": new Set([0, 3, 4, 6, 7, 8, 10, 11]),
-  "Power Chord": new Set([0, 7]),
-  "Guide Tones": new Set([3, 4, 10, 11]),
-  "Shell Voicing": new Set([0, 3, 4, 10, 11]),
-  "Root & 3rd": new Set([0, 3, 4]),
-  "Root & 5th": new Set([0, 6, 7, 8]),
-  "Root & 7th": new Set([0, 10, 11]),
-  "3rd & 5th": new Set([3, 4, 6, 7, 8]),
-  "3rd & 7th": new Set([3, 4, 10, 11]),
-};
-
-export const CHORD_FILTER_OPTIONS = Object.keys(CHORD_INTERVAL_FILTERS);
+export type { ViewMode, FocusPreset, ChordMemberName, ResolvedChordMember };
 
 export default function useDisplayState() {
   // Scale
@@ -73,13 +64,10 @@ export default function useDisplayState() {
   const [chordRoot, setChordRoot] = useAtom(chordRootAtom);
   const [chordType, setChordType] = useAtom(chordTypeAtom);
   const [linkChordRoot, setLinkChordRoot] = useAtom(linkChordRootAtom);
-  const [hideNonChordNotes, setHideNonChordNotes] = useAtom(
-    hideNonChordNotesAtom,
-  );
   const chordFretSpread = useAtomValue(chordFretSpreadAtom);
-  const [chordIntervalFilter, setChordIntervalFilter] = useAtom(
-    chordIntervalFilterAtom,
-  );
+  const [viewMode, setViewMode] = useAtom(viewModeAtom);
+  const [focusPreset, setFocusPreset] = useAtom(focusPresetAtom);
+  const [customMembers, setCustomMembers] = useAtom(customMembersAtom);
 
   // Fingering
   const [fingeringPattern, setFingeringPattern] = useAtom(fingeringPatternAtom);
@@ -134,23 +122,63 @@ export default function useDisplayState() {
 
   const currentTuning = TUNINGS[tuningName] || STANDARD_TUNING;
 
-  // Compute active chord tones (independent of scale)
+  // All chord tones for the selected chord (unfiltered; used for degree strip)
   const chordTones = useMemo(() => {
     if (!chordType) return [];
     return getChordNotes(chordRoot, chordType);
   }, [chordRoot, chordType]);
 
-  // Apply interval filter to chord tones (always preserve root)
-  const filteredChordTones = useMemo(() => {
-    if (!chordType || chordIntervalFilter === "All") return chordTones;
-    const allowed = CHORD_INTERVAL_FILTERS[chordIntervalFilter];
-    const intervals = CHORDS[chordType];
-    if (!intervals || !allowed) return chordTones;
-    const filtered = intervals.filter((i) => allowed.has(i));
-    // Always include root (interval 0) so root-active classification stays anchored
-    if (!filtered.includes(0)) filtered.unshift(0);
-    return getIntervalNotes(chordRoot, filtered);
-  }, [chordRoot, chordType, chordIntervalFilter, chordTones]);
+  // Available focus presets for the current chord quality
+  const availableFocusPresets = useMemo((): FocusPreset[] => {
+    if (!chordType) return ["all", "custom"];
+    return getAvailableFocusPresets(chordType);
+  }, [chordType]);
+
+  // Resolved chord members with note names attached
+  const chordMembers = useMemo((): ResolvedChordMember[] => {
+    if (!chordType) return [];
+    const def = CHORD_DEFINITIONS[chordType];
+    if (!def) return [];
+    const rootIndex = NOTES.indexOf(chordRoot);
+    if (rootIndex === -1) return [];
+    return def.members.map((m) => ({
+      ...m,
+      note: NOTES[(rootIndex + m.semitone) % 12],
+    }));
+  }, [chordRoot, chordType]);
+
+  // Active chord members after applying focus preset (with graceful fallback)
+  const activeChordMembers = useMemo((): ResolvedChordMember[] => {
+    if (!chordType) return [];
+    const def = CHORD_DEFINITIONS[chordType];
+    if (!def) return [];
+    const rootIndex = NOTES.indexOf(chordRoot);
+    if (rootIndex === -1) return [];
+    const effectivePreset = availableFocusPresets.includes(focusPreset)
+      ? focusPreset
+      : "all";
+    const members = applyFocusPreset(def, effectivePreset, customMembers);
+    return members.map((m) => ({
+      ...m,
+      note: NOTES[(rootIndex + m.semitone) % 12],
+    }));
+  }, [chordRoot, chordType, focusPreset, customMembers, availableFocusPresets]);
+
+  // Note names from active chord members — passed to Fretboard as chordTones
+  const activeChordTones = useMemo(
+    () => activeChordMembers.map((m) => m.note),
+    [activeChordMembers],
+  );
+
+  // Whether any chord member falls outside the current scale
+  const hasOutsideChordMembers = useMemo(() => {
+    if (!chordType || chordTones.length === 0) return false;
+    const scaleNoteSet = new Set(getScaleNotes(rootNote, scaleName));
+    return chordTones.some((note) => !scaleNoteSet.has(note));
+  }, [chordType, chordTones, rootNote, scaleName]);
+
+  // hideNonChordNotes derived from viewMode for Fretboard rendering path
+  const hideNonChordNotes = viewMode === "chord";
 
   const {
     highlightNotes,
@@ -308,7 +336,9 @@ export default function useDisplayState() {
     linkChordRoot,
     hideNonChordNotes,
     chordFretSpread,
-    chordIntervalFilter,
+    viewMode,
+    focusPreset,
+    customMembers,
     fingeringPattern,
     cagedShapes,
     npsPosition,
@@ -325,8 +355,9 @@ export default function useDisplayState() {
     setChordRoot,
     setChordType,
     setLinkChordRoot,
-    setHideNonChordNotes,
-    setChordIntervalFilter,
+    setViewMode,
+    setFocusPreset,
+    setCustomMembers,
     setFingeringPattern,
     setCagedShapes,
     setNpsPosition,
@@ -337,7 +368,11 @@ export default function useDisplayState() {
     useFlats,
     currentTuning,
     chordTones,
-    filteredChordTones,
+    chordMembers,
+    availableFocusPresets,
+    activeChordMembers,
+    activeChordTones,
+    hasOutsideChordMembers,
     highlightNotes,
     boxBounds,
     shapePolygons,

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -3,6 +3,11 @@ import { atomWithStorage, RESET } from "jotai/utils";
 import { CAGED_SHAPES, type CagedShape } from "../shapes";
 import { normalizeScaleName, type ScaleBrowseMode } from "../theoryCatalog";
 import { k, STORAGE_PREFIX } from "../utils/storage";
+import type {
+  ViewMode,
+  FocusPreset,
+  ChordMemberName,
+} from "../theory";
 
 export type FingeringPattern = "all" | "caged" | "3nps";
 
@@ -485,10 +490,133 @@ export const chordFretSpreadAtom = atomWithStorage(
   chordFretSpreadStorage,
   GET_ON_INIT,
 );
-export const chordIntervalFilterAtom = atomWithStorage(
-  k("chordIntervalFilter"),
-  "All",
-  rawStringStorage(),
+
+const VIEW_MODE_VALUES: ViewMode[] = ["compare", "chord", "outside"];
+
+const viewModeStorage = {
+  getItem(key: string, initialValue: ViewMode): ViewMode {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, initialValue);
+        return initialValue;
+      }
+      if ((VIEW_MODE_VALUES as string[]).includes(stored))
+        return stored as ViewMode;
+      localStorage.setItem(key, initialValue);
+      return initialValue;
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: ViewMode): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+};
+
+const FOCUS_PRESET_VALUES: FocusPreset[] = [
+  "all",
+  "triad",
+  "shell",
+  "guide-tones",
+  "rootless",
+  "custom",
+];
+
+const focusPresetStorage = {
+  getItem(key: string, initialValue: FocusPreset): FocusPreset {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, initialValue);
+        return initialValue;
+      }
+      if ((FOCUS_PRESET_VALUES as string[]).includes(stored))
+        return stored as FocusPreset;
+      localStorage.setItem(key, initialValue);
+      return initialValue;
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: FocusPreset): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+};
+
+const customMembersStorage = {
+  getItem(key: string, initialValue: ChordMemberName[]): ChordMemberName[] {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, JSON.stringify(initialValue));
+        return initialValue;
+      }
+      try {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) return parsed as ChordMemberName[];
+        return initialValue;
+      } catch {
+        return initialValue;
+      }
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: ChordMemberName[]): void {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+};
+
+export const viewModeAtom = atomWithStorage<ViewMode>(
+  k("viewMode"),
+  "compare",
+  viewModeStorage,
+  GET_ON_INIT,
+);
+export const focusPresetAtom = atomWithStorage<FocusPreset>(
+  k("focusPreset"),
+  "all",
+  focusPresetStorage,
+  GET_ON_INIT,
+);
+export const customMembersAtom = atomWithStorage<ChordMemberName[]>(
+  k("customMembers"),
+  [],
+  customMembersStorage,
   GET_ON_INIT,
 );
 
@@ -634,7 +762,9 @@ export const resetAtom = atom(null, (_get, set) => {
   set(linkChordRootAtom, RESET);
   set(hideNonChordNotesAtom, RESET);
   set(chordFretSpreadAtom, RESET);
-  set(chordIntervalFilterAtom, RESET);
+  set(viewModeAtom, RESET);
+  set(focusPresetAtom, RESET);
+  set(customMembersAtom, RESET);
   set(fingeringPatternAtom, RESET);
   set(cagedShapesAtom, RESET);
   set(npsPositionAtom, RESET);

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -63,15 +63,152 @@ export const FLAT_KEYS = [
 
 export { normalizeScaleName, SCALES, SCALE_TO_PARENT_MAJOR_OFFSET };
 
-export const CHORDS: Record<string, number[]> = {
-  "Major Triad": [0, 4, 7],
-  "Minor Triad": [0, 3, 7],
-  "Diminished Triad": [0, 3, 6],
-  "Major 7th": [0, 4, 7, 11],
-  "Minor 7th": [0, 3, 7, 10],
-  "Dominant 7th": [0, 4, 7, 10],
-  "Power Chord (5)": [0, 7],
+// Chord overlay types
+export type ChordMemberName = "root" | "b3" | "3" | "b5" | "5" | "b7" | "7";
+export type ChordQuality = "triad" | "seventh" | "power";
+export type ViewMode = "compare" | "chord" | "outside";
+export type FocusPreset =
+  | "all"
+  | "triad"
+  | "shell"
+  | "guide-tones"
+  | "rootless"
+  | "custom";
+
+export interface ChordMember {
+  name: ChordMemberName;
+  semitone: number;
+}
+
+export interface ChordDefinition {
+  quality: ChordQuality;
+  members: ChordMember[];
+}
+
+export interface ResolvedChordMember extends ChordMember {
+  note: string;
+}
+
+export const CHORD_DEFINITIONS: Record<string, ChordDefinition> = {
+  "Major Triad": {
+    quality: "triad",
+    members: [
+      { name: "root", semitone: 0 },
+      { name: "3", semitone: 4 },
+      { name: "5", semitone: 7 },
+    ],
+  },
+  "Minor Triad": {
+    quality: "triad",
+    members: [
+      { name: "root", semitone: 0 },
+      { name: "b3", semitone: 3 },
+      { name: "5", semitone: 7 },
+    ],
+  },
+  "Diminished Triad": {
+    quality: "triad",
+    members: [
+      { name: "root", semitone: 0 },
+      { name: "b3", semitone: 3 },
+      { name: "b5", semitone: 6 },
+    ],
+  },
+  "Major 7th": {
+    quality: "seventh",
+    members: [
+      { name: "root", semitone: 0 },
+      { name: "3", semitone: 4 },
+      { name: "5", semitone: 7 },
+      { name: "7", semitone: 11 },
+    ],
+  },
+  "Minor 7th": {
+    quality: "seventh",
+    members: [
+      { name: "root", semitone: 0 },
+      { name: "b3", semitone: 3 },
+      { name: "5", semitone: 7 },
+      { name: "b7", semitone: 10 },
+    ],
+  },
+  "Dominant 7th": {
+    quality: "seventh",
+    members: [
+      { name: "root", semitone: 0 },
+      { name: "3", semitone: 4 },
+      { name: "5", semitone: 7 },
+      { name: "b7", semitone: 10 },
+    ],
+  },
+  "Power Chord (5)": {
+    quality: "power",
+    members: [
+      { name: "root", semitone: 0 },
+      { name: "5", semitone: 7 },
+    ],
+  },
 };
+
+// Derived from CHORD_DEFINITIONS for backward compatibility
+export const CHORDS: Record<string, number[]> = Object.fromEntries(
+  Object.entries(CHORD_DEFINITIONS).map(([name, def]) => [
+    name,
+    def.members.map((m) => m.semitone),
+  ]),
+);
+
+const FOCUS_PRESETS_BY_QUALITY: Record<ChordQuality, FocusPreset[]> = {
+  triad: ["all", "rootless", "custom"],
+  seventh: ["all", "triad", "shell", "guide-tones", "rootless", "custom"],
+  power: ["all", "custom"],
+};
+
+export function getAvailableFocusPresets(chordName: string): FocusPreset[] {
+  const def = CHORD_DEFINITIONS[chordName];
+  if (!def) return ["all", "custom"];
+  return FOCUS_PRESETS_BY_QUALITY[def.quality];
+}
+
+const TRIAD_MEMBER_NAMES = new Set<ChordMemberName>([
+  "root",
+  "b3",
+  "3",
+  "b5",
+  "5",
+]);
+const SHELL_MEMBER_NAMES = new Set<ChordMemberName>([
+  "root",
+  "b3",
+  "3",
+  "b7",
+  "7",
+]);
+const GUIDE_TONE_NAMES = new Set<ChordMemberName>(["b3", "3", "b7", "7"]);
+
+export function applyFocusPreset(
+  def: ChordDefinition,
+  preset: FocusPreset,
+  customMembers: ChordMemberName[],
+): ChordMember[] {
+  switch (preset) {
+    case "all":
+      return def.members;
+    case "triad":
+      return def.members.filter((m) => TRIAD_MEMBER_NAMES.has(m.name));
+    case "shell":
+      return def.members.filter((m) => SHELL_MEMBER_NAMES.has(m.name));
+    case "guide-tones":
+      return def.members.filter((m) => GUIDE_TONE_NAMES.has(m.name));
+    case "rootless":
+      return def.members.filter((m) => m.name !== "root");
+    case "custom":
+      if (customMembers.length === 0) return def.members;
+      return def.members.filter((m) => customMembers.includes(m.name));
+    default:
+      return def.members;
+  }
+}
 
 // Circle of fifths order anchored in root notes (sharps default)
 export const CIRCLE_OF_FIFTHS = [


### PR DESCRIPTION
## Summary

- Replaces the `chordIntervalFilterAtom` + semitone-bucket filter system with a structured chord-member overlay model
- Adds `CHORD_DEFINITIONS` in `theory.ts` with named members (`root`, `b3`, `3`, `b5`, `5`, `b7`, `7`), chord quality metadata (`triad | seventh | power`), and helper functions (`getAvailableFocusPresets`, `applyFocusPreset`)
- Derives the existing `CHORDS` record from `CHORD_DEFINITIONS` for full backward compatibility
- Introduces three new persisted atoms: `viewModeAtom` (`compare | chord | outside`), `focusPresetAtom` (`all | triad | shell | guide-tones | rootless | custom`), and `customMembersAtom`
- `useDisplayState` now derives `chordMembers`, `activeChordMembers`, `activeChordTones`, `availableFocusPresets`, and `hasOutsideChordMembers`; `hideNonChordNotes` is derived from `viewMode === "chord"` instead of a separate atom
- Replaces the Interval Filter dropdown + "Chord only" checkbox in `TheoryControls` with **View** and **Focus** toggle bars plus per-member multi-select buttons for the `custom` preset
- Preset availability is chord-quality-aware: triads get `all / rootless / custom`; 7th chords get all six; power chords get `all / custom`
- `guide-tones` never forces the root; `outside` view is disabled when all chord tones are in-scale; presets gracefully fall back to `all` when the chord quality changes

## What's not in this phase

- No new fretboard visuals for `viewMode: outside`
- No new legend/degree strip redesign
- `hideNonChordNotesAtom` is kept in atoms for reset idempotency but is now vestigial

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test` — 722 tests pass, 10 snapshots updated
- [x] `npm run build` — clean TypeScript + Vite build
- Added theory tests for `CHORD_DEFINITIONS`, `getAvailableFocusPresets`, `applyFocusPreset`
- Added/updated `useDisplayState` tests for all new derivations + fallback behavior
- Added `TheoryControls` tests for View/Focus controls, disabled Outside option, custom member toggles
- Updated `atoms` tests to cover `viewModeAtom`, `focusPresetAtom`, `customMembersAtom` reset behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)