### PR TITLE
fix(fretboard): CAGED polygons no longer bleed past fret 0 at open position

### DIFF
--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -339,12 +339,19 @@ export function FretboardSVG({
     const halfVerts = verts.length / 2;
     const clampedMin = Math.max(0, poly.intendedMin);
     const clampedMax = Math.min(maxFret, poly.intendedMax);
+    // Only bleed past the edge when at least one vertex is already naturally
+    // outside the boundary (template offsets produce negative / over-max fret
+    // values). Without this guard, shapes whose template left offset is 0 at
+    // rootFret=0 (e.g. A-shape at open position) would be incorrectly pushed
+    // to intendedMin (<0), flooding the open-string column.
+    const minLeftFret = Math.min(...verts.slice(0, halfVerts).map(v => v.fret));
+    const maxRightFret = Math.max(...verts.slice(halfVerts).map(v => v.fret));
     const resolveLeftFret = (fret: number) =>
-      fret === clampedMin && poly.intendedMin < clampedMin
+      minLeftFret < 0 && fret === clampedMin && poly.intendedMin < clampedMin
         ? poly.intendedMin
         : fret;
     const resolveRightFret = (fret: number) =>
-      fret === clampedMax && poly.intendedMax > clampedMax
+      maxRightFret > maxFret && fret === clampedMax && poly.intendedMax > clampedMax
         ? poly.intendedMax
         : fret;
 


### PR DESCRIPTION
## Summary

- `resolveLeftFret` in `FretboardSVG.tsx` was incorrectly triggering the edge-bleed logic for CAGED shape polygons at the open position (rootFret=0), causing the polygon to flood the entire open-string column.
- The root cause: the bleed condition used `poly.intendedMin` (the shape search-window boundary, from `fretOffsetMin`) rather than the actual minimum vertex fret. For shapes like the A-shape (used by C-labeled shapes in C Major), all template left offsets are `0`, so vertices naturally land at fret 0 — not due to clamping. But `fretOffsetMin = -1` made `intendedMin = -1 < 0`, incorrectly triggering the bleed and pushing all left vertices to `fretToX(-1) ≈ -50px`. After SVG clipping at x=0, the polygon appeared to start at the very left edge of the fretboard instead of at the center of the open-string column.
- Fix: gate the bleed on `minLeftFret < 0` — only fire when at least one left vertex is *naturally* at a negative fret (i.e. the template genuinely extends past the nut). Same guard added symmetrically to `resolveRightFret`.

## Behaviour preserved

Shapes that are genuinely truncated at the left edge (e.g. E-shape in G Major at rootFret=0, where string 2 has template offset `-1` giving a vertex at fret `-1`) still bleed correctly, since `minLeftFret = -1 < 0` enables the guard.

## Test plan

- [ ] C Major scale, C shape: polygon left edge now anchors at center of open-string column, not at x=0
- [ ] A Minor scale, A shape: same fix applies (same template offsets)
- [ ] G Major scale, G shape (E effective, rootFret=0): bleed still fires — string 2 has offset -1, so `minLeftFret = -1` and the unified flush-left edge is preserved
- [ ] Shapes at non-zero rootFrets: no change in behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where fretboard polygon shapes would unintentionally shift into negative or open-string fret columns when boundary adjustments should not have affected them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->