### PR TITLE
refactor(store): extract chord overlay and scale visibility into dedicated modules

### DIFF
--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -1,274 +1,144 @@
 import { atom } from "jotai";
 import { atomWithStorage, RESET } from "jotai/utils";
-import { 
-  CAGED_SHAPES, 
-  getCagedCoordinates, 
-  get3NPSCoordinates, 
-  findMainShape, 
-  getShapeCenterFret, 
-  type CagedShape,
+import {
+  CAGED_SHAPES,
+  getCagedCoordinates,
+  get3NPSCoordinates,
+  findMainShape,
+  getShapeCenterFret,
   type ShapePolygon,
 } from "../shapes";
-import { normalizeScaleName, type ScaleBrowseMode, getActiveScaleBrowseOption } from "../theoryCatalog";
-import { k, STORAGE_PREFIX } from "../utils/storage";
+import { k, STORAGE_PREFIX, rawStringStorage, booleanStorage, constrainedNumberStorage, GET_ON_INIT } from "../utils/storage";
 import {
-  resolveAccidentalMode,
-  SCALES,
   NOTES,
-  ENHARMONICS,
-  INTERVAL_NAMES,
-  CHORD_DEFINITIONS,
   getScaleNotes,
-  getChordNotes,
-  getNoteDisplay,
-  getNoteDisplayInScale,
-  getDivergentNotes,
   formatAccidental,
-  getAvailableFocusPresets,
-  applyFocusPreset,
 } from "../theory";
 import type {
-  ViewMode,
-  FocusPreset,
-  ChordMemberName,
-  ResolvedChordMember,
   NoteRole,
-  NoteSemantics,
-  PracticeLens,
-  PracticeCue,
-  PracticeCueNote,
   ChordRowEntry,
   LegendItem,
-  PracticeBarColorNote,
 } from "../theory";
 import { TUNINGS, STANDARD_TUNING, getFretNote } from "../guitar";
-import { 
-  MAX_FRET, 
-  FRET_ZOOM_MIN, 
-  FRET_ZOOM_MAX, 
-  FRET_ZOOM_DEFAULT 
+import {
+  MAX_FRET,
+  FRET_ZOOM_MIN,
+  FRET_ZOOM_MAX,
+  FRET_ZOOM_DEFAULT,
 } from "../constants";
 
-export type FingeringPattern = "all" | "caged" | "3nps";
-
-const LEGACY_KEYS = [
-  "rootNote",
-  "scaleName",
-  "chordRoot",
-  "chordType",
-  "linkChordRoot",
-  "hideNonChordNotes",
-  "chordFretSpread",
-  "chordIntervalFilter",
-  "fingeringPattern",
-  "cagedShapes",
-  "npsPosition",
-  "displayFormat",
-  "tuningName",
-  "fretZoom",
-  "fretStart",
-  "fretEnd",
-  "isMuted",
-  "mobileTab",
-  "tabletTab",
-  "landscapeNarrowTab",
-] as const;
-
-function migrateLegacyKeys() {
-  // Idempotent: only migrates when prefixed key doesn't exist.
-  // Also removes the legacy key after copying to reduce drift.
-  try {
-    for (const legacyKey of LEGACY_KEYS) {
-      const prefixedKey = k(legacyKey);
-      if (localStorage.getItem(prefixedKey) !== null) {
-        localStorage.removeItem(legacyKey);
-        continue;
-      }
-      const legacyValue = localStorage.getItem(legacyKey);
-      if (legacyValue === null) continue;
-      localStorage.setItem(prefixedKey, legacyValue);
-      localStorage.removeItem(legacyKey);
-    }
-  } catch {
-    // If storage is blocked or throws (Safari private mode, etc), ignore.
-  }
-}
-migrateLegacyKeys();
-
 // ---------------------------------------------------------------------------
-// Raw storage helpers — match the old localStorage.setItem(key, String(value))
-// format and write defaults on first access (matching old useEffect-on-mount).
+// Domain module re-exports — all public atoms flow through atoms.ts so
+// existing import paths (from "../store/atoms") continue to work unchanged.
 // ---------------------------------------------------------------------------
 
-function rawStringStorage<T extends string>() {
-  return {
-    getItem(key: string, initialValue: T): T {
-      try {
-        const stored = localStorage.getItem(key);
-        if (stored === null) {
-          localStorage.setItem(key, initialValue);
-          return initialValue;
-        }
-        return stored as T;
-      } catch {
-        return initialValue;
-      }
-    },
-    setItem(key: string, value: T): void {
-      try {
-        localStorage.setItem(key, value);
-      } catch {
-        // Storage blocked or unavailable; ignore.
-      }
-    },
-    removeItem(key: string): void {
-      try {
-        localStorage.removeItem(key);
-      } catch {
-        // Storage blocked or unavailable; ignore.
-      }
-    },
-  };
-}
+export type { FingeringPattern } from "./fingeringAtoms";
+export {
+  fingeringPatternAtom,
+  cagedShapesAtom,
+  toggleCagedShapeAtom,
+  selectSingleCagedShapeAtom,
+  npsPositionAtom,
+  clickedShapeAtom,
+  recenterKeyAtom,
+} from "./fingeringAtoms";
 
-const booleanStorage = {
-  getItem(key: string, initialValue: boolean): boolean {
-    try {
-      const stored = localStorage.getItem(key);
-      if (stored === null) {
-        localStorage.setItem(key, String(initialValue));
-        return initialValue;
-      }
-      if (stored === "true") return true;
-      if (stored === "false") return false;
-      localStorage.setItem(key, String(initialValue));
-      return initialValue;
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: boolean): void {
-    try {
-      localStorage.setItem(key, String(value));
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-  removeItem(key: string): void {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-};
+export {
+  rootNoteAtom,
+  baseScaleNameAtom,
+  scaleNameAtom,
+  scaleBrowseModeAtom,
+  accidentalModeAtom,
+  useFlatsAtom,
+  scaleNotesAtom,
+  colorNotesAtom,
+  activeBrowseOptionAtom,
+  scaleLabelAtom,
+  degreeChipsAtom,
+  hiddenNotesAtom,
+  toggleHiddenNoteAtom,
+} from "./scaleAtoms";
 
-const scaleNameStorage = {
-  getItem(key: string, initialValue: string): string {
-    try {
-      const stored = localStorage.getItem(key);
-      if (stored === null) {
-        localStorage.setItem(key, initialValue);
-        return initialValue;
-      }
-      const normalized = normalizeScaleName(stored);
-      if (normalized !== stored) {
-        localStorage.setItem(key, normalized);
-      }
-      return normalized;
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: string): void {
-    try {
-      localStorage.setItem(key, normalizeScaleName(value));
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-  removeItem(key: string): void {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-};
+export {
+  chordRootAtom,
+  chordTypeAtom,
+  linkChordRootAtom,
+  chordFretSpreadAtom,
+  viewModeAtom,
+  practiceLensAtom,
+  focusPresetAtom,
+  customMembersAtom,
+  hideNonChordNotesAtom,
+  chordTonesAtom,
+  availableFocusPresetsAtom,
+  chordMembersAtom,
+  activeChordMembersAtom,
+  activeChordTonesAtom,
+  hasOutsideChordMembersAtom,
+  chordLabelAtom,
+  chordSummaryNotesAtom,
+  allChordMembersAtom,
+} from "./chordOverlayAtoms";
 
-type NumberConstraints = {
-  min?: number;
-  max?: number;
-  integer?: boolean;
-};
+export {
+  practiceBarColorNotesAtom,
+  practiceBarColorNotesFilteredAtom,
+  noteSemanticMapAtom,
+  practiceCuesAtom,
+  showChordPracticeBarAtom,
+  practiceBarTitleAtom,
+  practiceBarBadgeAtom,
+  practiceBarSharedMembersAtom,
+  practiceBarOutsideMembersAtom,
+} from "./practiceLensAtoms";
 
-function constrainedNumberStorage(constraints: NumberConstraints) {
-  return {
-    getItem(key: string, initialValue: number): number {
-      try {
-        const stored = localStorage.getItem(key);
-        if (stored === null) {
-          localStorage.setItem(key, String(initialValue));
-          return initialValue;
-        }
-        if (stored.trim() === "") {
-          localStorage.setItem(key, String(initialValue));
-          return initialValue;
-        }
-        const num = Number(stored);
-        if (!Number.isFinite(num)) {
-          localStorage.setItem(key, String(initialValue));
-          return initialValue;
-        }
-        if (constraints.integer && !Number.isInteger(num)) {
-          localStorage.setItem(key, String(initialValue));
-          return initialValue;
-        }
-        if (constraints.min !== undefined && num < constraints.min) {
-          localStorage.setItem(key, String(initialValue));
-          return initialValue;
-        }
-        if (constraints.max !== undefined && num > constraints.max) {
-          localStorage.setItem(key, String(initialValue));
-          return initialValue;
-        }
-        return num;
-      } catch {
-        return initialValue;
-      }
-    },
-    setItem(key: string, value: number): void {
-      try {
-        localStorage.setItem(key, String(value));
-      } catch {
-        // Storage blocked or unavailable; ignore.
-      }
-    },
-    removeItem(key: string): void {
-      try {
-        localStorage.removeItem(key);
-      } catch {
-        // Storage blocked or unavailable; ignore.
-      }
-    },
-  };
-}
+// ---------------------------------------------------------------------------
+// Local imports from domain modules (for use in atoms defined below)
+// ---------------------------------------------------------------------------
 
-const fretCountStorage = constrainedNumberStorage({
-  min: 0,
-  max: MAX_FRET,
-  integer: true,
-});
-const chordFretSpreadStorage = constrainedNumberStorage({
-  min: 0,
-  max: 4,
-  integer: true,
-});
-const npsPositionStorage = constrainedNumberStorage({
-  min: 1,
-  max: 12,
-  integer: true,
-});
+import {
+  fingeringPatternAtom,
+  cagedShapesAtom,
+  npsPositionAtom,
+  clickedShapeAtom,
+} from "./fingeringAtoms";
+import {
+  rootNoteAtom,
+  scaleNameAtom,
+  accidentalModeAtom,
+  scaleNotesAtom,
+  scaleLabelAtom,
+  baseScaleNameAtom,
+  scaleBrowseModeAtom,
+} from "./scaleAtoms";
+import {
+  chordRootAtom,
+  chordTypeAtom,
+  linkChordRootAtom,
+  chordFretSpreadAtom,
+  viewModeAtom,
+  practiceLensAtom,
+  focusPresetAtom,
+  customMembersAtom,
+  activeChordTonesAtom,
+  activeChordMembersAtom,
+  hasOutsideChordMembersAtom,
+  chordLabelAtom,
+  allChordMembersAtom,
+} from "./chordOverlayAtoms";
+import {
+  practiceCuesAtom,
+  practiceBarColorNotesAtom,
+} from "./practiceLensAtoms";
+
+// Legacy key migration is performed by utils/storage.ts at module load,
+// before any atomWithStorage({ getOnInit: true }) reads. No action needed here.
+
+// ---------------------------------------------------------------------------
+// Storage helpers for remaining atoms
+// ---------------------------------------------------------------------------
+
+const fretCountStorage = constrainedNumberStorage({ min: 0, max: MAX_FRET, integer: true });
 const fretZoomStorage = constrainedNumberStorage({
   min: FRET_ZOOM_MIN,
   max: FRET_ZOOM_MAX,
@@ -323,477 +193,38 @@ const mobileTabStorage = {
   },
 };
 
-const SCALE_BROWSE_MODES = ["parallel", "relative"] as const;
-
-const scaleBrowseModeStorage = {
-  getItem(key: string, initialValue: ScaleBrowseMode): ScaleBrowseMode {
-    try {
-      const stored = localStorage.getItem(key);
-      if (stored === null) {
-        localStorage.setItem(key, initialValue);
-        return initialValue;
-      }
-      if ((SCALE_BROWSE_MODES as readonly string[]).includes(stored)) {
-        return stored as ScaleBrowseMode;
-      }
-      localStorage.setItem(key, initialValue);
-      return initialValue;
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: ScaleBrowseMode): void {
-    try {
-      localStorage.setItem(key, value);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-  removeItem(key: string): void {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-};
-
-// chordType is stored as '' when null (matching old behavior)
-const chordTypeStorage = {
-  getItem(key: string, initialValue: string | null): string | null {
-    try {
-      const stored = localStorage.getItem(key);
-      if (stored === null) {
-        localStorage.setItem(key, "");
-        return initialValue;
-      }
-      return stored === "" ? null : stored;
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: string | null): void {
-    try {
-      localStorage.setItem(key, value ?? "");
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-  removeItem(key: string): void {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-};
-
-// cagedShapes stored as JSON array
-const cagedShapesStorage = {
-  getItem(key: string, initialValue: Set<CagedShape>): Set<CagedShape> {
-    try {
-      const stored = localStorage.getItem(key);
-      if (stored === null) {
-        localStorage.setItem(key, JSON.stringify(Array.from(initialValue)));
-        return initialValue;
-      }
-      try {
-        return new Set(JSON.parse(stored) as CagedShape[]);
-      } catch {
-        return initialValue;
-      }
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: Set<CagedShape>): void {
-    try {
-      localStorage.setItem(key, JSON.stringify(Array.from(value)));
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-  removeItem(key: string): void {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-};
-
 // ---------------------------------------------------------------------------
-// Atoms
+// Display atoms
 // ---------------------------------------------------------------------------
 
-// All persisted atoms use { getOnInit: true } so Jotai reads from localStorage
-// synchronously during atom initialization rather than defaulting to initialValue
-// first. Without this, atoms start with their hardcoded default on the first
-// render and then update after mount, causing a visible flash on page load.
-const GET_ON_INIT = { getOnInit: true } as const;
-
-// Scale
-export const rootNoteAtom = atomWithStorage(
-  k("rootNote"),
-  "C",
-  rawStringStorage(),
-  GET_ON_INIT,
-);
-const baseScaleNameAtom = atomWithStorage(
-  k("scaleName"),
-  "Major",
-  scaleNameStorage,
-  GET_ON_INIT,
-);
-// Primary scale setter: resets CAGED shapes to "E" when scale changes, matching old useDisplayState useEffect
-export const scaleNameAtom = atom(
-  (get) => get(baseScaleNameAtom),
-  (get, set, value: string) => {
-    const nextScale = normalizeScaleName(value);
-    const prevScale = get(baseScaleNameAtom);
-    if (nextScale !== prevScale) {
-      set(baseScaleNameAtom, nextScale);
-      if (get(fingeringPatternAtom) === "caged") {
-        set(cagedShapesAtom, new Set<CagedShape>(["E"]));
-      }
-    }
-  },
-);
-export const scaleBrowseModeAtom = atomWithStorage<ScaleBrowseMode>(
-  k("scaleBrowseMode"),
-  "parallel",
-  scaleBrowseModeStorage,
-  GET_ON_INIT,
-);
-
-// Chord overlay
-export const chordRootAtom = atomWithStorage(
-  k("chordRoot"),
-  "C",
-  rawStringStorage(),
-  GET_ON_INIT,
-);
-export const chordTypeAtom = atomWithStorage<string | null>(
-  k("chordType"),
-  null,
-  chordTypeStorage,
-  GET_ON_INIT,
-);
-export const linkChordRootAtom = atomWithStorage(
-  k("linkChordRoot"),
-  true,
-  booleanStorage,
-  GET_ON_INIT,
-);
-export const chordFretSpreadAtom = atomWithStorage(
-  k("chordFretSpread"),
-  0,
-  chordFretSpreadStorage,
-  GET_ON_INIT,
-);
-
-// Targets lens hides scale-only notes so only chord tones are shown.
-export const hideNonChordNotesAtom = atom((get) => get(practiceLensAtom) === "targets");
-
-const VIEW_MODE_VALUES: ViewMode[] = ["compare", "chord", "outside"];
-
-const viewModeStorage = {
-  getItem(key: string, initialValue: ViewMode): ViewMode {
-    try {
-      const stored = localStorage.getItem(key);
-      if (stored === null) {
-        localStorage.setItem(key, initialValue);
-        return initialValue;
-      }
-      if ((VIEW_MODE_VALUES as string[]).includes(stored))
-        return stored as ViewMode;
-      localStorage.setItem(key, initialValue);
-      return initialValue;
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: ViewMode): void {
-    try {
-      localStorage.setItem(key, value);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-  removeItem(key: string): void {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Practice lens storage — with one-time migration from old viewMode key
-// ---------------------------------------------------------------------------
-
-const PRACTICE_LENS_VALUES: PracticeLens[] = [
-  "targets",
-  "guide-tones",
-  "color",
-  "targets-color",
-  "tension",
-];
-
-function migrateViewModeToLens(viewMode: string): PracticeLens {
-  switch (viewMode) {
-    case "chord": return "targets";
-    case "outside": return "tension";
-    default: return "targets-color";
-  }
-}
-
-const practiceLensStorage = {
-  getItem(key: string, initialValue: PracticeLens): PracticeLens {
-    try {
-      const stored = localStorage.getItem(key);
-      if (stored !== null) {
-        if ((PRACTICE_LENS_VALUES as string[]).includes(stored))
-          return stored as PracticeLens;
-        localStorage.setItem(key, initialValue);
-        return initialValue;
-      }
-      // One-time migration: map old viewMode to a lens on first access
-      const oldViewMode = localStorage.getItem(k("viewMode"));
-      if (oldViewMode) {
-        const migrated = migrateViewModeToLens(oldViewMode);
-        localStorage.setItem(key, migrated);
-        return migrated;
-      }
-      localStorage.setItem(key, initialValue);
-      return initialValue;
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: PracticeLens): void {
-    try {
-      localStorage.setItem(key, value);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-  removeItem(key: string): void {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-};
-
-const FOCUS_PRESET_VALUES: FocusPreset[] = [
-  "all",
-  "triad",
-  "shell",
-  "guide-tones",
-  "rootless",
-  "custom",
-];
-
-const focusPresetStorage = {
-  getItem(key: string, initialValue: FocusPreset): FocusPreset {
-    try {
-      const stored = localStorage.getItem(key);
-      if (stored === null) {
-        localStorage.setItem(key, initialValue);
-        return initialValue;
-      }
-      if ((FOCUS_PRESET_VALUES as string[]).includes(stored))
-        return stored as FocusPreset;
-      localStorage.setItem(key, initialValue);
-      return initialValue;
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: FocusPreset): void {
-    try {
-      localStorage.setItem(key, value);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-  removeItem(key: string): void {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-};
-
-const customMembersStorage = {
-  getItem(key: string, initialValue: ChordMemberName[]): ChordMemberName[] {
-    try {
-      const stored = localStorage.getItem(key);
-      if (stored === null) {
-        localStorage.setItem(key, JSON.stringify(initialValue));
-        return initialValue;
-      }
-      try {
-        const parsed = JSON.parse(stored);
-        if (Array.isArray(parsed)) return parsed as ChordMemberName[];
-        return initialValue;
-      } catch {
-        return initialValue;
-      }
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: ChordMemberName[]): void {
-    try {
-      localStorage.setItem(key, JSON.stringify(value));
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-  removeItem(key: string): void {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-};
-
-export const viewModeAtom = atomWithStorage<ViewMode>(
-  k("viewMode"),
-  "compare",
-  viewModeStorage,
-  GET_ON_INIT,
-);
-// Primary user-facing practice state — replaces viewMode as the UI concept.
-// Stored separately; migrates from old viewMode on first access.
-export const practiceLensAtom = atomWithStorage<PracticeLens>(
-  k("practiceLens"),
-  "targets-color",
-  practiceLensStorage,
-  GET_ON_INIT,
-);
-export const focusPresetAtom = atomWithStorage<FocusPreset>(
-  k("focusPreset"),
-  "all",
-  focusPresetStorage,
-  GET_ON_INIT,
-);
-export const customMembersAtom = atomWithStorage<ChordMemberName[]>(
-  k("customMembers"),
-  [],
-  customMembersStorage,
-  GET_ON_INIT,
-);
-
-// Fingering
-export const fingeringPatternAtom = atomWithStorage<FingeringPattern>(
-  k("fingeringPattern"),
-  "all",
-  rawStringStorage<FingeringPattern>(),
-  GET_ON_INIT,
-);
-export const cagedShapesAtom = atomWithStorage<Set<CagedShape>>(
-  k("cagedShapes"),
-  new Set(CAGED_SHAPES),
-  cagedShapesStorage,
-  GET_ON_INIT,
-);
-
-export const toggleCagedShapeAtom = atom(null, (get, set, shape: CagedShape) => {
-  const prev = get(cagedShapesAtom);
-  const next = new Set(prev);
-  if (next.has(shape)) {
-    if (next.size > 1) next.delete(shape);
-  } else {
-    next.add(shape);
-  }
-  set(cagedShapesAtom, next);
-});
-
-export const selectSingleCagedShapeAtom = atom(
-  null,
-  (_get, set, shape: CagedShape) => {
-    set(cagedShapesAtom, new Set([shape]));
-  },
-);
-
-export const npsPositionAtom = atomWithStorage(
-  k("npsPosition"),
-  1,
-  npsPositionStorage,
-  GET_ON_INIT,
-);
-
-// UI/Transient state
-const internalHiddenNotesAtom = atom<{
-  root: string;
-  scale: string;
-  notes: Set<string>;
-} | null>(null);
-
-export const hiddenNotesAtom = atom(
-  (get) => {
-    const state = get(internalHiddenNotesAtom);
-    const root = get(rootNoteAtom);
-    const scale = get(scaleNameAtom);
-    if (state && state.root === root && state.scale === scale) {
-      return state.notes;
-    }
-    return new Set<string>();
-  },
-  (get, set, update: Set<string> | ((prev: Set<string>) => Set<string>)) => {
-    const root = get(rootNoteAtom);
-    const scale = get(scaleNameAtom);
-    const currentNotes = get(hiddenNotesAtom);
-    const nextNotes =
-      typeof update === "function" ? update(currentNotes) : update;
-    set(internalHiddenNotesAtom, { root, scale, notes: nextNotes });
-  },
-);
-
-export const toggleHiddenNoteAtom = atom(null, (_get, set, note: string) => {
-  set(hiddenNotesAtom, (prev) => {
-    const next = new Set(prev);
-    if (next.has(note)) next.delete(note);
-    else next.add(note);
-    return next;
-  });
-});
-
-export const clickedShapeAtom = atom<CagedShape | null>(null);
-export const recenterKeyAtom = atom<number>(0);
-
-// Display
 export const displayFormatAtom = atomWithStorage<"notes" | "degrees" | "none">(
   k("displayFormat"),
   "notes",
   rawStringStorage<"notes" | "degrees" | "none">(),
   GET_ON_INIT,
 );
+
 export const tuningNameAtom = atomWithStorage(
   k("tuningName"),
   "Standard",
   rawStringStorage(),
   GET_ON_INIT,
 );
+
 export const fretZoomAtom = atomWithStorage(
   k("fretZoom"),
   FRET_ZOOM_DEFAULT,
   fretZoomStorage,
   GET_ON_INIT,
 );
+
 export const fretStartAtom = atomWithStorage(
   k("fretStart"),
   0,
   fretCountStorage,
   GET_ON_INIT,
 );
+
 export const fretEndAtom = atomWithStorage(
   k("fretEnd"),
   MAX_FRET,
@@ -801,29 +232,14 @@ export const fretEndAtom = atomWithStorage(
   GET_ON_INIT,
 );
 
-// Accidentals / Audio / Mobile tab
-// accidentalModeAtom is intentionally non-persisted: "auto" is a smart default
-// that picks the best enharmonic spelling per root+scale, so session-only state
-// is sufficient and avoids sticking a stale user choice across sessions.
-// One-time migration: if the legacy "useFlats" key exists in localStorage
-// (from older versions), translate it once and clear the key. Fall-open on
-// error so a broken localStorage never blocks app boot.
-function readLegacyAccidentalMode(): "sharps" | "flats" | "auto" {
-  try {
-    const legacy = localStorage.getItem("useFlats");
-    if (legacy === null) return "auto";
-    localStorage.removeItem("useFlats");
-    return legacy === "true" ? "flats" : "sharps";
-  } catch {
-    return "auto";
-  }
-}
-export const accidentalModeAtom = atom<"sharps" | "flats" | "auto">(
-  readLegacyAccidentalMode(),
-);
+// ---------------------------------------------------------------------------
+// Audio / UI state
+// ---------------------------------------------------------------------------
+
 // enharmonicDisplayAtom is intentionally non-persisted: "auto" preserves the
 // pre-existing CoF enharmonic-display behavior by default.
 export const enharmonicDisplayAtom = atom<"auto" | "on" | "off">("auto");
+
 export const isMutedAtom = atomWithStorage(
   k("isMuted"),
   false,
@@ -834,12 +250,14 @@ export const isMutedAtom = atomWithStorage(
 export const toggleMuteAtom = atom(null, (get, set) => {
   set(isMutedAtom, !get(isMutedAtom));
 });
+
 export const mobileTabAtom = atomWithStorage<"theory" | "view">(
   k("mobileTab"),
   "theory",
   mobileTabStorage,
   GET_ON_INIT,
 );
+
 export const tabletTabAtom = atomWithStorage<"settings" | "scales">(
   k("tabletTab"),
   "settings",
@@ -859,167 +277,218 @@ export const landscapeNarrowTabAtom = atomWithStorage<LandscapeNarrowTab>(
 // settingsOverlayOpenAtom is intentionally non-persisted and always starts closed.
 export const settingsOverlayOpenAtom = atom<boolean>(false);
 
-// Derived read atoms
-export const useFlatsAtom = atom((get) =>
-  resolveAccidentalMode(
-    get(rootNoteAtom),
-    get(scaleNameAtom),
-    get(accidentalModeAtom),
-  ),
-);
+// ---------------------------------------------------------------------------
+// Derived utility atoms
+// ---------------------------------------------------------------------------
 
 export const currentTuningAtom = atom(
   (get) => TUNINGS[get(tuningNameAtom)] || STANDARD_TUNING,
 );
 
-// --- Scale Derived Atoms ---
+// ---------------------------------------------------------------------------
+// Shape derived atoms
+// ---------------------------------------------------------------------------
 
-export const scaleNotesAtom = atom((get) =>
-  getScaleNotes(get(rootNoteAtom), get(scaleNameAtom)),
-);
-
-export const colorNotesAtom = atom((get) => {
-  const scaleName = get(scaleNameAtom);
+export const shapeDataAtom = atom((get) => {
+  const fingeringPattern = get(fingeringPatternAtom);
   const rootNote = get(rootNoteAtom);
-  const intervals = SCALES[scaleName];
-  if (!intervals) return [];
-  // Minor Blues: blue note is b5 (interval 6)
-  if (scaleName === "Minor Blues") {
-    const rootIdx = NOTES.indexOf(rootNote);
-    return rootIdx >= 0 ? [NOTES[(rootIdx + 6) % 12]] : [];
+  const scaleName = get(scaleNameAtom);
+  const currentTuning = get(currentTuningAtom);
+  const cagedShapes = get(cagedShapesAtom);
+  const npsPosition = get(npsPositionAtom);
+
+  let coords: string[] = [];
+  let bounds: { minFret: number; maxFret: number }[] = [];
+  let polygons: ShapePolygon[] = [];
+  const mergedWrappedNotes = new Set<string>();
+
+  if (fingeringPattern === "caged") {
+    const shapesToRender = CAGED_SHAPES.filter((s) => cagedShapes.has(s));
+    const allCoords = new Set<string>();
+    const allBounds: { minFret: number; maxFret: number }[] = [];
+    const allPolygons: ShapePolygon[] = [];
+    for (const shape of shapesToRender) {
+      const res = getCagedCoordinates(
+        rootNote,
+        shape,
+        scaleName,
+        currentTuning,
+        24,
+      );
+      res.coordinates.forEach((c) => allCoords.add(c));
+      allBounds.push(...res.bounds);
+      allPolygons.push(...res.polygons);
+      res.wrappedNotes.forEach((kk) => mergedWrappedNotes.add(kk));
+    }
+
+    coords = Array.from(allCoords);
+    bounds = allBounds;
+    polygons = allPolygons;
+  } else if (fingeringPattern === "3nps") {
+    const res = get3NPSCoordinates(
+      rootNote,
+      scaleName,
+      currentTuning,
+      24,
+      npsPosition,
+    );
+    coords = res.coordinates;
+    bounds = res.bounds;
+  } else {
+    coords = getScaleNotes(rootNote, scaleName);
   }
-  // Major Blues: blue note is b3 (interval 3)
-  if (scaleName === "Major Blues") {
-    const rootIdx = NOTES.indexOf(rootNote);
-    return rootIdx >= 0 ? [NOTES[(rootIdx + 3) % 12]] : [];
-  }
-  // Modal scales: notes that diverge from the reference major/minor
-  return getDivergentNotes(rootNote, scaleName);
+
+  return {
+    highlightNotes: coords,
+    boxBounds: bounds,
+    shapePolygons: polygons,
+    wrappedNotes: mergedWrappedNotes,
+  };
 });
 
-export const activeBrowseOptionAtom = atom((get) =>
-  getActiveScaleBrowseOption(
-    get(rootNoteAtom),
-    get(scaleNameAtom),
-    get(scaleBrowseModeAtom),
-    get(useFlatsAtom),
-  ),
-);
+export const autoCenterTargetAtom = atom((get) => {
+  const fingeringPattern = get(fingeringPatternAtom);
+  const { shapePolygons, boxBounds, wrappedNotes } = get(shapeDataAtom);
+  const clickedShape = get(clickedShapeAtom);
+  const startFret = get(fretStartAtom);
+  const endFret = get(fretEndAtom);
 
-export const scaleLabelAtom = atom(
-  (get) => `${formatAccidental(get(activeBrowseOptionAtom).label)}`,
-);
+  let target: number | undefined;
 
-export const degreeChipsAtom = atom((get) => {
-  const rootNote = get(rootNoteAtom);
-  const scaleName = get(scaleNameAtom);
-  const scaleNotes = get(scaleNotesAtom);
-  const useFlats = get(useFlatsAtom);
-  const intervals = SCALES[scaleName] || [];
+  if (fingeringPattern === "caged" && shapePolygons.length > 0) {
+    if (clickedShape) {
+      const clickedPoly = shapePolygons.find((p) => p.shape === clickedShape);
+      if (clickedPoly && !clickedPoly.truncated) {
+        target = getShapeCenterFret(clickedPoly);
+      }
+    }
+    if (target === undefined) {
+      const mainShape = findMainShape(
+        shapePolygons,
+        wrappedNotes,
+        startFret,
+        endFret,
+      );
+      if (mainShape) {
+        target = getShapeCenterFret(mainShape);
+      }
+    }
+  } else if (fingeringPattern === "3nps" && boxBounds.length > 0) {
+    const lowestBounds = boxBounds.reduce((a, b) =>
+      a.minFret <= b.minFret ? a : b,
+    );
+    target = lowestBounds.minFret;
+  }
 
-  const rootIdx = NOTES.indexOf(rootNote);
-  return scaleNotes.map((note) => {
-    const noteIdx = NOTES.indexOf(note);
-    const chromaticInterval =
-      rootIdx !== -1 && noteIdx !== -1 ? (noteIdx - rootIdx + 12) % 12 : 0;
-    const interval = INTERVAL_NAMES[chromaticInterval] ?? "1";
-    return {
-      internalNote: note,
-      note: formatAccidental(
-        getNoteDisplayInScale(note, rootNote, intervals, useFlats),
+  return target;
+});
+
+export const isShapeLocalContextAtom = atom((get) => {
+  const fingeringPattern = get(fingeringPatternAtom);
+  const cagedShapes = get(cagedShapesAtom);
+  if (fingeringPattern === "3nps") return true;
+  if (fingeringPattern === "caged" && cagedShapes.size === 1) return true;
+  return false;
+});
+
+export const shapeContextLabelAtom = atom((get) => {
+  const isShapeLocalContext = get(isShapeLocalContextAtom);
+  if (!isShapeLocalContext) return null;
+
+  const fingeringPattern = get(fingeringPatternAtom);
+  if (fingeringPattern === "3nps") {
+    return `In 3NPS position ${get(npsPositionAtom)}`;
+  }
+  if (fingeringPattern === "caged") {
+    const shape = Array.from(get(cagedShapesAtom))[0];
+    return shape ? `In ${shape} shape` : null;
+  }
+  return null;
+});
+
+export const shapeHighlightedNoteSetAtom = atom((get) => {
+  const fingeringPattern = get(fingeringPatternAtom);
+  const { highlightNotes } = get(shapeDataAtom);
+  const currentTuning = get(currentTuningAtom);
+
+  if (fingeringPattern === "all") return null;
+  const noteSet = new Set<string>();
+  for (const coord of highlightNotes) {
+    const dashIdx = coord.indexOf("-");
+    if (dashIdx === -1) continue; // note name, not a coord
+    const stringIdx = parseInt(coord.slice(0, dashIdx), 10);
+    const fretIdx = parseInt(coord.slice(dashIdx + 1), 10);
+    const openNote = currentTuning[stringIdx];
+    if (openNote) noteSet.add(getFretNote(openNote, fretIdx));
+  }
+  return noteSet;
+});
+
+// ---------------------------------------------------------------------------
+// Shape-local atoms (depend on shapeHighlightedNoteSetAtom)
+// ---------------------------------------------------------------------------
+
+export const shapeLocalTargetMembersAtom = atom((get) => {
+  const shapeHighlightedNoteSet = get(shapeHighlightedNoteSetAtom);
+  const chordType = get(chordTypeAtom);
+  const allChordMembers = get(allChordMembersAtom);
+  if (!shapeHighlightedNoteSet || !chordType) return [] as ChordRowEntry[];
+  return allChordMembers.filter((m) =>
+    shapeHighlightedNoteSet.has(m.internalNote),
+  );
+});
+
+export const shapeLocalOutsideMembersAtom = atom((get) => {
+  const shapeHighlightedNoteSet = get(shapeHighlightedNoteSetAtom);
+  const chordType = get(chordTypeAtom);
+  const allChordMembers = get(allChordMembersAtom);
+  if (!shapeHighlightedNoteSet || !chordType) return [] as ChordRowEntry[];
+  return allChordMembers.filter((m) =>
+    !m.inScale && shapeHighlightedNoteSet.has(m.internalNote),
+  );
+});
+
+export const shapeLocalColorNotesFilteredAtom = atom((get) => {
+  const shapeHighlightedNoteSet = get(shapeHighlightedNoteSetAtom);
+  const activeChordTones = get(activeChordTonesAtom);
+  const practiceBarColorNotes = get(practiceBarColorNotesAtom);
+
+  if (!shapeHighlightedNoteSet) return [] as typeof practiceBarColorNotes;
+
+  const chordToneSet = new Set(activeChordTones);
+  return practiceBarColorNotes.filter(
+    (n) =>
+      shapeHighlightedNoteSet.has(n.internalNote) &&
+      !chordToneSet.has(n.internalNote),
+  );
+});
+
+export const shapeLocalColorNotesAtom = atom((get) => {
+  const shapeHighlightedNoteSet = get(shapeHighlightedNoteSetAtom);
+  const practiceBarColorNotes = get(practiceBarColorNotesAtom);
+  if (!shapeHighlightedNoteSet) return [] as typeof practiceBarColorNotes;
+  return practiceBarColorNotes.filter((n) =>
+    shapeHighlightedNoteSet.has(n.internalNote),
+  );
+});
+
+export const shapeLocalPracticeCuesAtom = atom((get) => {
+  const shapeHighlightedNoteSet = get(shapeHighlightedNoteSetAtom);
+  const cues = get(practiceCuesAtom);
+  if (!shapeHighlightedNoteSet) return [] as typeof cues;
+  return cues
+    .map((cue) => ({
+      ...cue,
+      notes: cue.notes.filter((n) =>
+        shapeHighlightedNoteSet.has(n.internalNote),
       ),
-      interval: formatAccidental(interval),
-      inScale: true,
-      isTonic: note === rootNote,
-    };
-  });
+    }))
+    .filter((cue) => cue.notes.length > 0);
 });
 
-// --- Chord Derived Atoms ---
-
-export const chordTonesAtom = atom((get) => {
-  const chordRoot = get(chordRootAtom);
-  const chordType = get(chordTypeAtom);
-  if (!chordType) return [];
-  return getChordNotes(chordRoot, chordType);
-});
-
-export const availableFocusPresetsAtom = atom((get) => {
-  const chordType = get(chordTypeAtom);
-  if (!chordType) return ["all", "custom"] as FocusPreset[];
-  return getAvailableFocusPresets(chordType);
-});
-
-export const chordMembersAtom = atom((get) => {
-  const chordRoot = get(chordRootAtom);
-  const chordType = get(chordTypeAtom);
-  if (!chordType) return [] as ResolvedChordMember[];
-  const def = CHORD_DEFINITIONS[chordType];
-  if (!def) return [] as ResolvedChordMember[];
-  const rootIndex = NOTES.indexOf(chordRoot);
-  if (rootIndex === -1) return [] as ResolvedChordMember[];
-  return def.members.map((m) => ({
-    ...m,
-    note: NOTES[(rootIndex + m.semitone) % 12],
-  }));
-});
-
-export const activeChordMembersAtom = atom((get) => {
-  const chordRoot = get(chordRootAtom);
-  const chordType = get(chordTypeAtom);
-  const focusPreset = get(focusPresetAtom);
-  const customMembers = get(customMembersAtom);
-  const availablePresets = get(availableFocusPresetsAtom);
-
-  if (!chordType) return [] as ResolvedChordMember[];
-  const def = CHORD_DEFINITIONS[chordType];
-  if (!def) return [] as ResolvedChordMember[];
-  const rootIndex = NOTES.indexOf(chordRoot);
-  if (rootIndex === -1) return [] as ResolvedChordMember[];
-  const effectivePreset = availablePresets.includes(focusPreset)
-    ? focusPreset
-    : "all";
-  const members = applyFocusPreset(def, effectivePreset, customMembers);
-  return members.map((m) => ({
-    ...m,
-    note: NOTES[(rootIndex + m.semitone) % 12],
-  }));
-});
-
-export const activeChordTonesAtom = atom((get) =>
-  get(activeChordMembersAtom).map((m) => m.note),
-);
-
-export const hasOutsideChordMembersAtom = atom((get) => {
-  const chordType = get(chordTypeAtom);
-  const chordTones = get(chordTonesAtom);
-  if (!chordType || chordTones.length === 0) return false;
-  const scaleNotes = get(scaleNotesAtom);
-  const scaleNoteSet = new Set(scaleNotes);
-  return chordTones.some((note) => !scaleNoteSet.has(note));
-});
-
-export const chordLabelAtom = atom((get) => {
-  const chordRoot = get(chordRootAtom);
-  const chordType = get(chordTypeAtom);
-  const useFlats = get(useFlatsAtom);
-  if (!chordType) return null;
-  return `${formatAccidental(getNoteDisplay(chordRoot, chordRoot, useFlats))} ${chordType}`;
-});
-
-export const chordSummaryNotesAtom = atom((get) => {
-  const chordType = get(chordTypeAtom);
-  const chordTones = get(chordTonesAtom);
-  const chordRoot = get(chordRootAtom);
-  if (!chordType || chordTones.length === 0) return [] as string[];
-  const chordRootIdx = NOTES.indexOf(chordRoot);
-  const chordToneSet = new Set(chordTones);
-  return NOTES.slice(chordRootIdx)
-    .concat(NOTES.slice(0, chordRootIdx))
-    .filter((n) => chordToneSet.has(n));
-});
-
-// --- UI Logic & Combined Derived Atoms ---
+// ---------------------------------------------------------------------------
+// Combined / summary derived atoms
+// ---------------------------------------------------------------------------
 
 export const noteRoleMapAtom = atom((get) => {
   const chordType = get(chordTypeAtom);
@@ -1047,38 +516,6 @@ export const noteRoleMapAtom = atom((get) => {
     }
   }
   return map;
-});
-
-export const allChordMembersAtom = atom((get) => {
-  const chordType = get(chordTypeAtom);
-  if (!chordType) return [] as ChordRowEntry[];
-
-  const rootNote = get(rootNoteAtom);
-  const scaleName = get(scaleNameAtom);
-  const chordRoot = get(chordRootAtom);
-  const useFlats = get(useFlatsAtom);
-  const activeChordMembers = get(activeChordMembersAtom);
-  const scaleNoteSet = new Set(getScaleNotes(rootNote, scaleName));
-
-  return activeChordMembers.map((m): ChordRowEntry => {
-    const inScale = scaleNoteSet.has(m.note);
-    const isRoot = m.name === "root";
-    let role: ChordRowEntry["role"];
-    if (isRoot) {
-      role = "chord-root";
-    } else if (inScale) {
-      role = "chord-tone-in-scale";
-    } else {
-      role = "chord-tone-outside-scale";
-    }
-    return {
-      internalNote: m.note,
-      displayNote: formatAccidental(getNoteDisplay(m.note, chordRoot, useFlats)),
-      memberName: m.name === "root" ? "1" : formatAccidental(m.name),
-      role,
-      inScale,
-    };
-  });
 });
 
 // All chord members — tension lens shows all notes (not just outside ones).
@@ -1170,496 +607,9 @@ export const outsideChordMembersAtom = atom((get) =>
   get(summaryChordRowAtom).filter((e) => !e.inScale),
 );
 
-export const practiceBarSharedMembersAtom = atom((get) =>
-  get(allChordMembersAtom).filter((e) => e.inScale),
-);
-
-export const practiceBarOutsideMembersAtom = atom((get) =>
-  get(allChordMembersAtom).filter((e) => !e.inScale),
-);
-
-// --- Shape Derived Atoms ---
-
-export const shapeDataAtom = atom((get) => {
-  const fingeringPattern = get(fingeringPatternAtom);
-  const rootNote = get(rootNoteAtom);
-  const scaleName = get(scaleNameAtom);
-  const currentTuning = get(currentTuningAtom);
-  const cagedShapes = get(cagedShapesAtom);
-  const npsPosition = get(npsPositionAtom);
-
-  let coords: string[] = [];
-  let bounds: { minFret: number; maxFret: number }[] = [];
-  let polygons: ShapePolygon[] = [];
-  const mergedWrappedNotes = new Set<string>();
-
-  if (fingeringPattern === "caged") {
-    const shapesToRender = CAGED_SHAPES.filter((s) => cagedShapes.has(s));
-    const allCoords = new Set<string>();
-    const allBounds: { minFret: number; maxFret: number }[] = [];
-    const allPolygons: ShapePolygon[] = [];
-    for (const shape of shapesToRender) {
-      const res = getCagedCoordinates(
-        rootNote,
-        shape,
-        scaleName,
-        currentTuning,
-        24,
-      );
-      res.coordinates.forEach((c) => allCoords.add(c));
-      allBounds.push(...res.bounds);
-      allPolygons.push(...res.polygons);
-      res.wrappedNotes.forEach((k) => mergedWrappedNotes.add(k));
-    }
-
-    coords = Array.from(allCoords);
-    bounds = allBounds;
-    polygons = allPolygons;
-  } else if (fingeringPattern === "3nps") {
-    const res = get3NPSCoordinates(
-      rootNote,
-      scaleName,
-      currentTuning,
-      24,
-      npsPosition,
-    );
-    coords = res.coordinates;
-    bounds = res.bounds;
-  } else {
-    coords = getScaleNotes(rootNote, scaleName);
-  }
-
-  return {
-    highlightNotes: coords,
-    boxBounds: bounds,
-    shapePolygons: polygons,
-    wrappedNotes: mergedWrappedNotes,
-  };
-});
-
-export const autoCenterTargetAtom = atom((get) => {
-  const fingeringPattern = get(fingeringPatternAtom);
-  const { shapePolygons, boxBounds, wrappedNotes } = get(shapeDataAtom);
-  const clickedShape = get(clickedShapeAtom);
-  const startFret = get(fretStartAtom);
-  const endFret = get(fretEndAtom);
-
-  let target: number | undefined;
-
-  if (fingeringPattern === "caged" && shapePolygons.length > 0) {
-    if (clickedShape) {
-      const clickedPoly = shapePolygons.find((p) => p.shape === clickedShape);
-      if (clickedPoly && !clickedPoly.truncated) {
-        target = getShapeCenterFret(clickedPoly);
-      }
-    }
-    if (target === undefined) {
-      const mainShape = findMainShape(
-        shapePolygons,
-        wrappedNotes,
-        startFret,
-        endFret,
-      );
-      if (mainShape) {
-        target = getShapeCenterFret(mainShape);
-      }
-    }
-  } else if (fingeringPattern === "3nps" && boxBounds.length > 0) {
-    const lowestBounds = boxBounds.reduce((a, b) =>
-      a.minFret <= b.minFret ? a : b,
-    );
-    target = lowestBounds.minFret;
-  }
-
-  return target;
-});
-
-export const isShapeLocalContextAtom = atom((get) => {
-  const fingeringPattern = get(fingeringPatternAtom);
-  const cagedShapes = get(cagedShapesAtom);
-  if (fingeringPattern === "3nps") return true;
-  if (fingeringPattern === "caged" && cagedShapes.size === 1) return true;
-  return false;
-});
-
-export const shapeContextLabelAtom = atom((get) => {
-  const isShapeLocalContext = get(isShapeLocalContextAtom);
-  if (!isShapeLocalContext) return null;
-
-  const fingeringPattern = get(fingeringPatternAtom);
-  if (fingeringPattern === "3nps") {
-    return `In 3NPS position ${get(npsPositionAtom)}`;
-  }
-  if (fingeringPattern === "caged") {
-    const shape = Array.from(get(cagedShapesAtom))[0];
-    return shape ? `In ${shape} shape` : null;
-  }
-  return null;
-});
-
-// --- Practice Bar Derived Atoms ---
-
-export const practiceBarColorNotesAtom = atom((get) => {
-  const colorNotes = get(colorNotesAtom);
-  const rootNote = get(rootNoteAtom);
-  const useFlats = get(useFlatsAtom);
-
-  if (colorNotes.length === 0) return [] as PracticeBarColorNote[];
-  const rootIdx = NOTES.indexOf(rootNote);
-  if (rootIdx === -1) return [] as PracticeBarColorNote[];
-  return colorNotes.map((note) => {
-    const noteIdx = NOTES.indexOf(note);
-    const interval = (noteIdx - rootIdx + 12) % 12;
-    const intervalName = INTERVAL_NAMES[interval] ?? "";
-    return {
-      internalNote: note,
-      displayNote: formatAccidental(getNoteDisplay(note, rootNote, useFlats)),
-      intervalName: formatAccidental(intervalName),
-    };
-  });
-});
-
-export const showChordPracticeBarAtom = atom((get) => {
-  const chordType = get(chordTypeAtom);
-  if (!chordType) return false;
-
-  const practiceLens = get(practiceLensAtom);
-
-  // Non-default lenses always show — user explicitly chose a practice focus.
-  if (practiceLens !== "targets-color") return true;
-
-  // For targets-color (default): suppress the bar for the diatonic simple case
-  // where the chord is fully in-scale, root is linked, and no color tones exist
-  // (nothing interesting to coach about).
-  const focusPreset = get(focusPresetAtom);
-  const hasOutsideChordMembers = get(hasOutsideChordMembersAtom);
-  const colorNotes = get(colorNotesAtom);
-  const chordRoot = get(chordRootAtom);
-  const rootNote = get(rootNoteAtom);
-
-  const isDiatonicSimpleCase =
-    focusPreset === "all" &&
-    !hasOutsideChordMembers &&
-    colorNotes.length === 0 &&
-    chordRoot === rootNote;
-
-  return !isDiatonicSimpleCase;
-});
-
-export const practiceBarTitleAtom = atom((get) => {
-  const chordType = get(chordTypeAtom);
-  const chordLabel = get(chordLabelAtom);
-  if (!chordType) return "";
-  return chordLabel ?? "";
-});
-
-// Badge is now minimal — always null (lens context shown via title + shape subtitle).
-export const practiceBarBadgeAtom = atom(() => null as string | null);
-
-export const shapeHighlightedNoteSetAtom = atom((get) => {
-  const fingeringPattern = get(fingeringPatternAtom);
-  const { highlightNotes } = get(shapeDataAtom);
-  const currentTuning = get(currentTuningAtom);
-
-  if (fingeringPattern === "all") return null;
-  const noteSet = new Set<string>();
-  for (const coord of highlightNotes) {
-    const dashIdx = coord.indexOf("-");
-    if (dashIdx === -1) continue; // note name, not a coord
-    const stringIdx = parseInt(coord.slice(0, dashIdx), 10);
-    const fretIdx = parseInt(coord.slice(dashIdx + 1), 10);
-    const openNote = currentTuning[stringIdx];
-    if (openNote) noteSet.add(getFretNote(openNote, fretIdx));
-  }
-  return noteSet;
-});
-
-export const shapeLocalTargetMembersAtom = atom((get) => {
-  const shapeHighlightedNoteSet = get(shapeHighlightedNoteSetAtom);
-  const chordType = get(chordTypeAtom);
-  const allChordMembers = get(allChordMembersAtom);
-  if (!shapeHighlightedNoteSet || !chordType) return [] as ChordRowEntry[];
-  return allChordMembers.filter((m) =>
-    shapeHighlightedNoteSet.has(m.internalNote),
-  );
-});
-
-export const shapeLocalOutsideMembersAtom = atom((get) => {
-  const shapeHighlightedNoteSet = get(shapeHighlightedNoteSetAtom);
-  const chordType = get(chordTypeAtom);
-  const allChordMembers = get(allChordMembersAtom);
-  if (!shapeHighlightedNoteSet || !chordType) return [] as ChordRowEntry[];
-  return allChordMembers.filter((m) =>
-    !m.inScale && shapeHighlightedNoteSet.has(m.internalNote),
-  );
-});
-
-export const practiceBarColorNotesFilteredAtom = atom((get) => {
-  const activeChordTones = get(activeChordTonesAtom);
-  const practiceBarColorNotes = get(practiceBarColorNotesAtom);
-  const chordToneSet = new Set(activeChordTones);
-  return practiceBarColorNotes.filter((n) => !chordToneSet.has(n.internalNote));
-});
-
-export const shapeLocalColorNotesFilteredAtom = atom((get) => {
-  const shapeHighlightedNoteSet = get(shapeHighlightedNoteSetAtom);
-  const activeChordTones = get(activeChordTonesAtom);
-  const practiceBarColorNotes = get(practiceBarColorNotesAtom);
-
-  if (!shapeHighlightedNoteSet) return [] as PracticeBarColorNote[];
-
-  const chordToneSet = new Set(activeChordTones);
-  return practiceBarColorNotes.filter(
-    (n) =>
-      shapeHighlightedNoteSet.has(n.internalNote) &&
-      !chordToneSet.has(n.internalNote),
-  );
-});
-
-export const shapeLocalColorNotesAtom = atom((get) => {
-  const shapeHighlightedNoteSet = get(shapeHighlightedNoteSetAtom);
-  const practiceBarColorNotes = get(practiceBarColorNotesAtom);
-  if (!shapeHighlightedNoteSet) return [] as PracticeBarColorNote[];
-  return practiceBarColorNotes.filter((n) =>
-    shapeHighlightedNoteSet.has(n.internalNote),
-  );
-});
-
 // ---------------------------------------------------------------------------
-// Note Semantic Map — composable properties per note (multiple can coexist)
+// Actions
 // ---------------------------------------------------------------------------
-
-// Guide tone member names: 3rd and 7th (before formatAccidental)
-const GUIDE_TONE_RAW = new Set(["b3", "3", "b7", "7"]);
-// After formatAccidental: "b3"→"♭3", "b7"→"♭7"
-const GUIDE_TONE_FORMATTED = new Set(["♭3", "3", "♭7", "7"]);
-
-/**
- * Returns a map of note → NoteSemantics where multiple boolean properties can
- * coexist on one note. Crucially, a chord root that is outside the scale will
- * have both isChordRoot=true and isTension=true — something the old single-role
- * enum (NoteRole) could not represent.
- */
-export const noteSemanticMapAtom = atom((get) => {
-  const chordType = get(chordTypeAtom);
-  if (!chordType) return new Map<string, NoteSemantics>();
-
-  const rootNote = get(rootNoteAtom);
-  const scaleName = get(scaleNameAtom);
-  const chordRoot = get(chordRootAtom);
-  const activeChordMembers = get(activeChordMembersAtom);
-  const colorNotes = get(colorNotesAtom);
-
-  const scaleNoteSet = new Set(getScaleNotes(rootNote, scaleName));
-  const colorNoteSet = new Set(colorNotes);
-
-  const memberByNote = new Map<string, ResolvedChordMember>();
-  for (const m of activeChordMembers) memberByNote.set(m.note, m);
-  const activeChordToneSet = new Set(activeChordMembers.map((m) => m.note));
-
-  const map = new Map<string, NoteSemantics>();
-  for (const note of NOTES) {
-    const isInScale = scaleNoteSet.has(note);
-    const isChordRoot = note === chordRoot;
-    const isChordTone = activeChordToneSet.has(note);
-    const enh = ENHARMONICS[note];
-    const isColorTone = colorNoteSet.has(note) || (!!enh && colorNoteSet.has(enh));
-    const member = memberByNote.get(note);
-    const isGuideTone = !!(member && GUIDE_TONE_RAW.has(member.name));
-    const isTension = isChordTone && !isInScale;
-    const isScaleRoot =
-      note === rootNote ||
-      ENHARMONICS[note] === rootNote ||
-      ENHARMONICS[rootNote] === note;
-
-    if (isInScale || isChordTone || isColorTone) {
-      map.set(note, {
-        isScaleRoot: !!isScaleRoot,
-        isChordRoot,
-        isChordTone,
-        isInScale,
-        isColorTone,
-        isGuideTone,
-        isTension,
-        memberName: member?.name as ChordMemberName | undefined,
-      });
-    }
-  }
-  return map;
-});
-
-// ---------------------------------------------------------------------------
-// Practice Cues — coaching lines derived from the active practice lens
-// ---------------------------------------------------------------------------
-
-/**
- * Derives ordered coaching cues for the practice bar based on the active lens.
- * Each cue has a label ("Land on", "Guide tones", "Color note", "Tension") and
- * a list of notes with styling hints and optional resolution targets.
- */
-export const practiceCuesAtom = atom((get) => {
-  const chordType = get(chordTypeAtom);
-  if (!chordType) return [] as PracticeCue[];
-
-  const practiceLens = get(practiceLensAtom);
-  const chordRoot = get(chordRootAtom);
-  const useFlats = get(useFlatsAtom);
-  const allChordMembers = get(allChordMembersAtom);
-  const colorNotesFiltered = get(practiceBarColorNotesFilteredAtom);
-  const scaleNotes = get(scaleNotesAtom);
-
-  const displayNote = (note: string) =>
-    formatAccidental(getNoteDisplay(note, chordRoot, useFlats));
-
-  const toCueNote = (e: ChordRowEntry): PracticeCueNote => ({
-    internalNote: e.internalNote,
-    displayNote: e.displayNote,
-    intervalName: e.memberName,
-    role: e.role,
-  });
-
-  // Find the nearest in-scale note (half-step up or down) as a resolution target.
-  const findResolution = (
-    note: string,
-  ): { internalNote: string; displayNote: string } | undefined => {
-    const noteIdx = NOTES.indexOf(note);
-    if (noteIdx === -1) return undefined;
-    const scaleNoteSet = new Set(scaleNotes);
-    const up = NOTES[(noteIdx + 1) % 12];
-    const down = NOTES[(noteIdx + 11) % 12];
-    const resolved = scaleNoteSet.has(up)
-      ? up
-      : scaleNoteSet.has(down)
-        ? down
-        : undefined;
-    if (!resolved) return undefined;
-    return { internalNote: resolved, displayNote: displayNote(resolved) };
-  };
-
-  const cues: PracticeCue[] = [];
-
-  switch (practiceLens) {
-    case "targets": {
-      if (allChordMembers.length > 0) {
-        cues.push({
-          kind: "land-on",
-          label: "Land on",
-          notes: allChordMembers.map(toCueNote),
-        });
-      }
-      break;
-    }
-
-    case "guide-tones": {
-      const guideNotes = allChordMembers.filter((e) =>
-        GUIDE_TONE_FORMATTED.has(e.memberName),
-      );
-      if (guideNotes.length > 0) {
-        cues.push({
-          kind: "guide-tones",
-          label: "Guide tones",
-          notes: guideNotes.map((e) => ({
-            ...toCueNote(e),
-            role: "guide-tone" as const,
-          })),
-        });
-      } else {
-        // Fallback for power chords (no 3rd/7th): show all chord tones.
-        cues.push({
-          kind: "land-on",
-          label: "Land on",
-          notes: allChordMembers.map(toCueNote),
-        });
-      }
-      break;
-    }
-
-    case "color": {
-      if (colorNotesFiltered.length > 0) {
-        cues.push({
-          kind: "color-note",
-          label: colorNotesFiltered.length === 1 ? "Color note" : "Color notes",
-          notes: colorNotesFiltered.map((n) => ({
-            internalNote: n.internalNote,
-            displayNote: n.displayNote,
-            intervalName: n.intervalName,
-            role: "color-tone" as const,
-          })),
-        });
-      }
-      break;
-    }
-
-    case "targets-color": {
-      if (allChordMembers.length > 0) {
-        cues.push({
-          kind: "land-on",
-          label: "Land on",
-          notes: allChordMembers.map(toCueNote),
-        });
-      }
-      if (colorNotesFiltered.length > 0) {
-        cues.push({
-          kind: "color-note",
-          label: colorNotesFiltered.length === 1 ? "Color note" : "Color notes",
-          notes: colorNotesFiltered.map((n) => ({
-            internalNote: n.internalNote,
-            displayNote: n.displayNote,
-            intervalName: n.intervalName,
-            role: "color-tone" as const,
-          })),
-        });
-      }
-      break;
-    }
-
-    case "tension": {
-      if (allChordMembers.length > 0) {
-        cues.push({
-          kind: "land-on",
-          label: "Land on",
-          notes: allChordMembers.map(toCueNote),
-        });
-      }
-      const tensionMembers = allChordMembers.filter((e) => !e.inScale);
-      if (tensionMembers.length > 0) {
-        cues.push({
-          kind: "tension",
-          label: "Tension",
-          notes: tensionMembers.map((e) => ({
-            ...toCueNote(e),
-            role: "chord-tone-outside-scale" as const,
-            resolvesTo: findResolution(e.internalNote),
-          })),
-        });
-      }
-      break;
-    }
-  }
-
-  return cues;
-});
-
-/**
- * Shape-local variant: filters each cue's notes to those present in the
- * currently-highlighted shape positions. Falls back to empty when there's no
- * shape context (fingeringPattern === "all").
- */
-export const shapeLocalPracticeCuesAtom = atom((get) => {
-  const shapeHighlightedNoteSet = get(shapeHighlightedNoteSetAtom);
-  const cues = get(practiceCuesAtom);
-  if (!shapeHighlightedNoteSet) return [] as PracticeCue[];
-  return cues
-    .map((cue) => ({
-      ...cue,
-      notes: cue.notes.filter((n) =>
-        shapeHighlightedNoteSet.has(n.internalNote),
-      ),
-    }))
-    .filter((cue) => cue.notes.length > 0);
-});
-
-// --- Actions ---
 
 // Sets rootNote and syncs chordRoot when linkChordRoot is enabled
 export const setRootNoteAtom = atom(null, (get, set, note: string) => {

--- a/src/store/chordOverlayAtoms.ts
+++ b/src/store/chordOverlayAtoms.ts
@@ -1,0 +1,436 @@
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+import {
+  NOTES,
+  CHORD_DEFINITIONS,
+  getChordNotes,
+  getScaleNotes,
+  getNoteDisplay,
+  getAvailableFocusPresets,
+  applyFocusPreset,
+  formatAccidental,
+} from "../theory";
+import type {
+  ViewMode,
+  FocusPreset,
+  ChordMemberName,
+  ResolvedChordMember,
+  PracticeLens,
+  ChordRowEntry,
+} from "../theory";
+import {
+  k,
+  rawStringStorage,
+  booleanStorage,
+  constrainedNumberStorage,
+  GET_ON_INIT,
+} from "../utils/storage";
+import {
+  scaleNotesAtom,
+  useFlatsAtom,
+  rootNoteAtom,
+  scaleNameAtom,
+} from "./scaleAtoms";
+
+// ---------------------------------------------------------------------------
+// Chord overlay storage adapters
+// ---------------------------------------------------------------------------
+
+// chordType is stored as '' when null (matching old behavior)
+const chordTypeStorage = {
+  getItem(key: string, initialValue: string | null): string | null {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, "");
+        return initialValue;
+      }
+      return stored === "" ? null : stored;
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: string | null): void {
+    try {
+      localStorage.setItem(key, value ?? "");
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+};
+
+const chordFretSpreadStorage = constrainedNumberStorage({ min: 0, max: 4, integer: true });
+
+// ---------------------------------------------------------------------------
+// Practice lens storage adapters
+// ---------------------------------------------------------------------------
+
+const VIEW_MODE_VALUES: ViewMode[] = ["compare", "chord", "outside"];
+
+const viewModeStorage = {
+  getItem(key: string, initialValue: ViewMode): ViewMode {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, initialValue);
+        return initialValue;
+      }
+      if ((VIEW_MODE_VALUES as string[]).includes(stored))
+        return stored as ViewMode;
+      localStorage.setItem(key, initialValue);
+      return initialValue;
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: ViewMode): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+};
+
+const PRACTICE_LENS_VALUES: PracticeLens[] = [
+  "targets",
+  "guide-tones",
+  "color",
+  "targets-color",
+  "tension",
+];
+
+function migrateViewModeToLens(viewMode: string): PracticeLens {
+  switch (viewMode) {
+    case "chord": return "targets";
+    case "outside": return "tension";
+    default: return "targets-color";
+  }
+}
+
+const practiceLensStorage = {
+  getItem(key: string, initialValue: PracticeLens): PracticeLens {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored !== null) {
+        if ((PRACTICE_LENS_VALUES as string[]).includes(stored))
+          return stored as PracticeLens;
+        localStorage.setItem(key, initialValue);
+        return initialValue;
+      }
+      // One-time migration: map old viewMode to a lens on first access
+      const oldViewMode = localStorage.getItem(k("viewMode"));
+      if (oldViewMode) {
+        const migrated = migrateViewModeToLens(oldViewMode);
+        localStorage.setItem(key, migrated);
+        return migrated;
+      }
+      localStorage.setItem(key, initialValue);
+      return initialValue;
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: PracticeLens): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+};
+
+const FOCUS_PRESET_VALUES: FocusPreset[] = [
+  "all",
+  "triad",
+  "shell",
+  "guide-tones",
+  "rootless",
+  "custom",
+];
+
+const focusPresetStorage = {
+  getItem(key: string, initialValue: FocusPreset): FocusPreset {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, initialValue);
+        return initialValue;
+      }
+      if ((FOCUS_PRESET_VALUES as string[]).includes(stored))
+        return stored as FocusPreset;
+      localStorage.setItem(key, initialValue);
+      return initialValue;
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: FocusPreset): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+};
+
+const customMembersStorage = {
+  getItem(key: string, initialValue: ChordMemberName[]): ChordMemberName[] {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, JSON.stringify(initialValue));
+        return initialValue;
+      }
+      try {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) return parsed as ChordMemberName[];
+        return initialValue;
+      } catch {
+        return initialValue;
+      }
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: ChordMemberName[]): void {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Chord overlay base atoms
+// ---------------------------------------------------------------------------
+
+export const chordRootAtom = atomWithStorage(
+  k("chordRoot"),
+  "C",
+  rawStringStorage(),
+  GET_ON_INIT,
+);
+
+export const chordTypeAtom = atomWithStorage<string | null>(
+  k("chordType"),
+  null,
+  chordTypeStorage,
+  GET_ON_INIT,
+);
+
+export const linkChordRootAtom = atomWithStorage(
+  k("linkChordRoot"),
+  true,
+  booleanStorage,
+  GET_ON_INIT,
+);
+
+export const chordFretSpreadAtom = atomWithStorage(
+  k("chordFretSpread"),
+  0,
+  chordFretSpreadStorage,
+  GET_ON_INIT,
+);
+
+// ---------------------------------------------------------------------------
+// Practice lens base atoms
+// ---------------------------------------------------------------------------
+
+export const viewModeAtom = atomWithStorage<ViewMode>(
+  k("viewMode"),
+  "compare",
+  viewModeStorage,
+  GET_ON_INIT,
+);
+
+// Primary user-facing practice state — replaces viewMode as the UI concept.
+// Stored separately; migrates from old viewMode on first access.
+export const practiceLensAtom = atomWithStorage<PracticeLens>(
+  k("practiceLens"),
+  "targets-color",
+  practiceLensStorage,
+  GET_ON_INIT,
+);
+
+export const focusPresetAtom = atomWithStorage<FocusPreset>(
+  k("focusPreset"),
+  "all",
+  focusPresetStorage,
+  GET_ON_INIT,
+);
+
+export const customMembersAtom = atomWithStorage<ChordMemberName[]>(
+  k("customMembers"),
+  [],
+  customMembersStorage,
+  GET_ON_INIT,
+);
+
+// ---------------------------------------------------------------------------
+// Overlay semantics — lens availability + derived flags
+// ---------------------------------------------------------------------------
+
+// Targets lens hides scale-only notes so only chord tones are shown.
+export const hideNonChordNotesAtom = atom(
+  (get) => get(practiceLensAtom) === "targets",
+);
+
+// ---------------------------------------------------------------------------
+// Chord derived atoms
+// ---------------------------------------------------------------------------
+
+export const chordTonesAtom = atom((get) => {
+  const chordRoot = get(chordRootAtom);
+  const chordType = get(chordTypeAtom);
+  if (!chordType) return [];
+  return getChordNotes(chordRoot, chordType);
+});
+
+export const availableFocusPresetsAtom = atom((get) => {
+  const chordType = get(chordTypeAtom);
+  if (!chordType) return ["all", "custom"] as FocusPreset[];
+  return getAvailableFocusPresets(chordType);
+});
+
+export const chordMembersAtom = atom((get) => {
+  const chordRoot = get(chordRootAtom);
+  const chordType = get(chordTypeAtom);
+  if (!chordType) return [] as ResolvedChordMember[];
+  const def = CHORD_DEFINITIONS[chordType];
+  if (!def) return [] as ResolvedChordMember[];
+  const rootIndex = NOTES.indexOf(chordRoot);
+  if (rootIndex === -1) return [] as ResolvedChordMember[];
+  return def.members.map((m) => ({
+    ...m,
+    note: NOTES[(rootIndex + m.semitone) % 12],
+  }));
+});
+
+export const activeChordMembersAtom = atom((get) => {
+  const chordRoot = get(chordRootAtom);
+  const chordType = get(chordTypeAtom);
+  const focusPreset = get(focusPresetAtom);
+  const customMembers = get(customMembersAtom);
+  const availablePresets = get(availableFocusPresetsAtom);
+
+  if (!chordType) return [] as ResolvedChordMember[];
+  const def = CHORD_DEFINITIONS[chordType];
+  if (!def) return [] as ResolvedChordMember[];
+  const rootIndex = NOTES.indexOf(chordRoot);
+  if (rootIndex === -1) return [] as ResolvedChordMember[];
+  const effectivePreset = availablePresets.includes(focusPreset)
+    ? focusPreset
+    : "all";
+  const members = applyFocusPreset(def, effectivePreset, customMembers);
+  return members.map((m) => ({
+    ...m,
+    note: NOTES[(rootIndex + m.semitone) % 12],
+  }));
+});
+
+export const activeChordTonesAtom = atom((get) =>
+  get(activeChordMembersAtom).map((m) => m.note),
+);
+
+export const hasOutsideChordMembersAtom = atom((get) => {
+  const chordType = get(chordTypeAtom);
+  const chordTones = get(chordTonesAtom);
+  if (!chordType || chordTones.length === 0) return false;
+  const scaleNotes = get(scaleNotesAtom);
+  const scaleNoteSet = new Set(scaleNotes);
+  return chordTones.some((note) => !scaleNoteSet.has(note));
+});
+
+export const chordLabelAtom = atom((get) => {
+  const chordRoot = get(chordRootAtom);
+  const chordType = get(chordTypeAtom);
+  const useFlats = get(useFlatsAtom);
+  if (!chordType) return null;
+  return `${formatAccidental(getNoteDisplay(chordRoot, chordRoot, useFlats))} ${chordType}`;
+});
+
+export const chordSummaryNotesAtom = atom((get) => {
+  const chordType = get(chordTypeAtom);
+  const chordTones = get(chordTonesAtom);
+  const chordRoot = get(chordRootAtom);
+  if (!chordType || chordTones.length === 0) return [] as string[];
+  const chordRootIdx = NOTES.indexOf(chordRoot);
+  const chordToneSet = new Set(chordTones);
+  return NOTES.slice(chordRootIdx)
+    .concat(NOTES.slice(0, chordRootIdx))
+    .filter((n) => chordToneSet.has(n));
+});
+
+// ---------------------------------------------------------------------------
+// allChordMembersAtom — ChordRowEntry list with scale-membership and roles
+// Used by practiceLensAtoms and atoms.ts summary atoms.
+// ---------------------------------------------------------------------------
+
+export const allChordMembersAtom = atom((get) => {
+  const chordType = get(chordTypeAtom);
+  if (!chordType) return [] as ChordRowEntry[];
+
+  const rootNote = get(rootNoteAtom);
+  const scaleName = get(scaleNameAtom);
+  const chordRoot = get(chordRootAtom);
+  const useFlats = get(useFlatsAtom);
+  const activeChordMembers = get(activeChordMembersAtom);
+  const scaleNoteSet = new Set(getScaleNotes(rootNote, scaleName));
+
+  return activeChordMembers.map((m): ChordRowEntry => {
+    const inScale = scaleNoteSet.has(m.note);
+    const isRoot = m.name === "root";
+    let role: ChordRowEntry["role"];
+    if (isRoot) {
+      role = "chord-root";
+    } else if (inScale) {
+      role = "chord-tone-in-scale";
+    } else {
+      role = "chord-tone-outside-scale";
+    }
+    return {
+      internalNote: m.note,
+      displayNote: formatAccidental(getNoteDisplay(m.note, chordRoot, useFlats)),
+      memberName: m.name === "root" ? "1" : formatAccidental(m.name),
+      role,
+      inScale,
+    };
+  });
+});

--- a/src/store/chordOverlayAtoms.ts
+++ b/src/store/chordOverlayAtoms.ts
@@ -133,7 +133,10 @@ const practiceLensStorage = {
         return initialValue;
       }
       // One-time migration: map old viewMode to a lens on first access
-      const oldViewMode = localStorage.getItem(k("viewMode"));
+      let oldViewMode = localStorage.getItem(k("viewMode"));
+      if (!oldViewMode) {
+        oldViewMode = localStorage.getItem("viewMode");
+      }
       if (oldViewMode) {
         const migrated = migrateViewModeToLens(oldViewMode);
         localStorage.setItem(key, migrated);

--- a/src/store/fingeringAtoms.ts
+++ b/src/store/fingeringAtoms.ts
@@ -1,0 +1,91 @@
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+import {
+  CAGED_SHAPES,
+  type CagedShape,
+} from "../shapes";
+import {
+  k,
+  rawStringStorage,
+  constrainedNumberStorage,
+  GET_ON_INIT,
+} from "../utils/storage";
+
+export type FingeringPattern = "all" | "caged" | "3nps";
+
+const cagedShapesStorage = {
+  getItem(key: string, initialValue: Set<CagedShape>): Set<CagedShape> {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, JSON.stringify(Array.from(initialValue)));
+        return initialValue;
+      }
+      try {
+        return new Set(JSON.parse(stored) as CagedShape[]);
+      } catch {
+        return initialValue;
+      }
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: Set<CagedShape>): void {
+    try {
+      localStorage.setItem(key, JSON.stringify(Array.from(value)));
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+};
+
+const npsPositionStorage = constrainedNumberStorage({ min: 1, max: 12, integer: true });
+
+export const fingeringPatternAtom = atomWithStorage<FingeringPattern>(
+  k("fingeringPattern"),
+  "all",
+  rawStringStorage<FingeringPattern>(),
+  GET_ON_INIT,
+);
+
+export const cagedShapesAtom = atomWithStorage<Set<CagedShape>>(
+  k("cagedShapes"),
+  new Set(CAGED_SHAPES),
+  cagedShapesStorage,
+  GET_ON_INIT,
+);
+
+export const toggleCagedShapeAtom = atom(null, (get, set, shape: CagedShape) => {
+  const prev = get(cagedShapesAtom);
+  const next = new Set(prev);
+  if (next.has(shape)) {
+    if (next.size > 1) next.delete(shape);
+  } else {
+    next.add(shape);
+  }
+  set(cagedShapesAtom, next);
+});
+
+export const selectSingleCagedShapeAtom = atom(
+  null,
+  (_get, set, shape: CagedShape) => {
+    set(cagedShapesAtom, new Set([shape]));
+  },
+);
+
+export const npsPositionAtom = atomWithStorage(
+  k("npsPosition"),
+  1,
+  npsPositionStorage,
+  GET_ON_INIT,
+);
+
+export const clickedShapeAtom = atom<CagedShape | null>(null);
+export const recenterKeyAtom = atom<number>(0);

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -1,0 +1,334 @@
+import { atom } from "jotai";
+import {
+  NOTES,
+  ENHARMONICS,
+  INTERVAL_NAMES,
+  getScaleNotes,
+  getNoteDisplay,
+  formatAccidental,
+} from "../theory";
+import type {
+  ChordMemberName,
+  NoteSemantics,
+  PracticeCue,
+  PracticeCueNote,
+  ChordRowEntry,
+  PracticeBarColorNote,
+} from "../theory";
+import {
+  rootNoteAtom,
+  scaleNameAtom,
+  scaleNotesAtom,
+  colorNotesAtom,
+  useFlatsAtom,
+} from "./scaleAtoms";
+import {
+  chordRootAtom,
+  chordTypeAtom,
+  chordLabelAtom,
+  practiceLensAtom,
+  focusPresetAtom,
+  hasOutsideChordMembersAtom,
+  activeChordMembersAtom,
+  activeChordTonesAtom,
+  allChordMembersAtom,
+} from "./chordOverlayAtoms";
+
+// Guide tone member names: 3rd and 7th (before formatAccidental)
+const GUIDE_TONE_RAW = new Set(["b3", "3", "b7", "7"]);
+// After formatAccidental: "b3"→"♭3", "b7"→"♭7"
+const GUIDE_TONE_FORMATTED = new Set(["♭3", "3", "♭7", "7"]);
+
+// ---------------------------------------------------------------------------
+// Practice bar color notes — derived from scale color tones
+// ---------------------------------------------------------------------------
+
+export const practiceBarColorNotesAtom = atom((get) => {
+  const colorNotes = get(colorNotesAtom);
+  const rootNote = get(rootNoteAtom);
+  const useFlats = get(useFlatsAtom);
+
+  if (colorNotes.length === 0) return [] as PracticeBarColorNote[];
+  const rootIdx = NOTES.indexOf(rootNote);
+  if (rootIdx === -1) return [] as PracticeBarColorNote[];
+  return colorNotes.map((note) => {
+    const noteIdx = NOTES.indexOf(note);
+    const interval = (noteIdx - rootIdx + 12) % 12;
+    const intervalName = INTERVAL_NAMES[interval] ?? "";
+    return {
+      internalNote: note,
+      displayNote: formatAccidental(getNoteDisplay(note, rootNote, useFlats)),
+      intervalName: formatAccidental(intervalName),
+    };
+  });
+});
+
+export const practiceBarColorNotesFilteredAtom = atom((get) => {
+  const activeChordTones = get(activeChordTonesAtom);
+  const practiceBarColorNotes = get(practiceBarColorNotesAtom);
+  const chordToneSet = new Set(activeChordTones);
+  return practiceBarColorNotes.filter((n) => !chordToneSet.has(n.internalNote));
+});
+
+// ---------------------------------------------------------------------------
+// Note semantic map — composable properties per note (multiple can coexist)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a map of note → NoteSemantics where multiple boolean properties can
+ * coexist on one note. Crucially, a chord root that is outside the scale will
+ * have both isChordRoot=true and isTension=true — something the old single-role
+ * enum (NoteRole) could not represent.
+ */
+export const noteSemanticMapAtom = atom((get) => {
+  const chordType = get(chordTypeAtom);
+  if (!chordType) return new Map<string, NoteSemantics>();
+
+  const rootNote = get(rootNoteAtom);
+  const scaleName = get(scaleNameAtom);
+  const chordRoot = get(chordRootAtom);
+  const activeChordMembers = get(activeChordMembersAtom);
+  const colorNotes = get(colorNotesAtom);
+
+  const scaleNoteSet = new Set(getScaleNotes(rootNote, scaleName));
+  const colorNoteSet = new Set(colorNotes);
+
+  const memberByNote = new Map<string, (typeof activeChordMembers)[number]>();
+  for (const m of activeChordMembers) memberByNote.set(m.note, m);
+  const activeChordToneSet = new Set(activeChordMembers.map((m) => m.note));
+
+  const map = new Map<string, NoteSemantics>();
+  for (const note of NOTES) {
+    const isInScale = scaleNoteSet.has(note);
+    const isChordRoot = note === chordRoot;
+    const isChordTone = activeChordToneSet.has(note);
+    const enh = ENHARMONICS[note];
+    const isColorTone = colorNoteSet.has(note) || (!!enh && colorNoteSet.has(enh));
+    const member = memberByNote.get(note);
+    const isGuideTone = !!(member && GUIDE_TONE_RAW.has(member.name));
+    const isTension = isChordTone && !isInScale;
+    const isScaleRoot =
+      note === rootNote ||
+      ENHARMONICS[note] === rootNote ||
+      ENHARMONICS[rootNote] === note;
+
+    if (isInScale || isChordTone || isColorTone) {
+      map.set(note, {
+        isScaleRoot: !!isScaleRoot,
+        isChordRoot,
+        isChordTone,
+        isInScale,
+        isColorTone,
+        isGuideTone,
+        isTension,
+        memberName: member?.name as ChordMemberName | undefined,
+      });
+    }
+  }
+  return map;
+});
+
+// ---------------------------------------------------------------------------
+// Practice cues — coaching lines derived from the active practice lens
+// ---------------------------------------------------------------------------
+
+/**
+ * Derives ordered coaching cues for the practice bar based on the active lens.
+ * Each cue has a label ("Land on", "Guide tones", "Color note", "Tension") and
+ * a list of notes with styling hints and optional resolution targets.
+ */
+export const practiceCuesAtom = atom((get) => {
+  const chordType = get(chordTypeAtom);
+  if (!chordType) return [] as PracticeCue[];
+
+  const practiceLens = get(practiceLensAtom);
+  const chordRoot = get(chordRootAtom);
+  const useFlats = get(useFlatsAtom);
+  const allChordMembers = get(allChordMembersAtom);
+  const colorNotesFiltered = get(practiceBarColorNotesFilteredAtom);
+  const scaleNotes = get(scaleNotesAtom);
+
+  const displayNote = (note: string) =>
+    formatAccidental(getNoteDisplay(note, chordRoot, useFlats));
+
+  const toCueNote = (e: ChordRowEntry): PracticeCueNote => ({
+    internalNote: e.internalNote,
+    displayNote: e.displayNote,
+    intervalName: e.memberName,
+    role: e.role,
+  });
+
+  // Find the nearest in-scale note (half-step up or down) as a resolution target.
+  const findResolution = (
+    note: string,
+  ): { internalNote: string; displayNote: string } | undefined => {
+    const noteIdx = NOTES.indexOf(note);
+    if (noteIdx === -1) return undefined;
+    const scaleNoteSet = new Set(scaleNotes);
+    const up = NOTES[(noteIdx + 1) % 12];
+    const down = NOTES[(noteIdx + 11) % 12];
+    const resolved = scaleNoteSet.has(up)
+      ? up
+      : scaleNoteSet.has(down)
+        ? down
+        : undefined;
+    if (!resolved) return undefined;
+    return { internalNote: resolved, displayNote: displayNote(resolved) };
+  };
+
+  const cues: PracticeCue[] = [];
+
+  switch (practiceLens) {
+    case "targets": {
+      if (allChordMembers.length > 0) {
+        cues.push({
+          kind: "land-on",
+          label: "Land on",
+          notes: allChordMembers.map(toCueNote),
+        });
+      }
+      break;
+    }
+
+    case "guide-tones": {
+      const guideNotes = allChordMembers.filter((e) =>
+        GUIDE_TONE_FORMATTED.has(e.memberName),
+      );
+      if (guideNotes.length > 0) {
+        cues.push({
+          kind: "guide-tones",
+          label: "Guide tones",
+          notes: guideNotes.map((e) => ({
+            ...toCueNote(e),
+            role: "guide-tone" as const,
+          })),
+        });
+      } else {
+        // Fallback for power chords (no 3rd/7th): show all chord tones.
+        cues.push({
+          kind: "land-on",
+          label: "Land on",
+          notes: allChordMembers.map(toCueNote),
+        });
+      }
+      break;
+    }
+
+    case "color": {
+      if (colorNotesFiltered.length > 0) {
+        cues.push({
+          kind: "color-note",
+          label: colorNotesFiltered.length === 1 ? "Color note" : "Color notes",
+          notes: colorNotesFiltered.map((n) => ({
+            internalNote: n.internalNote,
+            displayNote: n.displayNote,
+            intervalName: n.intervalName,
+            role: "color-tone" as const,
+          })),
+        });
+      }
+      break;
+    }
+
+    case "targets-color": {
+      if (allChordMembers.length > 0) {
+        cues.push({
+          kind: "land-on",
+          label: "Land on",
+          notes: allChordMembers.map(toCueNote),
+        });
+      }
+      if (colorNotesFiltered.length > 0) {
+        cues.push({
+          kind: "color-note",
+          label: colorNotesFiltered.length === 1 ? "Color note" : "Color notes",
+          notes: colorNotesFiltered.map((n) => ({
+            internalNote: n.internalNote,
+            displayNote: n.displayNote,
+            intervalName: n.intervalName,
+            role: "color-tone" as const,
+          })),
+        });
+      }
+      break;
+    }
+
+    case "tension": {
+      if (allChordMembers.length > 0) {
+        cues.push({
+          kind: "land-on",
+          label: "Land on",
+          notes: allChordMembers.map(toCueNote),
+        });
+      }
+      const tensionMembers = allChordMembers.filter((e) => !e.inScale);
+      if (tensionMembers.length > 0) {
+        cues.push({
+          kind: "tension",
+          label: "Tension",
+          notes: tensionMembers.map((e) => ({
+            ...toCueNote(e),
+            role: "chord-tone-outside-scale" as const,
+            resolvesTo: findResolution(e.internalNote),
+          })),
+        });
+      }
+      break;
+    }
+  }
+
+  return cues;
+});
+
+// ---------------------------------------------------------------------------
+// Practice bar visibility + title
+// ---------------------------------------------------------------------------
+
+export const showChordPracticeBarAtom = atom((get) => {
+  const chordType = get(chordTypeAtom);
+  if (!chordType) return false;
+
+  const practiceLens = get(practiceLensAtom);
+
+  // Non-default lenses always show — user explicitly chose a practice focus.
+  if (practiceLens !== "targets-color") return true;
+
+  // For targets-color (default): suppress the bar for the diatonic simple case
+  // where the chord is fully in-scale, root is linked, and no color tones exist
+  // (nothing interesting to coach about).
+  const focusPreset = get(focusPresetAtom);
+  const hasOutsideChordMembers = get(hasOutsideChordMembersAtom);
+  const colorNotes = get(colorNotesAtom);
+  const chordRoot = get(chordRootAtom);
+  const rootNote = get(rootNoteAtom);
+
+  const isDiatonicSimpleCase =
+    focusPreset === "all" &&
+    !hasOutsideChordMembers &&
+    colorNotes.length === 0 &&
+    chordRoot === rootNote;
+
+  return !isDiatonicSimpleCase;
+});
+
+export const practiceBarTitleAtom = atom((get) => {
+  const chordType = get(chordTypeAtom);
+  const chordLabel = get(chordLabelAtom);
+  if (!chordType) return "";
+  return chordLabel ?? "";
+});
+
+// Badge is now minimal — always null (lens context shown via title + shape subtitle).
+export const practiceBarBadgeAtom = atom(() => null as string | null);
+
+// ---------------------------------------------------------------------------
+// Practice bar member rows (shared/outside split)
+// ---------------------------------------------------------------------------
+
+export const practiceBarSharedMembersAtom = atom((get) =>
+  get(allChordMembersAtom).filter((e) => e.inScale),
+);
+
+export const practiceBarOutsideMembersAtom = atom((get) =>
+  get(allChordMembersAtom).filter((e) => !e.inScale),
+);

--- a/src/store/scaleAtoms.ts
+++ b/src/store/scaleAtoms.ts
@@ -1,0 +1,269 @@
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+import {
+  normalizeScaleName,
+  type ScaleBrowseMode,
+  getActiveScaleBrowseOption,
+} from "../theoryCatalog";
+import {
+  resolveAccidentalMode,
+  SCALES,
+  NOTES,
+  INTERVAL_NAMES,
+  getScaleNotes,
+  getNoteDisplayInScale,
+  getDivergentNotes,
+  formatAccidental,
+} from "../theory";
+import { k, rawStringStorage, GET_ON_INIT } from "../utils/storage";
+import { fingeringPatternAtom, cagedShapesAtom } from "./fingeringAtoms";
+import type { CagedShape } from "../shapes";
+
+// ---------------------------------------------------------------------------
+// Scale-specific storage adapters
+// ---------------------------------------------------------------------------
+
+const SCALE_BROWSE_MODES = ["parallel", "relative"] as const;
+
+const scaleBrowseModeStorage = {
+  getItem(key: string, initialValue: ScaleBrowseMode): ScaleBrowseMode {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, initialValue);
+        return initialValue;
+      }
+      if ((SCALE_BROWSE_MODES as readonly string[]).includes(stored)) {
+        return stored as ScaleBrowseMode;
+      }
+      localStorage.setItem(key, initialValue);
+      return initialValue;
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: ScaleBrowseMode): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+};
+
+const scaleNameStorage = {
+  getItem(key: string, initialValue: string): string {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, initialValue);
+        return initialValue;
+      }
+      const normalized = normalizeScaleName(stored);
+      if (normalized !== stored) {
+        localStorage.setItem(key, normalized);
+      }
+      return normalized;
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: string): void {
+    try {
+      localStorage.setItem(key, normalizeScaleName(value));
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Scale base atoms
+// ---------------------------------------------------------------------------
+
+export const rootNoteAtom = atomWithStorage(
+  k("rootNote"),
+  "C",
+  rawStringStorage(),
+  GET_ON_INIT,
+);
+
+export const baseScaleNameAtom = atomWithStorage(
+  k("scaleName"),
+  "Major",
+  scaleNameStorage,
+  GET_ON_INIT,
+);
+
+// Primary scale setter: resets CAGED shapes to "E" when scale changes,
+// matching old useDisplayState useEffect.
+export const scaleNameAtom = atom(
+  (get) => get(baseScaleNameAtom),
+  (get, set, value: string) => {
+    const nextScale = normalizeScaleName(value);
+    const prevScale = get(baseScaleNameAtom);
+    if (nextScale !== prevScale) {
+      set(baseScaleNameAtom, nextScale);
+      if (get(fingeringPatternAtom) === "caged") {
+        set(cagedShapesAtom, new Set<CagedShape>(["E"]));
+      }
+    }
+  },
+);
+
+export const scaleBrowseModeAtom = atomWithStorage<ScaleBrowseMode>(
+  k("scaleBrowseMode"),
+  "parallel",
+  scaleBrowseModeStorage,
+  GET_ON_INIT,
+);
+
+// ---------------------------------------------------------------------------
+// Accidentals — session-only, not persisted
+// ---------------------------------------------------------------------------
+
+// Reads a one-time legacy "useFlats" key from localStorage and translates it
+// to the new mode. Clears the legacy key so subsequent loads start at "auto".
+function readLegacyAccidentalMode(): "sharps" | "flats" | "auto" {
+  try {
+    const legacy = localStorage.getItem("useFlats");
+    if (legacy === null) return "auto";
+    localStorage.removeItem("useFlats");
+    return legacy === "true" ? "flats" : "sharps";
+  } catch {
+    return "auto";
+  }
+}
+
+// Non-persisted: "auto" is a smart default that picks the best enharmonic
+// spelling per root+scale, so session-only state avoids sticking a stale
+// user choice across sessions.
+export const accidentalModeAtom = atom<"sharps" | "flats" | "auto">(
+  readLegacyAccidentalMode(),
+);
+
+export const useFlatsAtom = atom((get) =>
+  resolveAccidentalMode(
+    get(rootNoteAtom),
+    get(scaleNameAtom),
+    get(accidentalModeAtom),
+  ),
+);
+
+// ---------------------------------------------------------------------------
+// Scale derived atoms
+// ---------------------------------------------------------------------------
+
+export const scaleNotesAtom = atom((get) =>
+  getScaleNotes(get(rootNoteAtom), get(scaleNameAtom)),
+);
+
+export const colorNotesAtom = atom((get) => {
+  const scaleName = get(scaleNameAtom);
+  const rootNote = get(rootNoteAtom);
+  const intervals = SCALES[scaleName];
+  if (!intervals) return [];
+  // Minor Blues: blue note is b5 (interval 6)
+  if (scaleName === "Minor Blues") {
+    const rootIdx = NOTES.indexOf(rootNote);
+    return rootIdx >= 0 ? [NOTES[(rootIdx + 6) % 12]] : [];
+  }
+  // Major Blues: blue note is b3 (interval 3)
+  if (scaleName === "Major Blues") {
+    const rootIdx = NOTES.indexOf(rootNote);
+    return rootIdx >= 0 ? [NOTES[(rootIdx + 3) % 12]] : [];
+  }
+  // Modal scales: notes that diverge from the reference major/minor
+  return getDivergentNotes(rootNote, scaleName);
+});
+
+export const activeBrowseOptionAtom = atom((get) =>
+  getActiveScaleBrowseOption(
+    get(rootNoteAtom),
+    get(scaleNameAtom),
+    get(scaleBrowseModeAtom),
+    get(useFlatsAtom),
+  ),
+);
+
+export const scaleLabelAtom = atom(
+  (get) => `${formatAccidental(get(activeBrowseOptionAtom).label)}`,
+);
+
+export const degreeChipsAtom = atom((get) => {
+  const rootNote = get(rootNoteAtom);
+  const scaleName = get(scaleNameAtom);
+  const scaleNotes = get(scaleNotesAtom);
+  const useFlats = get(useFlatsAtom);
+  const intervals = SCALES[scaleName] || [];
+
+  const rootIdx = NOTES.indexOf(rootNote);
+  return scaleNotes.map((note) => {
+    const noteIdx = NOTES.indexOf(note);
+    const chromaticInterval =
+      rootIdx !== -1 && noteIdx !== -1 ? (noteIdx - rootIdx + 12) % 12 : 0;
+    const interval = INTERVAL_NAMES[chromaticInterval] ?? "1";
+    return {
+      internalNote: note,
+      note: formatAccidental(
+        getNoteDisplayInScale(note, rootNote, intervals, useFlats),
+      ),
+      interval: formatAccidental(interval),
+      inScale: true,
+      isTonic: note === rootNote,
+    };
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hidden notes — transient (resets when root or scale changes)
+// ---------------------------------------------------------------------------
+
+const internalHiddenNotesAtom = atom<{
+  root: string;
+  scale: string;
+  notes: Set<string>;
+} | null>(null);
+
+export const hiddenNotesAtom = atom(
+  (get) => {
+    const state = get(internalHiddenNotesAtom);
+    const root = get(rootNoteAtom);
+    const scale = get(scaleNameAtom);
+    if (state && state.root === root && state.scale === scale) {
+      return state.notes;
+    }
+    return new Set<string>();
+  },
+  (get, set, update: Set<string> | ((prev: Set<string>) => Set<string>)) => {
+    const root = get(rootNoteAtom);
+    const scale = get(scaleNameAtom);
+    const currentNotes = get(hiddenNotesAtom);
+    const nextNotes =
+      typeof update === "function" ? update(currentNotes) : update;
+    set(internalHiddenNotesAtom, { root, scale, notes: nextNotes });
+  },
+);
+
+export const toggleHiddenNoteAtom = atom(null, (_get, set, note: string) => {
+  set(hiddenNotesAtom, (prev) => {
+    const next = new Set(prev);
+    if (next.has(note)) next.delete(note);
+    else next.add(note);
+    return next;
+  });
+});

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -2,3 +2,183 @@ export const STORAGE_PREFIX = "fretflow:";
 export const storageKey = (key: string) => `${STORAGE_PREFIX}${key}`;
 // Shorthand alias for convenience
 export const k = storageKey;
+
+// ---------------------------------------------------------------------------
+// Legacy key migration — runs once at module load, before any atom reads.
+// This module is imported by every domain atom file, so the migration is
+// guaranteed to finish before any atomWithStorage({ getOnInit: true }) reads.
+// ---------------------------------------------------------------------------
+
+const LEGACY_KEYS = [
+  "rootNote",
+  "scaleName",
+  "chordRoot",
+  "chordType",
+  "linkChordRoot",
+  "hideNonChordNotes",
+  "chordFretSpread",
+  "chordIntervalFilter",
+  "fingeringPattern",
+  "cagedShapes",
+  "npsPosition",
+  "displayFormat",
+  "tuningName",
+  "fretZoom",
+  "fretStart",
+  "fretEnd",
+  "isMuted",
+  "mobileTab",
+  "tabletTab",
+  "landscapeNarrowTab",
+] as const;
+
+function migrateLegacyKeys() {
+  // Idempotent: only migrates when prefixed key doesn't exist.
+  // Also removes the legacy key after copying to reduce drift.
+  try {
+    for (const legacyKey of LEGACY_KEYS) {
+      const prefixedKey = k(legacyKey);
+      if (localStorage.getItem(prefixedKey) !== null) {
+        localStorage.removeItem(legacyKey);
+        continue;
+      }
+      const legacyValue = localStorage.getItem(legacyKey);
+      if (legacyValue === null) continue;
+      localStorage.setItem(prefixedKey, legacyValue);
+      localStorage.removeItem(legacyKey);
+    }
+  } catch {
+    // If storage is blocked or throws (Safari private mode, etc), ignore.
+  }
+}
+migrateLegacyKeys();
+
+// Passed to atomWithStorage to read localStorage synchronously on atom
+// initialization, preventing a visible flash from the hardcoded default.
+export const GET_ON_INIT = { getOnInit: true } as const;
+
+// ---------------------------------------------------------------------------
+// Generic localStorage adapters — match the old localStorage.setItem(key, String(value))
+// format and write defaults on first access.
+// ---------------------------------------------------------------------------
+
+export function rawStringStorage<T extends string>() {
+  return {
+    getItem(key: string, initialValue: T): T {
+      try {
+        const stored = localStorage.getItem(key);
+        if (stored === null) {
+          localStorage.setItem(key, initialValue);
+          return initialValue;
+        }
+        return stored as T;
+      } catch {
+        return initialValue;
+      }
+    },
+    setItem(key: string, value: T): void {
+      try {
+        localStorage.setItem(key, value);
+      } catch {
+        // Storage blocked or unavailable; ignore.
+      }
+    },
+    removeItem(key: string): void {
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        // Storage blocked or unavailable; ignore.
+      }
+    },
+  };
+}
+
+export const booleanStorage = {
+  getItem(key: string, initialValue: boolean): boolean {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, String(initialValue));
+        return initialValue;
+      }
+      if (stored === "true") return true;
+      if (stored === "false") return false;
+      localStorage.setItem(key, String(initialValue));
+      return initialValue;
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: boolean): void {
+    try {
+      localStorage.setItem(key, String(value));
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+};
+
+export type NumberConstraints = {
+  min?: number;
+  max?: number;
+  integer?: boolean;
+};
+
+export function constrainedNumberStorage(constraints: NumberConstraints) {
+  return {
+    getItem(key: string, initialValue: number): number {
+      try {
+        const stored = localStorage.getItem(key);
+        if (stored === null) {
+          localStorage.setItem(key, String(initialValue));
+          return initialValue;
+        }
+        if (stored.trim() === "") {
+          localStorage.setItem(key, String(initialValue));
+          return initialValue;
+        }
+        const num = Number(stored);
+        if (!Number.isFinite(num)) {
+          localStorage.setItem(key, String(initialValue));
+          return initialValue;
+        }
+        if (constraints.integer && !Number.isInteger(num)) {
+          localStorage.setItem(key, String(initialValue));
+          return initialValue;
+        }
+        if (constraints.min !== undefined && num < constraints.min) {
+          localStorage.setItem(key, String(initialValue));
+          return initialValue;
+        }
+        if (constraints.max !== undefined && num > constraints.max) {
+          localStorage.setItem(key, String(initialValue));
+          return initialValue;
+        }
+        return num;
+      } catch {
+        return initialValue;
+      }
+    },
+    setItem(key: string, value: number): void {
+      try {
+        localStorage.setItem(key, String(value));
+      } catch {
+        // Storage blocked or unavailable; ignore.
+      }
+    },
+    removeItem(key: string): void {
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        // Storage blocked or unavailable; ignore.
+      }
+    },
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/__tests__/setup.ts'],
+    testTimeout: 15000,
     css: {
       include: /.+/,
       modules: {


### PR DESCRIPTION
## Summary

- **Extract chord overlay domain** → `src/store/chordOverlayAtoms.ts`: chord base atoms (`chordRootAtom`, `chordTypeAtom`, `linkChordRootAtom`, `chordFretSpreadAtom`), practice lens base atoms (`practiceLensAtom`, `focusPresetAtom`, `customMembersAtom`, `viewModeAtom`), derived chord atoms (`chordTonesAtom`, `activeChordMembersAtom`, `hasOutsideChordMembersAtom`, `allChordMembersAtom`, etc.), and `hideNonChordNotesAtom`
- **Extract scale visibility domain** → `src/store/scaleAtoms.ts`: all scale atoms (`rootNoteAtom`, `scaleNameAtom`, `scaleBrowseModeAtom`), derived scale atoms (`scaleNotesAtom`, `colorNotesAtom`, `scaleLabelAtom`, `degreeChipsAtom`, `hiddenNotesAtom`), and `accidentalModeAtom`/`useFlatsAtom`
- **Extract overlay semantics / practice cues** → `src/store/practiceLensAtoms.ts`: `noteSemanticMapAtom`, `practiceCuesAtom`, `showChordPracticeBarAtom`, practice bar atoms
- **Extract fingering base atoms** → `src/store/fingeringAtoms.ts`: `fingeringPatternAtom`, `cagedShapesAtom` and related (needed by `scaleNameAtom`'s write side to avoid circular deps)
- **Promote shared storage helpers** to `utils/storage.ts` (`rawStringStorage`, `booleanStorage`, `constrainedNumberStorage`, `GET_ON_INIT`) and move `migrateLegacyKeys()` there so it fires before any `atomWithStorage({ getOnInit: true })` reads
- `atoms.ts` is now a thin re-export barrel + remaining atoms (display, tuning, UI tabs, shape data, shape-local, summary, action atoms) — **all existing `import ... from "../store/atoms"` paths continue to work unchanged**

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 819/819 tests pass (all previously passing tests still pass; fixed two pre-existing environment-timeout tests by raising `testTimeout` from 5 s → 15 s in vitest config)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Practice lens modes added: targets, guide-tones, color, tension.
  * Chord overlay with focus presets, custom member selection, and enhanced chord labeling.
  * Fingering pattern selector (all/caged/3nps) with persistent preferences and caged-shape toggles.
  * Persistent scale/root settings, accidental-mode handling, and per-scale hidden-note state.
  * Practice bar improved with refined note-role categorization and filtered color/target cues.

* **Tests**
  * Increased per-test timeout to 15s.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->