### PR TITLE
refactor(atoms): derive useFlats + currentTuning via derived atoms (Phase 02)

### DIFF
--- a/src/__tests__/atoms.test.ts
+++ b/src/__tests__/atoms.test.ts
@@ -29,7 +29,10 @@ import {
   setRootNoteAtom,
   resetAtom,
   landscapeNarrowTabAtom,
+  useFlatsAtom,
+  currentTuningAtom,
 } from "../store/atoms";
+import { STANDARD_TUNING, TUNINGS } from "../guitar";
 import { CAGED_SHAPES } from "../shapes";
 
 function makeStore() {
@@ -513,6 +516,60 @@ describe("atoms", () => {
 
       expect(localStorage.getItem(k("rootNote"))).toBe("D");
       expect(localStorage.getItem("rootNote")).toBeNull();
+    });
+  });
+
+  describe("useFlatsAtom", () => {
+    it("returns false for G Major (sharps key, auto mode)", () => {
+      const store = makeStore();
+      store.set(rootNoteAtom, "G");
+      store.set(scaleNameAtom, "Major");
+      store.set(accidentalModeAtom, "auto");
+      expect(store.get(useFlatsAtom)).toBe(false);
+    });
+
+    it("returns true for F Major (flats key, auto mode)", () => {
+      const store = makeStore();
+      store.set(rootNoteAtom, "F");
+      store.set(scaleNameAtom, "Major");
+      store.set(accidentalModeAtom, "auto");
+      expect(store.get(useFlatsAtom)).toBe(true);
+    });
+
+    it("returns false when accidentalMode is forced to sharps", () => {
+      const store = makeStore();
+      store.set(rootNoteAtom, "F");
+      store.set(scaleNameAtom, "Major");
+      store.set(accidentalModeAtom, "sharps");
+      expect(store.get(useFlatsAtom)).toBe(false);
+    });
+
+    it("returns true when accidentalMode is forced to flats", () => {
+      const store = makeStore();
+      store.set(rootNoteAtom, "G");
+      store.set(scaleNameAtom, "Major");
+      store.set(accidentalModeAtom, "flats");
+      expect(store.get(useFlatsAtom)).toBe(true);
+    });
+  });
+
+  describe("currentTuningAtom", () => {
+    it("returns Standard tuning for standard tuning name", () => {
+      const store = makeStore();
+      store.set(tuningNameAtom, "Standard");
+      expect(store.get(currentTuningAtom)).toEqual(TUNINGS["Standard"]);
+    });
+
+    it("returns Drop D tuning for Drop D tuning name", () => {
+      const store = makeStore();
+      store.set(tuningNameAtom, "Drop D");
+      expect(store.get(currentTuningAtom)).toEqual(TUNINGS["Drop D"]);
+    });
+
+    it("falls back to STANDARD_TUNING for unknown tuning name", () => {
+      const store = makeStore();
+      store.set(tuningNameAtom, "Unknown Tuning That Does Not Exist");
+      expect(store.get(currentTuningAtom)).toEqual(STANDARD_TUNING);
     });
   });
 });

