### PR TITLE
refactor(a11y): extract useFocusTrap hook — Phase 05

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, lazy, Suspense } from "react";
+import { useState, useEffect, useRef, lazy, Suspense } from "react";
 import { useSetAtom, useAtomValue, createStore, Provider } from "jotai";
 import { Fretboard } from "./Fretboard";
 import { HelpCircle, Settings2, Volume2, VolumeX } from "lucide-react";
@@ -45,6 +45,7 @@ function AppContent() {
   const toggleMute = useSetAtom(toggleMuteAtom);
 
   const [showHelp, setShowHelp] = useState(false);
+  const helpTriggerRef = useRef<HTMLButtonElement>(null);
   const layout = useLayoutMode();
 
   // Sync mute state to audio synth (runs on mount and whenever isMuted changes)
@@ -93,6 +94,7 @@ function AppContent() {
                 )}
               </button>
               <button
+                ref={helpTriggerRef}
                 type="button"
                 onClick={() => setShowHelp(true)}
                 className="header-btn"
@@ -111,6 +113,7 @@ function AppContent() {
           <HelpModal
             isOpen={showHelp}
             onClose={() => setShowHelp(false)}
+            triggerRef={helpTriggerRef}
           />
         </Suspense>
       }

--- a/src/components/HelpModal.test.tsx
+++ b/src/components/HelpModal.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { useRef } from "react";
+import { HelpModal } from "./HelpModal";
+
+// Wrapper component that renders a trigger button + HelpModal together
+// so that the triggerRef can be attached to a real DOM button.
+function HelpModalWithTrigger({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}) {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  return (
+    <>
+      <button ref={triggerRef} type="button" aria-label="Trigger button">
+        Open help
+      </button>
+      <HelpModal isOpen={isOpen} onClose={onClose} triggerRef={triggerRef} />
+    </>
+  );
+}
+
+describe("HelpModal", () => {
+  it("renders dialog when isOpen=true", () => {
+    render(<HelpModal isOpen={true} onClose={vi.fn()} />);
+    expect(screen.getByRole("dialog", { name: "FretFlow Help" })).toBeInTheDocument();
+  });
+
+  it("does not render dialog when isOpen=false", () => {
+    render(<HelpModal isOpen={false} onClose={vi.fn()} />);
+    expect(screen.queryByRole("dialog", { name: "FretFlow Help" })).not.toBeInTheDocument();
+  });
+
+  it("calls onClose when Close help button is clicked", () => {
+    const onClose = vi.fn();
+    render(<HelpModal isOpen={true} onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText("Close help"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores focus to trigger button when modal closes", () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <HelpModalWithTrigger isOpen={true} onClose={onClose} />
+    );
+
+    // Focus the close button inside the modal so focus is inside the trap
+    const closeBtn = screen.getByLabelText("Close help");
+    closeBtn.focus();
+    expect(document.activeElement).toBe(closeBtn);
+
+    // Close the modal (set isOpen=false)
+    act(() => {
+      rerender(<HelpModalWithTrigger isOpen={false} onClose={onClose} />);
+    });
+
+    // Focus should be restored to the trigger button
+    expect(document.activeElement).toBe(screen.getByLabelText("Trigger button"));
+  });
+});

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -1,61 +1,34 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 import { X } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { getFocusableElements } from "../utils/dom";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 interface HelpModalProps {
   isOpen: boolean;
   onClose: () => void;
+  triggerRef?: RefObject<HTMLButtonElement | null>;
 }
 
-export function HelpModal({ isOpen, onClose }: HelpModalProps) {
+export function HelpModal({ isOpen, onClose, triggerRef }: HelpModalProps) {
   const helpModalRef = useRef<HTMLDivElement>(null);
 
-  // Focus trap + focus restoration for help modal
+  useFocusTrap({
+    containerRef: helpModalRef,
+    active: isOpen,
+    onEscape: onClose,
+    restoreFocusRef: triggerRef,
+  });
+
+  // Outside-click handler — close when clicking outside the modal container
   useEffect(() => {
     if (!isOpen) return;
-    const modal = helpModalRef.current;
-    const focusables = getFocusableElements(modal);
-    focusables[0]?.focus();
-
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-        return;
-      }
-      if (e.key !== "Tab") return;
-      const els = getFocusableElements(modal);
-      if (els.length === 0) return;
-      const first = els[0];
-      const last = els[els.length - 1];
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    }
-
-    function handlePointerDown(e: PointerEvent) {
-      const target = e.target;
-      if (!(target instanceof Node) || !modal) return;
-      if (!modal.contains(target)) {
+    const handlePointerDown = (e: PointerEvent) => {
+      if (helpModalRef.current && !helpModalRef.current.contains(e.target as Node)) {
         onClose();
       }
-    }
-
-    document.addEventListener("keydown", handleKeyDown);
-    document.addEventListener("pointerdown", handlePointerDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      document.removeEventListener("pointerdown", handlePointerDown);
     };
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
   }, [isOpen, onClose]);
 
   return (

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -25,8 +25,8 @@ import {
   getResponsiveTier,
   type ResponsiveTier,
 } from "../layout/responsive";
-import { getFocusableElements } from "../utils/dom";
-import { 
+import { useFocusTrap } from "../hooks/useFocusTrap";
+import {
   MAX_FRET, 
   FRET_ZOOM_MIN, 
   FRET_ZOOM_MAX 
@@ -321,61 +321,27 @@ function SettingsOverlaySurface({
     return () => document.removeEventListener("mousedown", handlePointerDown);
   }, [activeHelpField]);
 
-  // Trap focus inside the drawer while open and restore focus on close.
+  // Capture trigger element at open time so useFocusTrap can restore focus on close.
   useEffect(() => {
     triggerRef.current =
       document.activeElement instanceof HTMLElement
         ? document.activeElement
         : null;
+  }, []);
 
-    const drawer = drawerRef.current;
-    const focusInitial = window.requestAnimationFrame(() => {
-      const focusables = getFocusableElements(drawer);
-      (closeButtonRef.current ?? focusables[0] ?? drawer)?.focus();
-    });
-
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.stopPropagation();
-        if (activeHelpFieldRef.current) {
-          setActiveHelpField(null);
-        } else {
-          setIsOpen(false);
-        }
-        return;
+  // Trap focus inside the drawer while open and restore focus on close.
+  useFocusTrap({
+    containerRef: drawerRef,
+    active: true,
+    onEscape: () => {
+      if (activeHelpFieldRef.current) {
+        setActiveHelpField(null);
+      } else {
+        setIsOpen(false);
       }
-
-      if (e.key !== "Tab") return;
-
-      const focusables = getFocusableElements(drawer);
-      if (focusables.length === 0) {
-        e.preventDefault();
-        drawer?.focus();
-        return;
-      }
-
-      const first = focusables[0];
-      const last = focusables[focusables.length - 1];
-      const activeElement = document.activeElement;
-
-      if (e.shiftKey && activeElement === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && activeElement === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    };
-
-    window.addEventListener("keydown", onKeyDown);
-
-    return () => {
-      window.cancelAnimationFrame(focusInitial);
-      window.removeEventListener("keydown", onKeyDown);
-      triggerRef.current?.focus();
-      triggerRef.current = null;
-    };
-  }, [setIsOpen]);
+    },
+    restoreFocusRef: triggerRef,
+  });
 
   const renderField = (
     fieldKey: SettingFieldKey,

--- a/src/hooks/useFocusTrap.test.ts
+++ b/src/hooks/useFocusTrap.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRef } from "react";
+import { useFocusTrap } from "./useFocusTrap";
+
+describe("useFocusTrap", () => {
+  let container: HTMLDivElement;
+  let button1: HTMLButtonElement;
+  let button2: HTMLButtonElement;
+  let containerRef: { current: HTMLDivElement };
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    button1 = document.createElement("button");
+    button1.textContent = "Button 1";
+    button2 = document.createElement("button");
+    button2.textContent = "Button 2";
+    container.appendChild(button1);
+    container.appendChild(button2);
+    document.body.appendChild(container);
+
+    containerRef = { current: container };
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    vi.restoreAllMocks();
+  });
+
+  it("focuses the first focusable element after rAF tick when active=true", async () => {
+    const onEscape = vi.fn();
+
+    vi.useFakeTimers();
+    try {
+      renderHook(() =>
+        useFocusTrap({ containerRef, active: true, onEscape })
+      );
+
+      // rAF has not fired yet
+      expect(document.activeElement).not.toBe(button1);
+
+      // Flush all pending rAF callbacks
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(document.activeElement).toBe(button1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("Tab advances focus from button1 to button2", async () => {
+    const user = userEvent.setup();
+    const onEscape = vi.fn();
+
+    renderHook(() =>
+      useFocusTrap({ containerRef, active: true, onEscape })
+    );
+
+    // Move focus into the trap
+    button1.focus();
+    expect(document.activeElement).toBe(button1);
+
+    await user.tab();
+
+    expect(document.activeElement).toBe(button2);
+  });
+
+  it("Tab wraps from last button back to first button", async () => {
+    const user = userEvent.setup();
+    const onEscape = vi.fn();
+
+    renderHook(() =>
+      useFocusTrap({ containerRef, active: true, onEscape })
+    );
+
+    button2.focus();
+    expect(document.activeElement).toBe(button2);
+
+    await user.tab();
+
+    expect(document.activeElement).toBe(button1);
+  });
+
+  it("Shift+Tab moves focus from button2 to button1", async () => {
+    const user = userEvent.setup();
+    const onEscape = vi.fn();
+
+    renderHook(() =>
+      useFocusTrap({ containerRef, active: true, onEscape })
+    );
+
+    button2.focus();
+    expect(document.activeElement).toBe(button2);
+
+    await user.tab({ shift: true });
+
+    expect(document.activeElement).toBe(button1);
+  });
+
+  it("Shift+Tab wraps from first button back to last button", async () => {
+    const user = userEvent.setup();
+    const onEscape = vi.fn();
+
+    renderHook(() =>
+      useFocusTrap({ containerRef, active: true, onEscape })
+    );
+
+    button1.focus();
+    expect(document.activeElement).toBe(button1);
+
+    await user.tab({ shift: true });
+
+    expect(document.activeElement).toBe(button2);
+  });
+
+  it("Escape calls onEscape and calls event.preventDefault()", async () => {
+    const user = userEvent.setup();
+    const onEscape = vi.fn();
+
+    renderHook(() =>
+      useFocusTrap({ containerRef, active: true, onEscape })
+    );
+
+    button1.focus();
+
+    // Spy on preventDefault via keydown listener
+    const preventDefaultSpy = vi.fn();
+    window.addEventListener(
+      "keydown",
+      (e) => {
+        if (e.key === "Escape") preventDefaultSpy();
+      },
+      { once: true }
+    );
+
+    await user.keyboard("{Escape}");
+
+    expect(onEscape).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores focus to restoreFocusRef.current when active flips to false", async () => {
+    const restoreTarget = document.createElement("button");
+    restoreTarget.textContent = "Restore target";
+    document.body.appendChild(restoreTarget);
+
+    const restoreFocusRef = { current: restoreTarget };
+    const onEscape = vi.fn();
+
+    let active = true;
+    const { rerender } = renderHook(
+      ({ active: a }: { active: boolean }) =>
+        useFocusTrap({ containerRef, active: a, onEscape, restoreFocusRef }),
+      { initialProps: { active: true } }
+    );
+
+    button1.focus();
+
+    act(() => {
+      rerender({ active: false });
+    });
+
+    expect(document.activeElement).toBe(restoreTarget);
+
+    document.body.removeChild(restoreTarget);
+    void active;
+  });
+
+  it("removes event listener on unmount and does not call onEscape after unmount", async () => {
+    const user = userEvent.setup();
+    const onEscape = vi.fn();
+
+    const { unmount } = renderHook(() =>
+      useFocusTrap({ containerRef, active: true, onEscape })
+    );
+
+    button1.focus();
+    unmount();
+
+    // After unmount, pressing Escape should NOT call the old onEscape
+    await user.keyboard("{Escape}");
+
+    expect(onEscape).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useFocusTrap.test.ts
+++ b/src/hooks/useFocusTrap.test.ts
@@ -1,8 +1,7 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useRef } from "react";
 import { useFocusTrap } from "./useFocusTrap";
 
 describe("useFocusTrap", () => {
@@ -150,7 +149,6 @@ describe("useFocusTrap", () => {
     const restoreFocusRef = { current: restoreTarget };
     const onEscape = vi.fn();
 
-    let active = true;
     const { rerender } = renderHook(
       ({ active: a }: { active: boolean }) =>
         useFocusTrap({ containerRef, active: a, onEscape, restoreFocusRef }),
@@ -166,7 +164,6 @@ describe("useFocusTrap", () => {
     expect(document.activeElement).toBe(restoreTarget);
 
     document.body.removeChild(restoreTarget);
-    void active;
   });
 
   it("removes event listener on unmount and does not call onEscape after unmount", async () => {

--- a/src/hooks/useFocusTrap.test.ts
+++ b/src/hooks/useFocusTrap.test.ts
@@ -139,6 +139,7 @@ describe("useFocusTrap", () => {
     await user.keyboard("{Escape}");
 
     expect(onEscape).toHaveBeenCalledTimes(1);
+    expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
   });
 
   it("restores focus to restoreFocusRef.current when active flips to false", async () => {

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,67 @@
+import { useEffect, type RefObject } from "react";
+import { getFocusableElements } from "../utils/dom";
+
+interface UseFocusTrapOptions {
+  containerRef: RefObject<HTMLElement | null>;
+  active: boolean;
+  onEscape: () => void;
+  restoreFocusRef?: RefObject<HTMLElement | null>;
+}
+
+export function useFocusTrap({
+  containerRef,
+  active,
+  onEscape,
+  restoreFocusRef,
+}: UseFocusTrapOptions): void {
+  useEffect(() => {
+    if (!active || !containerRef.current) return;
+
+    const container = containerRef.current;
+
+    let rafId: number | undefined = requestAnimationFrame(() => {
+      rafId = undefined;
+      const focusable = getFocusableElements(container);
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      }
+    });
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onEscape();
+        return;
+      }
+
+      if (event.key === "Tab") {
+        event.preventDefault();
+        const focusable = getFocusableElements(container);
+        if (focusable.length === 0) return;
+
+        const focused = document.activeElement as HTMLElement;
+        const idx = focusable.indexOf(focused);
+
+        if (event.shiftKey) {
+          // Shift+Tab: backward cycling
+          const prevIdx = idx <= 0 ? focusable.length - 1 : idx - 1;
+          focusable[prevIdx].focus();
+        } else {
+          // Tab: forward cycling
+          const nextIdx = idx >= focusable.length - 1 ? 0 : idx + 1;
+          focusable[nextIdx].focus();
+        }
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      if (rafId !== undefined) {
+        cancelAnimationFrame(rafId);
+      }
+      window.removeEventListener("keydown", onKeyDown);
+      restoreFocusRef?.current?.focus();
+    };
+  }, [active, onEscape, containerRef, restoreFocusRef]);
+}

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,4 +1,4 @@
-import { useEffect, type RefObject } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 import { getFocusableElements } from "../utils/dom";
 
 interface UseFocusTrapOptions {
@@ -14,6 +14,12 @@ export function useFocusTrap({
   onEscape,
   restoreFocusRef,
 }: UseFocusTrapOptions): void {
+  const onEscapeRef = useRef(onEscape);
+
+  useEffect(() => {
+    onEscapeRef.current = onEscape;
+  }, [onEscape]);
+
   useEffect(() => {
     if (!active || !containerRef.current) return;
 
@@ -30,7 +36,7 @@ export function useFocusTrap({
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         event.preventDefault();
-        onEscape();
+        onEscapeRef.current();
         return;
       }
 
@@ -66,5 +72,5 @@ export function useFocusTrap({
       window.removeEventListener("keydown", onKeyDown);
       restoreTarget?.focus();
     };
-  }, [active, onEscape, containerRef, restoreFocusRef]);
+  }, [active, containerRef, restoreFocusRef]);
 }

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -56,12 +56,15 @@ export function useFocusTrap({
 
     window.addEventListener("keydown", onKeyDown);
 
+    // Capture at setup time to satisfy react-hooks/exhaustive-deps for cleanup
+    const restoreTarget = restoreFocusRef?.current ?? null;
+
     return () => {
       if (rafId !== undefined) {
         cancelAnimationFrame(rafId);
       }
       window.removeEventListener("keydown", onKeyDown);
-      restoreFocusRef?.current?.focus();
+      restoreTarget?.focus();
     };
   }, [active, onEscape, containerRef, restoreFocusRef]);
 }


### PR DESCRIPTION
## Summary

- Extract a reusable `useFocusTrap` hook (`src/hooks/useFocusTrap.ts`) that encapsulates modal focus-trap behaviour: rAF initial focus, Tab/Shift+Tab cycling with wrap-around, Escape handling with `preventDefault`, and focus restoration via `restoreFocusRef` on deactivate.
- Refactor `HelpModal` to use the hook; add optional `triggerRef` prop and wire `helpTriggerRef` in `App.tsx` so focus returns to the "Open help" button on close. Pointerdown outside-click handler preserved in its own `useEffect`.
- Refactor `SettingsOverlay` to use the hook; preserve the two-path Escape guard (clear inline help popover first, otherwise close overlay). Lines 311–322 mousedown handler for `activeHelpField` untouched.

Removes ~100 lines of duplicated focus-trap `useEffect` blocks across the two modals.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run test` passes (831/831 tests, 41 files — includes new 8-case `useFocusTrap.test.ts` and new `HelpModal.test.tsx` with focus-restoration assertion)
- [x] `npm run build` passes
- [ ] Manual: open Help modal → Tab cycles stay inside, Shift+Tab wraps correctly, Escape closes, focus returns to the help button
- [ ] Manual: open Settings overlay → Tab cycles stay inside; with an inline help popover open, Escape closes just the popover; with none open, Escape closes the overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus restoration to the trigger when closing help or overlays.
  * More reliable keyboard navigation (Tab, Shift+Tab) and Escape handling within modals and overlays.

* **New Features**
  * Accessibility improvements: modals/overlays now consistently trap focus while open.

* **Tests**
  * Added end-to-end tests covering focus-trap behavior, keyboard navigation, focus restoration, and modal open/close interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->