### PR TITLE
feat(practice): replace viewMode with practice-centric lens system

### DIFF
--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -287,6 +287,7 @@ export const FretboardSVG = memo(function FretboardSVG({
   chordFretSpread = 0,
   hideNonChordNotes = false,
   viewMode = "compare",
+  practiceLens,
   colorNotes = [],
   shapePolygons = [],
   wrappedNotes = new Set<string>(),
@@ -300,8 +301,7 @@ export const FretboardSVG = memo(function FretboardSVG({
   // around it) but non-uniform spacing inside this component is derived from
   // neckWidthPx + scale math, so the value isn't read here.
   void effectiveZoom;
-  // `viewMode` is kept in props for backward compat; emphasis is now via
-  // hideNonChordNotes (derived from practiceLens in the caller).
+  // `viewMode` is kept in props for backward compat; emphasis is now via lens.
   void viewMode;
   const internalId = useId().replace(/[^a-zA-Z0-9_-]/g, "");
   const defsPrefix = `fretboard-${id ?? internalId}`;
@@ -520,6 +520,10 @@ export const FretboardSVG = memo(function FretboardSVG({
   }, [totalColumns, startFret, stringRowPx, svgDefUrl, fretCenterX, inlayYAt, inlayYBottomAt, inlayYTopAt]);
 
   const noteData = useMemo(() => {
+    // practiceLens is the source of truth when provided; hideNonChordNotes is the
+    // legacy fallback for callers that haven't migrated yet.
+    const effectiveHideNonChordNotes =
+      practiceLens !== undefined ? practiceLens === "targets" : hideNonChordNotes;
     const notes = [];
     const scale = SCALES[scaleName] || [];
     const normRoot = rootNote && (ENHARMONICS[rootNote]?.includes("b") ? ENHARMONICS[rootNote] : rootNote);
@@ -656,7 +660,7 @@ export const FretboardSVG = memo(function FretboardSVG({
 
         const isHidden = (() => {
           // Targets lens: hide all non-chord scale notes, including color tones.
-          if (hideNonChordNotes && (noteClass === "scale-only" || noteClass === "color-tone")) return true;
+          if (effectiveHideNonChordNotes && (noteClass === "scale-only" || noteClass === "color-tone")) return true;
           // All other lenses show all notes; tension lens emphasizes through the practice bar.
           return false;
         })();
@@ -673,7 +677,7 @@ export const FretboardSVG = memo(function FretboardSVG({
       }
     }
     return notes;
-  }, [numStrings, fretboardLayout, totalColumns, startFret, maxFret, hiddenNotes, highlightNotes, hasChordOverlay, chordTones, rootNote, chordRoot, colorNotes, shapePolygons, boxBounds, chordFretSpread, scaleName, useFlats, displayFormat, wrappedNotes, hideNonChordNotes, tuning]);
+  }, [numStrings, fretboardLayout, totalColumns, startFret, maxFret, hiddenNotes, highlightNotes, hasChordOverlay, chordTones, rootNote, chordRoot, colorNotes, shapePolygons, boxBounds, chordFretSpread, scaleName, useFlats, displayFormat, wrappedNotes, hideNonChordNotes, practiceLens, tuning]);
 
   return (
     <div role="group" aria-label={ariaLabel} className="fretboard-board">

--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -655,8 +655,8 @@ export const FretboardSVG = memo(function FretboardSVG({
           (isWrapped && isHighlighted);
 
         const isHidden = (() => {
-          // Targets lens (hideNonChordNotes): hide scale-only notes so only chord tones show.
-          if (noteClass === "scale-only" && hideNonChordNotes) return true;
+          // Targets lens: hide all non-chord scale notes, including color tones.
+          if (hideNonChordNotes && (noteClass === "scale-only" || noteClass === "color-tone")) return true;
           // All other lenses show all notes; tension lens emphasizes through the practice bar.
           return false;
         })();

--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -9,6 +9,7 @@ import {
   formatAccidental,
   SCALES,
   type ViewMode,
+  type PracticeLens,
 } from "./theory";
 import { parseNote } from "./guitar";
 import { STRING_ROW_PX_TABLET } from "./layout/responsive";
@@ -41,6 +42,7 @@ interface FretboardSVGProps {
   chordFretSpread?: number;
   hideNonChordNotes?: boolean;
   viewMode?: ViewMode;
+  practiceLens?: PracticeLens;
   colorNotes?: string[];
   shapePolygons?: ShapePolygon[];
   wrappedNotes?: Set<string>;
@@ -298,6 +300,9 @@ export const FretboardSVG = memo(function FretboardSVG({
   // around it) but non-uniform spacing inside this component is derived from
   // neckWidthPx + scale math, so the value isn't read here.
   void effectiveZoom;
+  // `viewMode` is kept in props for backward compat; emphasis is now via
+  // hideNonChordNotes (derived from practiceLens in the caller).
+  void viewMode;
   const internalId = useId().replace(/[^a-zA-Z0-9_-]/g, "");
   const defsPrefix = `fretboard-${id ?? internalId}`;
   const svgDefId = useCallback((id: string) => `${defsPrefix}-${id}`, [defsPrefix]);
@@ -650,14 +655,9 @@ export const FretboardSVG = memo(function FretboardSVG({
           (isWrapped && isHighlighted);
 
         const isHidden = (() => {
-          // chord mode: hide all scale-only notes.
+          // Targets lens (hideNonChordNotes): hide scale-only notes so only chord tones show.
           if (noteClass === "scale-only" && hideNonChordNotes) return true;
-          // outside mode: only outside chord tones (and outside chord root) visible.
-          if (viewMode === "outside" && hasChordOverlay) {
-            if (noteClass === "chord-tone-outside-scale") return false;
-            if (noteClass === "chord-root" && !isHighlighted) return false;
-            return true;
-          }
+          // All other lenses show all notes; tension lens emphasizes through the practice bar.
           return false;
         })();
 
@@ -673,7 +673,7 @@ export const FretboardSVG = memo(function FretboardSVG({
       }
     }
     return notes;
-  }, [numStrings, fretboardLayout, totalColumns, startFret, maxFret, hiddenNotes, highlightNotes, hasChordOverlay, chordTones, rootNote, chordRoot, colorNotes, shapePolygons, boxBounds, chordFretSpread, scaleName, useFlats, displayFormat, wrappedNotes, hideNonChordNotes, viewMode, tuning]);
+  }, [numStrings, fretboardLayout, totalColumns, startFret, maxFret, hiddenNotes, highlightNotes, hasChordOverlay, chordTones, rootNote, chordRoot, colorNotes, shapePolygons, boxBounds, chordFretSpread, scaleName, useFlats, displayFormat, wrappedNotes, hideNonChordNotes, tuning]);
 
   return (
     <div role="group" aria-label={ariaLabel} className="fretboard-board">

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -404,22 +404,22 @@ describe("App", () => {
       });
     });
 
-    it("compare mode: renders primary scale strip inside ribbon", async () => {
+    it("targets-color lens: renders primary scale strip inside ribbon", async () => {
       localStorage.setItem(k("chordType"), "Major Triad");
-      localStorage.setItem(k("viewMode"), "compare");
+      localStorage.setItem(k("practiceLens"), "targets-color");
       render(<App />);
       await waitFor(() => {
         expect(document.querySelector(".summary-ribbon .degree-chip-strip")).toBeTruthy();
       });
     });
 
-    it("compare mode: chord practice bar hidden in simple diatonic case (same root, all preset, all in scale, C Major)", async () => {
+    it("targets-color lens: chord practice bar hidden in simple diatonic case (same root, all preset, all in scale, C Major)", async () => {
       localStorage.setItem(k("rootNote"), "C");
       localStorage.setItem(k("scaleName"), "Major");
       localStorage.setItem(k("chordRoot"), "C");
       localStorage.setItem(k("chordType"), "Major Triad");
       localStorage.setItem(k("focusPreset"), "all");
-      localStorage.setItem(k("viewMode"), "compare");
+      localStorage.setItem(k("practiceLens"), "targets-color");
       render(<App />);
       await waitFor(() => {
         expect(document.querySelector(".summary-ribbon")).toBeTruthy();
@@ -429,21 +429,21 @@ describe("App", () => {
       expect(document.querySelector(".relationship-row")).toBeNull();
     });
 
-    it("compare mode: shows chord practice bar when chordRoot differs from scale root", async () => {
+    it("targets-color lens: shows chord practice bar when chordRoot differs from scale root", async () => {
       localStorage.setItem(k("rootNote"), "C");
       localStorage.setItem(k("chordRoot"), "G");
       localStorage.setItem(k("chordType"), "Major Triad");
       localStorage.setItem(k("focusPreset"), "all");
-      localStorage.setItem(k("viewMode"), "compare");
+      localStorage.setItem(k("practiceLens"), "targets-color");
       render(<App />);
       await waitFor(() => {
         expect(document.querySelector(".chord-practice-bar")).toBeTruthy();
       });
     });
 
-    it("chord mode: renders chord practice bar and keeps degree-chip-strip inside ribbon", async () => {
+    it("targets lens: renders chord practice bar and keeps degree-chip-strip inside ribbon", async () => {
       localStorage.setItem(k("chordType"), "Major Triad");
-      localStorage.setItem(k("viewMode"), "chord");
+      localStorage.setItem(k("practiceLens"), "targets");
       render(<App />);
       await waitFor(() => {
         expect(document.querySelector(".summary-ribbon .chord-practice-bar")).toBeTruthy();
@@ -451,11 +451,11 @@ describe("App", () => {
       });
     });
 
-    it("outside mode: renders chord practice bar and keeps degree-chip-strip inside ribbon", async () => {
+    it("tension lens: renders chord practice bar and keeps degree-chip-strip inside ribbon", async () => {
       localStorage.setItem(k("rootNote"), "C");
       localStorage.setItem(k("chordRoot"), "D");
       localStorage.setItem(k("chordType"), "Dominant 7th");
-      localStorage.setItem(k("viewMode"), "outside");
+      localStorage.setItem(k("practiceLens"), "tension");
       render(<App />);
       await waitFor(() => {
         expect(document.querySelector(".summary-ribbon .chord-practice-bar")).toBeTruthy();
@@ -463,9 +463,9 @@ describe("App", () => {
       });
     });
 
-    it("no legend row is rendered in compare mode", async () => {
+    it("no legend row is rendered in targets-color lens", async () => {
       localStorage.setItem(k("chordType"), "Dominant 7th");
-      localStorage.setItem(k("viewMode"), "compare");
+      localStorage.setItem(k("practiceLens"), "targets-color");
       render(<App />);
       await waitFor(() => {
         expect(document.querySelector(".summary-ribbon")).toBeTruthy();
@@ -473,9 +473,9 @@ describe("App", () => {
       expect(document.querySelector(".chord-row-legend")).toBeNull();
     });
 
-    it("no legend row is rendered in chord mode", async () => {
+    it("no legend row is rendered in targets lens", async () => {
       localStorage.setItem(k("chordType"), "Major Triad");
-      localStorage.setItem(k("viewMode"), "chord");
+      localStorage.setItem(k("practiceLens"), "targets");
       render(<App />);
       await waitFor(() => {
         expect(document.querySelector(".summary-ribbon")).toBeTruthy();
@@ -483,22 +483,20 @@ describe("App", () => {
       expect(document.querySelector(".chord-row-legend")).toBeNull();
     });
 
-    it("practice bar shows chord label as title and Compare badge in compare mode", async () => {
+    it("practice bar shows chord label as title", async () => {
       localStorage.setItem(k("rootNote"), "C");
       localStorage.setItem(k("scaleName"), "Major");
       localStorage.setItem(k("chordRoot"), "C");
       // Dominant 7th has Bb which is outside C Major → bar is non-trivial and shown
       localStorage.setItem(k("chordType"), "Dominant 7th");
-      localStorage.setItem(k("viewMode"), "compare");
+      localStorage.setItem(k("practiceLens"), "targets-color");
       render(<App />);
       await waitFor(() => {
         expect(document.querySelector(".chord-practice-bar")).toBeTruthy();
       });
       const title = document.querySelector(".chord-practice-bar-title")!;
-      const badge = document.querySelector(".chord-practice-bar-badge")!;
       expect(title.textContent).toContain("C");
       expect(title.textContent).toContain("Dominant 7th");
-      expect(badge.textContent).toBe("Compare");
     });
   });
 

--- a/src/__tests__/ChordPracticeBar.test.tsx
+++ b/src/__tests__/ChordPracticeBar.test.tsx
@@ -1,511 +1,370 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ChordPracticeBar } from "../components/ChordPracticeBar";
-import type { ChordRowEntry, PracticeBarColorNote } from "../theory";
+import type { PracticeCue } from "../theory";
 import { axe } from "../test-utils/a11y";
 
-const root: ChordRowEntry = {
-  internalNote: "C",
-  displayNote: "C",
-  memberName: "1",
-  role: "chord-root",
-  inScale: true,
-};
-const third: ChordRowEntry = {
-  internalNote: "E",
-  displayNote: "E",
-  memberName: "3",
-  role: "chord-tone-in-scale",
-  inScale: true,
-};
-const fifth: ChordRowEntry = {
-  internalNote: "G",
-  displayNote: "G",
-  memberName: "5",
-  role: "chord-tone-in-scale",
-  inScale: true,
-};
-const flatSeven: ChordRowEntry = {
-  internalNote: "A#",
-  displayNote: "B♭",
-  memberName: "♭7",
-  role: "chord-tone-outside-scale",
-  inScale: false,
+// ── Fixture cues ──────────────────────────────────────────────────────────────
+
+const landOnCue: PracticeCue = {
+  kind: "land-on",
+  label: "Land on",
+  notes: [
+    { internalNote: "D", displayNote: "D", intervalName: "1", role: "chord-root" },
+    { internalNote: "F", displayNote: "F", intervalName: "♭3", role: "chord-tone-in-scale" },
+    { internalNote: "A", displayNote: "A", intervalName: "5", role: "chord-tone-in-scale" },
+    { internalNote: "C", displayNote: "C", intervalName: "♭7", role: "chord-tone-in-scale" },
+  ],
 };
 
-const bNatural: PracticeBarColorNote = {
-  internalNote: "B",
-  displayNote: "B",
-  intervalName: "6",
-};
-const fSharp: PracticeBarColorNote = {
-  internalNote: "F#",
-  displayNote: "F♯",
-  intervalName: "♯4",
+const colorCue: PracticeCue = {
+  kind: "color-note",
+  label: "Color note",
+  notes: [
+    { internalNote: "B", displayNote: "B", intervalName: "6", role: "color-tone" },
+  ],
 };
 
-const allMembers = [root, third, fifth, flatSeven];
-const inScaleMembers = [root, third, fifth];
-const outsideMembers = [flatSeven];
+const colorCuePlural: PracticeCue = {
+  kind: "color-note",
+  label: "Color notes",
+  notes: [
+    { internalNote: "B", displayNote: "B", intervalName: "6", role: "color-tone" },
+    { internalNote: "F#", displayNote: "F♯", intervalName: "♯4", role: "color-tone" },
+  ],
+};
+
+const guideToneCue: PracticeCue = {
+  kind: "guide-tones",
+  label: "Guide tones",
+  notes: [
+    { internalNote: "E", displayNote: "E", intervalName: "3", role: "guide-tone" },
+    { internalNote: "A#", displayNote: "B♭", intervalName: "♭7", role: "guide-tone" },
+  ],
+};
+
+const tensionCue: PracticeCue = {
+  kind: "tension",
+  label: "Tension",
+  notes: [
+    {
+      internalNote: "C#",
+      displayNote: "C♯",
+      intervalName: "1",
+      role: "chord-tone-outside-scale",
+      resolvesTo: { internalNote: "D", displayNote: "D" },
+    },
+    {
+      internalNote: "G#",
+      displayNote: "G♯",
+      intervalName: "5",
+      role: "chord-tone-outside-scale",
+      resolvesTo: { internalNote: "A", displayNote: "A" },
+    },
+  ],
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 describe("ChordPracticeBar", () => {
-  it("renders a role=group with aria-label", () => {
+  it("renders a role=group with aria-label containing the title", () => {
     render(
       <ChordPracticeBar
-        title="C Dominant 7th"
-        badge="Compare"
-        viewMode="compare"
-        targetMembers={allMembers}
-        outsideMembers={outsideMembers}
+        title="D Minor 7"
+        cues={[landOnCue]}
       />
     );
-    const group = screen.getByRole("group", { name: "Chord analysis: C Dominant 7th" });
+    const group = screen.getByRole("group", { name: "Practice cues: D Minor 7" });
     expect(group).toBeTruthy();
   });
 
-  it("renders title and badge", () => {
-    render(
-      <ChordPracticeBar
-        title="C Dominant 7th"
-        badge="Compare"
-        viewMode="compare"
-        targetMembers={allMembers}
-        outsideMembers={outsideMembers}
-      />
-    );
-    expect(screen.getByText("C Dominant 7th")).toBeTruthy();
-    expect(screen.getByText("Compare")).toBeTruthy();
+  it("renders the title", () => {
+    render(<ChordPracticeBar title="D Minor 7" cues={[landOnCue]} />);
+    expect(screen.getByText("D Minor 7")).toBeTruthy();
   });
 
-  describe("compare mode", () => {
-    it("shows Targets and Outside group labels (no Shared)", () => {
-      render(
-        <ChordPracticeBar
-          title="C Dom7"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={allMembers}
-          outsideMembers={outsideMembers}
-        />
-      );
-      expect(screen.getByText("Targets")).toBeTruthy();
-      expect(screen.queryByText("Shared")).toBeNull();
-      expect(screen.getByText("Outside")).toBeTruthy();
+  it("renders an optional badge when provided", () => {
+    render(<ChordPracticeBar title="D Minor 7" badge="Targets" cues={[landOnCue]} />);
+    expect(screen.getByText("Targets")).toBeTruthy();
+  });
+
+  it("does not render a badge element when badge is null", () => {
+    const { container } = render(
+      <ChordPracticeBar title="D Minor 7" badge={null} cues={[landOnCue]} />
+    );
+    expect(container.querySelector(".chord-practice-bar-badge")).toBeNull();
+  });
+
+  it("returns null when cues array is empty", () => {
+    const { container } = render(
+      <ChordPracticeBar title="Empty" cues={[]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  describe("Land on cue (targets / targets-color)", () => {
+    it("renders 'Land on:' cue label", () => {
+      render(<ChordPracticeBar title="D Minor 7" cues={[landOnCue]} />);
+      expect(screen.getByText("Land on:")).toBeTruthy();
     });
 
-    it("omits Outside group when outsideMembers is empty", () => {
-      render(
-        <ChordPracticeBar
-          title="C Major Triad"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={inScaleMembers}
-          outsideMembers={[]}
-        />
-      );
-      expect(screen.queryByText("Outside")).toBeNull();
+    it("renders all chord tone note names", () => {
+      render(<ChordPracticeBar title="D Minor 7" cues={[landOnCue]} />);
+      expect(screen.getByText("D")).toBeTruthy();
+      expect(screen.getByText("F")).toBeTruthy();
+      expect(screen.getByText("A")).toBeTruthy();
+      expect(screen.getByText("C")).toBeTruthy();
     });
 
-    it("shows Color tone group (singular) when one colorNoteEntry provided", () => {
-      render(
-        <ChordPracticeBar
-          title="D Dorian + Dm7"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={inScaleMembers}
-          outsideMembers={[]}
-          colorNoteEntries={[bNatural]}
-        />
-      );
-      expect(screen.getByText("Color tone")).toBeTruthy();
-      expect(screen.queryByText("Color tones")).toBeNull();
+    it("renders interval names alongside note names", () => {
+      render(<ChordPracticeBar title="D Minor 7" cues={[landOnCue]} />);
+      expect(screen.getByText("1")).toBeTruthy();
+      expect(screen.getByText("♭3")).toBeTruthy();
     });
 
-    it("shows Color tones group (plural) when multiple colorNoteEntries provided", () => {
-      render(
-        <ChordPracticeBar
-          title="C Lydian + CMaj7"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={inScaleMembers}
-          outsideMembers={[]}
-          colorNoteEntries={[bNatural, fSharp]}
-        />
-      );
-      expect(screen.getByText("Color tones")).toBeTruthy();
-      expect(screen.queryByText("Color tone")).toBeNull();
-    });
-
-    it("color pill has data-role=color-tone", () => {
+    it("pills have correct data-role for chord root and chord tones", () => {
       const { container } = render(
-        <ChordPracticeBar
-          title="D Dorian + Dm7"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={inScaleMembers}
-          outsideMembers={[]}
-          colorNoteEntries={[bNatural]}
-        />
+        <ChordPracticeBar title="D Minor 7" cues={[landOnCue]} />
+      );
+      expect(container.querySelector('[data-role="chord-root"]')).toBeTruthy();
+      expect(container.querySelectorAll('[data-role="chord-tone-in-scale"]').length).toBe(3);
+    });
+  });
+
+  describe("Color note cue", () => {
+    it("renders 'Color note:' label (singular)", () => {
+      render(<ChordPracticeBar title="D Dorian" cues={[colorCue]} />);
+      expect(screen.getByText("Color note:")).toBeTruthy();
+    });
+
+    it("renders 'Color notes:' label (plural)", () => {
+      render(<ChordPracticeBar title="C Lydian" cues={[colorCuePlural]} />);
+      expect(screen.getByText("Color notes:")).toBeTruthy();
+    });
+
+    it("pill has data-role=color-tone", () => {
+      const { container } = render(
+        <ChordPracticeBar title="D Dorian" cues={[colorCue]} />
       );
       expect(container.querySelector('[data-role="color-tone"]')).toBeTruthy();
     });
 
-    it("color pill shows note name and interval", () => {
-      render(
-        <ChordPracticeBar
-          title="D Dorian + Dm7"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={inScaleMembers}
-          outsideMembers={[]}
-          colorNoteEntries={[bNatural]}
-        />
-      );
+    it("renders color note name and interval", () => {
+      render(<ChordPracticeBar title="D Dorian" cues={[colorCue]} />);
       expect(screen.getByText("B")).toBeTruthy();
       expect(screen.getByText("6")).toBeTruthy();
     });
   });
 
-  describe("chord mode", () => {
-    it("shows Targets group only, no Shared or Outside or Color tone", () => {
-      render(
-        <ChordPracticeBar
-          title="C Major Triad"
-          badge="Chord only"
-          viewMode="chord"
-          targetMembers={inScaleMembers}
-          outsideMembers={[]}
-          colorNoteEntries={[bNatural]}
-        />
-      );
-      expect(screen.getByText("Targets")).toBeTruthy();
-      expect(screen.queryByText("Shared")).toBeNull();
-      expect(screen.queryByText("Outside")).toBeNull();
-      expect(screen.queryByText("Color tone")).toBeNull();
-      expect(screen.queryByText("Color tones")).toBeNull();
+  describe("Guide tones cue", () => {
+    it("renders 'Guide tones:' label", () => {
+      render(<ChordPracticeBar title="G7" cues={[guideToneCue]} />);
+      expect(screen.getByText("Guide tones:")).toBeTruthy();
     });
 
-    it("renders badge as 'Chord only'", () => {
-      render(
-        <ChordPracticeBar
-          title="C Major Triad"
-          badge="Chord only"
-          viewMode="chord"
-          targetMembers={inScaleMembers}
-          outsideMembers={[]}
-        />
+    it("pills have data-role=guide-tone", () => {
+      const { container } = render(
+        <ChordPracticeBar title="G7" cues={[guideToneCue]} />
       );
-      expect(screen.getByText("Chord only")).toBeTruthy();
+      const pills = container.querySelectorAll('[data-role="guide-tone"]');
+      expect(pills.length).toBe(2);
+    });
+
+    it("renders guide tone note names", () => {
+      render(<ChordPracticeBar title="G7" cues={[guideToneCue]} />);
+      expect(screen.getByText("E")).toBeTruthy();
+      expect(screen.getByText("B♭")).toBeTruthy();
     });
   });
 
-  describe("outside mode", () => {
-    it("shows Outside group only, no Targets or Color tone", () => {
-      render(
-        <ChordPracticeBar
-          title="Outside tones"
-          badge="against C Major"
-          viewMode="outside"
-          targetMembers={allMembers}
-          outsideMembers={outsideMembers}
-          colorNoteEntries={[bNatural]}
-        />
-      );
-      expect(screen.queryByText("Targets")).toBeNull();
-      expect(screen.queryByText("Shared")).toBeNull();
-      expect(screen.getByText("Outside")).toBeTruthy();
-      expect(screen.queryByText("Color tone")).toBeNull();
-      expect(screen.queryByText("Color tones")).toBeNull();
+  describe("Tension cue", () => {
+    it("renders 'Tension:' label", () => {
+      render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />);
+      expect(screen.getByText("Tension:")).toBeTruthy();
     });
 
-    it("renders title as 'Outside tones'", () => {
-      render(
-        <ChordPracticeBar
-          title="Outside tones"
-          badge="against C Major"
-          viewMode="outside"
-          targetMembers={allMembers}
-          outsideMembers={outsideMembers}
-        />
+    it("pills have data-role=chord-tone-outside-scale", () => {
+      const { container } = render(
+        <ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />
       );
-      expect(screen.getByText("Outside tones")).toBeTruthy();
+      const pills = container.querySelectorAll('[data-role="chord-tone-outside-scale"]');
+      expect(pills.length).toBe(2);
     });
 
-    it("renders badge as 'against {scale}'", () => {
-      render(
-        <ChordPracticeBar
-          title="Outside tones"
-          badge="against C Major"
-          viewMode="outside"
-          targetMembers={allMembers}
-          outsideMembers={outsideMembers}
-        />
-      );
-      expect(screen.getByText("against C Major")).toBeTruthy();
+    it("renders resolution arrows for tension notes with resolvesTo", () => {
+      render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />);
+      const resolves = screen.getAllByText(/→/);
+      expect(resolves.length).toBe(2);
+      expect(resolves[0]!.textContent).toBe("→D");
+      expect(resolves[1]!.textContent).toBe("→A");
+    });
+
+    it("outside chord root appears in tension cue (semantic fix)", () => {
+      // A chord root that is outside the scale should appear in a tension cue
+      const outsideRootTension: PracticeCue = {
+        kind: "tension",
+        label: "Tension",
+        notes: [
+          {
+            internalNote: "C#",
+            displayNote: "C♯",
+            intervalName: "1",
+            role: "chord-root",  // root role, but also tension
+            resolvesTo: { internalNote: "D", displayNote: "D" },
+          },
+        ],
+      };
+      render(<ChordPracticeBar title="C# Minor" cues={[outsideRootTension]} />);
+      expect(screen.getByText("Tension:")).toBeTruthy();
+      expect(screen.getByText("C♯")).toBeTruthy();
+      expect(screen.getByText("→D")).toBeTruthy();
     });
   });
 
-  it("returns null when all member arrays are empty", () => {
-    const { container } = render(
-      <ChordPracticeBar
-        title="Empty"
-        badge={null}
-        viewMode="compare"
-        targetMembers={[]}
-        outsideMembers={[]}
-      />
-    );
-    expect(container.firstChild).toBeNull();
-  });
-
-  it("pills have data-role attributes matching chord member roles", () => {
-    const { container } = render(
-      <ChordPracticeBar
-        title="C Dom7"
-        badge="Compare"
-        viewMode="compare"
-        targetMembers={allMembers}
-        outsideMembers={outsideMembers}
-      />
-    );
-    const lists = container.querySelectorAll(".practice-bar-pill-list");
-    expect(lists.length).toBeGreaterThan(0);
-    const targetList = lists[0]!;
-    expect(targetList.querySelector('[data-role="chord-root"]')).toBeTruthy();
-    expect(targetList.querySelectorAll('[data-role="chord-tone-in-scale"]').length).toBe(2);
-    expect(targetList.querySelector('[data-role="chord-tone-outside-scale"]')).toBeTruthy();
-  });
-
-  describe("shape-local context", () => {
-    it("shows 'Targets here' label when isShapeLocal and shapeLocalTargetMembers provided", () => {
+  describe("Targets + Color (default lens)", () => {
+    it("renders both Land on and Color note cues", () => {
       render(
         <ChordPracticeBar
           title="D Minor 7"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={allMembers}
-          outsideMembers={[]}
-          isShapeLocal
-          shapeContextLabel="In E shape"
-          shapeLocalTargetMembers={inScaleMembers}
-          shapeLocalOutsideMembers={[]}
+          cues={[landOnCue, colorCue]}
         />
       );
-      expect(screen.getByText("Targets here")).toBeTruthy();
-      expect(screen.queryByText("Targets")).toBeNull();
+      expect(screen.getByText("Land on:")).toBeTruthy();
+      expect(screen.getByText("Color note:")).toBeTruthy();
     });
 
-    it("shows 'Outside here' label when isShapeLocal and shapeLocalOutsideMembers provided", () => {
+    it("does not duplicate color note when it is already a chord tone (filtered upstream)", () => {
+      // colorCuePlural contains B and F# — if these were chord tones they'd be filtered
+      // out before reaching the component. This test just verifies the component renders
+      // them as-is (filtering is done in atoms).
       render(
         <ChordPracticeBar
-          title="C# Minor Triad"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={allMembers}
-          outsideMembers={outsideMembers}
-          isShapeLocal
-          shapeContextLabel="In E shape"
-          shapeLocalTargetMembers={[]}
-          shapeLocalOutsideMembers={outsideMembers}
+          title="G Mixolydian + G7"
+          cues={[landOnCue]}
         />
       );
-      expect(screen.getByText("Outside here")).toBeTruthy();
+      // No color cue because it was filtered upstream; component just shows land-on.
+      expect(screen.queryByText("Color note:")).toBeNull();
     });
+  });
 
-    it("shows 'Color tone here' (singular) when isShapeLocal and one shape-local color entry", () => {
-      render(
-        <ChordPracticeBar
-          title="D Dorian + Dm7"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={inScaleMembers}
-          outsideMembers={[]}
-          colorNoteEntries={[bNatural]}
-          isShapeLocal
-          shapeContextLabel="In E shape"
-          shapeLocalTargetMembers={inScaleMembers}
-          shapeLocalOutsideMembers={[]}
-          shapeLocalColorNoteEntries={[bNatural]}
-        />
-      );
-      expect(screen.getByText("Color tone here")).toBeTruthy();
-    });
-
-    it("shows 'Color tones here' (plural) when isShapeLocal and multiple shape-local color entries", () => {
-      render(
-        <ChordPracticeBar
-          title="C Lydian + CMaj7"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={inScaleMembers}
-          outsideMembers={[]}
-          colorNoteEntries={[bNatural, fSharp]}
-          isShapeLocal
-          shapeContextLabel="In E shape"
-          shapeLocalTargetMembers={inScaleMembers}
-          shapeLocalOutsideMembers={[]}
-          shapeLocalColorNoteEntries={[bNatural, fSharp]}
-        />
-      );
-      expect(screen.getByText("Color tones here")).toBeTruthy();
-    });
-
-    it("renders context label as subtitle when provided", () => {
+  describe("Shape-local context", () => {
+    it("renders shapeContextLabel as subtitle", () => {
       render(
         <ChordPracticeBar
           title="D Minor 7"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={inScaleMembers}
-          outsideMembers={[]}
+          cues={[landOnCue, colorCue]}
           isShapeLocal
           shapeContextLabel="In E shape"
-          shapeLocalTargetMembers={inScaleMembers}
-          shapeLocalOutsideMembers={[]}
+          shapeLocalCues={[landOnCue]}
         />
       );
       expect(screen.getByText("In E shape")).toBeTruthy();
     });
 
-    it("does not render context label element when shapeContextLabel is null", () => {
+    it("uses shapeLocalCues when isShapeLocal and shapeLocalCues is non-empty", () => {
+      const shapeLandOn: PracticeCue = {
+        kind: "land-on",
+        label: "Land on",
+        notes: [
+          { internalNote: "D", displayNote: "D", intervalName: "1", role: "chord-root" },
+        ],
+      };
       render(
         <ChordPracticeBar
           title="D Minor 7"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={inScaleMembers}
-          outsideMembers={[]}
+          cues={[landOnCue, colorCue]}
+          isShapeLocal
+          shapeContextLabel="In E shape"
+          shapeLocalCues={[shapeLandOn]}
+        />
+      );
+      // Shape-local cue shows only D (not F, A, C from global cue)
+      expect(screen.getByText("D")).toBeTruthy();
+      expect(screen.queryByText("Color note:")).toBeNull();
+    });
+
+    it("falls back to global cues when shapeLocalCues is empty", () => {
+      render(
+        <ChordPracticeBar
+          title="D Minor 7"
+          cues={[landOnCue]}
+          isShapeLocal
+          shapeContextLabel="In E shape"
+          shapeLocalCues={[]}
+        />
+      );
+      // Falls back to global; still shows global cue notes
+      expect(screen.getByText("Land on:")).toBeTruthy();
+    });
+
+    it("does not render context label when shapeContextLabel is null", () => {
+      render(
+        <ChordPracticeBar
+          title="D Minor 7"
+          cues={[landOnCue]}
           isShapeLocal={false}
           shapeContextLabel={null}
-          shapeLocalTargetMembers={inScaleMembers}
-          shapeLocalOutsideMembers={[]}
         />
       );
       expect(screen.queryByText("In E shape")).toBeNull();
     });
 
-    it("uses global labels when isShapeLocal is false even with shapeLocal arrays provided", () => {
-      render(
-        <ChordPracticeBar
-          title="C Dom7"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={allMembers}
-          outsideMembers={outsideMembers}
-          isShapeLocal={false}
-          shapeLocalTargetMembers={inScaleMembers}
-          shapeLocalOutsideMembers={[]}
-        />
-      );
-      expect(screen.getByText("Targets")).toBeTruthy();
-      expect(screen.queryByText("Targets here")).toBeNull();
-    });
-
-    it("omits empty Targets here group when shape-local targets is empty", () => {
-      render(
-        <ChordPracticeBar
-          title="C# Minor Triad"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={allMembers}
-          outsideMembers={outsideMembers}
-          isShapeLocal
-          shapeContextLabel="In E shape"
-          shapeLocalTargetMembers={[]}
-          shapeLocalOutsideMembers={outsideMembers}
-        />
-      );
-      expect(screen.queryByText("Targets here")).toBeNull();
-    });
-
-    it("returns null when all shape-local effective arrays are empty", () => {
+    it("returns null when shapeLocalCues is non-empty array but all empty after lens filter (empty shapeLocalCues)", () => {
       const { container } = render(
         <ChordPracticeBar
-          title="C# Minor Triad"
-          badge="Compare"
-          viewMode="compare"
-          targetMembers={allMembers}
-          outsideMembers={outsideMembers}
+          title="D Minor 7"
+          cues={[landOnCue]}
           isShapeLocal
           shapeContextLabel="In E shape"
-          shapeLocalTargetMembers={[]}
-          shapeLocalOutsideMembers={[]}
-          shapeLocalColorNoteEntries={[]}
+          shapeLocalCues={[]}
         />
       );
-      expect(container.firstChild).toBeNull();
+      // Falls back to global cues — not null
+      expect(container.firstChild).not.toBeNull();
     });
   });
 
-  it("has no accessibility violations in compare mode", async () => {
-    const { container } = render(
-      <ChordPracticeBar
-        title="C Dominant 7th"
-        badge="Compare"
-        viewMode="compare"
-        targetMembers={allMembers}
-        outsideMembers={outsideMembers}
-      />
-    );
-    expect(await axe(container)).toHaveNoViolations();
-  });
+  describe("Accessibility", () => {
+    it("has no a11y violations with a land-on cue", async () => {
+      const { container } = render(
+        <ChordPracticeBar title="D Minor 7" cues={[landOnCue]} />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
 
-  it("has no accessibility violations in chord mode", async () => {
-    const { container } = render(
-      <ChordPracticeBar
-        title="C Major Triad"
-        badge="Chord only"
-        viewMode="chord"
-        targetMembers={inScaleMembers}
-        outsideMembers={[]}
-      />
-    );
-    expect(await axe(container)).toHaveNoViolations();
-  });
+    it("has no a11y violations with targets+color cues", async () => {
+      const { container } = render(
+        <ChordPracticeBar title="D Dorian + Dm7" cues={[landOnCue, colorCue]} />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
 
-  it("has no accessibility violations in outside mode", async () => {
-    const { container } = render(
-      <ChordPracticeBar
-        title="Outside tones"
-        badge="against C Major"
-        viewMode="outside"
-        targetMembers={allMembers}
-        outsideMembers={outsideMembers}
-      />
-    );
-    expect(await axe(container)).toHaveNoViolations();
-  });
+    it("has no a11y violations with guide-tones cue", async () => {
+      const { container } = render(
+        <ChordPracticeBar title="G7" cues={[guideToneCue]} />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
 
-  it("has no accessibility violations with color tones", async () => {
-    const { container } = render(
-      <ChordPracticeBar
-        title="D Dorian + Dm7"
-        badge="Compare"
-        viewMode="compare"
-        targetMembers={inScaleMembers}
-        outsideMembers={[]}
-        colorNoteEntries={[bNatural]}
-      />
-    );
-    expect(await axe(container)).toHaveNoViolations();
-  });
+    it("has no a11y violations with tension cue and resolution arrows", async () => {
+      const { container } = render(
+        <ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
 
-  it("has no accessibility violations in shape-local context", async () => {
-    const { container } = render(
-      <ChordPracticeBar
-        title="D Minor 7"
-        badge="Compare"
-        viewMode="compare"
-        targetMembers={inScaleMembers}
-        outsideMembers={[]}
-        colorNoteEntries={[bNatural]}
-        isShapeLocal
-        shapeContextLabel="In E shape"
-        shapeLocalTargetMembers={inScaleMembers}
-        shapeLocalOutsideMembers={[]}
-        shapeLocalColorNoteEntries={[bNatural]}
-      />
-    );
-    expect(await axe(container)).toHaveNoViolations();
+    it("has no a11y violations in shape-local context", async () => {
+      const { container } = render(
+        <ChordPracticeBar
+          title="D Minor 7"
+          cues={[landOnCue, colorCue]}
+          isShapeLocal
+          shapeContextLabel="In E shape"
+          shapeLocalCues={[landOnCue]}
+        />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
   });
 });

--- a/src/__tests__/FretboardSVG.test.tsx
+++ b/src/__tests__/FretboardSVG.test.tsx
@@ -132,19 +132,23 @@ describe("FretboardSVG", () => {
     expect(onNoteClick).toHaveBeenCalledTimes(1);
   });
 
-  it("hides scale-only circles when hideNonChordNotes is true", () => {
+  it("hides scale-only and color-tone circles when hideNonChordNotes is true", () => {
     render(
       <FretboardSVG
         {...BASE_PROPS}
         chordTones={["C"]}
         chordRoot="C"
         highlightNotes={["C", "E", "G"]}
+        colorNotes={["E"]}
         hideNonChordNotes={true}
       />
     );
-    // scale-only notes should have the 'hidden' class
-    const hiddenNotes = document.querySelectorAll(".scale-only.hidden");
-    expect(hiddenNotes.length).toBeGreaterThan(0);
+    // scale-only notes should be hidden
+    const hiddenScaleOnly = document.querySelectorAll(".scale-only.hidden");
+    expect(hiddenScaleOnly.length).toBeGreaterThan(0);
+    // color-tone notes (E is colorNote but not a chord tone) should also be hidden
+    const hiddenColorTone = document.querySelectorAll(".color-tone.hidden");
+    expect(hiddenColorTone.length).toBeGreaterThan(0);
   });
 
   it("classifies outside-scale chord tones with chord-tone-outside-scale class", () => {

--- a/src/__tests__/FretboardSVG.test.tsx
+++ b/src/__tests__/FretboardSVG.test.tsx
@@ -163,7 +163,9 @@ describe("FretboardSVG", () => {
     expect(outsideTones.length).toBeGreaterThan(0);
   });
 
-  it("outside view hides in-scale notes and only shows outside chord tones", () => {
+  it("tension lens (old outside mode) shows all notes — in-scale chord root is not hidden", () => {
+    // The old viewMode="outside" used to hide in-scale notes. The new tension lens
+    // shows all notes and uses the practice bar to coach about outside tones instead.
     const { container } = render(
       <FretboardSVG
         {...BASE_PROPS}
@@ -171,19 +173,20 @@ describe("FretboardSVG", () => {
         chordRoot="C"
         rootNote="C"
         highlightNotes={["C", "E", "G"]}
-        viewMode="outside"
+        practiceLens="tension"
       />
     );
-    // C (chord root) is in scale → hidden in outside mode
+    // C (chord root, in scale) must NOT be hidden in tension lens
     const hiddenChordRoot = container.querySelectorAll(".chord-root.hidden");
-    expect(hiddenChordRoot.length).toBeGreaterThan(0);
-    // A# (outside-scale chord tone) → NOT hidden
+    expect(hiddenChordRoot.length).toBe(0);
+    // A# (outside-scale chord tone) is still visible
     const visibleOutside = container.querySelectorAll(".chord-tone-outside-scale:not(.hidden)");
     expect(visibleOutside.length).toBeGreaterThan(0);
   });
 
-  it("outside view shows outside chord root when it is outside scale", () => {
-    // chordRoot=D is not in highlightNotes (C,E,G) → outside scale → visible in outside mode
+  it("outside chord root is visible and not hidden in tension lens", () => {
+    // D (chord root) is outside the scale notes (C,E,G) → classified as chord-root
+    // and must not be hidden under the tension lens
     const { container } = render(
       <FretboardSVG
         {...BASE_PROPS}
@@ -191,10 +194,9 @@ describe("FretboardSVG", () => {
         chordRoot="D"
         rootNote="C"
         highlightNotes={["C", "E", "G"]}
-        viewMode="outside"
+        practiceLens="tension"
       />
     );
-    // D (chord root) is outside scale → should appear as chord-root and NOT be hidden
     const visibleChordRoot = container.querySelectorAll(".chord-root:not(.hidden)");
     expect(visibleChordRoot.length).toBeGreaterThan(0);
   });

--- a/src/__tests__/atoms.test.ts
+++ b/src/__tests__/atoms.test.ts
@@ -24,6 +24,7 @@ import {
   hideNonChordNotesAtom,
   chordFretSpreadAtom,
   viewModeAtom,
+  practiceLensAtom,
   focusPresetAtom,
   customMembersAtom,
   setRootNoteAtom,
@@ -456,7 +457,7 @@ describe("atoms", () => {
       const store = makeStore();
       store.set(chordRootAtom, "G");
       store.set(linkChordRootAtom, false);
-      store.set(viewModeAtom, "chord"); // sets hideNonChordNotesAtom to true
+      store.set(practiceLensAtom, "targets"); // targets lens → hideNonChordNotesAtom = true
       store.set(chordFretSpreadAtom, 5);
       store.set(focusPresetAtom, "triad");
       store.set(customMembersAtom, ["root", "3"]);
@@ -476,7 +477,7 @@ describe("atoms", () => {
 
       expect(store.get(chordRootAtom)).toBe("C");
       expect(store.get(linkChordRootAtom)).toBe(true);
-      expect(store.get(hideNonChordNotesAtom)).toBe(false); // compare mode -> false
+      expect(store.get(hideNonChordNotesAtom)).toBe(false); // targets-color lens → false
       expect(store.get(chordFretSpreadAtom)).toBe(0);
       expect(store.get(viewModeAtom)).toBe("compare");
       expect(store.get(focusPresetAtom)).toBe("all");

--- a/src/__tests__/practiceLens.test.ts
+++ b/src/__tests__/practiceLens.test.ts
@@ -1,0 +1,398 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { createStore } from "jotai";
+import type { PracticeLens } from "../theory";
+import { k } from "../utils/storage";
+import {
+  practiceLensAtom,
+  practiceCuesAtom,
+  shapeLocalPracticeCuesAtom,
+  hideNonChordNotesAtom,
+  showChordPracticeBarAtom,
+  noteSemanticMapAtom,
+  rootNoteAtom,
+  scaleNameAtom,
+  chordRootAtom,
+  chordTypeAtom,
+  fingeringPatternAtom,
+} from "../store/atoms";
+
+function makeStore() {
+  return createStore();
+}
+
+describe("practiceLensAtom", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("defaults to targets-color", () => {
+    const store = makeStore();
+    expect(store.get(practiceLensAtom)).toBe("targets-color");
+  });
+
+  it("reads stored value", () => {
+    localStorage.setItem(k("practiceLens"), "targets");
+    const store = makeStore();
+    const unsub = store.sub(practiceLensAtom, () => {});
+    expect(store.get(practiceLensAtom)).toBe("targets");
+    unsub();
+  });
+
+  it("migrates old viewMode=chord to targets lens", () => {
+    localStorage.setItem(k("viewMode"), "chord");
+    const store = makeStore();
+    const unsub = store.sub(practiceLensAtom, () => {});
+    expect(store.get(practiceLensAtom)).toBe("targets");
+    unsub();
+  });
+
+  it("migrates old viewMode=outside to tension lens", () => {
+    localStorage.setItem(k("viewMode"), "outside");
+    const store = makeStore();
+    const unsub = store.sub(practiceLensAtom, () => {});
+    expect(store.get(practiceLensAtom)).toBe("tension");
+    unsub();
+  });
+
+  it("migrates old viewMode=compare to targets-color lens", () => {
+    localStorage.setItem(k("viewMode"), "compare");
+    const store = makeStore();
+    const unsub = store.sub(practiceLensAtom, () => {});
+    expect(store.get(practiceLensAtom)).toBe("targets-color");
+    unsub();
+  });
+
+  it("ignores invalid stored value and falls back to default", () => {
+    localStorage.setItem(k("practiceLens"), "invalid-lens");
+    const store = makeStore();
+    const unsub = store.sub(practiceLensAtom, () => {});
+    expect(store.get(practiceLensAtom)).toBe("targets-color");
+    unsub();
+  });
+});
+
+describe("hideNonChordNotesAtom", () => {
+  it("is true when lens is targets", () => {
+    const store = makeStore();
+    store.set(practiceLensAtom, "targets");
+    expect(store.get(hideNonChordNotesAtom)).toBe(true);
+  });
+
+  it("is false for all other lenses", () => {
+    const store = makeStore();
+    for (const lens of ["guide-tones", "color", "targets-color", "tension"] as const) {
+      store.set(practiceLensAtom, lens);
+      expect(store.get(hideNonChordNotesAtom)).toBe(false);
+    }
+  });
+});
+
+describe("practiceCuesAtom", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  function makeChordStore(
+    scaleName: string,
+    chordRoot: string,
+    chordType: string,
+    lens: PracticeLens,
+  ) {
+    const store = makeStore();
+    store.set(rootNoteAtom, chordRoot);
+    store.set(scaleNameAtom, scaleName);
+    store.set(chordRootAtom, chordRoot);
+    store.set(chordTypeAtom, chordType);
+    store.set(practiceLensAtom, lens);
+    return store;
+  }
+
+  describe("targets lens", () => {
+    it("returns a land-on cue with all chord tones", () => {
+      const store = makeChordStore("Major", "C", "Major Triad", "targets");
+      const cues = store.get(practiceCuesAtom);
+      expect(cues.length).toBe(1);
+      expect(cues[0]!.kind).toBe("land-on");
+      expect(cues[0]!.label).toBe("Land on");
+      const noteNames = cues[0]!.notes.map((n) => n.internalNote);
+      expect(noteNames).toContain("C");
+      expect(noteNames).toContain("E");
+      expect(noteNames).toContain("G");
+    });
+
+    it("returns empty cues when no chord is set", () => {
+      const store = makeStore();
+      store.set(chordTypeAtom, null);
+      store.set(practiceLensAtom, "targets");
+      expect(store.get(practiceCuesAtom)).toHaveLength(0);
+    });
+  });
+
+  describe("guide-tones lens", () => {
+    it("returns guide tones cue for a seventh chord (3rd + 7th)", () => {
+      const store = makeChordStore("Major", "G", "Dominant 7th", "guide-tones");
+      const cues = store.get(practiceCuesAtom);
+      expect(cues.length).toBe(1);
+      expect(cues[0]!.kind).toBe("guide-tones");
+      expect(cues[0]!.label).toBe("Guide tones");
+      // G7 = G B D F; guide tones = B (3) and F (b7)
+      const noteNames = cues[0]!.notes.map((n) => n.internalNote);
+      expect(noteNames).toContain("B");
+      expect(noteNames).toContain("F");
+    });
+
+    it("guide tones for a triad returns the 3rd", () => {
+      const store = makeChordStore("Major", "C", "Major Triad", "guide-tones");
+      const cues = store.get(practiceCuesAtom);
+      expect(cues[0]!.kind).toBe("guide-tones");
+      const noteNames = cues[0]!.notes.map((n) => n.internalNote);
+      expect(noteNames).toContain("E"); // major 3rd
+    });
+
+    it("falls back to land-on for power chord (no 3rd/7th)", () => {
+      const store = makeChordStore("Major", "G", "Power Chord (5)", "guide-tones");
+      const cues = store.get(practiceCuesAtom);
+      expect(cues[0]!.kind).toBe("land-on");
+    });
+
+    it("guide tone notes have role=guide-tone", () => {
+      const store = makeChordStore("Major", "G", "Dominant 7th", "guide-tones");
+      const cues = store.get(practiceCuesAtom);
+      expect(cues[0]!.notes.every((n) => n.role === "guide-tone")).toBe(true);
+    });
+  });
+
+  describe("color lens", () => {
+    it("returns a color-note cue for a modal scale with divergent notes", () => {
+      // D Dorian has B♮ as its color note (diverges from D Natural Minor)
+      const store = makeChordStore("Dorian", "D", "Minor 7th", "color");
+      const cues = store.get(practiceCuesAtom);
+      expect(cues.some((c) => c.kind === "color-note")).toBe(true);
+    });
+
+    it("returns empty cues when scale has no color tones", () => {
+      // C Major has no divergent notes (reference scale)
+      const store = makeChordStore("Major", "C", "Major Triad", "color");
+      const cues = store.get(practiceCuesAtom);
+      expect(cues.length).toBe(0);
+    });
+
+    it("color notes already in chord tones are filtered out", () => {
+      // G Mixolydian: color note is F (the b7). G7 chord includes F.
+      // F should be filtered from color cue (covered by land-on in targets-color).
+      const store = makeChordStore("Mixolydian", "G", "Dominant 7th", "color");
+      const cues = store.get(practiceCuesAtom);
+      // Color lens: if F is in chord tones, it's filtered → no color cue at all
+      const colorCues = cues.filter((c) => c.kind === "color-note");
+      if (colorCues.length > 0) {
+        const colorNotes = colorCues[0]!.notes.map((n) => n.internalNote);
+        expect(colorNotes).not.toContain("F");
+      }
+    });
+  });
+
+  describe("targets-color lens (default)", () => {
+    it("returns land-on + color-note cues for Dorian + Dm7", () => {
+      const store = makeChordStore("Dorian", "D", "Minor 7th", "targets-color");
+      const cues = store.get(practiceCuesAtom);
+      const kinds = cues.map((c) => c.kind);
+      expect(kinds).toContain("land-on");
+      expect(kinds).toContain("color-note");
+    });
+
+    it("returns only land-on when scale has no color tones (C Major + C Major Triad)", () => {
+      const store = makeChordStore("Major", "C", "Major Triad", "targets-color");
+      const cues = store.get(practiceCuesAtom);
+      const kinds = cues.map((c) => c.kind);
+      expect(kinds).toContain("land-on");
+      expect(kinds).not.toContain("color-note");
+    });
+
+    it("does not duplicate notes already in land-on as color notes", () => {
+      // G Mixolydian + G7: F is in both chord and scale divergence
+      const store = makeChordStore("Mixolydian", "G", "Dominant 7th", "targets-color");
+      const cues = store.get(practiceCuesAtom);
+      const colorCues = cues.filter((c) => c.kind === "color-note");
+      if (colorCues.length > 0) {
+        const landOnNotes = cues
+          .filter((c) => c.kind === "land-on")
+          .flatMap((c) => c.notes.map((n) => n.internalNote));
+        const colorNotes = colorCues[0]!.notes.map((n) => n.internalNote);
+        for (const note of colorNotes) {
+          expect(landOnNotes).not.toContain(note);
+        }
+      }
+    });
+  });
+
+  describe("tension lens", () => {
+    it("returns land-on + tension cues when chord has outside-scale tones", () => {
+      // C Major + C# Minor Triad: C#, E, G# — C# and G# are outside C Major
+      const store = makeStore();
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(chordRootAtom, "C#");
+      store.set(chordTypeAtom, "Minor Triad");
+      store.set(practiceLensAtom, "tension");
+      const cues = store.get(practiceCuesAtom);
+      const kinds = cues.map((c) => c.kind);
+      expect(kinds).toContain("land-on");
+      expect(kinds).toContain("tension");
+    });
+
+    it("tension notes include outside chord root (semantic fix)", () => {
+      // The chord root (C#) is outside C Major — must appear in tension cue
+      const store = makeStore();
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(chordRootAtom, "C#");
+      store.set(chordTypeAtom, "Minor Triad");
+      store.set(practiceLensAtom, "tension");
+      const cues = store.get(practiceCuesAtom);
+      const tensionCue = cues.find((c) => c.kind === "tension");
+      expect(tensionCue).toBeDefined();
+      const tensionNotes = tensionCue!.notes.map((n) => n.internalNote);
+      expect(tensionNotes).toContain("C#"); // chord root, outside scale
+    });
+
+    it("tension notes have resolution targets (resolvesTo)", () => {
+      const store = makeStore();
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(chordRootAtom, "C#");
+      store.set(chordTypeAtom, "Minor Triad");
+      store.set(practiceLensAtom, "tension");
+      const cues = store.get(practiceCuesAtom);
+      const tensionCue = cues.find((c) => c.kind === "tension");
+      // At least one tension note should have a resolution target
+      const hasResolution = tensionCue!.notes.some((n) => n.resolvesTo !== undefined);
+      expect(hasResolution).toBe(true);
+    });
+
+    it("returns only land-on when chord is fully in-scale (no outside tones)", () => {
+      const store = makeChordStore("Major", "C", "Major Triad", "tension");
+      const cues = store.get(practiceCuesAtom);
+      const kinds = cues.map((c) => c.kind);
+      expect(kinds).toContain("land-on");
+      expect(kinds).not.toContain("tension");
+    });
+  });
+});
+
+describe("noteSemanticMapAtom", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("correctly identifies outside chord root as both isChordRoot and isTension", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C#");
+    store.set(chordTypeAtom, "Minor Triad");
+
+    const semanticMap = store.get(noteSemanticMapAtom);
+    const cSharpSemantics = semanticMap.get("C#");
+    expect(cSharpSemantics).toBeDefined();
+    expect(cSharpSemantics!.isChordRoot).toBe(true);
+    expect(cSharpSemantics!.isTension).toBe(true);
+    expect(cSharpSemantics!.isInScale).toBe(false);
+  });
+
+  it("identifies guide tones (3rd and 7th) correctly", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "G");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "G");
+    store.set(chordTypeAtom, "Dominant 7th");
+
+    const semanticMap = store.get(noteSemanticMapAtom);
+    // B = major 3rd of G7
+    const bSemantics = semanticMap.get("B");
+    expect(bSemantics?.isGuideTone).toBe(true);
+    // F = b7 of G7
+    const fSemantics = semanticMap.get("F");
+    expect(fSemantics?.isGuideTone).toBe(true);
+    // D = 5th, not a guide tone
+    const dSemantics = semanticMap.get("D");
+    expect(dSemantics?.isGuideTone).toBe(false);
+  });
+
+  it("a note can be both color tone and chord tone", () => {
+    // G Mixolydian: F is the b7 color note AND a chord tone of G7
+    const store = makeStore();
+    store.set(rootNoteAtom, "G");
+    store.set(scaleNameAtom, "Mixolydian");
+    store.set(chordRootAtom, "G");
+    store.set(chordTypeAtom, "Dominant 7th");
+
+    const semanticMap = store.get(noteSemanticMapAtom);
+    const fSemantics = semanticMap.get("F");
+    expect(fSemantics?.isColorTone).toBe(true);
+    expect(fSemantics?.isChordTone).toBe(true);
+  });
+
+  it("returns empty map when no chord is active", () => {
+    const store = makeStore();
+    store.set(chordTypeAtom, null);
+    expect(store.get(noteSemanticMapAtom).size).toBe(0);
+  });
+});
+
+describe("showChordPracticeBarAtom", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns false when no chord is set", () => {
+    const store = makeStore();
+    store.set(chordTypeAtom, null);
+    expect(store.get(showChordPracticeBarAtom)).toBe(false);
+  });
+
+  it("returns true for non-default lenses even in diatonic simple case", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    // Diatonic simple case but lens is not targets-color
+    store.set(practiceLensAtom, "targets");
+    expect(store.get(showChordPracticeBarAtom)).toBe(true);
+  });
+
+  it("returns false for targets-color lens in diatonic simple case", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    store.set(practiceLensAtom, "targets-color");
+    // C Major + C Major Triad with all preset — diatonic simple case
+    expect(store.get(showChordPracticeBarAtom)).toBe(false);
+  });
+
+  it("returns true for targets-color when there are outside chord members", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Dominant 7th"); // Bb is outside C Major
+    store.set(practiceLensAtom, "targets-color");
+    expect(store.get(showChordPracticeBarAtom)).toBe(true);
+  });
+});
+
+describe("shapeLocalPracticeCuesAtom", () => {
+  it("returns empty when fingeringPattern is all (no shape context)", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    store.set(practiceLensAtom, "targets");
+    store.set(fingeringPatternAtom, "all");
+    expect(store.get(shapeLocalPracticeCuesAtom)).toHaveLength(0);
+  });
+});

--- a/src/components/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls.tsx
@@ -2,7 +2,7 @@ import { startTransition, useId, useState } from "react";
 import clsx from "clsx";
 import {
   NOTES,
-  type ViewMode,
+  type PracticeLens,
   type FocusPreset,
   type ChordMemberName,
 } from "../theory";
@@ -28,10 +28,12 @@ const CHORD_OPTIONS: (string | { divider: string })[] = [
 
 const CHORD_NONE_VALUE = "__none__";
 
-const VIEW_MODE_OPTIONS: { value: ViewMode; label: string }[] = [
-  { value: "compare", label: "Scale + Chord" },
-  { value: "chord", label: "Chord Only" },
-  { value: "outside", label: "Outside" },
+const PRACTICE_LENS_OPTIONS: { value: PracticeLens; label: string }[] = [
+  { value: "targets-color", label: "Targets + Color" },
+  { value: "targets", label: "Targets" },
+  { value: "guide-tones", label: "Guide Tones" },
+  { value: "color", label: "Color" },
+  { value: "tension", label: "Tension" },
 ];
 
 const FOCUS_PRESET_LABELS: Record<FocusPreset, string> = {
@@ -57,8 +59,8 @@ export function ChordOverlayControls() {
     setChordType,
     linkChordRoot,
     setLinkChordRoot,
-    viewMode,
-    setViewMode,
+    practiceLens,
+    setPracticeLens,
     focusPreset,
     setFocusPreset,
     customMembers,
@@ -83,9 +85,10 @@ export function ChordOverlayControls() {
     })),
   ];
 
-  const viewModeOptions = VIEW_MODE_OPTIONS.map((opt) => ({
+  // Tension lens requires outside chord members to be meaningful.
+  const lensOptions = PRACTICE_LENS_OPTIONS.map((opt) => ({
     ...opt,
-    disabled: opt.value === "outside" && !hasOutsideChordMembers,
+    disabled: opt.value === "tension" && !hasOutsideChordMembers,
   }));
 
   const focusPresetOptions = availableFocusPresets.map((preset) => ({
@@ -167,12 +170,12 @@ export function ChordOverlayControls() {
               ) : null}
 
               <div className={shared["control-section"]}>
-                <span className={shared["section-label"]}>View</span>
+                <span className={shared["section-label"]}>Lens</span>
                 <ToggleBar
-                  options={viewModeOptions}
-                  value={viewMode}
-                  onChange={setViewMode}
-                  label="View mode"
+                  options={lensOptions}
+                  value={practiceLens}
+                  onChange={setPracticeLens}
+                  label="Practice lens"
                 />
               </div>
 

--- a/src/components/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useId, useState } from "react";
+import { startTransition, useEffect, useId, useState } from "react";
 import clsx from "clsx";
 import {
   NOTES,
@@ -90,6 +90,13 @@ export function ChordOverlayControls() {
     ...opt,
     disabled: opt.value === "tension" && !hasOutsideChordMembers,
   }));
+
+  // Auto-exit tension lens when chord becomes fully diatonic.
+  useEffect(() => {
+    if (practiceLens === "tension" && !hasOutsideChordMembers) {
+      setPracticeLens("targets-color");
+    }
+  }, [practiceLens, hasOutsideChordMembers, setPracticeLens]);
 
   const focusPresetOptions = availableFocusPresets.map((preset) => ({
     value: preset,

--- a/src/components/ChordPracticeBar.css
+++ b/src/components/ChordPracticeBar.css
@@ -63,7 +63,33 @@
   line-height: 1;
 }
 
-/* Groups row: lays out Targets / Shared / Outside horizontally */
+/* Coaching cues — stacked rows, one cue per line */
+.chord-practice-bar-cues {
+  display: flex;
+  flex-direction: column;
+  gap: 0.32rem;
+}
+
+/* Individual cue row: label + pill list side by side */
+.practice-bar-cue {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.practice-bar-cue-label {
+  font-family: var(--font-sans);
+  font-size: 0.68rem;
+  font-weight: var(--font-weight-medium);
+  color: rgb(255 255 255 / 0.38);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Legacy group layout kept for backward compat with any external CSS */
 .chord-practice-bar-groups {
   display: flex;
   align-items: flex-start;
@@ -71,7 +97,6 @@
   flex-wrap: wrap;
 }
 
-/* Individual group: label + pill row */
 .practice-bar-group {
   display: flex;
   align-items: center;
@@ -138,6 +163,12 @@
   box-shadow: 0 0 5px rgb(167 139 250 / 0.3);
 }
 
+.practice-bar-pill[data-role="guide-tone"] {
+  background: rgb(30 60 120 / 0.22);
+  border-color: rgb(96 165 250 / 0.7);
+  box-shadow: 0 0 5px rgb(96 165 250 / 0.25);
+}
+
 .practice-bar-pill-note {
   font-family: var(--font-sans);
   font-size: var(--pill-font);
@@ -154,6 +185,16 @@
   color: rgb(255 255 255 / 0.48);
   line-height: 1;
   letter-spacing: 0.02em;
+}
+
+/* Resolution arrow shown after tension notes: "→D" */
+.practice-bar-pill-resolve {
+  font-family: var(--font-sans);
+  font-size: calc(var(--pill-font) - 0.06rem);
+  font-weight: var(--font-weight-medium);
+  color: rgb(167 139 250 / 0.8);
+  line-height: 1;
+  letter-spacing: 0.01em;
 }
 
 /* Responsive — mobile */

--- a/src/components/ChordPracticeBar.tsx
+++ b/src/components/ChordPracticeBar.tsx
@@ -1,56 +1,41 @@
 import clsx from "clsx";
-import type { ChordRowEntry, PracticeBarColorNote, ViewMode } from "../theory";
+import type { PracticeCue } from "../theory";
 import "./ChordPracticeBar.css";
 
-interface PillGroupProps {
-  label: string;
-  members: ChordRowEntry[];
-  ariaLabel: string;
+function cueKindDefaultRole(kind: PracticeCue["kind"]): string {
+  switch (kind) {
+    case "guide-tones": return "guide-tone";
+    case "color-note": return "color-tone";
+    case "tension": return "chord-tone-outside-scale";
+    default: return "chord-tone-in-scale";
+  }
 }
 
-function PillGroup({ label, members, ariaLabel }: PillGroupProps) {
-  if (members.length === 0) return null;
+interface CueLineProps {
+  cue: PracticeCue;
+}
+
+function CueLine({ cue }: CueLineProps) {
   return (
-    <div className="practice-bar-group">
-      <span className="practice-bar-group-label">{label}</span>
-      <ul className="practice-bar-pill-list" aria-label={ariaLabel}>
-        {members.map((entry, i) => (
+    <div className="practice-bar-cue">
+      <span className="practice-bar-cue-label">{cue.label}:</span>
+      <ul className="practice-bar-pill-list" aria-label={cue.label}>
+        {cue.notes.map((note, i) => (
           <li
-            key={`${entry.internalNote}-${i}`}
+            key={`${note.internalNote}-${i}`}
             className="practice-bar-pill"
-            data-role={entry.role}
-            aria-label={`${entry.displayNote}, ${entry.memberName}`}
+            data-role={note.role ?? cueKindDefaultRole(cue.kind)}
+            aria-label={[note.displayNote, note.intervalName].filter(Boolean).join(", ")}
           >
-            <span className="practice-bar-pill-note">{entry.displayNote}</span>
-            <span className="practice-bar-pill-interval">{entry.memberName}</span>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-interface ColorPillGroupProps {
-  label: string;
-  entries: PracticeBarColorNote[];
-  ariaLabel: string;
-}
-
-function ColorPillGroup({ label, entries, ariaLabel }: ColorPillGroupProps) {
-  if (entries.length === 0) return null;
-  return (
-    <div className="practice-bar-group">
-      <span className="practice-bar-group-label">{label}</span>
-      <ul className="practice-bar-pill-list" aria-label={ariaLabel}>
-        {entries.map((entry, i) => (
-          <li
-            key={`${entry.internalNote}-${i}`}
-            className="practice-bar-pill"
-            data-role="color-tone"
-            aria-label={`${entry.displayNote}, ${entry.intervalName}`}
-          >
-            <span className="practice-bar-pill-note">{entry.displayNote}</span>
-            <span className="practice-bar-pill-interval">{entry.intervalName}</span>
+            <span className="practice-bar-pill-note">{note.displayNote}</span>
+            {note.intervalName && (
+              <span className="practice-bar-pill-interval">{note.intervalName}</span>
+            )}
+            {note.resolvesTo && (
+              <span className="practice-bar-pill-resolve" aria-label={`resolves to ${note.resolvesTo.displayNote}`}>
+                →{note.resolvesTo.displayNote}
+              </span>
+            )}
           </li>
         ))}
       </ul>
@@ -60,71 +45,35 @@ function ColorPillGroup({ label, entries, ariaLabel }: ColorPillGroupProps) {
 
 export interface ChordPracticeBarProps {
   title: string;
-  badge: string | null;
-  viewMode: ViewMode;
-  targetMembers: ChordRowEntry[];
-  outsideMembers: ChordRowEntry[];
-  colorNoteEntries?: PracticeBarColorNote[];
-  // Shape-local context
+  badge?: string | null;
+  cues: PracticeCue[];
   isShapeLocal?: boolean;
   shapeContextLabel?: string | null;
-  shapeLocalTargetMembers?: ChordRowEntry[];
-  shapeLocalOutsideMembers?: ChordRowEntry[];
-  shapeLocalColorNoteEntries?: PracticeBarColorNote[];
+  /** Shape-filtered cues — shown instead of global cues when in single-shape context */
+  shapeLocalCues?: PracticeCue[];
   className?: string;
 }
 
 export function ChordPracticeBar({
   title,
   badge,
-  viewMode,
-  targetMembers,
-  outsideMembers,
-  colorNoteEntries = [],
+  cues,
   isShapeLocal = false,
   shapeContextLabel = null,
-  shapeLocalTargetMembers,
-  shapeLocalOutsideMembers,
-  shapeLocalColorNoteEntries,
+  shapeLocalCues,
   className,
 }: ChordPracticeBarProps) {
-  // In single-shape context, prefer shape-local arrays over global ones
-  const effectiveTargets =
-    isShapeLocal && shapeLocalTargetMembers !== undefined
-      ? shapeLocalTargetMembers
-      : targetMembers;
-  const effectiveOutside =
-    isShapeLocal && shapeLocalOutsideMembers !== undefined
-      ? shapeLocalOutsideMembers
-      : outsideMembers;
-  const effectiveColor =
-    isShapeLocal && shapeLocalColorNoteEntries !== undefined
-      ? shapeLocalColorNoteEntries
-      : colorNoteEntries;
+  const effectiveCues =
+    isShapeLocal && shapeLocalCues && shapeLocalCues.length > 0
+      ? shapeLocalCues
+      : cues;
 
-  const hasTargets = effectiveTargets.length > 0;
-  const hasOutside = effectiveOutside.length > 0;
-  const hasColor = effectiveColor.length > 0;
-
-  if (!hasTargets && !hasOutside && !hasColor) return null;
-
-  // Label suffix and color label (singular when exactly one tone)
-  const suffix = isShapeLocal ? " here" : "";
-  const colorLabel =
-    effectiveColor.length === 1
-      ? `Color tone${suffix}`
-      : `Color tones${suffix}`;
-
-  const showTargets =
-    (viewMode === "compare" || viewMode === "chord") && hasTargets;
-  const showOutside =
-    (viewMode === "compare" || viewMode === "outside") && hasOutside;
-  const showColor = viewMode === "compare" && hasColor;
+  if (effectiveCues.length === 0) return null;
 
   return (
     <section
       role="group"
-      aria-label={`Chord analysis: ${title}`}
+      aria-label={`Practice cues: ${title}`}
       className={clsx("chord-practice-bar", className)}
     >
       <div className="chord-practice-bar-header">
@@ -134,38 +83,10 @@ export function ChordPracticeBar({
       {shapeContextLabel && (
         <div className="chord-practice-bar-context">{shapeContextLabel}</div>
       )}
-      <div className="chord-practice-bar-groups">
-        {showTargets && (
-          <PillGroup
-            label={`Targets${suffix}`}
-            members={effectiveTargets}
-            ariaLabel={
-              isShapeLocal
-                ? "Target chord members in shape"
-                : "Target chord members"
-            }
-          />
-        )}
-        {showOutside && (
-          <PillGroup
-            label={`Outside${suffix}`}
-            members={effectiveOutside}
-            ariaLabel={
-              isShapeLocal ? "Outside scale in shape" : "Outside scale"
-            }
-          />
-        )}
-        {showColor && (
-          <ColorPillGroup
-            label={colorLabel}
-            entries={effectiveColor}
-            ariaLabel={
-              isShapeLocal
-                ? "Characteristic color tones in shape"
-                : "Characteristic color tones"
-            }
-          />
-        )}
+      <div className="chord-practice-bar-cues">
+        {effectiveCues.map((cue, i) => (
+          <CueLine key={`${cue.kind}-${i}`} cue={cue} />
+        ))}
       </div>
     </section>
   );

--- a/src/components/SummaryRibbon.tsx
+++ b/src/components/SummaryRibbon.tsx
@@ -12,20 +12,16 @@ export function SummaryRibbon() {
     degreeChips,
   } = useScaleState();
 
-  const { chordType, viewMode } = useChordState();
+  const { chordType } = useChordState();
 
   const {
     showChordPracticeBar,
     practiceBarTitle,
     practiceBarBadge,
-    practiceBarColorNotesFiltered,
     isShapeLocalContext,
     shapeContextLabel,
-    shapeLocalTargetMembers,
-    shapeLocalOutsideMembers,
-    shapeLocalColorNotesFiltered,
-    allChordMembers,
-    practiceBarOutsideMembers,
+    practiceCues,
+    shapeLocalPracticeCues,
   } = usePracticeBarState();
 
   const scaleStrip = (
@@ -49,15 +45,10 @@ export function SummaryRibbon() {
         <ChordPracticeBar
           title={practiceBarTitle}
           badge={practiceBarBadge}
-          viewMode={viewMode}
-          targetMembers={allChordMembers}
-          outsideMembers={practiceBarOutsideMembers}
-          colorNoteEntries={practiceBarColorNotesFiltered}
+          cues={practiceCues}
           isShapeLocal={isShapeLocalContext}
           shapeContextLabel={shapeContextLabel}
-          shapeLocalTargetMembers={shapeLocalTargetMembers}
-          shapeLocalOutsideMembers={shapeLocalOutsideMembers}
-          shapeLocalColorNoteEntries={shapeLocalColorNotesFiltered}
+          shapeLocalCues={shapeLocalPracticeCues}
         />
       )}
     </div>

--- a/src/components/TheoryControls.test.tsx
+++ b/src/components/TheoryControls.test.tsx
@@ -8,7 +8,7 @@ import {
   scaleNameAtom,
   scaleBrowseModeAtom,
   chordTypeAtom,
-  viewModeAtom,
+  practiceLensAtom,
   focusPresetAtom,
 } from "../store/atoms";
 
@@ -116,33 +116,33 @@ describe("TheoryControls", () => {
     expect(screen.getByText("Key Wheel")).toBeInTheDocument();
   });
 
-  it("shows View and Focus controls when a chord type is selected", () => {
+  it("shows Lens and Focus controls when a chord type is selected", () => {
     const store = createStore();
     store.set(chordTypeAtom, "Major Triad");
 
     renderWithStore(<TheoryControls />, store);
 
-    expect(screen.getByText("View")).toBeInTheDocument();
+    expect(screen.getByText("Lens")).toBeInTheDocument();
     expect(screen.getByText("Focus")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Scale + Chord" }),
+      screen.getByRole("button", { name: "Targets + Color" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Chord Only" }),
+      screen.getByRole("button", { name: "Targets" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Rootless" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Custom" })).toBeInTheDocument();
   });
 
-  it("calls setViewMode when a view option is clicked", () => {
+  it("calls setPracticeLens when a lens option is clicked", () => {
     const store = createStore();
     store.set(chordTypeAtom, "Major Triad");
 
     renderWithStore(<TheoryControls />, store);
 
-    fireEvent.click(screen.getByRole("button", { name: "Chord Only" }));
-    expect(store.get(viewModeAtom)).toBe("chord");
+    fireEvent.click(screen.getByRole("button", { name: "Targets" }));
+    expect(store.get(practiceLensAtom)).toBe("targets");
   });
 
   it("calls setFocusPreset when a focus option is clicked", () => {
@@ -168,7 +168,7 @@ describe("TheoryControls", () => {
     expect(screen.getByRole("button", { name: "5" })).toBeInTheDocument();
   });
 
-  it("Outside view option is disabled when hasOutsideChordMembers is false", () => {
+  it("Tension lens option is disabled when hasOutsideChordMembers is false", () => {
     const store = createStore();
     store.set(rootNoteAtom, "C");
     store.set(scaleNameAtom, "Major");
@@ -176,22 +176,17 @@ describe("TheoryControls", () => {
 
     renderWithStore(<TheoryControls />, store);
 
-    expect(screen.getByRole("button", { name: "Outside" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Tension" })).toBeDisabled();
   });
 
-  it("Outside view option is enabled when hasOutsideChordMembers is true", () => {
+  it("Tension lens option is enabled when hasOutsideChordMembers is true", () => {
     const store = createStore();
     store.set(rootNoteAtom, "C");
-    store.set(scaleNameAtom, "Major");
-    store.set(chordTypeAtom, "Major 7th"); // This will have outside members if scale is major pentatonic? 
-    // No, Major 7th (C E G B) is in C Major (C D E F G A B).
-    // Let's use a chord that is definitely outside.
-    // Major 7th against Minor Pentatonic.
     store.set(scaleNameAtom, "Minor Pentatonic"); // C Eb F G Bb
     store.set(chordTypeAtom, "Major Triad"); // C E G -> E is outside.
 
     renderWithStore(<TheoryControls />, store);
 
-    expect(screen.getByRole("button", { name: "Outside" })).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "Tension" })).not.toBeDisabled();
   });
 });

--- a/src/hooks/useChordState.ts
+++ b/src/hooks/useChordState.ts
@@ -3,7 +3,7 @@ import {
   chordRootAtom,
   chordTypeAtom,
   linkChordRootAtom,
-  viewModeAtom,
+  practiceLensAtom,
   focusPresetAtom,
   customMembersAtom,
   chordTonesAtom,
@@ -21,7 +21,7 @@ export function useChordState() {
   const [chordRoot, setChordRoot] = useAtom(chordRootAtom);
   const [chordType, setChordType] = useAtom(chordTypeAtom);
   const [linkChordRoot, setLinkChordRoot] = useAtom(linkChordRootAtom);
-  const [viewMode, setViewMode] = useAtom(viewModeAtom);
+  const [practiceLens, setPracticeLens] = useAtom(practiceLensAtom);
   const [focusPreset, setFocusPreset] = useAtom(focusPresetAtom);
   const [customMembers, setCustomMembers] = useAtom(customMembersAtom);
   const chordFretSpread = useAtomValue(chordFretSpreadAtom);
@@ -42,8 +42,8 @@ export function useChordState() {
     setChordType,
     linkChordRoot,
     setLinkChordRoot,
-    viewMode,
-    setViewMode,
+    practiceLens,
+    setPracticeLens,
     focusPreset,
     setFocusPreset,
     customMembers,

--- a/src/hooks/useFretboardState.ts
+++ b/src/hooks/useFretboardState.ts
@@ -16,6 +16,7 @@ import {
   chordFretSpreadAtom,
   hideNonChordNotesAtom,
   viewModeAtom,
+  practiceLensAtom,
   colorNotesAtom,
   hiddenNotesAtom,
 } from "../store/atoms";
@@ -39,6 +40,7 @@ export function useFretboardState() {
   const chordFretSpread = useAtomValue(chordFretSpreadAtom);
   const hideNonChordNotes = useAtomValue(hideNonChordNotesAtom);
   const viewMode = useAtomValue(viewModeAtom);
+  const practiceLens = useAtomValue(practiceLensAtom);
   const colorNotes = useAtomValue(colorNotesAtom);
   const hiddenNotes = useAtomValue(hiddenNotesAtom);
 
@@ -62,6 +64,7 @@ export function useFretboardState() {
     chordFretSpread,
     hideNonChordNotes,
     viewMode,
+    practiceLens,
     colorNotes,
     hiddenNotes,
   };

--- a/src/hooks/usePracticeBarState.ts
+++ b/src/hooks/usePracticeBarState.ts
@@ -3,56 +3,31 @@ import {
   showChordPracticeBarAtom,
   practiceBarTitleAtom,
   practiceBarBadgeAtom,
-  practiceBarColorNotesAtom,
-  allChordMembersAtom,
-  practiceBarColorNotesFilteredAtom,
   isShapeLocalContextAtom,
   shapeContextLabelAtom,
-  shapeLocalTargetMembersAtom,
-  shapeLocalOutsideMembersAtom,
-  shapeLocalColorNotesFilteredAtom,
-  shapeLocalColorNotesAtom,
-  viewModeAtom,
-  practiceBarSharedMembersAtom,
-  practiceBarOutsideMembersAtom,
+  practiceLensAtom,
+  practiceCuesAtom,
+  shapeLocalPracticeCuesAtom,
 } from "../store/atoms";
 
 export function usePracticeBarState() {
   const showChordPracticeBar = useAtomValue(showChordPracticeBarAtom);
   const practiceBarTitle = useAtomValue(practiceBarTitleAtom);
   const practiceBarBadge = useAtomValue(practiceBarBadgeAtom);
-  const practiceBarColorNotes = useAtomValue(practiceBarColorNotesAtom);
-  const allChordMembers = useAtomValue(allChordMembersAtom);
-  const practiceBarColorNotesFiltered = useAtomValue(
-    practiceBarColorNotesFilteredAtom,
-  );
   const isShapeLocalContext = useAtomValue(isShapeLocalContextAtom);
   const shapeContextLabel = useAtomValue(shapeContextLabelAtom);
-  const shapeLocalTargetMembers = useAtomValue(shapeLocalTargetMembersAtom);
-  const shapeLocalOutsideMembers = useAtomValue(shapeLocalOutsideMembersAtom);
-  const shapeLocalColorNotesFiltered = useAtomValue(
-    shapeLocalColorNotesFilteredAtom,
-  );
-  const shapeLocalColorNotes = useAtomValue(shapeLocalColorNotesAtom);
-  const viewMode = useAtomValue(viewModeAtom);
-  const practiceBarSharedMembers = useAtomValue(practiceBarSharedMembersAtom);
-  const practiceBarOutsideMembers = useAtomValue(practiceBarOutsideMembersAtom);
+  const practiceLens = useAtomValue(practiceLensAtom);
+  const practiceCues = useAtomValue(practiceCuesAtom);
+  const shapeLocalPracticeCues = useAtomValue(shapeLocalPracticeCuesAtom);
 
   return {
     showChordPracticeBar,
     practiceBarTitle,
     practiceBarBadge,
-    practiceBarColorNotes,
-    allChordMembers,
-    practiceBarColorNotesFiltered,
     isShapeLocalContext,
     shapeContextLabel,
-    shapeLocalTargetMembers,
-    shapeLocalOutsideMembers,
-    shapeLocalColorNotesFiltered,
-    shapeLocalColorNotes,
-    viewMode,
-    practiceBarSharedMembers,
-    practiceBarOutsideMembers,
+    practiceLens,
+    practiceCues,
+    shapeLocalPracticeCues,
   };
 }

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -11,10 +11,11 @@ import {
 } from "../shapes";
 import { normalizeScaleName, type ScaleBrowseMode, getActiveScaleBrowseOption } from "../theoryCatalog";
 import { k, STORAGE_PREFIX } from "../utils/storage";
-import { 
+import {
   resolveAccidentalMode,
   SCALES,
   NOTES,
+  ENHARMONICS,
   INTERVAL_NAMES,
   CHORD_DEFINITIONS,
   getScaleNotes,
@@ -32,6 +33,10 @@ import type {
   ChordMemberName,
   ResolvedChordMember,
   NoteRole,
+  NoteSemantics,
+  PracticeLens,
+  PracticeCue,
+  PracticeCueNote,
   ChordRowEntry,
   LegendItem,
   PracticeBarColorNote,
@@ -487,7 +492,8 @@ export const chordFretSpreadAtom = atomWithStorage(
   GET_ON_INIT,
 );
 
-export const hideNonChordNotesAtom = atom((get) => get(viewModeAtom) === "chord");
+// Targets lens hides scale-only notes so only chord tones are shown.
+export const hideNonChordNotesAtom = atom((get) => get(practiceLensAtom) === "targets");
 
 const VIEW_MODE_VALUES: ViewMode[] = ["compare", "chord", "outside"];
 
@@ -508,6 +514,65 @@ const viewModeStorage = {
     }
   },
   setItem(key: string, value: ViewMode): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Practice lens storage — with one-time migration from old viewMode key
+// ---------------------------------------------------------------------------
+
+const PRACTICE_LENS_VALUES: PracticeLens[] = [
+  "targets",
+  "guide-tones",
+  "color",
+  "targets-color",
+  "tension",
+];
+
+function migrateViewModeToLens(viewMode: string): PracticeLens {
+  switch (viewMode) {
+    case "chord": return "targets";
+    case "outside": return "tension";
+    default: return "targets-color";
+  }
+}
+
+const practiceLensStorage = {
+  getItem(key: string, initialValue: PracticeLens): PracticeLens {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored !== null) {
+        if ((PRACTICE_LENS_VALUES as string[]).includes(stored))
+          return stored as PracticeLens;
+        localStorage.setItem(key, initialValue);
+        return initialValue;
+      }
+      // One-time migration: map old viewMode to a lens on first access
+      const oldViewMode = localStorage.getItem(k("viewMode"));
+      if (oldViewMode) {
+        const migrated = migrateViewModeToLens(oldViewMode);
+        localStorage.setItem(key, migrated);
+        return migrated;
+      }
+      localStorage.setItem(key, initialValue);
+      return initialValue;
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: PracticeLens): void {
     try {
       localStorage.setItem(key, value);
     } catch {
@@ -603,6 +668,14 @@ export const viewModeAtom = atomWithStorage<ViewMode>(
   k("viewMode"),
   "compare",
   viewModeStorage,
+  GET_ON_INIT,
+);
+// Primary user-facing practice state — replaces viewMode as the UI concept.
+// Stored separately; migrates from old viewMode on first access.
+export const practiceLensAtom = atomWithStorage<PracticeLens>(
+  k("practiceLens"),
+  "targets-color",
+  practiceLensStorage,
   GET_ON_INIT,
 );
 export const focusPresetAtom = atomWithStorage<FocusPreset>(
@@ -1008,29 +1081,15 @@ export const allChordMembersAtom = atom((get) => {
   });
 });
 
-export const summaryChordRowAtom = atom((get) => {
-  const chordType = get(chordTypeAtom);
-  const allChordMembers = get(allChordMembersAtom);
-  const viewMode = get(viewModeAtom);
-
-  if (!chordType) return allChordMembers;
-  // In outside view: keep only outside-scale entries (plus outside chord root).
-  if (viewMode === "outside") {
-    return allChordMembers.filter(
-      (e) =>
-        e.role === "chord-tone-outside-scale" ||
-        (e.role === "chord-root" && !e.inScale),
-    );
-  }
-  return allChordMembers;
-});
+// All chord members — tension lens shows all notes (not just outside ones).
+export const summaryChordRowAtom = atom((get) => get(allChordMembersAtom));
 
 export const summaryLegendItemsAtom = atom((get) => {
   const chordType = get(chordTypeAtom);
   if (!chordType) return [] as LegendItem[];
 
   const summaryChordRow = get(summaryChordRowAtom);
-  const viewMode = get(viewModeAtom);
+  const practiceLens = get(practiceLensAtom);
   const noteRoleMap = get(noteRoleMapAtom);
 
   const rolesPresent = new Set(summaryChordRow.map((e) => e.role));
@@ -1041,9 +1100,9 @@ export const summaryLegendItemsAtom = atom((get) => {
     items.push({ role: "chord-tone-in-scale", label: "Chord tone" });
   if (rolesPresent.has("chord-tone-outside-scale"))
     items.push({ role: "chord-tone-outside-scale", label: "Outside scale" });
-  // In compare mode, mention scale-only only when that role is actually present on the board.
+  // Show scale-only legend entry when the lens is not targets (which hides them).
   const hasScaleOnly = Array.from(noteRoleMap.values()).includes("scale-only");
-  if (viewMode === "compare" && hasScaleOnly) {
+  if (practiceLens !== "targets" && hasScaleOnly) {
     items.push({ role: "scale-only", label: "Scale only" });
   }
   return items;
@@ -1051,7 +1110,7 @@ export const summaryLegendItemsAtom = atom((get) => {
 
 export const showRelationshipRowAtom = atom((get) => {
   const chordType = get(chordTypeAtom);
-  const viewMode = get(viewModeAtom);
+  const practiceLens = get(practiceLensAtom);
   const chordRoot = get(chordRootAtom);
   const rootNote = get(rootNoteAtom);
   const focusPreset = get(focusPresetAtom);
@@ -1059,7 +1118,7 @@ export const showRelationshipRowAtom = atom((get) => {
 
   return !!(
     chordType &&
-    viewMode === "compare" &&
+    practiceLens !== "targets" &&
     (chordRoot !== rootNote || focusPreset !== "all" || hasOutsideChordMembers)
   );
 });
@@ -1074,34 +1133,33 @@ export const chordMemberLabelsAtom = atom((get) =>
 
 export const summaryHeaderLeftAtom = atom((get) => {
   const chordType = get(chordTypeAtom);
-  const viewMode = get(viewModeAtom);
+  const practiceLens = get(practiceLensAtom);
   const scaleLabel = get(scaleLabelAtom);
   const chordLabel = get(chordLabelAtom);
 
   if (!chordType) return scaleLabel;
-  if (viewMode === "chord") return chordLabel ?? "";
-  if (viewMode === "outside") return "Outside tones";
-  return scaleLabel; // compare
+  // Targets lens is chord-focused: show the chord name as the primary header.
+  if (practiceLens === "targets") return chordLabel ?? scaleLabel;
+  return scaleLabel;
 });
 
 export const summaryHeaderRightAtom = atom((get) => {
   const chordType = get(chordTypeAtom);
   const chordLabel = get(chordLabelAtom);
-  const scaleLabel = get(scaleLabelAtom);
-  const viewMode = get(viewModeAtom);
+  const practiceLens = get(practiceLensAtom);
 
   if (!chordType || !chordLabel) return null;
-  if (viewMode === "chord") return "Chord only";
-  if (viewMode === "outside") return `against ${scaleLabel}`;
+  // Targets lens already shows the chord in the left header.
+  if (practiceLens === "targets") return null;
   return chordLabel;
 });
 
 export const summaryPrimaryModeAtom = atom((get) => {
   const chordType = get(chordTypeAtom);
-  const viewMode = get(viewModeAtom);
-  if (!chordType || viewMode === "compare") return "scale";
-  if (viewMode === "chord") return "chord";
-  return "outside";
+  const practiceLens = get(practiceLensAtom);
+  if (!chordType) return "scale";
+  if (practiceLens === "targets") return "chord";
+  return "scale";
 });
 
 export const sharedChordMembersAtom = atom((get) =>
@@ -1263,45 +1321,40 @@ export const practiceBarColorNotesAtom = atom((get) => {
 
 export const showChordPracticeBarAtom = atom((get) => {
   const chordType = get(chordTypeAtom);
-  const viewMode = get(viewModeAtom);
+  if (!chordType) return false;
+
+  const practiceLens = get(practiceLensAtom);
+
+  // Non-default lenses always show — user explicitly chose a practice focus.
+  if (practiceLens !== "targets-color") return true;
+
+  // For targets-color (default): suppress the bar for the diatonic simple case
+  // where the chord is fully in-scale, root is linked, and no color tones exist
+  // (nothing interesting to coach about).
   const focusPreset = get(focusPresetAtom);
   const hasOutsideChordMembers = get(hasOutsideChordMembersAtom);
   const colorNotes = get(colorNotesAtom);
   const chordRoot = get(chordRootAtom);
   const rootNote = get(rootNoteAtom);
 
-  if (!chordType) return false;
-  
-  // Diatonic simple case check
-  const isDiatonicSimpleCase = (
-    viewMode === "compare" &&
+  const isDiatonicSimpleCase =
     focusPreset === "all" &&
     !hasOutsideChordMembers &&
     colorNotes.length === 0 &&
-    chordRoot === rootNote
-  );
+    chordRoot === rootNote;
 
   return !isDiatonicSimpleCase;
 });
 
 export const practiceBarTitleAtom = atom((get) => {
   const chordType = get(chordTypeAtom);
-  const viewMode = get(viewModeAtom);
   const chordLabel = get(chordLabelAtom);
   if (!chordType) return "";
-  if (viewMode === "outside") return "Outside tones";
   return chordLabel ?? "";
 });
 
-export const practiceBarBadgeAtom = atom((get) => {
-  const chordType = get(chordTypeAtom);
-  const viewMode = get(viewModeAtom);
-  const scaleLabel = get(scaleLabelAtom);
-  if (!chordType) return null;
-  if (viewMode === "chord") return "Chord only";
-  if (viewMode === "outside") return `against ${scaleLabel}`;
-  return "Compare";
-});
+// Badge is now minimal — always null (lens context shown via title + shape subtitle).
+export const practiceBarBadgeAtom = atom(() => null as string | null);
 
 export const shapeHighlightedNoteSetAtom = atom((get) => {
   const fingeringPattern = get(fingeringPatternAtom);
@@ -1372,6 +1425,240 @@ export const shapeLocalColorNotesAtom = atom((get) => {
   );
 });
 
+// ---------------------------------------------------------------------------
+// Note Semantic Map — composable properties per note (multiple can coexist)
+// ---------------------------------------------------------------------------
+
+// Guide tone member names: 3rd and 7th (before formatAccidental)
+const GUIDE_TONE_RAW = new Set(["b3", "3", "b7", "7"]);
+// After formatAccidental: "b3"→"♭3", "b7"→"♭7"
+const GUIDE_TONE_FORMATTED = new Set(["♭3", "3", "♭7", "7"]);
+
+/**
+ * Returns a map of note → NoteSemantics where multiple boolean properties can
+ * coexist on one note. Crucially, a chord root that is outside the scale will
+ * have both isChordRoot=true and isTension=true — something the old single-role
+ * enum (NoteRole) could not represent.
+ */
+export const noteSemanticMapAtom = atom((get) => {
+  const chordType = get(chordTypeAtom);
+  if (!chordType) return new Map<string, NoteSemantics>();
+
+  const rootNote = get(rootNoteAtom);
+  const scaleName = get(scaleNameAtom);
+  const chordRoot = get(chordRootAtom);
+  const activeChordMembers = get(activeChordMembersAtom);
+  const colorNotes = get(colorNotesAtom);
+
+  const scaleNoteSet = new Set(getScaleNotes(rootNote, scaleName));
+  const colorNoteSet = new Set(colorNotes);
+
+  const memberByNote = new Map<string, ResolvedChordMember>();
+  for (const m of activeChordMembers) memberByNote.set(m.note, m);
+  const activeChordToneSet = new Set(activeChordMembers.map((m) => m.note));
+
+  const map = new Map<string, NoteSemantics>();
+  for (const note of NOTES) {
+    const isInScale = scaleNoteSet.has(note);
+    const isChordRoot = note === chordRoot;
+    const isChordTone = activeChordToneSet.has(note);
+    const enh = ENHARMONICS[note];
+    const isColorTone = colorNoteSet.has(note) || (!!enh && colorNoteSet.has(enh));
+    const member = memberByNote.get(note);
+    const isGuideTone = !!(member && GUIDE_TONE_RAW.has(member.name));
+    const isTension = isChordTone && !isInScale;
+    const isScaleRoot =
+      note === rootNote ||
+      ENHARMONICS[note] === rootNote ||
+      ENHARMONICS[rootNote] === note;
+
+    if (isInScale || isChordTone || isColorTone) {
+      map.set(note, {
+        isScaleRoot: !!isScaleRoot,
+        isChordRoot,
+        isChordTone,
+        isInScale,
+        isColorTone,
+        isGuideTone,
+        isTension,
+        memberName: member?.name as ChordMemberName | undefined,
+      });
+    }
+  }
+  return map;
+});
+
+// ---------------------------------------------------------------------------
+// Practice Cues — coaching lines derived from the active practice lens
+// ---------------------------------------------------------------------------
+
+/**
+ * Derives ordered coaching cues for the practice bar based on the active lens.
+ * Each cue has a label ("Land on", "Guide tones", "Color note", "Tension") and
+ * a list of notes with styling hints and optional resolution targets.
+ */
+export const practiceCuesAtom = atom((get) => {
+  const chordType = get(chordTypeAtom);
+  if (!chordType) return [] as PracticeCue[];
+
+  const practiceLens = get(practiceLensAtom);
+  const chordRoot = get(chordRootAtom);
+  const useFlats = get(useFlatsAtom);
+  const allChordMembers = get(allChordMembersAtom);
+  const colorNotesFiltered = get(practiceBarColorNotesFilteredAtom);
+  const scaleNotes = get(scaleNotesAtom);
+
+  const displayNote = (note: string) =>
+    formatAccidental(getNoteDisplay(note, chordRoot, useFlats));
+
+  const toCueNote = (e: ChordRowEntry): PracticeCueNote => ({
+    internalNote: e.internalNote,
+    displayNote: e.displayNote,
+    intervalName: e.memberName,
+    role: e.role,
+  });
+
+  // Find the nearest in-scale note (half-step up or down) as a resolution target.
+  const findResolution = (
+    note: string,
+  ): { internalNote: string; displayNote: string } | undefined => {
+    const noteIdx = NOTES.indexOf(note);
+    if (noteIdx === -1) return undefined;
+    const scaleNoteSet = new Set(scaleNotes);
+    const up = NOTES[(noteIdx + 1) % 12];
+    const down = NOTES[(noteIdx + 11) % 12];
+    const resolved = scaleNoteSet.has(up)
+      ? up
+      : scaleNoteSet.has(down)
+        ? down
+        : undefined;
+    if (!resolved) return undefined;
+    return { internalNote: resolved, displayNote: displayNote(resolved) };
+  };
+
+  const cues: PracticeCue[] = [];
+
+  switch (practiceLens) {
+    case "targets": {
+      if (allChordMembers.length > 0) {
+        cues.push({
+          kind: "land-on",
+          label: "Land on",
+          notes: allChordMembers.map(toCueNote),
+        });
+      }
+      break;
+    }
+
+    case "guide-tones": {
+      const guideNotes = allChordMembers.filter((e) =>
+        GUIDE_TONE_FORMATTED.has(e.memberName),
+      );
+      if (guideNotes.length > 0) {
+        cues.push({
+          kind: "guide-tones",
+          label: "Guide tones",
+          notes: guideNotes.map((e) => ({
+            ...toCueNote(e),
+            role: "guide-tone" as const,
+          })),
+        });
+      } else {
+        // Fallback for power chords (no 3rd/7th): show all chord tones.
+        cues.push({
+          kind: "land-on",
+          label: "Land on",
+          notes: allChordMembers.map(toCueNote),
+        });
+      }
+      break;
+    }
+
+    case "color": {
+      if (colorNotesFiltered.length > 0) {
+        cues.push({
+          kind: "color-note",
+          label: colorNotesFiltered.length === 1 ? "Color note" : "Color notes",
+          notes: colorNotesFiltered.map((n) => ({
+            internalNote: n.internalNote,
+            displayNote: n.displayNote,
+            intervalName: n.intervalName,
+            role: "color-tone" as const,
+          })),
+        });
+      }
+      break;
+    }
+
+    case "targets-color": {
+      if (allChordMembers.length > 0) {
+        cues.push({
+          kind: "land-on",
+          label: "Land on",
+          notes: allChordMembers.map(toCueNote),
+        });
+      }
+      if (colorNotesFiltered.length > 0) {
+        cues.push({
+          kind: "color-note",
+          label: colorNotesFiltered.length === 1 ? "Color note" : "Color notes",
+          notes: colorNotesFiltered.map((n) => ({
+            internalNote: n.internalNote,
+            displayNote: n.displayNote,
+            intervalName: n.intervalName,
+            role: "color-tone" as const,
+          })),
+        });
+      }
+      break;
+    }
+
+    case "tension": {
+      if (allChordMembers.length > 0) {
+        cues.push({
+          kind: "land-on",
+          label: "Land on",
+          notes: allChordMembers.map(toCueNote),
+        });
+      }
+      const tensionMembers = allChordMembers.filter((e) => !e.inScale);
+      if (tensionMembers.length > 0) {
+        cues.push({
+          kind: "tension",
+          label: "Tension",
+          notes: tensionMembers.map((e) => ({
+            ...toCueNote(e),
+            role: "chord-tone-outside-scale" as const,
+            resolvesTo: findResolution(e.internalNote),
+          })),
+        });
+      }
+      break;
+    }
+  }
+
+  return cues;
+});
+
+/**
+ * Shape-local variant: filters each cue's notes to those present in the
+ * currently-highlighted shape positions. Falls back to empty when there's no
+ * shape context (fingeringPattern === "all").
+ */
+export const shapeLocalPracticeCuesAtom = atom((get) => {
+  const shapeHighlightedNoteSet = get(shapeHighlightedNoteSetAtom);
+  const cues = get(practiceCuesAtom);
+  if (!shapeHighlightedNoteSet) return [] as PracticeCue[];
+  return cues
+    .map((cue) => ({
+      ...cue,
+      notes: cue.notes.filter((n) =>
+        shapeHighlightedNoteSet.has(n.internalNote),
+      ),
+    }))
+    .filter((cue) => cue.notes.length > 0);
+});
+
 // --- Actions ---
 
 // Sets rootNote and syncs chordRoot when linkChordRoot is enabled
@@ -1400,6 +1687,7 @@ export const resetAtom = atom(null, (_get, set) => {
   set(linkChordRootAtom, RESET);
   set(chordFretSpreadAtom, RESET);
   set(viewModeAtom, RESET);
+  set(practiceLensAtom, RESET);
   set(focusPresetAtom, RESET);
   set(customMembersAtom, RESET);
   set(fingeringPatternAtom, RESET);

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -120,6 +120,51 @@ export interface LegendItem {
   label: string;
 }
 
+// ---------------------------------------------------------------------------
+// Practice lenses — user-facing practice model replacing raw viewMode
+// ---------------------------------------------------------------------------
+
+export type PracticeLens =
+  | "targets"       // chord root + active chord tones — for landing and outlining harmony
+  | "guide-tones"   // 3rd/7th — for voice-leading and strong chord definition
+  | "color"         // characteristic modal/blue notes — for hearing why the scale sounds like itself
+  | "targets-color" // targets + color (best general-purpose soloing practice view)
+  | "tension";      // outside/altered tones — secondary/advanced lens
+
+// Composable note semantics — multiple properties can coexist on one note.
+// A note can be simultaneously a chord root and outside the scale (isTension),
+// which the old single-role enum could not represent correctly.
+export interface NoteSemantics {
+  isScaleRoot: boolean;
+  isChordRoot: boolean;
+  isChordTone: boolean;
+  isInScale: boolean;
+  isColorTone: boolean;
+  isGuideTone: boolean; // 3rd or 7th of the chord
+  isTension: boolean;   // chord tone that is outside the scale
+  memberName?: ChordMemberName;
+}
+
+// Practice bar coaching cue types
+export type PracticeCueKind = "land-on" | "guide-tones" | "color-note" | "tension";
+
+export interface PracticeCueNote {
+  internalNote: string;
+  displayNote: string;
+  intervalName?: string;
+  /** Visual role for pill styling — mirrors ChordRowEntry roles plus guide/color variants */
+  role?: "chord-root" | "chord-tone-in-scale" | "chord-tone-outside-scale" | "color-tone" | "guide-tone";
+  /** Nearest in-scale resolution target for tension/outside notes */
+  resolvesTo?: { internalNote: string; displayNote: string };
+}
+
+export interface PracticeCue {
+  kind: PracticeCueKind;
+  /** Coaching label shown to the player: "Land on", "Guide tones", "Color note", "Tension" */
+  label: string;
+  notes: PracticeCueNote[];
+}
+
 export const CHORD_DEFINITIONS: Record<string, ChordDefinition> = {
   "Major Triad": {
     quality: "triad",


### PR DESCRIPTION
## Summary

- Replaces the theory-centric `viewMode` (compare / chord / outside) with five **practice lenses**: Targets + Color, Targets, Guide Tones, Color, Tension
- Fixes a semantic bug where a note could only hold one role — chord root *or* outside-scale, never both. The new `NoteSemantics` composable model gives every note independent boolean properties (`isChordRoot`, `isTension`, `isGuideTone`, etc.)
- Rewrites the practice bar as a **coaching cue list** with labels like "Land on:", "Guide tones:", "Color note:", "Tension:" — tension cues include resolution arrows (e.g., `F# →G`)
- Removes the old outside-mode fretboard hiding; the Tension lens shows all notes and coaches via the bar instead

## What changed

### Core types (`theory.ts`)
- `PracticeLens` union type
- `NoteSemantics` composable interface
- `PracticeCue` / `PracticeCueNote` / `PracticeCueKind` for the cue model

### State (`atoms.ts`)
- `practiceLensAtom` — stored at `k("practiceLens")`, defaults to `"targets-color"`, migrates old `viewMode` key on first access
- `noteSemanticMapAtom` — `Map<string, NoteSemantics>` with composable properties
- `practiceCuesAtom` — emits the right cue list for the active lens
- `shapeLocalPracticeCuesAtom` — filters cues to the current CAGED/3NPS shape
- `hideNonChordNotesAtom` is now a derived atom (`practiceLens === "targets"`) rather than persisted state

### Components
- `ChordOverlayControls` — "Lens" section replaces "View"; Tension option disabled when chord is fully diatonic
- `ChordPracticeBar` — completely rewritten around the `cues: PracticeCue[]` prop; renders `CueLine` components with pill lists and resolution arrows
- `SummaryRibbon` — wired to new cue API
- `FretboardSVG` — `viewMode` prop kept for backward compat but no longer drives note hiding; `practiceLens` prop added

### Tests
- `ChordPracticeBar.test.tsx` — rewritten for cue-based API
- `practiceLens.test.ts` — new file covering atom behavior, migration, cues per lens, shape-local filtering
- `FretboardSVG.test.tsx`, `atoms.test.ts`, `TheoryControls.test.tsx`, `App.test.tsx` — updated to reflect new labels and lens-based behavior

808 tests pass. Lint clean. Build succeeds.

## Test plan

- [ ] Select a scale and chord — verify Targets + Color lens shows land-on and color-note cues in the practice bar
- [ ] Switch to Targets lens — verify scale-only notes are hidden on the fretboard
- [ ] Switch to Guide Tones lens — verify only 3rd/7th appear in the cue
- [ ] Switch to Tension lens with an outside chord (e.g., C Major scale + D Dominant 7th) — verify resolution arrows appear (F# →G, C# →C)
- [ ] Verify Tension option is disabled when chord is fully in-scale
- [ ] Confirm old `viewMode` localStorage value migrates correctly on first load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a "Practice Lens" selector (Targets + Color, Targets, Guide Tones, Color, Tension) and a cue-driven coaching pipeline that surfaces ordered practice cues and resolution targets.

* **Behavior**
  * Fretboard note visibility and practice-bar visibility now follow the selected lens; legacy view settings are migrated to lenses.

* **Style**
  * Practice bar shows vertical cue rows, role-styled pills, and resolve indicators.

* **Tests**
  * Updated and expanded tests to validate lens migration, cue generation, and UI rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->