### PR TITLE
feat(chord): color tones, hexagon shape, smarter practice bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,8 +84,8 @@ function AppContent() {
     practiceBarTitle,
     practiceBarBadge,
     practiceBarTargetMembers,
-    practiceBarSharedMembers,
     practiceBarOutsideMembers,
+    practiceBarColorNotes,
     recenterKey,
     onShapeClick,
     onRecenter,
@@ -233,8 +233,8 @@ function AppContent() {
           badge={practiceBarBadge}
           viewMode={viewMode}
           targetMembers={practiceBarTargetMembers}
-          sharedMembers={practiceBarSharedMembers}
           outsideMembers={practiceBarOutsideMembers}
+          colorNoteEntries={practiceBarColorNotes}
         />
       )}
     </div>

--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -54,7 +54,7 @@ interface FretboardSVGProps {
 type BoxBound = { minFret: number; maxFret: number };
 
 // Roles: key-tonic, chord-root, chord-tone-in-scale, chord-tone-outside-scale,
-//        scale-only, note-active, note-blue, note-inactive
+//        color-tone, scale-only, note-active, note-blue, note-inactive
 function classifyNote(
   isScaleRoot: boolean,
   isChordRootNote: boolean,
@@ -84,13 +84,15 @@ function classifyNote(
   // Chord overlay active: chord-root takes priority (even if outside scale).
   if (isChordRootNote && isChordTone && isChordInRange) return "chord-root";
   if (isHighlighted && isChordTone) return "chord-tone-in-scale";
+  // Color/characteristic tone: scale note not covered by chord role → hexagon.
+  if (isHighlighted && isColorNote) return "color-tone";
   if (isHighlighted) return "scale-only";
   if (!isHighlighted && isChordTone && isChordInRange)
     return "chord-tone-outside-scale";
   return "note-inactive";
 }
 
-type NoteShape = "circle" | "squircle" | "diamond";
+type NoteShape = "circle" | "squircle" | "diamond" | "hexagon";
 
 type NoteVisuals = {
   stroke: string;
@@ -106,7 +108,7 @@ type NoteVisuals = {
 
 function getNoteVisuals(
   noteClass: string,
-  glowFilterUrls: { cyan: string; orange: string },
+  glowFilterUrls: { cyan: string; orange: string; violet: string },
 ): NoteVisuals {
   switch (noteClass) {
     case "key-tonic":
@@ -157,16 +159,29 @@ function getNoteVisuals(
         noteShape: "circle",
       };
     case "scale-only":
-      // Hollow circle — scale note, no chord role.
+      // Hollow circle — scale note, not a chord tone. Full brightness so the
+      // scale map stays readable even when chord overlay is active.
       return {
-        stroke: "var(--note-ring-dim)",
+        stroke: "var(--note-ring)",
         filter: glowFilterUrls.cyan,
         fill: "transparent",
-        textFill: "rgb(255 255 255 / 0.75)",
-        radiusScale: 0.78,
-        strokeWidth: 1.7,
-        textOpacity: 0.82,
+        textFill: "#ffffff",
+        radiusScale: 0.82,
+        strokeWidth: 1.9,
+        textOpacity: 1,
         noteShape: "circle",
+      };
+    case "color-tone":
+      // Hexagon — characteristic/divergent tone for the current mode/scale.
+      return {
+        stroke: "var(--note-ring-color-tone)",
+        filter: glowFilterUrls.violet,
+        fill: "rgb(30 18 55 / 0.82)",
+        textFill: "#e8d8ff",
+        radiusScale: 0.80,
+        strokeWidth: 1.8,
+        textOpacity: 1,
+        noteShape: "hexagon",
       };
     case "chord-tone-outside-scale":
       // Diamond with dashed amber-dim border — outside the scale.
@@ -231,6 +246,7 @@ export function FretboardSVG({
   const glowFilterUrls = {
     cyan: svgDefUrl("glow-cyan"),
     orange: svgDefUrl("glow-orange"),
+    violet: svgDefUrl("glow-violet"),
   };
   const noteBubblePx = Math.round(stringRowPx * 0.78);
   const noteFontPx = Math.round(stringRowPx * 0.44);
@@ -788,6 +804,21 @@ export function FretboardSVG({
                 floodOpacity="0.65"
               />
             </filter>
+            <filter
+              id={svgDefId("glow-violet")}
+              x="-50%"
+              y="-50%"
+              width="200%"
+              height="200%"
+            >
+              <feDropShadow
+                dx="0"
+                dy="0"
+                stdDeviation="3"
+                floodColor="#A78BFA"
+                floodOpacity="0.65"
+              />
+            </filter>
             {/* Trapezoidal fretboard silhouette — everything inside the tapered
                 region is clipped. Strings, frets, inlays, polygons, and note
                 circles all live inside this clip. */}
@@ -1110,6 +1141,14 @@ export function FretboardSVG({
                   ) : noteShape === "diamond" ? (
                     <polygon
                       points={`${cx},${cy - r} ${cx + r},${cy} ${cx},${cy + r} ${cx - r},${cy}`}
+                      {...commonShapeProps}
+                    />
+                  ) : noteShape === "hexagon" ? (
+                    <polygon
+                      points={Array.from({ length: 6 }, (_, i) => {
+                        const a = (Math.PI / 3) * i - Math.PI / 6;
+                        return `${cx + r * Math.cos(a)},${cy + r * Math.sin(a)}`;
+                      }).join(" ")}
                       {...commonShapeProps}
                     />
                   ) : (

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -412,8 +412,9 @@ describe("App", () => {
       });
     });
 
-    it("compare mode: chord practice bar shown even in simple diatonic case (same root, all preset, all in scale)", async () => {
+    it("compare mode: chord practice bar hidden in simple diatonic case (same root, all preset, all in scale, C Major)", async () => {
       localStorage.setItem(k("rootNote"), "C");
+      localStorage.setItem(k("scaleName"), "Major");
       localStorage.setItem(k("chordRoot"), "C");
       localStorage.setItem(k("chordType"), "Major Triad");
       localStorage.setItem(k("focusPreset"), "all");
@@ -422,7 +423,8 @@ describe("App", () => {
       await waitFor(() => {
         expect(document.querySelector(".summary-ribbon")).toBeTruthy();
       });
-      expect(document.querySelector(".chord-practice-bar")).toBeTruthy();
+      // Bar is intentionally hidden: C Major Triad over C Major is fully diatonic, no new information.
+      expect(document.querySelector(".chord-practice-bar")).toBeNull();
       expect(document.querySelector(".relationship-row")).toBeNull();
     });
 
@@ -482,8 +484,10 @@ describe("App", () => {
 
     it("practice bar shows chord label as title and Compare badge in compare mode", async () => {
       localStorage.setItem(k("rootNote"), "C");
+      localStorage.setItem(k("scaleName"), "Major");
       localStorage.setItem(k("chordRoot"), "C");
-      localStorage.setItem(k("chordType"), "Major Triad");
+      // Dominant 7th has Bb which is outside C Major → bar is non-trivial and shown
+      localStorage.setItem(k("chordType"), "Dominant 7th");
       localStorage.setItem(k("viewMode"), "compare");
       render(<App />);
       await waitFor(() => {
@@ -492,7 +496,7 @@ describe("App", () => {
       const title = document.querySelector(".chord-practice-bar-title")!;
       const badge = document.querySelector(".chord-practice-bar-badge")!;
       expect(title.textContent).toContain("C");
-      expect(title.textContent).toContain("Major Triad");
+      expect(title.textContent).toContain("Dominant 7th");
       expect(badge.textContent).toBe("Compare");
     });
   });

--- a/src/__tests__/ChordPracticeBar.test.tsx
+++ b/src/__tests__/ChordPracticeBar.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ChordPracticeBar } from "../components/ChordPracticeBar";
-import type { ChordRowEntry } from "../theory";
+import type { ChordRowEntry, PracticeBarColorNote } from "../theory";
 import { axe } from "../test-utils/a11y";
 
 const root: ChordRowEntry = {
@@ -33,8 +33,14 @@ const flatSeven: ChordRowEntry = {
   inScale: false,
 };
 
+const bNatural: PracticeBarColorNote = {
+  internalNote: "B",
+  displayNote: "B",
+  intervalName: "6",
+};
+
 const allMembers = [root, third, fifth, flatSeven];
-const sharedMembers = [root, third, fifth];
+const inScaleMembers = [root, third, fifth];
 const outsideMembers = [flatSeven];
 
 describe("ChordPracticeBar", () => {
@@ -45,7 +51,6 @@ describe("ChordPracticeBar", () => {
         badge="Compare"
         viewMode="compare"
         targetMembers={allMembers}
-        sharedMembers={sharedMembers}
         outsideMembers={outsideMembers}
       />
     );
@@ -60,7 +65,6 @@ describe("ChordPracticeBar", () => {
         badge="Compare"
         viewMode="compare"
         targetMembers={allMembers}
-        sharedMembers={sharedMembers}
         outsideMembers={outsideMembers}
       />
     );
@@ -69,34 +73,19 @@ describe("ChordPracticeBar", () => {
   });
 
   describe("compare mode", () => {
-    it("shows Targets, Shared, and Outside group labels", () => {
+    it("shows Targets and Outside group labels (no Shared)", () => {
       render(
         <ChordPracticeBar
           title="C Dom7"
           badge="Compare"
           viewMode="compare"
           targetMembers={allMembers}
-          sharedMembers={sharedMembers}
           outsideMembers={outsideMembers}
         />
       );
       expect(screen.getByText("Targets")).toBeTruthy();
-      expect(screen.getByText("Shared")).toBeTruthy();
-      expect(screen.getByText("Outside")).toBeTruthy();
-    });
-
-    it("omits Shared group when sharedMembers is empty", () => {
-      render(
-        <ChordPracticeBar
-          title="C Augmented"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={outsideMembers}
-          sharedMembers={[]}
-          outsideMembers={outsideMembers}
-        />
-      );
       expect(screen.queryByText("Shared")).toBeNull();
+      expect(screen.getByText("Outside")).toBeTruthy();
     });
 
     it("omits Outside group when outsideMembers is empty", () => {
@@ -105,30 +94,73 @@ describe("ChordPracticeBar", () => {
           title="C Major Triad"
           badge="Compare"
           viewMode="compare"
-          targetMembers={sharedMembers}
-          sharedMembers={sharedMembers}
+          targetMembers={inScaleMembers}
           outsideMembers={[]}
         />
       );
       expect(screen.queryByText("Outside")).toBeNull();
     });
+
+    it("shows Color group when colorNoteEntries provided", () => {
+      render(
+        <ChordPracticeBar
+          title="D Dorian + Dm7"
+          badge="Compare"
+          viewMode="compare"
+          targetMembers={inScaleMembers}
+          outsideMembers={[]}
+          colorNoteEntries={[bNatural]}
+        />
+      );
+      expect(screen.getByText("Color")).toBeTruthy();
+    });
+
+    it("color pill has data-role=color-tone", () => {
+      const { container } = render(
+        <ChordPracticeBar
+          title="D Dorian + Dm7"
+          badge="Compare"
+          viewMode="compare"
+          targetMembers={inScaleMembers}
+          outsideMembers={[]}
+          colorNoteEntries={[bNatural]}
+        />
+      );
+      expect(container.querySelector('[data-role="color-tone"]')).toBeTruthy();
+    });
+
+    it("color pill shows note name and interval", () => {
+      render(
+        <ChordPracticeBar
+          title="D Dorian + Dm7"
+          badge="Compare"
+          viewMode="compare"
+          targetMembers={inScaleMembers}
+          outsideMembers={[]}
+          colorNoteEntries={[bNatural]}
+        />
+      );
+      expect(screen.getByText("B")).toBeTruthy();
+      expect(screen.getByText("6")).toBeTruthy();
+    });
   });
 
   describe("chord mode", () => {
-    it("shows Targets group only", () => {
+    it("shows Targets group only, no Shared or Outside or Color", () => {
       render(
         <ChordPracticeBar
           title="C Major Triad"
           badge="Chord only"
           viewMode="chord"
-          targetMembers={sharedMembers}
-          sharedMembers={sharedMembers}
+          targetMembers={inScaleMembers}
           outsideMembers={[]}
+          colorNoteEntries={[bNatural]}
         />
       );
       expect(screen.getByText("Targets")).toBeTruthy();
       expect(screen.queryByText("Shared")).toBeNull();
       expect(screen.queryByText("Outside")).toBeNull();
+      expect(screen.queryByText("Color")).toBeNull();
     });
 
     it("renders badge as 'Chord only'", () => {
@@ -137,8 +169,7 @@ describe("ChordPracticeBar", () => {
           title="C Major Triad"
           badge="Chord only"
           viewMode="chord"
-          targetMembers={sharedMembers}
-          sharedMembers={sharedMembers}
+          targetMembers={inScaleMembers}
           outsideMembers={[]}
         />
       );
@@ -147,20 +178,21 @@ describe("ChordPracticeBar", () => {
   });
 
   describe("outside mode", () => {
-    it("shows Outside group only", () => {
+    it("shows Outside group only, no Targets or Color", () => {
       render(
         <ChordPracticeBar
           title="Outside tones"
           badge="against C Major"
           viewMode="outside"
           targetMembers={allMembers}
-          sharedMembers={sharedMembers}
           outsideMembers={outsideMembers}
+          colorNoteEntries={[bNatural]}
         />
       );
       expect(screen.queryByText("Targets")).toBeNull();
       expect(screen.queryByText("Shared")).toBeNull();
       expect(screen.getByText("Outside")).toBeTruthy();
+      expect(screen.queryByText("Color")).toBeNull();
     });
 
     it("renders title as 'Outside tones'", () => {
@@ -170,7 +202,6 @@ describe("ChordPracticeBar", () => {
           badge="against C Major"
           viewMode="outside"
           targetMembers={allMembers}
-          sharedMembers={sharedMembers}
           outsideMembers={outsideMembers}
         />
       );
@@ -184,7 +215,6 @@ describe("ChordPracticeBar", () => {
           badge="against C Major"
           viewMode="outside"
           targetMembers={allMembers}
-          sharedMembers={sharedMembers}
           outsideMembers={outsideMembers}
         />
       );
@@ -199,7 +229,6 @@ describe("ChordPracticeBar", () => {
         badge={null}
         viewMode="compare"
         targetMembers={[]}
-        sharedMembers={[]}
         outsideMembers={[]}
       />
     );
@@ -213,13 +242,11 @@ describe("ChordPracticeBar", () => {
         badge="Compare"
         viewMode="compare"
         targetMembers={allMembers}
-        sharedMembers={sharedMembers}
         outsideMembers={outsideMembers}
       />
     );
     const lists = container.querySelectorAll(".practice-bar-pill-list");
     expect(lists.length).toBeGreaterThan(0);
-    // Targets list (first) should have chord-root, chord-tone-in-scale, chord-tone-outside-scale
     const targetList = lists[0]!;
     expect(targetList.querySelector('[data-role="chord-root"]')).toBeTruthy();
     expect(targetList.querySelectorAll('[data-role="chord-tone-in-scale"]').length).toBe(2);
@@ -233,7 +260,6 @@ describe("ChordPracticeBar", () => {
         badge="Compare"
         viewMode="compare"
         targetMembers={allMembers}
-        sharedMembers={sharedMembers}
         outsideMembers={outsideMembers}
       />
     );
@@ -246,8 +272,7 @@ describe("ChordPracticeBar", () => {
         title="C Major Triad"
         badge="Chord only"
         viewMode="chord"
-        targetMembers={sharedMembers}
-        sharedMembers={sharedMembers}
+        targetMembers={inScaleMembers}
         outsideMembers={[]}
       />
     );
@@ -261,8 +286,21 @@ describe("ChordPracticeBar", () => {
         badge="against C Major"
         viewMode="outside"
         targetMembers={allMembers}
-        sharedMembers={sharedMembers}
         outsideMembers={outsideMembers}
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("has no accessibility violations with color tones", async () => {
+    const { container } = render(
+      <ChordPracticeBar
+        title="D Dorian + Dm7"
+        badge="Compare"
+        viewMode="compare"
+        targetMembers={inScaleMembers}
+        outsideMembers={[]}
+        colorNoteEntries={[bNatural]}
       />
     );
     expect(await axe(container)).toHaveNoViolations();

--- a/src/__tests__/FretboardSVG.test.tsx
+++ b/src/__tests__/FretboardSVG.test.tsx
@@ -297,5 +297,62 @@ describe("FretboardSVG", () => {
       const activeNotes = container.querySelectorAll('.note-active[data-note-shape="circle"]');
       expect(activeNotes.length).toBeGreaterThan(0);
     });
+
+    it("color-tone notes have data-note-shape=hexagon when chord overlay active", () => {
+      // D Dorian scale: D E F G A B C. colorNote=B. chordTones=D F A (Dm triad).
+      // B is in scale, is a color note, NOT a chord tone → should be color-tone (hexagon)
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          rootNote="D"
+          highlightNotes={["D", "E", "F", "G", "A", "B", "C"]}
+          colorNotes={["B"]}
+          chordTones={["D", "F", "A"]}
+          chordRoot="D"
+        />
+      );
+      const colorToneHexagons = container.querySelectorAll('.color-tone[data-note-shape="hexagon"]');
+      expect(colorToneHexagons.length).toBeGreaterThan(0);
+    });
+
+    it("chord role wins over color-tone when a note is both", () => {
+      // If B is both a color note AND a chord tone, it should be chord-tone-in-scale, not color-tone
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          rootNote="D"
+          highlightNotes={["D", "E", "F", "G", "A", "B", "C"]}
+          colorNotes={["B"]}
+          chordTones={["D", "F", "A", "B"]}
+          chordRoot="D"
+        />
+      );
+      // B should not be color-tone since it's in the chord
+      const colorToneNotes = container.querySelectorAll(".color-tone");
+      // All color-tone notes should not include B (B is now chord-tone-in-scale)
+      expect(
+        Array.from(colorToneNotes).some((el) =>
+          el.getAttribute("aria-label")?.includes("B")
+        )
+      ).toBe(false);
+      // B should be chord-tone-in-scale instead
+      const chordInScale = container.querySelectorAll(".chord-tone-in-scale");
+      expect(chordInScale.length).toBeGreaterThan(0);
+    });
+
+    it("scale-only notes without chord overlay show as note-active (not color-tone)", () => {
+      // No chord overlay: color notes show as note-blue, others as note-active
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          rootNote="D"
+          highlightNotes={["D", "E", "F", "G", "A", "B", "C"]}
+          colorNotes={["B"]}
+        />
+      );
+      // Without chord overlay, color notes are note-blue, not color-tone
+      expect(container.querySelectorAll(".note-blue").length).toBeGreaterThan(0);
+      expect(container.querySelectorAll(".color-tone").length).toBe(0);
+    });
   });
 });

--- a/src/components/ChordPracticeBar.css
+++ b/src/components/ChordPracticeBar.css
@@ -122,6 +122,12 @@
   border-style: dashed;
 }
 
+.practice-bar-pill[data-role="color-tone"] {
+  background: rgb(50 30 90 / 0.22);
+  border-color: rgb(167 139 250 / 0.75);
+  box-shadow: 0 0 5px rgb(167 139 250 / 0.3);
+}
+
 .practice-bar-pill-note {
   font-family: var(--font-sans);
   font-size: var(--pill-font);

--- a/src/components/ChordPracticeBar.tsx
+++ b/src/components/ChordPracticeBar.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import type { ChordRowEntry, ViewMode } from "../theory";
+import type { ChordRowEntry, PracticeBarColorNote, ViewMode } from "../theory";
 import "./ChordPracticeBar.css";
 
 interface PillGroupProps {
@@ -30,13 +30,41 @@ function PillGroup({ label, members, ariaLabel }: PillGroupProps) {
   );
 }
 
+interface ColorPillGroupProps {
+  label: string;
+  entries: PracticeBarColorNote[];
+  ariaLabel: string;
+}
+
+function ColorPillGroup({ label, entries, ariaLabel }: ColorPillGroupProps) {
+  if (entries.length === 0) return null;
+  return (
+    <div className="practice-bar-group">
+      <span className="practice-bar-group-label">{label}</span>
+      <ul className="practice-bar-pill-list" aria-label={ariaLabel}>
+        {entries.map((entry, i) => (
+          <li
+            key={`${entry.internalNote}-${i}`}
+            className="practice-bar-pill"
+            data-role="color-tone"
+            aria-label={`${entry.displayNote}, ${entry.intervalName}`}
+          >
+            <span className="practice-bar-pill-note">{entry.displayNote}</span>
+            <span className="practice-bar-pill-interval">{entry.intervalName}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 export interface ChordPracticeBarProps {
   title: string;
   badge: string | null;
   viewMode: ViewMode;
   targetMembers: ChordRowEntry[];
-  sharedMembers: ChordRowEntry[];
   outsideMembers: ChordRowEntry[];
+  colorNoteEntries?: PracticeBarColorNote[];
   className?: string;
 }
 
@@ -45,20 +73,19 @@ export function ChordPracticeBar({
   badge,
   viewMode,
   targetMembers,
-  sharedMembers,
   outsideMembers,
+  colorNoteEntries = [],
   className,
 }: ChordPracticeBarProps) {
-  if (
-    targetMembers.length === 0 &&
-    sharedMembers.length === 0 &&
-    outsideMembers.length === 0
-  )
-    return null;
+  const hasTargets = targetMembers.length > 0;
+  const hasOutside = outsideMembers.length > 0;
+  const hasColor = colorNoteEntries.length > 0;
 
-  const showTargets = viewMode === "compare" || viewMode === "chord";
-  const showShared = viewMode === "compare";
-  const showOutside = viewMode === "compare" || viewMode === "outside";
+  if (!hasTargets && !hasOutside && !hasColor) return null;
+
+  const showTargets = (viewMode === "compare" || viewMode === "chord") && hasTargets;
+  const showOutside = (viewMode === "compare" || viewMode === "outside") && hasOutside;
+  const showColor = viewMode === "compare" && hasColor;
 
   return (
     <section
@@ -80,18 +107,18 @@ export function ChordPracticeBar({
             ariaLabel="Target chord members"
           />
         )}
-        {showShared && (
-          <PillGroup
-            label="Shared"
-            members={sharedMembers}
-            ariaLabel="Shared with scale"
-          />
-        )}
         {showOutside && (
           <PillGroup
             label="Outside"
             members={outsideMembers}
             ariaLabel="Outside scale"
+          />
+        )}
+        {showColor && (
+          <ColorPillGroup
+            label="Color"
+            entries={colorNoteEntries}
+            ariaLabel="Characteristic color tones"
           />
         )}
       </div>

--- a/src/hooks/useDisplayState.test.ts
+++ b/src/hooks/useDisplayState.test.ts
@@ -1272,4 +1272,191 @@ describe("useDisplayState", () => {
         .toEqual(r2.current.practiceBarTargetMembers.map(m => m.internalNote));
     });
   });
+
+  describe("showChordPracticeBar smart hiding", () => {
+    it("hides practice bar for simple diatonic case: same root, all preset, all in scale, no color tones", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad"); // C E G — all in C Major
+      store.set(focusPresetAtom, "all");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      // Set scale to Major explicitly (localStorage may carry other values in test env)
+      act(() => { result.current.setScaleName("Major"); });
+      // C Major has no divergent notes, C Major Triad fully diatonic → hide bar
+      expect(result.current.showChordPracticeBar).toBe(false);
+    });
+
+    it("shows practice bar when chord has outside-scale members", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      store.set(chordRootAtom, "D");
+      store.set(chordTypeAtom, "Dominant 7th"); // F# outside C Major
+      store.set(focusPresetAtom, "all");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.showChordPracticeBar).toBe(true);
+    });
+
+    it("shows practice bar in chord mode even for simple diatonic case", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      store.set(focusPresetAtom, "all");
+      store.set(viewModeAtom, "chord");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      act(() => { result.current.setScaleName("Major"); });
+      expect(result.current.showChordPracticeBar).toBe(true);
+    });
+
+    it("shows practice bar when modal scale has color tones even with diatonic chord", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "D");
+      store.set(chordRootAtom, "D");
+      store.set(chordTypeAtom, "Minor Triad"); // D F A — all in D Dorian
+      store.set(focusPresetAtom, "all");
+      store.set(viewModeAtom, "compare");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      act(() => {
+        result.current.setScaleName("Dorian");
+      });
+      // D Dorian has B as color tone → bar should show
+      expect(result.current.showChordPracticeBar).toBe(true);
+    });
+
+    it("shows practice bar in outside mode regardless of diatonic simplicity", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      store.set(focusPresetAtom, "all");
+      store.set(viewModeAtom, "outside");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.showChordPracticeBar).toBe(true);
+    });
+  });
+
+  describe("practiceBarColorNotes", () => {
+    it("is empty when scale has no divergent notes (C Major)", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      act(() => { result.current.setScaleName("Major"); });
+      expect(result.current.practiceBarColorNotes).toEqual([]);
+    });
+
+    it("contains B as color tone for D Dorian with correct interval name", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "D");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      act(() => {
+        result.current.setScaleName("Dorian");
+      });
+      const colorNotes = result.current.practiceBarColorNotes;
+      expect(colorNotes.length).toBeGreaterThan(0);
+      const bNote = colorNotes.find(n => n.internalNote === "B");
+      expect(bNote).toBeDefined();
+      expect(bNote?.intervalName).toBe("6");
+    });
+
+    it("contains F# as color tone for C Lydian with #4 interval", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      act(() => {
+        result.current.setScaleName("Lydian");
+      });
+      const colorNotes = result.current.practiceBarColorNotes;
+      const fSharp = colorNotes.find(n => n.internalNote === "F#");
+      expect(fSharp).toBeDefined();
+    });
+
+    it("contains F as color tone for G Mixolydian with b7 interval", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "G");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      act(() => {
+        result.current.setScaleName("Mixolydian");
+      });
+      const colorNotes = result.current.practiceBarColorNotes;
+      const fNote = colorNotes.find(n => n.internalNote === "F");
+      expect(fNote).toBeDefined();
+      expect(fNote?.intervalName).toBe("♭7");
+    });
+
+    it("each entry has internalNote, displayNote, and intervalName fields", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "D");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      act(() => {
+        result.current.setScaleName("Dorian");
+      });
+      for (const entry of result.current.practiceBarColorNotes) {
+        expect(typeof entry.internalNote).toBe("string");
+        expect(typeof entry.displayNote).toBe("string");
+        expect(typeof entry.intervalName).toBe("string");
+      }
+    });
+  });
+
+  describe("shapeLocalTargetMembers and shapeLocalColorNotes", () => {
+    it("shapeLocalTargetMembers is empty when chordType is null", () => {
+      const store = createStore();
+      store.set(chordTypeAtom, null);
+      store.set(fingeringPatternAtom, "caged");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      expect(result.current.shapeLocalTargetMembers).toEqual([]);
+    });
+
+    it("shapeLocalColorNotes is empty when fingeringPattern is all", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "D");
+      store.set(fingeringPatternAtom, "all");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      act(() => {
+        result.current.setScaleName("Dorian");
+      });
+      expect(result.current.shapeLocalColorNotes).toEqual([]);
+    });
+
+    it("shapeLocalTargetMembers is non-empty for caged mode with chord active", () => {
+      const store = createStore();
+      store.set(rootNoteAtom, "C");
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      store.set(fingeringPatternAtom, "caged");
+      const { result } = renderHook(() => useDisplayState(), {
+        wrapper: makeWrapper(store),
+      });
+      // C Major Triad (C E G) — in CAGED mode, at least some chord tones should
+      // appear in the highlighted shape positions
+      expect(result.current.shapeLocalTargetMembers.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/src/hooks/useDisplayState.ts
+++ b/src/hooks/useDisplayState.ts
@@ -25,6 +25,7 @@ import {
 import {
   SCALES,
   NOTES,
+  INTERVAL_NAMES,
   CHORD_DEFINITIONS,
   getScaleNotes,
   getChordNotes,
@@ -41,7 +42,9 @@ import {
   type NoteRole,
   type ChordRowEntry,
   type LegendItem,
+  type PracticeBarColorNote,
 } from "../theory";
+import { getFretNote } from "../guitar";
 import { getActiveScaleBrowseOption } from "../theoryCatalog";
 import { STANDARD_TUNING, TUNINGS } from "../guitar";
 import {
@@ -62,6 +65,7 @@ export type {
   NoteRole,
   ChordRowEntry,
   LegendItem,
+  PracticeBarColorNote,
 };
 
 export default function useDisplayState() {
@@ -479,8 +483,41 @@ export default function useDisplayState() {
 
   // ── ChordPracticeBar derived values ─────────────────────────────────────────
 
-  // Whether the practice bar should render (chord is active)
-  const showChordPracticeBar = !!chordType;
+  // Color/characteristic tone entries with display names and interval labels
+  const practiceBarColorNotes = useMemo((): PracticeBarColorNote[] => {
+    if (colorNotes.length === 0) return [];
+    const rootIdx = NOTES.indexOf(rootNote);
+    if (rootIdx === -1) return [];
+    return colorNotes.map((note) => {
+      const noteIdx = NOTES.indexOf(note);
+      const interval = (noteIdx - rootIdx + 12) % 12;
+      const intervalName = INTERVAL_NAMES[interval] ?? "";
+      return {
+        internalNote: note,
+        displayNote: formatAccidental(getNoteDisplay(note, rootNote, useFlats)),
+        intervalName: formatAccidental(intervalName),
+      };
+    });
+  }, [colorNotes, rootNote, useFlats]);
+
+  // Simple diatonic compare case: tonic chord, all in scale, no focus filter,
+  // no color tones that would add information. Hide the practice bar here.
+  // Non-tonic chords (chordRoot ≠ rootNote) still benefit from showing targets.
+  const isDiatonicSimpleCase = useMemo(() => {
+    if (!chordType) return false;
+    if (viewMode !== "compare") return false;
+    if (focusPreset !== "all") return false;
+    if (hasOutsideChordMembers) return false;
+    if (colorNotes.length > 0) return false;
+    if (chordRoot !== rootNote) return false;
+    return true;
+  }, [chordType, viewMode, focusPreset, hasOutsideChordMembers, colorNotes, chordRoot, rootNote]);
+
+  // Whether the practice bar should render
+  const showChordPracticeBar = useMemo(
+    () => !!chordType && !isDiatonicSimpleCase,
+    [chordType, isDiatonicSimpleCase],
+  );
 
   // Practice bar title — varies by viewMode
   const practiceBarTitle = useMemo((): string => {
@@ -500,7 +537,7 @@ export default function useDisplayState() {
   // All active chord members for the "Targets" group
   const practiceBarTargetMembers = allChordMembers;
 
-  // Active chord members that are also in the scale, for the "Shared" group
+  // Active chord members that are also in the scale (kept for backward compat)
   const practiceBarSharedMembers = useMemo(
     () => allChordMembers.filter((e) => e.inScale),
     [allChordMembers],
@@ -511,6 +548,38 @@ export default function useDisplayState() {
     () => allChordMembers.filter((e) => !e.inScale),
     [allChordMembers],
   );
+
+  // Shape-local note set: notes that appear within the current highlighted pattern.
+  // Only meaningful in CAGED/3NPS modes where highlightNotes are coord pairs.
+  const shapeHighlightedNoteSet = useMemo((): Set<string> | null => {
+    if (fingeringPattern === "all") return null;
+    const noteSet = new Set<string>();
+    for (const coord of highlightNotes) {
+      const dashIdx = coord.indexOf("-");
+      if (dashIdx === -1) continue; // note name, not a coord
+      const stringIdx = parseInt(coord.slice(0, dashIdx), 10);
+      const fretIdx = parseInt(coord.slice(dashIdx + 1), 10);
+      const openNote = currentTuning[stringIdx];
+      if (openNote) noteSet.add(getFretNote(openNote, fretIdx));
+    }
+    return noteSet;
+  }, [fingeringPattern, highlightNotes, currentTuning]);
+
+  // Which target chord members appear in the current shape's highlighted notes
+  const shapeLocalTargetMembers = useMemo((): ChordRowEntry[] => {
+    if (!shapeHighlightedNoteSet || !chordType) return [];
+    return practiceBarTargetMembers.filter((m) =>
+      shapeHighlightedNoteSet.has(m.internalNote),
+    );
+  }, [shapeHighlightedNoteSet, chordType, practiceBarTargetMembers]);
+
+  // Which color tones appear in the current shape's highlighted notes
+  const shapeLocalColorNotes = useMemo((): PracticeBarColorNote[] => {
+    if (!shapeHighlightedNoteSet) return [];
+    return practiceBarColorNotes.filter((n) =>
+      shapeHighlightedNoteSet.has(n.internalNote),
+    );
+  }, [shapeHighlightedNoteSet, practiceBarColorNotes]);
 
   return {
     // Atom values
@@ -586,6 +655,9 @@ export default function useDisplayState() {
     practiceBarTargetMembers,
     practiceBarSharedMembers,
     practiceBarOutsideMembers,
+    practiceBarColorNotes,
+    shapeLocalTargetMembers,
+    shapeLocalColorNotes,
     // Internal state + callbacks
     clickedShape,
     recenterKey,

--- a/src/semantic.css
+++ b/src/semantic.css
@@ -84,6 +84,7 @@
   --note-ring: var(--neon-cyan);
   --note-ring-tonic: var(--neon-orange);
   --note-ring-dim: var(--neon-cyan-dim);
+  --note-ring-color-tone: var(--neon-violet);
   --note-fill: transparent;
   --note-fill-in-chord: var(--neon-orange);
   --note-text-in-scale: var(--neon-cyan-bright);

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -95,9 +95,17 @@ export type NoteRole =
   | "chord-root"
   | "chord-tone-in-scale"
   | "chord-tone-outside-scale"
+  | "color-tone"
   | "scale-only"
   | "note-active"
   | "note-blue";
+
+// Color/characteristic note entry for the practice bar Color group
+export interface PracticeBarColorNote {
+  internalNote: string;
+  displayNote: string;
+  intervalName: string;
+}
 
 export interface ChordRowEntry {
   internalNote: string;

--- a/src/tokens.css
+++ b/src/tokens.css
@@ -87,6 +87,8 @@
   --neon-orange: #FF9A4D;          /* tonic / chord-tone emphasis */
   --neon-orange-bright: #FFB366;   /* brighter hover/focus variant */
   --neon-orange-dim: #CC7A3D;      /* dimmed variant */
+  --neon-violet: #A78BFA;          /* color/characteristic tone accent */
+  --neon-violet-dim: #7C5FD4;      /* dimmed violet variant */
   --neon-brand-gradient: linear-gradient(90deg, #4DE4FF 0%, #A78BFA 50%, #4DE4FF 100%);
 }
 


### PR DESCRIPTION
## Summary

- **Color/characteristic tones**: Modal scales (Dorian, Lydian, Mixolydian, etc.) now expose their divergent notes as a first-class `color-tone` role. On the fretboard these render as **hexagons** with a violet ring, distinct from all other shapes. The practice bar surfaces them as a `Color` group (e.g. D Dorian → B as "6", G Mixolydian → F as "♭7").
- **Practice-bar cleanup**: Dropped the redundant `Shared` group. Compare mode now shows `Targets`, `Outside` (when present), and `Color` (when modal color tones exist). The bar is hidden entirely for the trivial tonic-diatonic case (C Major + C Major Triad → no bar); non-tonic chords, outside tones, or modal color tones always show it.
- **Scale-only visual revert**: `scale-only` notes in chord overlay mode now use full-brightness `--note-ring` and full text opacity — reverts the dimming that made the scale map feel weaker during chord overlay.
- **Shape-local derived values**: `shapeLocalTargetMembers` and `shapeLocalColorNotes` identify which chord targets and color tones appear within the current CAGED/3NPS shape's highlighted positions (groundwork for shape-aware practice cues).

## What changed

### `src/theory.ts`
- Added `"color-tone"` to the `NoteRole` union.
- Added `PracticeBarColorNote` interface `{ internalNote, displayNote, intervalName }`.

### `src/FretboardSVG.tsx`
- `classifyNote`: new `color-tone` branch — scale note that is a color tone but has no chord role → `color-tone`. Chord roles always win.
- `NoteShape`: added `"hexagon"`. Hexagon rendering via SVG polygon with 6 vertices.
- `getNoteVisuals`: `color-tone` → violet ring (`--note-ring-color-tone`), violet glow filter, hexagon shape. `scale-only` → reverted to `--note-ring` + full opacity.
- Added `glow-violet` SVG filter to defs.

### `src/hooks/useDisplayState.ts`
- `practiceBarColorNotes`: maps `colorNotes` → `PracticeBarColorNote[]` with interval labels.
- `isDiatonicSimpleCase`: true when `viewMode=compare`, `focusPreset=all`, no outside members, no color tones, and `chordRoot === rootNote`.
- `showChordPracticeBar`: hides bar in `isDiatonicSimpleCase`.
- `shapeHighlightedNoteSet` / `shapeLocalTargetMembers` / `shapeLocalColorNotes`: shape-local intersection using `getFretNote` on CAGED/3NPS coords.

### `src/components/ChordPracticeBar.tsx`
- Removed `sharedMembers` prop. Added `colorNoteEntries?: PracticeBarColorNote[]`.
- Compare mode: Targets + Outside + Color. Chord mode: Targets only. Outside mode: Outside only.
- New `ColorPillGroup` component renders color-tone pills with `data-role="color-tone"`.

### `src/tokens.css` / `src/semantic.css`
- `--neon-violet`, `--neon-violet-dim` added to token palette.
- `--note-ring-color-tone` semantic alias.

### `src/components/ChordPracticeBar.css`
- `data-role="color-tone"` pill: violet border + subtle glow.

### Tests
- `ChordPracticeBar.test.tsx`: updated for new props (no `sharedMembers`), added Color group and color-tone pill tests.
- `useDisplayState.test.ts`: added suites for `showChordPracticeBar` smart hiding, `practiceBarColorNotes` derivation (Dorian B/6, Lydian F#/#4, Mixolydian F/b7), and `shapeLocal*` values.
- `FretboardSVG.test.tsx`: added color-tone hexagon test, chord-role-wins test, and no-color-tone-without-overlay test.
- `App.test.tsx`: updated two tests to reflect the new behavior (bar hidden for tonic diatonic case; test for title/badge now uses Dominant 7th which has an outside tone).
- Snapshots updated for violet glow filter addition.

## Test plan

- [ ] All 858 tests pass (`npm run test`)
- [ ] Lint clean (`npm run lint`)
- [ ] Build clean (`npm run build`)
- [ ] Manual: D Dorian scale + Dm7 chord in compare mode → bar shows `Targets: D F A C`, `Color: B (6)`, B note renders as hexagon
- [ ] Manual: C Major scale + C Major Triad, same root, compare → bar is hidden (clean, no redundant info)
- [ ] Manual: C Major scale + G Major Triad (non-tonic chord) → bar shows `Targets: G B D`
- [ ] Manual: G Mixolydian + G7 in compare → bar shows `Targets: G B D F`, Color group shows F (♭7) only if F is not already covered by chord role (it is → no Color group here)
- [ ] Manual: scale-only notes in chord overlay are full brightness, same as without overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added color-tone highlighting for modal scale notes with distinct violet visual styling and hexagon shape.
  * Chord practice bar now displays color tones in compare mode alongside target and outside notes.

* **Improvements**
  * Chord practice bar intelligently hides for simple diatonic chord scenarios to reduce visual clutter.
  * Enhanced note classification with improved role precedence (chord tones override color tones).

* **Style**
  * Updated note visuals with violet glow effects and brighter styling for better contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->