### PR TITLE
feat(chord): scale-strip/practice-bar split + fretboard role shapes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,8 +30,7 @@ import { AppHeader } from "./components/AppHeader";
 import { BrandMark } from "./components/BrandMark";
 import { FretFlowWordmark } from "./components/FretFlowWordmark";
 import { DegreeChipStrip } from "./components/DegreeChipStrip";
-import { ChordRowStrip } from "./components/ChordRowStrip";
-import { RelationshipRow } from "./components/RelationshipRow";
+import { ChordPracticeBar } from "./components/ChordPracticeBar";
 import "./App.css";
 
 const END_FRET = 25;
@@ -81,15 +80,12 @@ function AppContent() {
     colorNotes,
     summaryNotes,
     scaleLabel,
-    chordLabel,
-    chordSummaryNotes,
-    summaryChordRow,
-    summaryHeaderLeft,
-    summaryHeaderRight,
-    summaryPrimaryMode,
-    showRelationshipRow,
-    sharedChordMembers,
-    outsideChordMembers,
+    showChordPracticeBar,
+    practiceBarTitle,
+    practiceBarBadge,
+    practiceBarTargetMembers,
+    practiceBarSharedMembers,
+    practiceBarOutsideMembers,
     recenterKey,
     onShapeClick,
     onRecenter,
@@ -196,16 +192,14 @@ function AppContent() {
     [rootNote, scaleName],
   );
 
-  // Build DegreeChip[] from scale/chord atoms for DegreeChipStrip
+  // Build DegreeChip[] from scale atoms for DegreeChipStrip — scale-only, no chord semantics.
   const degreeChips = useMemo(() => {
     const rootIdx = NOTES.indexOf(rootNote);
-    const chordToneSet = new Set(chordSummaryNotes);
     return summaryNotes.map((note) => {
       const noteIdx = NOTES.indexOf(note);
       const chromaticInterval =
         rootIdx !== -1 && noteIdx !== -1 ? (noteIdx - rootIdx + 12) % 12 : 0;
       const interval = INTERVAL_NAMES[chromaticInterval] ?? "1";
-      const inChord = chordToneSet.has(note);
       return {
         internalNote: note,
         note: formatAccidental(
@@ -219,52 +213,28 @@ function AppContent() {
         interval: formatAccidental(interval),
         inScale: true,
         isTonic: note === rootNote,
-        inChord,
-        isChordRoot: inChord && note === chordRoot,
       };
     });
-  }, [summaryNotes, rootNote, scaleName, useFlats, chordSummaryNotes, chordRoot]);
+  }, [summaryNotes, rootNote, scaleName, useFlats]);
 
-  // Summary notes content shared by every non-landscape layout.
-  // When no chord: standalone scale strip. When chord active: single adaptive ribbon.
-  const summaryContent = !chordType ? (
-    <DegreeChipStrip
-      scaleName={scaleLabel}
-      chips={degreeChips}
-      hiddenNotes={hiddenNotes}
-      onChipToggle={toggleHiddenNote}
-      aria-label="Scale degrees"
-    />
-  ) : (
-    <div className="summary-ribbon">
-      <div className="summary-ribbon-header">
-        <span className="summary-ribbon-header-left">{summaryHeaderLeft}</span>
-        {summaryHeaderRight && (
-          <span className="summary-ribbon-header-right">{summaryHeaderRight}</span>
-        )}
-      </div>
-      {summaryPrimaryMode === "scale" && (
-        <DegreeChipStrip
-          scaleName={scaleLabel}
-          chips={degreeChips}
-          hiddenNotes={hiddenNotes}
-          onChipToggle={toggleHiddenNote}
-          aria-label="Scale degrees"
-          hideHeader
-          chordActive
-        />
-      )}
-      {summaryPrimaryMode !== "scale" && (
-        <ChordRowStrip
-          chordLabel={chordLabel ?? ""}
-          chordRow={summaryChordRow}
-          legendItems={[]}
-        />
-      )}
-      {showRelationshipRow && (
-        <RelationshipRow
-          sharedMembers={sharedChordMembers}
-          outsideMembers={outsideChordMembers}
+  // Summary content: scale strip is always shown. ChordPracticeBar appears below when chord is active.
+  const summaryContent = (
+    <div className={chordType ? "summary-ribbon" : undefined}>
+      <DegreeChipStrip
+        scaleName={scaleLabel}
+        chips={degreeChips}
+        hiddenNotes={hiddenNotes}
+        onChipToggle={toggleHiddenNote}
+        aria-label="Scale degrees"
+      />
+      {showChordPracticeBar && (
+        <ChordPracticeBar
+          title={practiceBarTitle}
+          badge={practiceBarBadge}
+          viewMode={viewMode}
+          targetMembers={practiceBarTargetMembers}
+          sharedMembers={practiceBarSharedMembers}
+          outsideMembers={practiceBarOutsideMembers}
         />
       )}
     </div>

--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -90,6 +90,8 @@ function classifyNote(
   return "note-inactive";
 }
 
+type NoteShape = "circle" | "squircle" | "diamond";
+
 type NoteVisuals = {
   stroke: string;
   filter: string;
@@ -99,6 +101,7 @@ type NoteVisuals = {
   strokeWidth: number;
   textOpacity: number;
   strokeDasharray?: string;
+  noteShape: NoteShape;
 };
 
 function getNoteVisuals(
@@ -115,9 +118,10 @@ function getNoteVisuals(
         radiusScale: 0.82,
         strokeWidth: 2.3,
         textOpacity: 1,
+        noteShape: "circle",
       };
     case "chord-root":
-      // Amber ring, larger radius — visually dominant among chord tones.
+      // Squircle with amber ring — dominant shape among chord tones.
       return {
         stroke: "var(--note-ring-tonic)",
         filter: glowFilterUrls.orange,
@@ -126,17 +130,19 @@ function getNoteVisuals(
         radiusScale: 0.86,
         strokeWidth: 2.5,
         textOpacity: 1,
+        noteShape: "squircle",
       };
     case "chord-tone-in-scale":
-      // Cyan ring — chord member, in scale, clearly distinct from root.
+      // Squircle with amber ring — chord member in scale.
       return {
-        stroke: "var(--note-ring)",
-        filter: glowFilterUrls.cyan,
-        fill: "rgb(14 30 44 / 0.95)",
+        stroke: "var(--note-ring-tonic)",
+        filter: glowFilterUrls.orange,
+        fill: "rgb(40 22 10 / 0.88)",
         textFill: "#ffffff",
         radiusScale: 0.82,
-        strokeWidth: 2.1,
+        strokeWidth: 2.0,
         textOpacity: 1,
+        noteShape: "squircle",
       };
     case "note-active":
     case "note-blue":
@@ -148,19 +154,22 @@ function getNoteVisuals(
         radiusScale: 0.82,
         strokeWidth: 1.9,
         textOpacity: 1,
+        noteShape: "circle",
       };
     case "scale-only":
+      // Hollow circle — scale note, no chord role.
       return {
         stroke: "var(--note-ring-dim)",
         filter: glowFilterUrls.cyan,
-        fill: "rgb(18 26 34 / 0.85)",
-        textFill: "#ffffff",
+        fill: "transparent",
+        textFill: "rgb(255 255 255 / 0.75)",
         radiusScale: 0.78,
         strokeWidth: 1.7,
         textOpacity: 0.82,
+        noteShape: "circle",
       };
     case "chord-tone-outside-scale":
-      // Dashed amber-dim border — chord-relevant but outside the current scale.
+      // Diamond with dashed amber-dim border — outside the scale.
       return {
         stroke: "var(--neon-orange-dim)",
         filter: glowFilterUrls.orange,
@@ -170,6 +179,7 @@ function getNoteVisuals(
         strokeWidth: 2.0,
         textOpacity: 0.9,
         strokeDasharray: "5 3",
+        noteShape: "diamond",
       };
     default:
       return {
@@ -180,6 +190,7 @@ function getNoteVisuals(
         radiusScale: 0.8,
         strokeWidth: 0,
         textOpacity: 0,
+        noteShape: "circle",
       };
   }
 }
@@ -1053,8 +1064,50 @@ export function FretboardSVG({
                   strokeWidth,
                   textOpacity,
                   strokeDasharray,
+                  noteShape,
                 } = getNoteVisuals(noteClass, glowFilterUrls);
                 const r = baseRadius * radiusScale;
+                const commonShapeProps = {
+                  fill,
+                  stroke,
+                  strokeWidth,
+                  strokeDasharray,
+                  filter: filter !== "none" ? filter : undefined,
+                };
+                const shapeEl =
+                  noteShape === "squircle" ? (
+                    <>
+                      {noteClass === "chord-root" && (
+                        <rect
+                          x={cx - r - 3.5}
+                          y={cy - r - 3.5}
+                          width={(r + 3.5) * 2}
+                          height={(r + 3.5) * 2}
+                          rx={(r + 3.5) * 0.38}
+                          ry={(r + 3.5) * 0.38}
+                          fill="none"
+                          stroke="rgb(255 154 77 / 0.22)"
+                          strokeWidth={1.5}
+                        />
+                      )}
+                      <rect
+                        x={cx - r}
+                        y={cy - r}
+                        width={r * 2}
+                        height={r * 2}
+                        rx={r * 0.38}
+                        ry={r * 0.38}
+                        {...commonShapeProps}
+                      />
+                    </>
+                  ) : noteShape === "diamond" ? (
+                    <polygon
+                      points={`${cx},${cy - r} ${cx + r},${cy} ${cx},${cy + r} ${cx - r},${cy}`}
+                      {...commonShapeProps}
+                    />
+                  ) : (
+                    <circle cx={cx} cy={cy} r={r} {...commonShapeProps} />
+                  );
                 return (
                   <g
                     key={`note-${stringIndex}-${fretIndex}`}
@@ -1064,18 +1117,10 @@ export function FretboardSVG({
                       isHidden && "hidden",
                     )}
                     data-note-role={noteClass !== "note-inactive" ? noteClass : undefined}
+                    data-note-shape={noteShape}
                     style={{ opacity: applyDimOpacity ? 0.8 : 1 }}
                   >
-                    <circle
-                      cx={cx}
-                      cy={cy}
-                      r={r}
-                      fill={fill}
-                      stroke={stroke}
-                      strokeWidth={strokeWidth}
-                      strokeDasharray={strokeDasharray}
-                      filter={filter !== "none" ? filter : undefined}
-                    />
+                    {shapeEl}
                     {displayFormat !== "none" && (
                       <text
                         x={cx}

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -412,7 +412,7 @@ describe("App", () => {
       });
     });
 
-    it("compare mode: no relationship row in simple diatonic case (same root, all preset, all in scale)", async () => {
+    it("compare mode: chord practice bar shown even in simple diatonic case (same root, all preset, all in scale)", async () => {
       localStorage.setItem(k("rootNote"), "C");
       localStorage.setItem(k("chordRoot"), "C");
       localStorage.setItem(k("chordType"), "Major Triad");
@@ -422,10 +422,11 @@ describe("App", () => {
       await waitFor(() => {
         expect(document.querySelector(".summary-ribbon")).toBeTruthy();
       });
+      expect(document.querySelector(".chord-practice-bar")).toBeTruthy();
       expect(document.querySelector(".relationship-row")).toBeNull();
     });
 
-    it("compare mode: shows relationship row when chordRoot differs from scale root", async () => {
+    it("compare mode: shows chord practice bar when chordRoot differs from scale root", async () => {
       localStorage.setItem(k("rootNote"), "C");
       localStorage.setItem(k("chordRoot"), "G");
       localStorage.setItem(k("chordType"), "Major Triad");
@@ -433,29 +434,29 @@ describe("App", () => {
       localStorage.setItem(k("viewMode"), "compare");
       render(<App />);
       await waitFor(() => {
-        expect(document.querySelector(".relationship-row")).toBeTruthy();
+        expect(document.querySelector(".chord-practice-bar")).toBeTruthy();
       });
     });
 
-    it("chord mode: renders chord rail as primary, no degree-chip-strip inside ribbon", async () => {
+    it("chord mode: renders chord practice bar and keeps degree-chip-strip inside ribbon", async () => {
       localStorage.setItem(k("chordType"), "Major Triad");
       localStorage.setItem(k("viewMode"), "chord");
       render(<App />);
       await waitFor(() => {
-        expect(document.querySelector(".summary-ribbon .chord-row-strip")).toBeTruthy();
-        expect(document.querySelector(".summary-ribbon .degree-chip-strip")).toBeNull();
+        expect(document.querySelector(".summary-ribbon .chord-practice-bar")).toBeTruthy();
+        expect(document.querySelector(".summary-ribbon .degree-chip-strip")).toBeTruthy();
       });
     });
 
-    it("outside mode: renders outside rail as primary, no degree-chip-strip inside ribbon", async () => {
+    it("outside mode: renders chord practice bar and keeps degree-chip-strip inside ribbon", async () => {
       localStorage.setItem(k("rootNote"), "C");
       localStorage.setItem(k("chordRoot"), "D");
       localStorage.setItem(k("chordType"), "Dominant 7th");
       localStorage.setItem(k("viewMode"), "outside");
       render(<App />);
       await waitFor(() => {
-        expect(document.querySelector(".summary-ribbon .chord-row-strip")).toBeTruthy();
-        expect(document.querySelector(".summary-ribbon .degree-chip-strip")).toBeNull();
+        expect(document.querySelector(".summary-ribbon .chord-practice-bar")).toBeTruthy();
+        expect(document.querySelector(".summary-ribbon .degree-chip-strip")).toBeTruthy();
       });
     });
 
@@ -479,20 +480,20 @@ describe("App", () => {
       expect(document.querySelector(".chord-row-legend")).toBeNull();
     });
 
-    it("ribbon header shows scale label on left and chord info on right in compare mode", async () => {
+    it("practice bar shows chord label as title and Compare badge in compare mode", async () => {
       localStorage.setItem(k("rootNote"), "C");
       localStorage.setItem(k("chordRoot"), "C");
       localStorage.setItem(k("chordType"), "Major Triad");
       localStorage.setItem(k("viewMode"), "compare");
       render(<App />);
       await waitFor(() => {
-        expect(document.querySelector(".summary-ribbon-header-left")).toBeTruthy();
-        expect(document.querySelector(".summary-ribbon-header-right")).toBeTruthy();
+        expect(document.querySelector(".chord-practice-bar")).toBeTruthy();
       });
-      const left = document.querySelector(".summary-ribbon-header-left")!;
-      const right = document.querySelector(".summary-ribbon-header-right")!;
-      expect(left.textContent).toContain("C Major");
-      expect(right.textContent).toContain("C Major Triad");
+      const title = document.querySelector(".chord-practice-bar-title")!;
+      const badge = document.querySelector(".chord-practice-bar-badge")!;
+      expect(title.textContent).toContain("C");
+      expect(title.textContent).toContain("Major Triad");
+      expect(badge.textContent).toBe("Compare");
     });
   });
 

--- a/src/__tests__/ChordPracticeBar.test.tsx
+++ b/src/__tests__/ChordPracticeBar.test.tsx
@@ -1,0 +1,269 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ChordPracticeBar } from "../components/ChordPracticeBar";
+import type { ChordRowEntry } from "../theory";
+import { axe } from "../test-utils/a11y";
+
+const root: ChordRowEntry = {
+  internalNote: "C",
+  displayNote: "C",
+  memberName: "1",
+  role: "chord-root",
+  inScale: true,
+};
+const third: ChordRowEntry = {
+  internalNote: "E",
+  displayNote: "E",
+  memberName: "3",
+  role: "chord-tone-in-scale",
+  inScale: true,
+};
+const fifth: ChordRowEntry = {
+  internalNote: "G",
+  displayNote: "G",
+  memberName: "5",
+  role: "chord-tone-in-scale",
+  inScale: true,
+};
+const flatSeven: ChordRowEntry = {
+  internalNote: "A#",
+  displayNote: "B♭",
+  memberName: "♭7",
+  role: "chord-tone-outside-scale",
+  inScale: false,
+};
+
+const allMembers = [root, third, fifth, flatSeven];
+const sharedMembers = [root, third, fifth];
+const outsideMembers = [flatSeven];
+
+describe("ChordPracticeBar", () => {
+  it("renders a role=group with aria-label", () => {
+    render(
+      <ChordPracticeBar
+        title="C Dominant 7th"
+        badge="Compare"
+        viewMode="compare"
+        targetMembers={allMembers}
+        sharedMembers={sharedMembers}
+        outsideMembers={outsideMembers}
+      />
+    );
+    const group = screen.getByRole("group", { name: "Chord analysis: C Dominant 7th" });
+    expect(group).toBeTruthy();
+  });
+
+  it("renders title and badge", () => {
+    render(
+      <ChordPracticeBar
+        title="C Dominant 7th"
+        badge="Compare"
+        viewMode="compare"
+        targetMembers={allMembers}
+        sharedMembers={sharedMembers}
+        outsideMembers={outsideMembers}
+      />
+    );
+    expect(screen.getByText("C Dominant 7th")).toBeTruthy();
+    expect(screen.getByText("Compare")).toBeTruthy();
+  });
+
+  describe("compare mode", () => {
+    it("shows Targets, Shared, and Outside group labels", () => {
+      render(
+        <ChordPracticeBar
+          title="C Dom7"
+          badge="Compare"
+          viewMode="compare"
+          targetMembers={allMembers}
+          sharedMembers={sharedMembers}
+          outsideMembers={outsideMembers}
+        />
+      );
+      expect(screen.getByText("Targets")).toBeTruthy();
+      expect(screen.getByText("Shared")).toBeTruthy();
+      expect(screen.getByText("Outside")).toBeTruthy();
+    });
+
+    it("omits Shared group when sharedMembers is empty", () => {
+      render(
+        <ChordPracticeBar
+          title="C Augmented"
+          badge="Compare"
+          viewMode="compare"
+          targetMembers={outsideMembers}
+          sharedMembers={[]}
+          outsideMembers={outsideMembers}
+        />
+      );
+      expect(screen.queryByText("Shared")).toBeNull();
+    });
+
+    it("omits Outside group when outsideMembers is empty", () => {
+      render(
+        <ChordPracticeBar
+          title="C Major Triad"
+          badge="Compare"
+          viewMode="compare"
+          targetMembers={sharedMembers}
+          sharedMembers={sharedMembers}
+          outsideMembers={[]}
+        />
+      );
+      expect(screen.queryByText("Outside")).toBeNull();
+    });
+  });
+
+  describe("chord mode", () => {
+    it("shows Targets group only", () => {
+      render(
+        <ChordPracticeBar
+          title="C Major Triad"
+          badge="Chord only"
+          viewMode="chord"
+          targetMembers={sharedMembers}
+          sharedMembers={sharedMembers}
+          outsideMembers={[]}
+        />
+      );
+      expect(screen.getByText("Targets")).toBeTruthy();
+      expect(screen.queryByText("Shared")).toBeNull();
+      expect(screen.queryByText("Outside")).toBeNull();
+    });
+
+    it("renders badge as 'Chord only'", () => {
+      render(
+        <ChordPracticeBar
+          title="C Major Triad"
+          badge="Chord only"
+          viewMode="chord"
+          targetMembers={sharedMembers}
+          sharedMembers={sharedMembers}
+          outsideMembers={[]}
+        />
+      );
+      expect(screen.getByText("Chord only")).toBeTruthy();
+    });
+  });
+
+  describe("outside mode", () => {
+    it("shows Outside group only", () => {
+      render(
+        <ChordPracticeBar
+          title="Outside tones"
+          badge="against C Major"
+          viewMode="outside"
+          targetMembers={allMembers}
+          sharedMembers={sharedMembers}
+          outsideMembers={outsideMembers}
+        />
+      );
+      expect(screen.queryByText("Targets")).toBeNull();
+      expect(screen.queryByText("Shared")).toBeNull();
+      expect(screen.getByText("Outside")).toBeTruthy();
+    });
+
+    it("renders title as 'Outside tones'", () => {
+      render(
+        <ChordPracticeBar
+          title="Outside tones"
+          badge="against C Major"
+          viewMode="outside"
+          targetMembers={allMembers}
+          sharedMembers={sharedMembers}
+          outsideMembers={outsideMembers}
+        />
+      );
+      expect(screen.getByText("Outside tones")).toBeTruthy();
+    });
+
+    it("renders badge as 'against {scale}'", () => {
+      render(
+        <ChordPracticeBar
+          title="Outside tones"
+          badge="against C Major"
+          viewMode="outside"
+          targetMembers={allMembers}
+          sharedMembers={sharedMembers}
+          outsideMembers={outsideMembers}
+        />
+      );
+      expect(screen.getByText("against C Major")).toBeTruthy();
+    });
+  });
+
+  it("returns null when all member arrays are empty", () => {
+    const { container } = render(
+      <ChordPracticeBar
+        title="Empty"
+        badge={null}
+        viewMode="compare"
+        targetMembers={[]}
+        sharedMembers={[]}
+        outsideMembers={[]}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("pills have data-role attributes matching chord member roles", () => {
+    const { container } = render(
+      <ChordPracticeBar
+        title="C Dom7"
+        badge="Compare"
+        viewMode="compare"
+        targetMembers={allMembers}
+        sharedMembers={sharedMembers}
+        outsideMembers={outsideMembers}
+      />
+    );
+    const lists = container.querySelectorAll(".practice-bar-pill-list");
+    // Targets list (first) should have chord-root, chord-tone-in-scale, chord-tone-outside-scale
+    const targetList = lists[0];
+    expect(targetList.querySelector('[data-role="chord-root"]')).toBeTruthy();
+    expect(targetList.querySelectorAll('[data-role="chord-tone-in-scale"]').length).toBe(2);
+    expect(targetList.querySelector('[data-role="chord-tone-outside-scale"]')).toBeTruthy();
+  });
+
+  it("has no accessibility violations in compare mode", async () => {
+    const { container } = render(
+      <ChordPracticeBar
+        title="C Dominant 7th"
+        badge="Compare"
+        viewMode="compare"
+        targetMembers={allMembers}
+        sharedMembers={sharedMembers}
+        outsideMembers={outsideMembers}
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("has no accessibility violations in chord mode", async () => {
+    const { container } = render(
+      <ChordPracticeBar
+        title="C Major Triad"
+        badge="Chord only"
+        viewMode="chord"
+        targetMembers={sharedMembers}
+        sharedMembers={sharedMembers}
+        outsideMembers={[]}
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("has no accessibility violations in outside mode", async () => {
+    const { container } = render(
+      <ChordPracticeBar
+        title="Outside tones"
+        badge="against C Major"
+        viewMode="outside"
+        targetMembers={allMembers}
+        sharedMembers={sharedMembers}
+        outsideMembers={outsideMembers}
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/src/__tests__/ChordPracticeBar.test.tsx
+++ b/src/__tests__/ChordPracticeBar.test.tsx
@@ -218,8 +218,9 @@ describe("ChordPracticeBar", () => {
       />
     );
     const lists = container.querySelectorAll(".practice-bar-pill-list");
+    expect(lists.length).toBeGreaterThan(0);
     // Targets list (first) should have chord-root, chord-tone-in-scale, chord-tone-outside-scale
-    const targetList = lists[0];
+    const targetList = lists[0]!;
     expect(targetList.querySelector('[data-role="chord-root"]')).toBeTruthy();
     expect(targetList.querySelectorAll('[data-role="chord-tone-in-scale"]').length).toBe(2);
     expect(targetList.querySelector('[data-role="chord-tone-outside-scale"]')).toBeTruthy();

--- a/src/__tests__/DegreeChipStrip.test.tsx
+++ b/src/__tests__/DegreeChipStrip.test.tsx
@@ -74,17 +74,27 @@ describe('DegreeChipStrip', () => {
     expect(allChips.length).toBe(3);
   });
 
-  it('in-chord chips have data-in-chord attribute', () => {
-    const chipsWithChord: DegreeChip[] = [
-      { note: 'A', internalNote: 'A', interval: '1', inScale: true, isTonic: true, inChord: true },
-      { note: 'C', internalNote: 'C', interval: 'b3', inScale: true, inChord: true },
-      { note: 'E', internalNote: 'E', interval: '5', inScale: true, inChord: true },
-    ];
+  it('scale strip does not render data-in-chord or data-is-chord-root attributes', () => {
     const { container } = render(
-      <DegreeChipStrip scaleName="Am chord" chips={chipsWithChord} />
+      <DegreeChipStrip
+        scaleName="A Natural Minor"
+        chips={aMinorChips}
+      />
     );
-    const chordChips = container.querySelectorAll('[data-in-chord="true"]');
-    expect(chordChips.length).toBe(3);
+    expect(container.querySelector('[data-in-chord]')).toBeNull();
+    expect(container.querySelector('[data-is-chord-root]')).toBeNull();
+  });
+
+  it('scale strip does not render data-chord-active attribute even when chord is active externally', () => {
+    // DegreeChipStrip no longer accepts a chordActive prop — the section never has this attribute
+    const { container } = render(
+      <DegreeChipStrip
+        scaleName="A Natural Minor"
+        chips={aMinorChips}
+      />
+    );
+    const section = container.querySelector('.degree-chip-strip');
+    expect(section?.getAttribute('data-chord-active')).toBeNull();
   });
 
   it('uses custom aria-label when provided', () => {
@@ -110,7 +120,7 @@ describe('DegreeChipStrip', () => {
 
   it('has no accessibility violations with mixed chip states', async () => {
     const mixedChips: DegreeChip[] = [
-      { note: 'A', internalNote: 'A', interval: '1', inScale: true, isTonic: true, inChord: true },
+      { note: 'A', internalNote: 'A', interval: '1', inScale: true, isTonic: true },
       { note: 'B', internalNote: 'B', interval: '2', inScale: true },
       { note: 'C', internalNote: 'C', interval: 'b3', inScale: false },
     ];
@@ -139,43 +149,5 @@ describe('DegreeChipStrip', () => {
       />
     );
     expect(container.querySelector('.degree-chip-strip-header')).toBeTruthy();
-  });
-
-  it('chordActive adds data-chord-active attribute to the section', () => {
-    const { container } = render(
-      <DegreeChipStrip
-        scaleName="A Natural Minor"
-        chips={aMinorChips}
-        chordActive
-      />
-    );
-    const section = container.querySelector('.degree-chip-strip');
-    expect(section?.getAttribute('data-chord-active')).toBe('true');
-  });
-
-  it('without chordActive data-chord-active is absent', () => {
-    const { container } = render(
-      <DegreeChipStrip
-        scaleName="A Natural Minor"
-        chips={aMinorChips}
-      />
-    );
-    const section = container.querySelector('.degree-chip-strip');
-    expect(section?.getAttribute('data-chord-active')).toBeNull();
-  });
-
-  it('isChordRoot chip has data-is-chord-root attribute', () => {
-    const chipsWithRoot: DegreeChip[] = [
-      { note: 'A', internalNote: 'A', interval: '1', inScale: true, isTonic: true, inChord: true, isChordRoot: true },
-      { note: 'C', internalNote: 'C', interval: 'b3', inScale: true, inChord: true },
-      { note: 'E', internalNote: 'E', interval: '5', inScale: true, inChord: true },
-    ];
-    const { container } = render(
-      <DegreeChipStrip scaleName="Am" chips={chipsWithRoot} chordActive />
-    );
-    const rootChip = container.querySelector('[data-is-chord-root="true"]');
-    expect(rootChip).toBeTruthy();
-    const nonRootChips = container.querySelectorAll('[data-in-chord="true"]:not([data-is-chord-root="true"])');
-    expect(nonRootChips).toHaveLength(2);
   });
 });

--- a/src/__tests__/FretboardSVG.test.tsx
+++ b/src/__tests__/FretboardSVG.test.tsx
@@ -228,4 +228,74 @@ describe("FretboardSVG", () => {
     const { container } = render(<FretboardSVG {...BASE_PROPS} />);
     expect(await axe(container)).toHaveNoViolations();
   });
+
+  describe("role-based shapes", () => {
+    it("chord-root notes have data-note-shape=squircle", () => {
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          chordTones={["C", "E", "G"]}
+          chordRoot="C"
+          rootNote="C"
+          highlightNotes={["C", "E", "G"]}
+        />
+      );
+      const chordRootNotes = container.querySelectorAll('.chord-root[data-note-shape="squircle"]');
+      expect(chordRootNotes.length).toBeGreaterThan(0);
+    });
+
+    it("chord-tone-in-scale notes have data-note-shape=squircle", () => {
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          chordTones={["C", "E", "G"]}
+          chordRoot="C"
+          rootNote="C"
+          highlightNotes={["C", "E", "G"]}
+        />
+      );
+      const inScaleTones = container.querySelectorAll('.chord-tone-in-scale[data-note-shape="squircle"]');
+      expect(inScaleTones.length).toBeGreaterThan(0);
+    });
+
+    it("chord-tone-outside-scale notes have data-note-shape=diamond", () => {
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          chordTones={["C", "E", "G", "A#"]}
+          chordRoot="C"
+          rootNote="C"
+          highlightNotes={["C", "E", "G"]}
+        />
+      );
+      const outsideTones = container.querySelectorAll('.chord-tone-outside-scale[data-note-shape="diamond"]');
+      expect(outsideTones.length).toBeGreaterThan(0);
+    });
+
+    it("scale-only notes have data-note-shape=circle", () => {
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          chordTones={["C"]}
+          chordRoot="C"
+          rootNote="C"
+          highlightNotes={["C", "E", "G"]}
+        />
+      );
+      const scaleOnly = container.querySelectorAll('.scale-only[data-note-shape="circle"]');
+      expect(scaleOnly.length).toBeGreaterThan(0);
+    });
+
+    it("note-active notes (no chord overlay) have data-note-shape=circle", () => {
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          rootNote="C"
+          highlightNotes={["C", "E", "G"]}
+        />
+      );
+      const activeNotes = container.querySelectorAll('.note-active[data-note-shape="circle"]');
+      expect(activeNotes.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/src/components/ChordPracticeBar.css
+++ b/src/components/ChordPracticeBar.css
@@ -1,0 +1,168 @@
+/* Chord practice bar — compact analysis cue strip shown below the scale strip
+   when a chord overlay is active. Uses pills/capsules instead of circular chips
+   to read as "analysis" rather than "another note strip". */
+
+.chord-practice-bar {
+  --pill-h: 1.55rem;
+  --pill-font: 0.82rem;
+  --pill-px: 0.55rem;
+  --pill-gap: 0.3rem;
+  --bar-fill: rgb(18 23 34);
+
+  display: flex;
+  flex-direction: column;
+  gap: 0.38rem;
+  width: min(100%, 30rem);
+  margin: 0 auto;
+  padding: 0.42rem 0.85rem 0.48rem;
+  border-radius: 0.85rem;
+  background: var(--bar-fill);
+  border: 1px solid rgb(255 255 255 / 0.07);
+  box-shadow: 0 4px 14px rgb(0 0 0 / 0.2);
+}
+
+/* Header row: title + optional badge */
+.chord-practice-bar-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.chord-practice-bar-title {
+  font-family: var(--font-sans);
+  font-size: clamp(0.82rem, 1.3vw, 0.94rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-soft-white);
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+}
+
+.chord-practice-bar-badge {
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  font-weight: var(--font-weight-medium);
+  color: rgb(255 255 255 / 0.45);
+  line-height: 1;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgb(255 255 255 / 0.07);
+  border: 1px solid rgb(255 255 255 / 0.1);
+  border-radius: 0.3rem;
+  padding: 0.15rem 0.35rem;
+  white-space: nowrap;
+}
+
+/* Groups row: lays out Targets / Shared / Outside horizontally */
+.chord-practice-bar-groups {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+/* Individual group: label + pill row */
+.practice-bar-group {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+
+.practice-bar-group-label {
+  font-family: var(--font-sans);
+  font-size: 0.68rem;
+  font-weight: var(--font-weight-medium);
+  color: rgb(255 255 255 / 0.38);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Pill list */
+.practice-bar-pill-list {
+  display: flex;
+  align-items: center;
+  gap: var(--pill-gap);
+  flex-wrap: wrap;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* Base pill — capsule shape */
+.practice-bar-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.22rem;
+  height: var(--pill-h);
+  padding: 0 var(--pill-px);
+  border-radius: 999px;
+  background: rgb(255 255 255 / 0.05);
+  border: 1.5px solid rgb(255 255 255 / 0.18);
+  cursor: default;
+}
+
+/* Role-based pill variants */
+.practice-bar-pill[data-role="chord-root"] {
+  background: rgb(255 154 77 / 0.18);
+  border-color: rgb(255 154 77 / 0.85);
+  box-shadow: 0 0 6px rgb(255 154 77 / 0.4);
+}
+
+.practice-bar-pill[data-role="chord-tone-in-scale"] {
+  background: rgb(255 154 77 / 0.08);
+  border-color: rgb(255 154 77 / 0.55);
+}
+
+.practice-bar-pill[data-role="chord-tone-outside-scale"] {
+  background: rgb(120 50 20 / 0.22);
+  border-color: rgb(204 122 61 / 0.7);
+  border-style: dashed;
+}
+
+.practice-bar-pill-note {
+  font-family: var(--font-sans);
+  font-size: var(--pill-font);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-soft-white);
+  line-height: 1;
+  letter-spacing: 0.01em;
+}
+
+.practice-bar-pill-interval {
+  font-family: var(--font-sans);
+  font-size: calc(var(--pill-font) - 0.06rem);
+  font-weight: var(--font-weight-medium);
+  color: rgb(255 255 255 / 0.48);
+  line-height: 1;
+  letter-spacing: 0.02em;
+}
+
+/* Responsive — mobile */
+.app-container[data-layout-tier="mobile"] .chord-practice-bar {
+  width: 100%;
+  border-radius: 0.7rem;
+  padding: 0.38rem 0.7rem 0.42rem;
+  gap: 0.32rem;
+}
+
+.app-container[data-layout-tier="mobile"] .chord-practice-bar-title {
+  font-size: 0.82rem;
+}
+
+.app-container[data-layout-tier="mobile"] .practice-bar-group-label {
+  font-size: 0.64rem;
+}
+
+/* Responsive — desktop */
+.app-container[data-layout-tier="desktop"] .chord-practice-bar {
+  width: min(100%, 32rem);
+  padding: 0.3rem 0.78rem 0.34rem;
+  gap: 0.28rem;
+}
+
+.app-container[data-layout-tier="desktop"] .chord-practice-bar-title {
+  font-size: clamp(0.76rem, 1.1vw, 0.88rem);
+}

--- a/src/components/ChordPracticeBar.tsx
+++ b/src/components/ChordPracticeBar.tsx
@@ -1,0 +1,100 @@
+import clsx from "clsx";
+import type { ChordRowEntry, ViewMode } from "../theory";
+import "./ChordPracticeBar.css";
+
+interface PillGroupProps {
+  label: string;
+  members: ChordRowEntry[];
+  ariaLabel: string;
+}
+
+function PillGroup({ label, members, ariaLabel }: PillGroupProps) {
+  if (members.length === 0) return null;
+  return (
+    <div className="practice-bar-group">
+      <span className="practice-bar-group-label">{label}</span>
+      <ul className="practice-bar-pill-list" aria-label={ariaLabel}>
+        {members.map((entry, i) => (
+          <li
+            key={`${entry.internalNote}-${i}`}
+            className="practice-bar-pill"
+            data-role={entry.role}
+            aria-label={`${entry.displayNote}, ${entry.memberName}`}
+          >
+            <span className="practice-bar-pill-note">{entry.displayNote}</span>
+            <span className="practice-bar-pill-interval">{entry.memberName}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export interface ChordPracticeBarProps {
+  title: string;
+  badge: string | null;
+  viewMode: ViewMode;
+  targetMembers: ChordRowEntry[];
+  sharedMembers: ChordRowEntry[];
+  outsideMembers: ChordRowEntry[];
+  className?: string;
+}
+
+export function ChordPracticeBar({
+  title,
+  badge,
+  viewMode,
+  targetMembers,
+  sharedMembers,
+  outsideMembers,
+  className,
+}: ChordPracticeBarProps) {
+  if (
+    targetMembers.length === 0 &&
+    sharedMembers.length === 0 &&
+    outsideMembers.length === 0
+  )
+    return null;
+
+  const showTargets = viewMode === "compare" || viewMode === "chord";
+  const showShared = viewMode === "compare";
+  const showOutside = viewMode === "compare" || viewMode === "outside";
+
+  return (
+    <section
+      role="group"
+      aria-label={`Chord analysis: ${title}`}
+      className={clsx("chord-practice-bar", className)}
+    >
+      <div className="chord-practice-bar-header">
+        <span className="chord-practice-bar-title">{title}</span>
+        {badge && (
+          <span className="chord-practice-bar-badge">{badge}</span>
+        )}
+      </div>
+      <div className="chord-practice-bar-groups">
+        {showTargets && (
+          <PillGroup
+            label="Targets"
+            members={targetMembers}
+            ariaLabel="Target chord members"
+          />
+        )}
+        {showShared && (
+          <PillGroup
+            label="Shared"
+            members={sharedMembers}
+            ariaLabel="Shared with scale"
+          />
+        )}
+        {showOutside && (
+          <PillGroup
+            label="Outside"
+            members={outsideMembers}
+            ariaLabel="Outside scale"
+          />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/DegreeChipStrip.css
+++ b/src/components/DegreeChipStrip.css
@@ -102,47 +102,11 @@
   opacity: 1;
 }
 
-.degree-chip-item[data-is-tonic='true'] .degree-chip,
-.degree-chip-item[data-in-chord='true'] .degree-chip {
+.degree-chip-item[data-is-tonic='true'] .degree-chip {
   border-color: rgb(255 154 77 / 0.95);
   box-shadow: var(--chip-glow-orange);
   opacity: 1;
-}
-
-.degree-chip-item[data-is-tonic='true'] .degree-chip {
   border-width: var(--chip-border-width);
-}
-
-/* Chord overlay active: strengthen role hierarchy across scale strip.
-   Specificity (.degree-chip-strip[…] .degree-chip-item[…] .degree-chip) beats
-   the base per-role rules above, so these always win when chord is active. */
-
-/* scale-only: very subdued — clearly background to chord tones */
-.degree-chip-strip[data-chord-active='true'] .degree-chip-item[data-in-scale='true']:not([data-in-chord='true']) .degree-chip {
-  border-color: rgb(77 228 255 / 0.18);
-  box-shadow: none;
-  opacity: 0.28;
-}
-
-.degree-chip-strip[data-chord-active='true'] .degree-chip-item[data-in-scale='true']:not([data-in-chord='true']) .degree-chip-interval {
-  opacity: 0.3;
-}
-
-/* chord-tone: solid warm fill, brighter — clearly stronger than scale-only */
-.degree-chip-strip[data-chord-active='true'] .degree-chip-item[data-in-chord='true']:not([data-is-chord-root='true']) .degree-chip {
-  background: rgb(255 154 77 / 0.12);
-  border-color: rgb(255 154 77 / 0.88);
-  box-shadow: var(--chip-glow-orange);
-  opacity: 1;
-}
-
-/* chord-root: strongest — solid fill + halo ring */
-.degree-chip-strip[data-chord-active='true'] .degree-chip-item[data-is-chord-root='true'] .degree-chip {
-  background: rgb(255 154 77 / 0.22);
-  border-color: rgb(255 154 77);
-  border-width: calc(var(--chip-border-width) + 1px);
-  box-shadow: var(--chip-glow-orange), 0 0 0 3px rgb(255 154 77 / 0.14);
-  opacity: 1;
 }
 
 /* Hidden state overrides all active states — connector line grey glow. */

--- a/src/components/DegreeChipStrip.tsx
+++ b/src/components/DegreeChipStrip.tsx
@@ -7,8 +7,6 @@ export interface DegreeChip {
   interval: string;
   inScale: boolean;
   isTonic?: boolean;
-  inChord?: boolean;
-  isChordRoot?: boolean;
 }
 
 export interface DegreeChipStripProps {
@@ -19,7 +17,6 @@ export interface DegreeChipStripProps {
   className?: string;
   'aria-label'?: string;
   hideHeader?: boolean;
-  chordActive?: boolean;
 }
 
 export function DegreeChipStrip({
@@ -30,7 +27,6 @@ export function DegreeChipStrip({
   className,
   'aria-label': ariaLabel,
   hideHeader,
-  chordActive,
 }: DegreeChipStripProps) {
   const label = ariaLabel ?? `Scale degrees for ${scaleName}`;
 
@@ -39,7 +35,6 @@ export function DegreeChipStrip({
       role="group"
       aria-label={label}
       className={clsx('degree-chip-strip', className)}
-      data-chord-active={chordActive ? 'true' : undefined}
     >
       {!hideHeader && (
         <header className="degree-chip-strip-header">{scaleName}</header>
@@ -53,8 +48,6 @@ export function DegreeChipStrip({
               className="degree-chip-item"
               data-in-scale={chip.inScale ? 'true' : undefined}
               data-is-tonic={chip.isTonic ? 'true' : undefined}
-              data-in-chord={chip.inChord ? 'true' : undefined}
-              data-is-chord-root={chip.isChordRoot ? 'true' : undefined}
               data-hidden={isHidden ? 'true' : undefined}
             >
               <button

--- a/src/hooks/useDisplayState.test.ts
+++ b/src/hooks/useDisplayState.test.ts
@@ -1119,4 +1119,157 @@ describe("useDisplayState", () => {
       expect(items.some((i) => i.role === "chord-tone-outside-scale")).toBe(false);
     });
   });
+
+  describe("ChordPracticeBar derived values", () => {
+    it("showChordPracticeBar is false when no chord type", () => {
+      const store = createStore();
+      store.set(chordTypeAtom, null);
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.showChordPracticeBar).toBe(false);
+    });
+
+    it("showChordPracticeBar is true when chord type is set", () => {
+      const store = createStore();
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.showChordPracticeBar).toBe(true);
+    });
+
+    it("practiceBarTitle is chord label in compare mode", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.practiceBarTitle).toContain("C");
+      expect(result.current.practiceBarTitle).toContain("Major Triad");
+    });
+
+    it("practiceBarTitle is chord label in chord mode", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      store.set(viewModeAtom, "chord");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.practiceBarTitle).toContain("C");
+      expect(result.current.practiceBarTitle).toContain("Major Triad");
+    });
+
+    it("practiceBarTitle is 'Outside tones' in outside mode", () => {
+      const store = createStore();
+      store.set(chordRootAtom, "D");
+      store.set(chordTypeAtom, "Dominant 7th");
+      store.set(viewModeAtom, "outside");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.practiceBarTitle).toBe("Outside tones");
+    });
+
+    it("practiceBarBadge is 'Compare' in compare mode", () => {
+      const store = createStore();
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.practiceBarBadge).toBe("Compare");
+    });
+
+    it("practiceBarBadge is 'Chord only' in chord mode", () => {
+      const store = createStore();
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      store.set(viewModeAtom, "chord");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.practiceBarBadge).toBe("Chord only");
+    });
+
+    it("practiceBarBadge starts with 'against' in outside mode", () => {
+      const store = createStore();
+      store.set(chordRootAtom, "D");
+      store.set(chordTypeAtom, "Dominant 7th");
+      store.set(viewModeAtom, "outside");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.practiceBarBadge).toMatch(/^against /);
+    });
+
+    it("practiceBarTargetMembers contains all active chord tones", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.practiceBarTargetMembers).toHaveLength(3);
+      expect(result.current.practiceBarTargetMembers.some(m => m.internalNote === "C")).toBe(true);
+      expect(result.current.practiceBarTargetMembers.some(m => m.internalNote === "E")).toBe(true);
+      expect(result.current.practiceBarTargetMembers.some(m => m.internalNote === "G")).toBe(true);
+    });
+
+    it("practiceBarSharedMembers contains only in-scale chord tones", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C"); // C Major
+      store.set(chordRootAtom, "D");
+      store.set(chordTypeAtom, "Dominant 7th"); // D F# A C — F# outside C Major
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      const shared = result.current.practiceBarSharedMembers;
+      expect(shared.every(m => m.inScale)).toBe(true);
+      expect(shared.some(m => m.internalNote === "F#")).toBe(false);
+    });
+
+    it("practiceBarOutsideMembers contains only outside-scale chord tones", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C"); // C Major
+      store.set(chordRootAtom, "D");
+      store.set(chordTypeAtom, "Dominant 7th"); // D F# A C — F# outside C Major
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      const outside = result.current.practiceBarOutsideMembers;
+      expect(outside.every(m => !m.inScale)).toBe(true);
+      expect(outside.some(m => m.internalNote === "F#")).toBe(true);
+    });
+
+    it("practiceBarTargetMembers is viewMode-independent (same in compare and outside)", () => {
+      const makeStore = (viewMode: "compare" | "outside") => {
+        const store = createStore();
+        store.set(rootNoteAtom, "C");
+        store.set(chordRootAtom, "D");
+        store.set(chordTypeAtom, "Dominant 7th");
+        store.set(viewModeAtom, viewMode);
+        return store;
+      };
+      const { result: r1 } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(makeStore("compare")),
+      });
+      const { result: r2 } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(makeStore("outside")),
+      });
+      expect(r1.current.practiceBarTargetMembers.map(m => m.internalNote))
+        .toEqual(r2.current.practiceBarTargetMembers.map(m => m.internalNote));
+    });
+  });
 });

--- a/src/hooks/useDisplayState.ts
+++ b/src/hooks/useDisplayState.ts
@@ -210,11 +210,12 @@ export default function useDisplayState() {
     return map;
   }, [chordType, rootNote, scaleName, chordRoot, activeChordTones]);
 
-  // Chord row entries for the summary strip, filtered by viewMode.
-  const summaryChordRow = useMemo((): ChordRowEntry[] => {
+  // All active chord members as ChordRowEntry[], viewMode-independent.
+  // Consumed by ChordPracticeBar and as the base for summaryChordRow.
+  const allChordMembers = useMemo((): ChordRowEntry[] => {
     if (!chordType) return [];
     const scaleNoteSet = new Set(getScaleNotes(rootNote, scaleName));
-    const entries = activeChordMembers.map((m): ChordRowEntry => {
+    return activeChordMembers.map((m): ChordRowEntry => {
       const inScale = scaleNoteSet.has(m.note);
       const isRoot = m.name === "root";
       let role: ChordRowEntry["role"];
@@ -233,24 +234,21 @@ export default function useDisplayState() {
         inScale,
       };
     });
+  }, [chordType, activeChordMembers, rootNote, scaleName, chordRoot, useFlats]);
+
+  // Chord row entries for the summary strip, filtered by viewMode.
+  const summaryChordRow = useMemo((): ChordRowEntry[] => {
+    if (!chordType) return allChordMembers;
     // In outside view: keep only outside-scale entries (plus outside chord root).
     if (viewMode === "outside") {
-      return entries.filter(
+      return allChordMembers.filter(
         (e) =>
           e.role === "chord-tone-outside-scale" ||
           (e.role === "chord-root" && !e.inScale),
       );
     }
-    return entries;
-  }, [
-    chordType,
-    activeChordMembers,
-    rootNote,
-    scaleName,
-    chordRoot,
-    useFlats,
-    viewMode,
-  ]);
+    return allChordMembers;
+  }, [chordType, allChordMembers, viewMode]);
 
   // Legend items: only roles actually present in the current chord row.
   const summaryLegendItems = useMemo((): LegendItem[] => {
@@ -479,6 +477,41 @@ export default function useDisplayState() {
     [summaryChordRow],
   );
 
+  // ── ChordPracticeBar derived values ─────────────────────────────────────────
+
+  // Whether the practice bar should render (chord is active)
+  const showChordPracticeBar = !!chordType;
+
+  // Practice bar title — varies by viewMode
+  const practiceBarTitle = useMemo((): string => {
+    if (!chordType) return "";
+    if (viewMode === "outside") return "Outside tones";
+    return chordLabel ?? "";
+  }, [chordType, viewMode, chordLabel]);
+
+  // Practice bar badge — contextual label beside the title
+  const practiceBarBadge = useMemo((): string | null => {
+    if (!chordType) return null;
+    if (viewMode === "chord") return "Chord only";
+    if (viewMode === "outside") return `against ${scaleLabel}`;
+    return "Compare";
+  }, [chordType, viewMode, scaleLabel]);
+
+  // All active chord members for the "Targets" group
+  const practiceBarTargetMembers = allChordMembers;
+
+  // Active chord members that are also in the scale, for the "Shared" group
+  const practiceBarSharedMembers = useMemo(
+    () => allChordMembers.filter((e) => e.inScale),
+    [allChordMembers],
+  );
+
+  // Active chord members outside the scale, for the "Outside" group
+  const practiceBarOutsideMembers = useMemo(
+    () => allChordMembers.filter((e) => !e.inScale),
+    [allChordMembers],
+  );
+
   return {
     // Atom values
     rootNote,
@@ -545,6 +578,14 @@ export default function useDisplayState() {
     scaleLabel,
     chordLabel,
     chordSummaryNotes,
+    allChordMembers,
+    // ChordPracticeBar
+    showChordPracticeBar,
+    practiceBarTitle,
+    practiceBarBadge,
+    practiceBarTargetMembers,
+    practiceBarSharedMembers,
+    practiceBarOutsideMembers,
     // Internal state + callbacks
     clickedShape,
     recenterKey,


### PR DESCRIPTION
## Summary

- **Scale strip is now scale-only.** `DegreeChipStrip` no longer receives chord-overlay props (`chordActive`, `inChord`, `isChordRoot`). The chip styling is driven purely by scale membership and tonic status — no chord semantics bleed in.
- **New `ChordPracticeBar` component** renders below the scale strip when a chord is active. Uses compact horizontal pills (capsules, not circular chips) grouped into contextual sections based on view mode.
- **Fretboard note shapes are now role-differentiated.** Each chord overlay role maps to a distinct SVG primitive so shape alone communicates role — independent of color.

## What changed

### `DegreeChipStrip`
- Removed `chordActive` prop, `inChord`/`isChordRoot` fields from `DegreeChip`, and all `[data-chord-active]` CSS blocks.
- The strip is a stable reference map for the scale at all times.

### `ChordPracticeBar` (new)
Compact analysis bar rendered below the scale strip. Grouped pill sections per mode:
| Mode | Title | Badge | Sections shown |
|------|-------|-------|----------------|
| `compare` | chord label | `Compare` | Targets + Shared + Outside (omit empty) |
| `chord` | chord label | `Chord only` | Targets only |
| `outside` | `Outside tones` | `against {scale}` | Outside only |

### FretboardSVG shapes
| Role | Shape |
|------|-------|
| `scale-only` | hollow circle |
| `chord-tone-in-scale` | squircle |
| `chord-root` | squircle + outer halo ring |
| `chord-tone-outside-scale` | dashed diamond |

Each `<g>` carries `data-note-shape` for testability.

### `useDisplayState`
New exports: `allChordMembers`, `showChordPracticeBar`, `practiceBarTitle`, `practiceBarBadge`, `practiceBarTargetMembers`, `practiceBarSharedMembers`, `practiceBarOutsideMembers`.

### `App.tsx`
`summaryContent` always renders `DegreeChipStrip` + optional `ChordPracticeBar`. Removed `ChordRowStrip` and `RelationshipRow` from the summary path.

## Test plan

- [x] New `ChordPracticeBar.test.tsx` — a11y, mode-based group visibility, pill `data-role` attributes, empty-state null return
- [x] Updated `DegreeChipStrip.test.tsx` — asserts scale-only contract (no `data-in-chord`, no `data-chord-active`)
- [x] New `FretboardSVG` shape tests — asserts `data-note-shape` per role class
- [x] New `useDisplayState` tests — `practiceBarTitle/Badge` per mode, `practiceBarTargetMembers` is viewMode-independent
- [x] Updated `App.test.tsx` — ribbon tests updated for new structure
- [x] 839/839 tests pass; 22 snapshots updated; lint clean; build clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Chord Practice Bar to surface targets, shared, and outside chord tones with title and badge variants.

* **UI Changes**
  * Fretboard notes use distinct shapes for chord roots/tone types and scale-only notes.
  * Simplified the summary ribbon to always show the scale degree strip and integrate the practice bar when applicable.

* **Tests**
  * Updated and added tests covering the practice bar, degree strip, fretboard shapes, and summary ribbon behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->