### PR TITLE
fix(fretboard): add guard for empty ResizeObserver entries

### DIFF
--- a/src/Fretboard.tsx
+++ b/src/Fretboard.tsx
@@ -108,6 +108,7 @@ export function Fretboard(props: FretboardProps) {
     if (!el) return;
     setContainerWidth(el.clientWidth);
     const ro = new ResizeObserver((entries) => {
+      if (entries.length === 0) return;
       const entry = entries[0];
       if (entry) setContainerWidth(entry.contentRect.width);
     });


### PR DESCRIPTION
## Summary
- Add defensive check in ResizeObserver callback to guard against empty entries array
- Prevents potential undefined access when entries is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash in the Fretboard component that could occur during certain resize or layout observation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->