### PR TITLE
feat(chord): relationship row replaces compact chord rail

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1256,6 +1256,17 @@
   padding-top: 0.18rem;
 }
 
+/* Relationship row sits flush inside the ribbon — no extra card chrome */
+.app-container .summary-ribbon .relationship-row {
+  width: 100%;
+  margin: 0;
+}
+
+/* Chord overlay active: scale-only fretboard notes dim further so chord tones lead */
+.app-container[data-chord-active="true"] .note-scale-only {
+  opacity: 0.45;
+}
+
 /* Mobile ribbon */
 .app-container[data-layout-tier="mobile"] .summary-ribbon {
   width: 100%;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { BrandMark } from "./components/BrandMark";
 import { FretFlowWordmark } from "./components/FretFlowWordmark";
 import { DegreeChipStrip } from "./components/DegreeChipStrip";
 import { ChordRowStrip } from "./components/ChordRowStrip";
+import { RelationshipRow } from "./components/RelationshipRow";
 import "./App.css";
 
 const END_FRET = 25;
@@ -86,7 +87,9 @@ function AppContent() {
     summaryHeaderLeft,
     summaryHeaderRight,
     summaryPrimaryMode,
-    showSecondaryChordRail,
+    showRelationshipRow,
+    sharedChordMembers,
+    outsideChordMembers,
     recenterKey,
     onShapeClick,
     onRecenter,
@@ -258,12 +261,10 @@ function AppContent() {
           legendItems={[]}
         />
       )}
-      {showSecondaryChordRail && (
-        <ChordRowStrip
-          chordLabel={chordLabel ?? ""}
-          chordRow={summaryChordRow}
-          legendItems={[]}
-          compact
+      {showRelationshipRow && (
+        <RelationshipRow
+          sharedMembers={sharedChordMembers}
+          outsideMembers={outsideChordMembers}
         />
       )}
     </div>
@@ -335,6 +336,7 @@ function AppContent() {
       className="app-container"
       data-layout-tier={layout.tier}
       data-layout-variant={layout.variant}
+      data-chord-active={chordType ? "true" : undefined}
       data-header-subtitle={layout.showHeaderSubtitle ? "visible" : "hidden"}
       data-header-actions={layout.compactHeaderActions ? "compact" : "default"}
       data-full-width-overlay={layout.fullWidthOverlay ? "true" : "false"}

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -412,7 +412,7 @@ describe("App", () => {
       });
     });
 
-    it("compare mode: no secondary chord rail when same root, all preset, all in scale", async () => {
+    it("compare mode: no relationship row in simple diatonic case (same root, all preset, all in scale)", async () => {
       localStorage.setItem(k("rootNote"), "C");
       localStorage.setItem(k("chordRoot"), "C");
       localStorage.setItem(k("chordType"), "Major Triad");
@@ -422,10 +422,10 @@ describe("App", () => {
       await waitFor(() => {
         expect(document.querySelector(".summary-ribbon")).toBeTruthy();
       });
-      expect(document.querySelector(".chord-row-strip--compact")).toBeNull();
+      expect(document.querySelector(".relationship-row")).toBeNull();
     });
 
-    it("compare mode: shows secondary compact rail when chordRoot differs from scale root", async () => {
+    it("compare mode: shows relationship row when chordRoot differs from scale root", async () => {
       localStorage.setItem(k("rootNote"), "C");
       localStorage.setItem(k("chordRoot"), "G");
       localStorage.setItem(k("chordType"), "Major Triad");
@@ -433,7 +433,7 @@ describe("App", () => {
       localStorage.setItem(k("viewMode"), "compare");
       render(<App />);
       await waitFor(() => {
-        expect(document.querySelector(".chord-row-strip--compact")).toBeTruthy();
+        expect(document.querySelector(".relationship-row")).toBeTruthy();
       });
     });
 

--- a/src/__tests__/RelationshipRow.test.tsx
+++ b/src/__tests__/RelationshipRow.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RelationshipRow } from "../components/RelationshipRow";
+import type { ChordRowEntry } from "../theory";
+import { axe } from "../test-utils/a11y";
+
+const sharedEntry = (note: string, role: ChordRowEntry["role"] = "chord-tone-in-scale"): ChordRowEntry => ({
+  internalNote: note,
+  displayNote: note,
+  memberName: "3",
+  role,
+  inScale: true,
+});
+
+const outsideEntry = (note: string, role: ChordRowEntry["role"] = "chord-tone-outside-scale"): ChordRowEntry => ({
+  internalNote: note,
+  displayNote: note,
+  memberName: "♭7",
+  role,
+  inScale: false,
+});
+
+// C# Minor Triad over C Major: Shared=E, Outside=C#,G#
+const shared = [sharedEntry("E")];
+const outside = [
+  outsideEntry("C#", "chord-root"),
+  outsideEntry("G#"),
+];
+
+describe("RelationshipRow", () => {
+  it("renders role=group with correct aria-label", () => {
+    render(<RelationshipRow sharedMembers={shared} outsideMembers={outside} />);
+    expect(screen.getByRole("group", { name: "Chord-scale relationship" })).toBeTruthy();
+  });
+
+  it("renders Shared group when shared members are present", () => {
+    const { container } = render(
+      <RelationshipRow sharedMembers={shared} outsideMembers={[]} />
+    );
+    expect(container.querySelector('[data-group="shared"]')).toBeTruthy();
+    expect(screen.getByText("Shared")).toBeTruthy();
+  });
+
+  it("renders Outside group when outside members are present", () => {
+    const { container } = render(
+      <RelationshipRow sharedMembers={[]} outsideMembers={outside} />
+    );
+    expect(container.querySelector('[data-group="outside"]')).toBeTruthy();
+    expect(screen.getByText("Outside")).toBeTruthy();
+  });
+
+  it("renders both groups when both have members", () => {
+    const { container } = render(
+      <RelationshipRow sharedMembers={shared} outsideMembers={outside} />
+    );
+    expect(container.querySelector('[data-group="shared"]')).toBeTruthy();
+    expect(container.querySelector('[data-group="outside"]')).toBeTruthy();
+  });
+
+  it("renders correct note text in each group", () => {
+    render(<RelationshipRow sharedMembers={shared} outsideMembers={outside} />);
+    expect(screen.getByText("E")).toBeTruthy();
+    expect(screen.getByText("C#")).toBeTruthy();
+    expect(screen.getByText("G#")).toBeTruthy();
+  });
+
+  it("pills are capsule-shaped (no circular chip language)", () => {
+    const { container } = render(
+      <RelationshipRow sharedMembers={shared} outsideMembers={outside} />
+    );
+    const pills = container.querySelectorAll(".relationship-pill");
+    expect(pills.length).toBeGreaterThan(0);
+    // Pills should not use the degree-chip class (which is circular)
+    expect(container.querySelector(".degree-chip")).toBeNull();
+  });
+
+  it("each pill has correct data-role attribute", () => {
+    const { container } = render(
+      <RelationshipRow sharedMembers={shared} outsideMembers={outside} />
+    );
+    const sharedPill = container.querySelector('[data-group="shared"] .relationship-pill');
+    expect(sharedPill?.getAttribute("data-role")).toBe("chord-tone-in-scale");
+
+    const outsideRootPill = container.querySelector(
+      '[data-group="outside"] .relationship-pill[data-role="chord-root"]'
+    );
+    expect(outsideRootPill).toBeTruthy();
+  });
+
+  it("returns null when both groups are empty", () => {
+    const { container } = render(
+      <RelationshipRow sharedMembers={[]} outsideMembers={[]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("omits Shared group when sharedMembers is empty", () => {
+    const { container } = render(
+      <RelationshipRow sharedMembers={[]} outsideMembers={outside} />
+    );
+    expect(container.querySelector('[data-group="shared"]')).toBeNull();
+    expect(container.querySelector('[data-group="outside"]')).toBeTruthy();
+  });
+
+  it("omits Outside group when outsideMembers is empty", () => {
+    const { container } = render(
+      <RelationshipRow sharedMembers={shared} outsideMembers={[]} />
+    );
+    expect(container.querySelector('[data-group="outside"]')).toBeNull();
+    expect(container.querySelector('[data-group="shared"]')).toBeTruthy();
+  });
+
+  it("does not duplicate notes between shared and outside groups", () => {
+    const { container } = render(
+      <RelationshipRow sharedMembers={shared} outsideMembers={outside} />
+    );
+    const sharedNotes = Array.from(
+      container.querySelectorAll('[data-group="shared"] .relationship-pill-note')
+    ).map((el) => el.textContent);
+    const outsideNotes = Array.from(
+      container.querySelectorAll('[data-group="outside"] .relationship-pill-note')
+    ).map((el) => el.textContent);
+    const allNotes = [...sharedNotes, ...outsideNotes];
+    const uniqueNotes = new Set(allNotes);
+    expect(uniqueNotes.size).toBe(allNotes.length);
+  });
+
+  it("shared aria-label is 'Shared with scale'", () => {
+    render(<RelationshipRow sharedMembers={shared} outsideMembers={[]} />);
+    expect(screen.getByRole("list", { name: "Shared with scale" })).toBeTruthy();
+  });
+
+  it("outside aria-label is 'Outside scale'", () => {
+    render(<RelationshipRow sharedMembers={[]} outsideMembers={outside} />);
+    expect(screen.getByRole("list", { name: "Outside scale" })).toBeTruthy();
+  });
+
+  it("accepts an optional className", () => {
+    const { container } = render(
+      <RelationshipRow
+        sharedMembers={shared}
+        outsideMembers={outside}
+        className="custom-class"
+      />
+    );
+    expect(container.querySelector(".relationship-row.custom-class")).toBeTruthy();
+  });
+
+  it("has no accessibility violations with both groups", async () => {
+    const { container } = render(
+      <RelationshipRow sharedMembers={shared} outsideMembers={outside} />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("has no accessibility violations with only shared group", async () => {
+    const { container } = render(
+      <RelationshipRow sharedMembers={shared} outsideMembers={[]} />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("has no accessibility violations with only outside group", async () => {
+    const { container } = render(
+      <RelationshipRow sharedMembers={[]} outsideMembers={outside} />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  describe("compare mode semantics (C Major + C# Minor Triad)", () => {
+    it("shared group contains only E (in-scale chord tone)", () => {
+      const { container } = render(
+        <RelationshipRow sharedMembers={shared} outsideMembers={outside} />
+      );
+      const sharedPills = container.querySelectorAll(
+        '[data-group="shared"] .relationship-pill-note'
+      );
+      expect(sharedPills).toHaveLength(1);
+      expect(sharedPills[0].textContent).toBe("E");
+    });
+
+    it("outside group contains C# (chord root) and G#", () => {
+      const { container } = render(
+        <RelationshipRow sharedMembers={shared} outsideMembers={outside} />
+      );
+      const outsidePills = container.querySelectorAll(
+        '[data-group="outside"] .relationship-pill-note'
+      );
+      expect(outsidePills).toHaveLength(2);
+      const texts = Array.from(outsidePills).map((el) => el.textContent);
+      expect(texts).toContain("C#");
+      expect(texts).toContain("G#");
+    });
+  });
+});

--- a/src/components/DegreeChipStrip.css
+++ b/src/components/DegreeChipStrip.css
@@ -117,15 +117,15 @@
    Specificity (.degree-chip-strip[…] .degree-chip-item[…] .degree-chip) beats
    the base per-role rules above, so these always win when chord is active. */
 
-/* scale-only: subdued hollow ring — clearly subordinate to chord tones */
+/* scale-only: very subdued — clearly background to chord tones */
 .degree-chip-strip[data-chord-active='true'] .degree-chip-item[data-in-scale='true']:not([data-in-chord='true']) .degree-chip {
-  border-color: rgb(77 228 255 / 0.28);
+  border-color: rgb(77 228 255 / 0.18);
   box-shadow: none;
-  opacity: 0.42;
+  opacity: 0.28;
 }
 
 .degree-chip-strip[data-chord-active='true'] .degree-chip-item[data-in-scale='true']:not([data-in-chord='true']) .degree-chip-interval {
-  opacity: 0.4;
+  opacity: 0.3;
 }
 
 /* chord-tone: solid warm fill, brighter — clearly stronger than scale-only */

--- a/src/components/RelationshipRow.css
+++ b/src/components/RelationshipRow.css
@@ -1,0 +1,124 @@
+/* Relationship row: chord-scale analysis strip shown in compare mode.
+   Replaces the compact chord rail. Uses capsule pills — not circular chips —
+   to visually distinguish from the scale degree strip above. */
+
+.relationship-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.7rem;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0 0;
+  border-top: 1px solid rgb(255 255 255 / 0.07);
+}
+
+.relationship-group {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.relationship-group-label {
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  font-weight: var(--font-weight-medium);
+  color: var(--text-soft-white);
+  opacity: 0.5;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.relationship-pill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.22rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* Capsule pill — explicitly NOT circular to distinguish from degree chip circles */
+.relationship-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.1rem 0.48rem;
+  border-radius: 9999px;
+  border: 1.5px solid rgb(255 255 255 / 0.2);
+  background: transparent;
+}
+
+/* Shared (in-scale) pills */
+.relationship-group[data-group="shared"] .relationship-pill {
+  border-color: rgb(77 228 255 / 0.5);
+  background: rgb(77 228 255 / 0.06);
+}
+
+/* Shared chord root (edge case: chord root is also in scale) */
+.relationship-group[data-group="shared"] .relationship-pill[data-role="chord-root"] {
+  border-color: rgb(255 154 77 / 0.75);
+  background: rgb(255 154 77 / 0.1);
+}
+
+/* Outside scale pills — dashed border signals tension */
+.relationship-group[data-group="outside"] .relationship-pill {
+  border-color: rgb(204 122 61 / 0.65);
+  border-style: dashed;
+  background: rgb(100 40 15 / 0.2);
+}
+
+/* Outside chord root: solid border, strongest outside emphasis */
+.relationship-group[data-group="outside"] .relationship-pill[data-role="chord-root"] {
+  border-style: solid;
+  border-width: 2px;
+  border-color: rgb(255 154 77 / 0.8);
+  background: rgb(255 154 77 / 0.12);
+}
+
+.relationship-pill-note {
+  font-family: var(--font-sans);
+  font-size: clamp(0.8rem, 1.25vw, 0.9rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-soft-white);
+  line-height: 1.5;
+  letter-spacing: 0.01em;
+}
+
+/* Mobile */
+.app-container[data-layout-tier="mobile"] .relationship-row {
+  gap: 0.35rem 0.55rem;
+  padding-top: 0.15rem;
+}
+
+.app-container[data-layout-tier="mobile"] .relationship-group-label {
+  font-size: 0.66rem;
+}
+
+.app-container[data-layout-tier="mobile"] .relationship-pill {
+  padding: 0.08rem 0.42rem;
+}
+
+.app-container[data-layout-tier="mobile"] .relationship-pill-note {
+  font-size: 0.8rem;
+}
+
+/* Desktop */
+.app-container[data-layout-tier="desktop"] .relationship-row {
+  gap: 0.28rem 0.55rem;
+  padding-top: 0.12rem;
+}
+
+.app-container[data-layout-tier="desktop"] .relationship-group-label {
+  font-size: 0.65rem;
+}
+
+.app-container[data-layout-tier="desktop"] .relationship-pill {
+  padding: 0.08rem 0.42rem;
+}
+
+.app-container[data-layout-tier="desktop"] .relationship-pill-note {
+  font-size: clamp(0.74rem, 1.15vw, 0.84rem);
+}

--- a/src/components/RelationshipRow.tsx
+++ b/src/components/RelationshipRow.tsx
@@ -1,0 +1,58 @@
+import clsx from "clsx";
+import type { ChordRowEntry } from "../theory";
+import "./RelationshipRow.css";
+
+interface RelationshipRowProps {
+  sharedMembers: ChordRowEntry[];
+  outsideMembers: ChordRowEntry[];
+  className?: string;
+}
+
+export function RelationshipRow({
+  sharedMembers,
+  outsideMembers,
+  className,
+}: RelationshipRowProps) {
+  if (sharedMembers.length === 0 && outsideMembers.length === 0) return null;
+
+  return (
+    <div
+      className={clsx("relationship-row", className)}
+      role="group"
+      aria-label="Chord-scale relationship"
+    >
+      {sharedMembers.length > 0 && (
+        <div className="relationship-group" data-group="shared">
+          <span className="relationship-group-label">Shared</span>
+          <ul className="relationship-pill-list" aria-label="Shared with scale">
+            {sharedMembers.map((entry, i) => (
+              <li
+                key={`${entry.internalNote}-${i}`}
+                className="relationship-pill"
+                data-role={entry.role}
+              >
+                <span className="relationship-pill-note">{entry.displayNote}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {outsideMembers.length > 0 && (
+        <div className="relationship-group" data-group="outside">
+          <span className="relationship-group-label">Outside</span>
+          <ul className="relationship-pill-list" aria-label="Outside scale">
+            {outsideMembers.map((entry, i) => (
+              <li
+                key={`${entry.internalNote}-${i}`}
+                className="relationship-pill"
+                data-role={entry.role}
+              >
+                <span className="relationship-pill-note">{entry.displayNote}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useDisplayState.test.ts
+++ b/src/hooks/useDisplayState.test.ts
@@ -844,7 +844,7 @@ describe("useDisplayState", () => {
       expect(result.current.summaryHeaderLeft).toBe(result.current.scaleLabel);
     });
 
-    it("headerRight in compare mode contains chordLabel and member labels", () => {
+    it("headerRight in compare mode is chordLabel only (member intervals moved to relationship row)", () => {
       const store = createStore();
       store.set(rootNoteAtom, "C");
       store.set(chordRootAtom, "C");
@@ -854,8 +854,9 @@ describe("useDisplayState", () => {
         wrapper: makeWrapper(store),
       });
       const right = result.current.summaryHeaderRight;
-      expect(right).toContain("C Major Triad");
-      expect(right).toContain("1");
+      expect(right).toBe("C Major Triad");
+      // Member interval labels (e.g. "1 3 5") are no longer in the header
+      expect(right).not.toContain(" \u2022 ");
     });
 
     it("headerLeft is chordLabel in chord viewMode", () => {
@@ -900,6 +901,169 @@ describe("useDisplayState", () => {
       });
       expect(result.current.summaryHeaderRight).toMatch(/^against /);
       expect(result.current.summaryHeaderRight).toContain(result.current.scaleLabel);
+    });
+  });
+
+  describe("sharedChordMembers and outsideChordMembers", () => {
+    it("sharedChordMembers contains only in-scale chord members", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C"); // C Major: C D E F G A B
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Dominant 7th"); // C E G A# — A# outside
+      store.set(focusPresetAtom, "all");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      const shared = result.current.sharedChordMembers;
+      expect(shared.every((e) => e.inScale)).toBe(true);
+      expect(shared.some((e) => e.internalNote === "A#")).toBe(false);
+    });
+
+    it("outsideChordMembers contains only out-of-scale chord members", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C"); // C Major
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Dominant 7th"); // C E G A# — A# outside
+      store.set(focusPresetAtom, "all");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      const outside = result.current.outsideChordMembers;
+      expect(outside.every((e) => !e.inScale)).toBe(true);
+      expect(outside.some((e) => e.internalNote === "A#")).toBe(true);
+    });
+
+    it("shared + outside together equal all active chord members", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      store.set(chordRootAtom, "D");
+      store.set(chordTypeAtom, "Dominant 7th"); // D F# A C — F# outside
+      store.set(focusPresetAtom, "all");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      const total =
+        result.current.sharedChordMembers.length +
+        result.current.outsideChordMembers.length;
+      expect(total).toBe(result.current.summaryChordRow.length);
+    });
+
+    it("no note appears in both shared and outside groups", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      store.set(chordRootAtom, "D");
+      store.set(chordTypeAtom, "Dominant 7th");
+      store.set(focusPresetAtom, "all");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      const sharedNotes = new Set(result.current.sharedChordMembers.map((e) => e.internalNote));
+      const outsideNotes = result.current.outsideChordMembers.map((e) => e.internalNote);
+      expect(outsideNotes.some((n) => sharedNotes.has(n))).toBe(false);
+    });
+
+    it("sharedChordMembers is empty when chord root is outside scale and it's the only tone", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C"); // C Major
+      store.set(chordRootAtom, "F#");
+      store.set(chordTypeAtom, "Power Chord (5)"); // F# C# — both outside C Major
+      store.set(focusPresetAtom, "all");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      // F# and C# are both outside C Major
+      expect(result.current.sharedChordMembers).toHaveLength(0);
+      expect(result.current.outsideChordMembers.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("showRelationshipRow", () => {
+    it("is false when no chord type is set", () => {
+      const store = createStore();
+      store.set(chordTypeAtom, null);
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.showRelationshipRow).toBe(false);
+    });
+
+    it("is false in simple diatonic compare case: same root, all preset, all in scale", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad"); // C E G — all in C Major
+      store.set(focusPresetAtom, "all");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.showRelationshipRow).toBe(false);
+    });
+
+    it("is true when chordRoot differs from rootNote", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      store.set(chordRootAtom, "E");
+      store.set(chordTypeAtom, "Major Triad");
+      store.set(focusPresetAtom, "all");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.showRelationshipRow).toBe(true);
+    });
+
+    it("is true when chord has outside-scale members", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      store.set(chordRootAtom, "D");
+      store.set(chordTypeAtom, "Dominant 7th"); // F# outside C Major
+      store.set(focusPresetAtom, "all");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.showRelationshipRow).toBe(true);
+    });
+
+    it("is false when viewMode is chord", () => {
+      const store = createStore();
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      store.set(viewModeAtom, "chord");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.showRelationshipRow).toBe(false);
+    });
+
+    it("is false when viewMode is outside", () => {
+      const store = createStore();
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      store.set(viewModeAtom, "outside");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.showRelationshipRow).toBe(false);
+    });
+
+    it("matches showSecondaryChordRail value exactly", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      store.set(chordRootAtom, "D");
+      store.set(chordTypeAtom, "Dominant 7th");
+      store.set(focusPresetAtom, "all");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.showRelationshipRow).toBe(result.current.showSecondaryChordRail);
     });
   });
 

--- a/src/hooks/useDisplayState.ts
+++ b/src/hooks/useDisplayState.ts
@@ -442,11 +442,9 @@ export default function useDisplayState() {
     if (!chordType || !chordLabel) return null;
     if (viewMode === "chord") return "Chord only";
     if (viewMode === "outside") return `against ${scaleLabel}`;
-    // compare: chord label + member intervals
-    return chordMemberLabels
-      ? `${chordLabel} \u2022 ${chordMemberLabels}`
-      : chordLabel;
-  }, [chordType, viewMode, scaleLabel, chordLabel, chordMemberLabels]);
+    // compare: chord label only — member intervals moved to relationship row
+    return chordLabel;
+  }, [chordType, viewMode, scaleLabel, chordLabel]);
 
   // Primary strip mode: "scale" for compare or no chord, "chord"/"outside" for those viewModes
   const summaryPrimaryMode = useMemo((): "scale" | "chord" | "outside" => {
@@ -464,6 +462,21 @@ export default function useDisplayState() {
         (chordRoot !== rootNote || focusPreset !== "all" || hasOutsideChordMembers)
       ),
     [chordType, viewMode, chordRoot, rootNote, focusPreset, hasOutsideChordMembers],
+  );
+
+  // Alias used by the RelationshipRow rendering path (same logic as showSecondaryChordRail)
+  const showRelationshipRow = showSecondaryChordRail;
+
+  // Chord members shared with the scale (in-scale), for the relationship row
+  const sharedChordMembers = useMemo(
+    () => summaryChordRow.filter((e) => e.inScale),
+    [summaryChordRow],
+  );
+
+  // Chord members outside the scale, for the relationship row
+  const outsideChordMembers = useMemo(
+    () => summaryChordRow.filter((e) => !e.inScale),
+    [summaryChordRow],
   );
 
   return {
@@ -519,6 +532,9 @@ export default function useDisplayState() {
     summaryHeaderRight,
     summaryPrimaryMode,
     showSecondaryChordRail,
+    showRelationshipRow,
+    sharedChordMembers,
+    outsideChordMembers,
     highlightNotes,
     boxBounds,
     shapePolygons,


### PR DESCRIPTION
## Summary

- Replaces the secondary compact chord rail in compare mode with a new **RelationshipRow** component that groups active chord members into **Shared** (in-scale) and **Outside** (out-of-scale) labelled capsule pills
- Removes member interval labels from the summary ribbon header right side — they're now implicit in the relationship row grouping
- Dims scale-only chips (0.42 → 0.28 opacity) and fretboard scale-only notes (0.85 → 0.45) when chord overlay is active, reinforcing chord-first visual hierarchy
- Relationship row is omitted entirely in fully diatonic compare cases (same root, `all` preset, chord fully in scale)

**Example — C Major + C# Minor Triad:**
- Scale strip: `C D E F G A B` (E accented as shared chord tone)
- Relationship row: `Shared: E  ·  Outside: C# G#`

## What changed

| File | Change |
|---|---|
| `src/components/RelationshipRow.tsx` | New capsule-pill relationship row component |
| `src/components/RelationshipRow.css` | Capsule pill styling (non-circular, distinct from degree chips) |
| `src/hooks/useDisplayState.ts` | Adds `sharedChordMembers`, `outsideChordMembers`, `showRelationshipRow`; strips interval labels from compare-mode header right |
| `src/App.tsx` | Uses `RelationshipRow` instead of secondary `ChordRowStrip`; adds `data-chord-active` attribute |
| `src/App.css` | `.note-scale-only` dims under `[data-chord-active]`; ribbon suppresses relationship-row chrome |
| `src/components/DegreeChipStrip.css` | Scale-only opacity lowered when chord active |
| `src/__tests__/RelationshipRow.test.tsx` | 18 new tests for the new component |
| `src/hooks/useDisplayState.test.ts` | Updated header test + 3 new describe blocks for new derived state |
| `src/__tests__/App.test.tsx` | Updated 2 tests that referenced `.chord-row-strip--compact` |

## Test plan

- [x] 809 tests pass (`npm run test`)
- [x] Build clean (`npm run build`)
- [ ] Visual: compare mode with non-diatonic chord shows Shared/Outside groups
- [ ] Visual: simple diatonic compare shows no relationship row
- [ ] Visual: chord mode and outside mode unchanged
- [ ] Visual: fretboard scale-only notes noticeably dimmer when chord active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a visual component displaying shared and outside chord members relative to the selected scale

* **Style**
  * Improved chord overlay prominence with refined opacity and styling adjustments
  * Simplified chord label display in compare mode

* **Tests**
  * Added comprehensive test coverage for new chord-scale relationship visualization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->