### PR TITLE
feat(fretboard): add aria-label to fretboard container

### DIFF
--- a/src/Fretboard.tsx
+++ b/src/Fretboard.tsx
@@ -206,6 +206,7 @@ export function Fretboard(props: FretboardProps) {
     <div 
       className="fretboard-outer" 
       data-testid="fretboard-main"
+      aria-label="Interactive guitar fretboard"
       style={{
         minHeight: `${tuning.length * stringRowPx + 24}px`
       }}


### PR DESCRIPTION
## Summary
- Adds accessible `aria-label="Interactive guitar fretboard"` to main fretboard container
- Maintains existing `data-testid="fretboard-main"` for testing