--- a/src/components/ExpandedControlsPanel.tsx
+++ b/src/components/ExpandedControlsPanel.tsx
@@ -17,15 +17,14 @@ import {
   viewModeAtom,
   focusPresetAtom,
   customMembersAtom,
-  accidentalModeAtom,
   enharmonicDisplayAtom,
   fretStartAtom,
   fretEndAtom,
+  useFlatsAtom,
 } from "../store/atoms";
 import {
   NOTES,
   CHORD_DEFINITIONS,
-  resolveAccidentalMode,
   getScaleNotes,
   getChordNotes,
   getAvailableFocusPresets,
@@ -98,11 +97,7 @@ export function ScaleChordSection() {
   const [customMembers, setCustomMembers] = useAtom(customMembersAtom);
   const rootNote = useAtomValue(rootNoteAtom);
   const setRootNote = useSetAtom(setRootNoteAtom);
-  const accidentalMode = useAtomValue(accidentalModeAtom);
-  const useFlats = useMemo(
-    () => resolveAccidentalMode(rootNote, scaleName, accidentalMode),
-    [rootNote, scaleName, accidentalMode],
-  );
+  const useFlats = useAtomValue(useFlatsAtom);
 
   const availableFocusPresets = useMemo((): FocusPreset[] => {
     if (!chordType) return ["all", "custom"];
@@ -170,11 +165,7 @@ export function KeyColumn() {
   const rootNote = useAtomValue(rootNoteAtom);
   const handleSetRootNote = useSetAtom(setRootNoteAtom);
   const [scaleName] = useAtom(scaleNameAtom);
-  const accidentalMode = useAtomValue(accidentalModeAtom);
-  const useFlats = useMemo(
-    () => resolveAccidentalMode(rootNote, scaleName, accidentalMode),
-    [rootNote, scaleName, accidentalMode],
-  );
+  const useFlats = useAtomValue(useFlatsAtom);
   const enharmonicDisplay = useAtomValue(enharmonicDisplayAtom);
 
   return (

--- a/src/hooks/useDisplayState.ts
+++ b/src/hooks/useDisplayState.ts
@@ -21,6 +21,8 @@ import {
   enharmonicDisplayAtom,
   setRootNoteAtom,
   scaleBrowseModeAtom,
+  useFlatsAtom,
+  currentTuningAtom,
 } from "../store/atoms";
 import {
   SCALES,
@@ -31,7 +33,6 @@ import {
   getNoteDisplay,
   getDivergentNotes,
   formatAccidental,
-  resolveAccidentalMode,
   getAvailableFocusPresets,
   applyFocusPreset,
   type ViewMode,
@@ -43,7 +44,6 @@ import {
   type LegendItem,
 } from "../theory";
 import { getActiveScaleBrowseOption } from "../theoryCatalog";
-import { STANDARD_TUNING, TUNINGS } from "../guitar";
 import {
   CAGED_SHAPES,
   getCagedCoordinates,
@@ -124,12 +124,9 @@ export default function useDisplayState() {
 
   // useMemo derivations (copied verbatim from App.tsx)
 
-  const useFlats = useMemo(
-    () => resolveAccidentalMode(rootNote, scaleName, accidentalMode),
-    [rootNote, scaleName, accidentalMode],
-  );
+  const useFlats = useAtomValue(useFlatsAtom);
 
-  const currentTuning = TUNINGS[tuningName] || STANDARD_TUNING;
+  const currentTuning = useAtomValue(currentTuningAtom);
 
   // All chord tones for the selected chord (unfiltered; used for degree strip)
   const chordTones = useMemo(() => {

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -3,11 +3,13 @@ import { atomWithStorage, RESET } from "jotai/utils";
 import { CAGED_SHAPES, type CagedShape } from "../shapes";
 import { normalizeScaleName, type ScaleBrowseMode } from "../theoryCatalog";
 import { k, STORAGE_PREFIX } from "../utils/storage";
+import { resolveAccidentalMode } from "../theory";
 import type {
   ViewMode,
   FocusPreset,
   ChordMemberName,
 } from "../theory";
+import { TUNINGS, STANDARD_TUNING } from "../guitar";
 
 export type FingeringPattern = "all" | "caged" | "3nps";
 
@@ -684,6 +686,19 @@ export const landscapeNarrowTabAtom = atomWithStorage<LandscapeNarrowTab>(
 
 // settingsOverlayOpenAtom is intentionally non-persisted and always starts closed.
 export const settingsOverlayOpenAtom = atom<boolean>(false);
+
+// Derived read atoms
+export const useFlatsAtom = atom((get) =>
+  resolveAccidentalMode(
+    get(rootNoteAtom),
+    get(scaleNameAtom),
+    get(accidentalModeAtom),
+  ),
+);
+
+export const currentTuningAtom = atom(
+  (get) => TUNINGS[get(tuningNameAtom)] || STANDARD_TUNING,
+);
 
 // ---------------------------------------------------------------------------
 // Write atoms (actions)


### PR DESCRIPTION
## Summary
- Add `useFlatsAtom` and `currentTuningAtom` derived atoms in `src/store/atoms.ts`
- Replace in-component `useMemo(resolveAccidentalMode)` and `TUNINGS[tuningName]` lookups with `useAtomValue(...)` subscriptions in hooks and controls
- Drop now-unused imports (`resolveAccidentalMode`, `TUNINGS`, `STANDARD_TUNING`, `accidentalModeAtom`) from consumers
- Add tests covering sharps/flats auto + forced modes and tuning fallback (`Drop D`, unknown → `STANDARD_TUNING`)

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (37 files, 816 tests pass)
- [x] `npm run build`
- [ ] Manual smoke: flats display in flat keys, sharps in sharp keys, tuning switch reflects on fretboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for state management atoms related to accidental modes and tuning resolution.

* **Refactor**
  * Optimized internal state management by centralizing accidental mode and tuning resolution logic into derived atoms, improving code consistency across components and hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->