### PR TITLE
fix(chord): restore connector line in scale strip when chord overlay is off

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -218,15 +218,20 @@ function AppContent() {
   }, [summaryNotes, rootNote, scaleName, useFlats]);
 
   // Summary content: scale strip is always shown. ChordPracticeBar appears below when chord is active.
-  const summaryContent = (
-    <div className={chordType ? "summary-ribbon" : undefined}>
-      <DegreeChipStrip
-        scaleName={scaleLabel}
-        chips={degreeChips}
-        hiddenNotes={hiddenNotes}
-        onChipToggle={toggleHiddenNote}
-        aria-label="Scale degrees"
-      />
+  // When no chord: strip is a direct child of summary-shell so width: 100% resolves correctly
+  // and chips have room to space out, keeping the connector line visible.
+  const scaleStrip = (
+    <DegreeChipStrip
+      scaleName={scaleLabel}
+      chips={degreeChips}
+      hiddenNotes={hiddenNotes}
+      onChipToggle={toggleHiddenNote}
+      aria-label="Scale degrees"
+    />
+  );
+  const summaryContent = chordType ? (
+    <div className="summary-ribbon">
+      {scaleStrip}
       {showChordPracticeBar && (
         <ChordPracticeBar
           title={practiceBarTitle}
@@ -238,6 +243,8 @@ function AppContent() {
         />
       )}
     </div>
+  ) : (
+    scaleStrip
   );
 
   const mobileKeyExplorer = (


### PR DESCRIPTION
## Summary

- Restores the horizontal connector line between note circles in `DegreeChipStrip` when no chord overlay is active.
- Removes the unnecessary plain wrapper `<div>` that was introduced in #151 when chord is inactive.

## What broke and why

In #151, `summaryContent` was refactored to always render a wrapper `<div className={chordType ? "summary-ribbon" : undefined}>`. When `chordType` is null, this renders a classless `<div>` as a flex item inside `.summary-shell`.

Because the wrapper has no explicit width, it shrinks to fit its content. Inside it, `DegreeChipStrip`'s `width: min(100%, 30rem)` resolves `100%` against the wrapper's content-sized width — meaning the strip collapses to its intrinsic size (7 × `chip-size` + padding). This leaves **zero gap** between chips.

With chips touching, each chip's opaque circular background (`background: var(--strip-fill)`) covers the `::before` connector line continuously from edge to edge — making it invisible.

In the chord-active case (`.summary-ribbon` wrapper), the ribbon has an explicit `background`, `padding`, and `width: min(100%, 30rem)` resolved against the flex container's full width, giving chips room to spread out and the connector line to show through.

## Fix

Render `DegreeChipStrip` as a direct child of `summary-shell` when no chord is active — exactly as before #151. The `.summary-ribbon` wrapper is kept only when a chord is active. A `scaleStrip` constant avoids duplicating the JSX.

## Test plan

- [x] 839/839 tests pass; 9 snapshots updated to reflect structure change; lint clean
- [x] Visually verified connector line visible in no-chord state
- [x] Visually verified chord-active ribbon still renders correctly with `ChordPracticeBar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization for summary section rendering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->