### PR TITLE
perf(fretboard): eliminate scroll repaint hotspots

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -299,6 +299,7 @@
   width: 100%;
   min-width: 0;
   overflow-x: hidden;
+  contain: layout paint;
 }
 
 /* Dynamic Box Overlays behind strings */
@@ -316,7 +317,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  box-shadow: -2px 0 4px rgba(0, 0, 0, 0.5);
+  border-left: 1px solid rgba(0, 0, 0, 0.4);
 }
 
 .fret-zero {

--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, useCallback, memo, type CSSProperties, type ReactNode } from "react";
+import { useId, useMemo, useCallback, memo, useState, useEffect, useRef, type CSSProperties, type ReactNode } from "react";
 import { clsx } from "clsx";
 import {
   NOTES,
@@ -157,7 +157,60 @@ function getNoteVisuals(
   }
 }
 
-const FretboardBackground = memo(({ 
+/** Pre-rasterizes the three feTurbulence wood-grain layers to a PNG dataURL so
+ *  the browser can GPU-composite it during scroll instead of re-running
+ *  CPU-bound fractalNoise every frame. */
+function useWoodGrainTexture(width: number, height: number): string | null {
+  const [dataUrl, setDataUrl] = useState<string | null>(null);
+  const prevKey = useRef('');
+
+  useEffect(() => {
+    const key = `${width}x${height}`;
+    if (key === prevKey.current || width <= 0 || height <= 0) return;
+    prevKey.current = key;
+
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+      <defs>
+        <filter id="wg" x="0%" y="0%" width="100%" height="100%">
+          <feTurbulence type="fractalNoise" baseFrequency="0.012 0.95" numOctaves="2" seed="3" result="grain"/>
+          <feColorMatrix in="grain" type="matrix" values="0 0 0 0 0.09 0 0 0 0 0.05 0 0 0 0 0.03 0 0 0 0.72 0" result="grainTinted"/>
+          <feComposite in="grainTinted" in2="SourceGraphic" operator="in"/>
+        </filter>
+        <filter id="wh" x="0%" y="0%" width="100%" height="100%">
+          <feTurbulence type="fractalNoise" baseFrequency="0.022 0.55" numOctaves="1" seed="11" result="hl"/>
+          <feColorMatrix in="hl" type="matrix" values="0 0 0 0 0.32 0 0 0 0 0.21 0 0 0 0 0.12 0 0 0 0.09 0"/>
+        </filter>
+        <filter id="wp" x="0%" y="0%" width="100%" height="100%">
+          <feTurbulence type="fractalNoise" baseFrequency="0.55 0.55" numOctaves="1" seed="23" result="pores"/>
+          <feColorMatrix in="pores" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.16 0"/>
+        </filter>
+      </defs>
+      <rect width="${width}" height="${height}" fill="#000" filter="url(#wg)" opacity="0.92"/>
+      <rect width="${width}" height="${height}" fill="#000" filter="url(#wh)" opacity="0.6"/>
+      <rect width="${width}" height="${height}" fill="#000" filter="url(#wp)" opacity="0.5"/>
+    </svg>`;
+
+    const blob = new Blob([svg], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) { URL.revokeObjectURL(url); return; }
+      ctx.drawImage(img, 0, 0);
+      URL.revokeObjectURL(url);
+      try { setDataUrl(canvas.toDataURL('image/png')); } catch { /* tainted canvas — stay on live filters */ }
+    };
+    img.onerror = () => URL.revokeObjectURL(url);
+    img.src = url;
+  }, [width, height]);
+
+  return dataUrl;
+}
+
+const FretboardBackground = memo(({
   neckWidthPx, 
   neckHeight, 
   startFret, 
@@ -180,12 +233,27 @@ const FretboardBackground = memo(({
   taperYLeft: number;
   inlays: ReactNode[];
 }) => {
+  const woodGrainDataUrl = useWoodGrainTexture(neckWidthPx, neckHeight);
+
   const woodStack = (
     <>
       <rect x={0} y={0} width={neckWidthPx} height={neckHeight} fill={svgDefUrl("fretboard-wood")} />
-      <rect x={0} y={0} width={neckWidthPx} height={neckHeight} fill="#000" filter={svgDefUrl("wood-grain-filter")} opacity={0.92} />
-      <rect x={0} y={0} width={neckWidthPx} height={neckHeight} fill="#000" filter={svgDefUrl("wood-highlights-filter")} opacity={0.6} />
-      <rect x={0} y={0} width={neckWidthPx} height={neckHeight} fill="#000" filter={svgDefUrl("wood-pores-filter")} opacity={0.5} />
+      {woodGrainDataUrl ? (
+        <image
+          href={woodGrainDataUrl}
+          x={0}
+          y={0}
+          width={neckWidthPx}
+          height={neckHeight}
+          preserveAspectRatio="none"
+        />
+      ) : (
+        <>
+          <rect x={0} y={0} width={neckWidthPx} height={neckHeight} fill="#000" filter={svgDefUrl("wood-grain-filter")} opacity={0.92} />
+          <rect x={0} y={0} width={neckWidthPx} height={neckHeight} fill="#000" filter={svgDefUrl("wood-highlights-filter")} opacity={0.6} />
+          <rect x={0} y={0} width={neckWidthPx} height={neckHeight} fill="#000" filter={svgDefUrl("wood-pores-filter")} opacity={0.5} />
+        </>
+      )}
       <rect x={0} y={0} width={neckWidthPx} height={neckHeight} fill={svgDefUrl("fretboard-vignette")} />
     </>
   );
@@ -683,6 +751,7 @@ export const FretboardSVG = memo(function FretboardSVG({
           {
             height: `${neckHeight + NECK_BORDER * 2}px`,
             width: `${neckWidthPx + NECK_BORDER * 2}px`,
+            willChange: "transform",
             "--string-row-px": `${stringRowPx}px`,
             "--glow-cyan": glowFilterUrls.cyan,
             "--glow-orange": glowFilterUrls.orange,

--- a/src/components/BottomTabBar.css
+++ b/src/components/BottomTabBar.css
@@ -4,9 +4,8 @@
   left: 0;
   right: 0;
   z-index: var(--z-bottom-nav);
-  background: var(--header-surface);
+  background: color-mix(in srgb, var(--header-surface) 95%, transparent);
   border-top: 1px solid var(--header-border);
-  backdrop-filter: blur(8px);
   padding-bottom: env(safe-area-inset-bottom);
 }
 


### PR DESCRIPTION
## Summary

- **Pre-rasterize wood grain**: The three `feTurbulence` SVG filters (grain, highlights, pores) that cover the full fretboard background are the #1 scroll bottleneck — `fractalNoise` is CPU-only and re-executes for every pixel that scrolls into view. A new `useWoodGrainTexture` hook renders them to an offscreen canvas on mount and replaces the live-filtered `<rect>` elements with a static PNG `<image>`. Live filters remain as fallback until the async render completes.
- **`will-change: transform` on `.fretboard-neck`**: Promotes the SVG subtree to its own GPU compositing layer so the browser can tile-cache it during horizontal scroll.
- **`contain: layout paint` on `.fretboard-wrapper`**: Scopes layout and paint invalidation to the fretboard subtree, preventing unrelated state changes from triggering full-page repaints.
- **`.fret-column` box-shadow → border-left**: Removes per-column `box-shadow: -2px 0 4px` (22+ rasterization surfaces during scroll) in favour of a cheap `border-left`.
- **Remove `backdrop-filter: blur(8px)` from `BottomTabBar`**: Backdrop filters force the GPU to composite every scroll frame on mobile. Replaced with a 95%-opaque solid background.

## Test plan

- [ ] Fretboard wood grain renders correctly after mount (brief flash of plain wood on first load is acceptable)
- [ ] Horizontal scroll on mobile/tablet is visibly smoother
- [ ] Bottom tab bar background remains opaque and visually consistent
- [ ] Fret column separators still visible (border-left instead of box-shadow)
- [ ] All 894 tests pass, lint clean, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)