### PR TITLE
feat(store): chord-overlay domain split — facts, lens registry, composable renderer

### DIFF
--- a/src/Fretboard.tsx
+++ b/src/Fretboard.tsx
@@ -73,6 +73,7 @@ export function Fretboard(props: FretboardProps) {
   const hiddenNotes = props.hiddenNotes ?? state.hiddenNotes;
   const useFlats = props.useFlats ?? state.useFlats;
   const scaleName = props.scaleName ?? state.scaleName;
+  const noteSemantics = state.noteSemanticMap.size > 0 ? state.noteSemanticMap : undefined;
   const startFret = state.startFret;
   const endFret = state.endFret;
   const stringRowPx = props.stringRowPx ?? STRING_ROW_PX_DEFAULT;
@@ -249,6 +250,7 @@ export function Fretboard(props: FretboardProps) {
           hiddenNotes={hiddenNotes}
           useFlats={useFlats}
           scaleName={scaleName}
+          noteSemantics={noteSemantics}
           id={id}
           onNoteClick={handleFretClick}
         />

--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -10,6 +10,7 @@ import {
   SCALES,
   type ViewMode,
   type PracticeLens,
+  type NoteSemantics,
 } from "./theory";
 import { parseNote } from "./guitar";
 import { STRING_ROW_PX_TABLET } from "./layout/responsive";
@@ -61,6 +62,13 @@ interface FretboardSVGProps {
   hiddenNotes?: Set<string>;
   useFlats?: boolean;
   scaleName?: string;
+  /**
+   * Composable per-note semantics from noteSemanticMapAtom. When provided,
+   * each rendered note element gains supplementary data attributes
+   * (data-note-tension, data-note-guide-tone) so a note can carry multiple
+   * semantic roles simultaneously — e.g. chord root AND tension note.
+   */
+  noteSemantics?: Map<string, NoteSemantics>;
   id?: string;
   onNoteClick?: (
     stringIndex: number,
@@ -368,6 +376,7 @@ export const FretboardSVG = memo(function FretboardSVG({
   hiddenNotes,
   useFlats = false,
   scaleName = "",
+  noteSemantics,
   id,
   onNoteClick,
 }: FretboardSVGProps) {
@@ -736,6 +745,7 @@ export const FretboardSVG = memo(function FretboardSVG({
           return false;
         })();
 
+        const semantics = noteSemantics?.get(noteName);
         notes.push({
           stringIndex,
           fretIndex,
@@ -744,11 +754,13 @@ export const FretboardSVG = memo(function FretboardSVG({
           displayValue,
           applyDimOpacity,
           isHidden,
+          isTension: semantics?.isTension ?? false,
+          isGuideTone: semantics?.isGuideTone ?? false,
         });
       }
     }
     return notes;
-  }, [numStrings, fretboardLayout, totalColumns, startFret, maxFret, hiddenNotes, highlightNotes, hasChordOverlay, chordTones, rootNote, chordRoot, colorNotes, shapePolygons, boxBounds, chordFretSpread, scaleName, useFlats, displayFormat, wrappedNotes, hideNonChordNotes, practiceLens, tuning]);
+  }, [numStrings, fretboardLayout, totalColumns, startFret, maxFret, hiddenNotes, highlightNotes, hasChordOverlay, chordTones, rootNote, chordRoot, colorNotes, shapePolygons, boxBounds, chordFretSpread, scaleName, useFlats, displayFormat, wrappedNotes, hideNonChordNotes, practiceLens, tuning, noteSemantics]);
 
   return (
     <div role="group" aria-label={ariaLabel} className="fretboard-board">
@@ -1026,6 +1038,8 @@ export const FretboardSVG = memo(function FretboardSVG({
                 displayValue,
                 applyDimOpacity,
                 isHidden,
+                isTension,
+                isGuideTone,
               }) => {
                 const cx = fretCenterX(fretIndex);
                 const cy = stringYAt(stringIndex, cx);
@@ -1082,6 +1096,8 @@ export const FretboardSVG = memo(function FretboardSVG({
                     )}
                     data-note-role={noteClass !== "note-inactive" ? noteClass : undefined}
                     data-note-shape={noteShape}
+                    data-note-tension={isTension || undefined}
+                    data-note-guide-tone={isGuideTone || undefined}
                     style={{ opacity: applyDimOpacity ? 0.8 : 1 }}
                   >
                     {shapeEl}
@@ -1109,7 +1125,7 @@ export const FretboardSVG = memo(function FretboardSVG({
           }}
         >
           {noteData.map(
-            ({ stringIndex, fretIndex, noteClass, displayValue, isHidden, noteName }) => {
+            ({ stringIndex, fretIndex, noteClass, displayValue, isHidden, noteName, isTension, isGuideTone }) => {
               const cx = fretCenterX(fretIndex);
               const cy = stringYAt(stringIndex, cx);
               const r = noteBubblePx / 2;
@@ -1127,6 +1143,8 @@ export const FretboardSVG = memo(function FretboardSVG({
                   tabIndex={isHidden ? -1 : undefined}
                   aria-label={`${formatAccidental(displayValue)} on string ${stringIndex + 1}, fret ${fretIndex}`}
                   data-note-role={noteClass !== "note-inactive" ? noteClass : undefined}
+                  data-note-tension={isTension || undefined}
+                  data-note-guide-tone={isGuideTone || undefined}
                   className={clsx(
                     "note-bubble",
                     noteClass,

--- a/src/__tests__/FretboardSVG.test.tsx
+++ b/src/__tests__/FretboardSVG.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from "@testing-library/react";
 import { FretboardSVG } from "../FretboardSVG";
 import { getFretboardNotes } from "../guitar";
 import type { CagedShape } from "../shapes";
+import type { NoteSemantics } from "../theory";
 import { axe } from "../test-utils/a11y";
 
 const STANDARD_TUNING = ["E4", "B3", "G3", "D3", "A2", "E2"];
@@ -359,6 +360,158 @@ describe("FretboardSVG", () => {
       // Without chord overlay, color notes are note-blue, not color-tone
       expect(container.querySelectorAll(".note-blue").length).toBeGreaterThan(0);
       expect(container.querySelectorAll(".color-tone").length).toBe(0);
+    });
+  });
+
+  describe("composable renderer contract — noteSemantics", () => {
+    it("outside chord root gets data-note-tension when noteSemantics provided", () => {
+      // C# is the chord root but is outside C Major scale (C,E,G highlights)
+      const semantics = new Map<string, NoteSemantics>([
+        [
+          "C#",
+          {
+            isScaleRoot: false,
+            isChordRoot: true,
+            isChordTone: true,
+            isInScale: false,
+            isColorTone: false,
+            isGuideTone: false,
+            isTension: true,
+            memberName: "root",
+          },
+        ],
+      ]);
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          chordTones={["C#", "F", "G#"]}
+          chordRoot="C#"
+          rootNote="C"
+          highlightNotes={["C", "E", "G"]}
+          noteSemantics={semantics}
+        />,
+      );
+      // C# should be classified as chord-root (visual role)
+      const chordRootNotes = container.querySelectorAll(".chord-root");
+      expect(chordRootNotes.length).toBeGreaterThan(0);
+      // AND carry data-note-tension (composable semantic attribute)
+      const tensionChordRoot = container.querySelectorAll(
+        '.chord-root[data-note-tension="true"]',
+      );
+      expect(tensionChordRoot.length).toBeGreaterThan(0);
+    });
+
+    it("in-scale chord root does NOT get data-note-tension", () => {
+      const semantics = new Map<string, NoteSemantics>([
+        [
+          "C",
+          {
+            isScaleRoot: true,
+            isChordRoot: true,
+            isChordTone: true,
+            isInScale: true,
+            isColorTone: false,
+            isGuideTone: false,
+            isTension: false,
+            memberName: "root",
+          },
+        ],
+      ]);
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          chordTones={["C", "E", "G"]}
+          chordRoot="C"
+          rootNote="C"
+          highlightNotes={["C", "E", "G"]}
+          noteSemantics={semantics}
+        />,
+      );
+      const tensionChordRoot = container.querySelectorAll(
+        '.chord-root[data-note-tension="true"]',
+      );
+      expect(tensionChordRoot.length).toBe(0);
+    });
+
+    it("guide tone gets data-note-guide-tone attribute", () => {
+      // B is the 3rd of G7 — a guide tone
+      const semantics = new Map<string, NoteSemantics>([
+        [
+          "B",
+          {
+            isScaleRoot: false,
+            isChordRoot: false,
+            isChordTone: true,
+            isInScale: true,
+            isColorTone: false,
+            isGuideTone: true,
+            isTension: false,
+            memberName: "3",
+          },
+        ],
+      ]);
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          chordTones={["G", "B", "D", "F"]}
+          chordRoot="G"
+          rootNote="G"
+          highlightNotes={["G", "A", "B", "C", "D", "E", "F"]}
+          noteSemantics={semantics}
+        />,
+      );
+      const guideToneNotes = container.querySelectorAll(
+        '[data-note-guide-tone="true"]',
+      );
+      expect(guideToneNotes.length).toBeGreaterThan(0);
+    });
+
+    it("notes without semantics entry have no data-note-tension or data-note-guide-tone", () => {
+      // Pass semantics for C only; E and G should have no extra attributes
+      const semantics = new Map<string, NoteSemantics>([
+        [
+          "C",
+          {
+            isScaleRoot: true,
+            isChordRoot: true,
+            isChordTone: true,
+            isInScale: true,
+            isColorTone: false,
+            isGuideTone: false,
+            isTension: false,
+            memberName: "root",
+          },
+        ],
+      ]);
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          chordTones={["C", "E", "G"]}
+          chordRoot="C"
+          rootNote="C"
+          highlightNotes={["C", "E", "G"]}
+          noteSemantics={semantics}
+        />,
+      );
+      // Only C has semantics — no tension/guide for E or G
+      const tensionNotes = container.querySelectorAll('[data-note-tension="true"]');
+      expect(tensionNotes.length).toBe(0);
+      const guideNotes = container.querySelectorAll('[data-note-guide-tone="true"]');
+      expect(guideNotes.length).toBe(0);
+    });
+
+    it("without noteSemantics prop no data-note-tension attributes are emitted", () => {
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          chordTones={["C#", "F", "G#"]}
+          chordRoot="C#"
+          rootNote="C"
+          highlightNotes={["C", "E", "G"]}
+        />,
+      );
+      const tensionNotes = container.querySelectorAll('[data-note-tension="true"]');
+      expect(tensionNotes.length).toBe(0);
     });
   });
 });

--- a/src/__tests__/chordDomainSplit.test.ts
+++ b/src/__tests__/chordDomainSplit.test.ts
@@ -1,11 +1,4 @@
 // @vitest-environment jsdom
-/**
- * Tests for the chord-overlay domain split:
- * 1. chordMemberFactsAtom — chord facts independent of scale
- * 2. lensAvailabilityAtom / lensAvailabilityContextAtom — registry-backed availability
- * 3. Renderer composability — noteSemantics data attributes on FretboardSVG
- *    (renderer tests live in FretboardSVG.test.tsx; atom tests here)
- */
 import { describe, it, expect, beforeEach } from "vitest";
 import { createStore } from "jotai";
 import {
@@ -450,5 +443,29 @@ describe("lensAvailabilityAtom", () => {
     const targetsEntry = entries.find((e) => e.id === "targets");
     expect(targetsEntry!.available).toBe(true);
     expect(targetsEntry!.reason).toBeNull();
+  });
+
+  it("targets-color lens unavailable for C Major (no color notes)", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    const entries = store.get(lensAvailabilityAtom);
+    const tcEntry = entries.find((e) => e.id === "targets-color");
+    expect(tcEntry!.available).toBe(false);
+    expect(tcEntry!.reason).toMatch(/color notes/i);
+  });
+
+  it("targets-color lens available for D Dorian (has color notes)", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "D");
+    store.set(scaleNameAtom, "Dorian");
+    store.set(chordRootAtom, "D");
+    store.set(chordTypeAtom, "Minor 7th");
+    const entries = store.get(lensAvailabilityAtom);
+    const tcEntry = entries.find((e) => e.id === "targets-color");
+    expect(tcEntry!.available).toBe(true);
+    expect(tcEntry!.reason).toBeNull();
   });
 });

--- a/src/__tests__/chordDomainSplit.test.ts
+++ b/src/__tests__/chordDomainSplit.test.ts
@@ -1,0 +1,454 @@
+// @vitest-environment jsdom
+/**
+ * Tests for the chord-overlay domain split:
+ * 1. chordMemberFactsAtom — chord facts independent of scale
+ * 2. lensAvailabilityAtom / lensAvailabilityContextAtom — registry-backed availability
+ * 3. Renderer composability — noteSemantics data attributes on FretboardSVG
+ *    (renderer tests live in FretboardSVG.test.tsx; atom tests here)
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { createStore } from "jotai";
+import {
+  LENS_REGISTRY,
+  type LensAvailabilityContext,
+} from "../theory";
+import {
+  chordMemberFactsAtom,
+  chordRootAtom,
+  chordTypeAtom,
+  rootNoteAtom,
+  scaleNameAtom,
+  practiceLensAtom,
+  lensAvailabilityContextAtom,
+  lensAvailabilityAtom,
+} from "../store/atoms";
+
+function makeStore() {
+  return createStore();
+}
+
+// ---------------------------------------------------------------------------
+// chordMemberFactsAtom — scale-independent chord member facts
+// ---------------------------------------------------------------------------
+
+describe("chordMemberFactsAtom", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns empty array when no chord type is set", () => {
+    const store = makeStore();
+    store.set(chordTypeAtom, null);
+    expect(store.get(chordMemberFactsAtom)).toHaveLength(0);
+  });
+
+  it("returns all members for a triad regardless of scale", () => {
+    const store = makeStore();
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    const facts = store.get(chordMemberFactsAtom);
+    expect(facts).toHaveLength(3);
+  });
+
+  it("root member has isChordRoot=true, others false", () => {
+    const store = makeStore();
+    store.set(chordRootAtom, "G");
+    store.set(chordTypeAtom, "Dominant 7th");
+    const facts = store.get(chordMemberFactsAtom);
+    const rootFact = facts.find((f) => f.isChordRoot);
+    expect(rootFact).toBeDefined();
+    expect(rootFact!.internalNote).toBe("G");
+    expect(rootFact!.semitone).toBe(0);
+    const nonRoots = facts.filter((f) => !f.isChordRoot);
+    expect(nonRoots.length).toBe(3); // B, D, F
+  });
+
+  it("exposes correct semitones for Dominant 7th (G)", () => {
+    const store = makeStore();
+    store.set(chordRootAtom, "G");
+    store.set(chordTypeAtom, "Dominant 7th");
+    const facts = store.get(chordMemberFactsAtom);
+    const semitones = facts.map((f) => f.semitone).sort((a, b) => a - b);
+    expect(semitones).toEqual([0, 4, 7, 10]); // root, 3, 5, b7
+  });
+
+  it("exposes correct internal notes for C Minor Triad", () => {
+    const store = makeStore();
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Minor Triad");
+    const facts = store.get(chordMemberFactsAtom);
+    const notes = facts.map((f) => f.internalNote);
+    expect(notes).toContain("C");
+    expect(notes).toContain("D#"); // b3
+    expect(notes).toContain("G");
+  });
+
+  it("does NOT depend on scale — same result regardless of rootNoteAtom/scaleNameAtom", () => {
+    // Scale A Major
+    const storeA = makeStore();
+    storeA.set(chordRootAtom, "C");
+    storeA.set(chordTypeAtom, "Major Triad");
+    storeA.set(rootNoteAtom, "A");
+    storeA.set(scaleNameAtom, "Major");
+
+    // Scale F# Dorian (very different from C major)
+    const storeB = makeStore();
+    storeB.set(chordRootAtom, "C");
+    storeB.set(chordTypeAtom, "Major Triad");
+    storeB.set(rootNoteAtom, "F#");
+    storeB.set(scaleNameAtom, "Dorian");
+
+    const factsA = storeA.get(chordMemberFactsAtom);
+    const factsB = storeB.get(chordMemberFactsAtom);
+
+    // Both should give the exact same chord facts
+    expect(factsA.map((f) => f.internalNote)).toEqual(
+      factsB.map((f) => f.internalNote),
+    );
+    expect(factsA.map((f) => f.semitone)).toEqual(
+      factsB.map((f) => f.semitone),
+    );
+    expect(factsA.map((f) => f.isChordRoot)).toEqual(
+      factsB.map((f) => f.isChordRoot),
+    );
+  });
+
+  it("memberName is formatted correctly (root=1, b3=♭3, b7=♭7)", () => {
+    const store = makeStore();
+    store.set(chordRootAtom, "G");
+    store.set(chordTypeAtom, "Minor 7th");
+    const facts = store.get(chordMemberFactsAtom);
+    const names = facts.map((f) => f.memberName);
+    expect(names).toContain("1");
+    expect(names).toContain("♭3");
+    expect(names).toContain("5");
+    expect(names).toContain("♭7");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LENS_REGISTRY — pure data, no atoms
+// ---------------------------------------------------------------------------
+
+describe("LENS_REGISTRY", () => {
+  it("contains all five practice lenses", () => {
+    const ids = LENS_REGISTRY.map((e) => e.id);
+    expect(ids).toContain("targets");
+    expect(ids).toContain("guide-tones");
+    expect(ids).toContain("color");
+    expect(ids).toContain("targets-color");
+    expect(ids).toContain("tension");
+  });
+
+  it("every entry has a non-empty label and description", () => {
+    for (const entry of LENS_REGISTRY) {
+      expect(entry.label.length).toBeGreaterThan(0);
+      expect(entry.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  describe("targets lens", () => {
+    const entry = LENS_REGISTRY.find((e) => e.id === "targets")!;
+
+    it("is available when chord overlay is active", () => {
+      const ctx: LensAvailabilityContext = {
+        hasChordOverlay: true,
+        hasGuideTones: false,
+        hasColorNotes: false,
+        hasOutsideTones: false,
+      };
+      expect(entry.isAvailable(ctx)).toBe(true);
+      expect(entry.unavailableReason(ctx)).toBeNull();
+    });
+
+    it("is unavailable without chord overlay, reason explains why", () => {
+      const ctx: LensAvailabilityContext = {
+        hasChordOverlay: false,
+        hasGuideTones: false,
+        hasColorNotes: false,
+        hasOutsideTones: false,
+      };
+      expect(entry.isAvailable(ctx)).toBe(false);
+      expect(entry.unavailableReason(ctx)).toMatch(/chord overlay/i);
+    });
+  });
+
+  describe("guide-tones lens", () => {
+    const entry = LENS_REGISTRY.find((e) => e.id === "guide-tones")!;
+
+    it("is available when chord overlay + guide tones both present", () => {
+      const ctx: LensAvailabilityContext = {
+        hasChordOverlay: true,
+        hasGuideTones: true,
+        hasColorNotes: false,
+        hasOutsideTones: false,
+      };
+      expect(entry.isAvailable(ctx)).toBe(true);
+    });
+
+    it("is unavailable when chord has no guide tones", () => {
+      const ctx: LensAvailabilityContext = {
+        hasChordOverlay: true,
+        hasGuideTones: false,
+        hasColorNotes: false,
+        hasOutsideTones: false,
+      };
+      expect(entry.isAvailable(ctx)).toBe(false);
+      expect(entry.unavailableReason(ctx)).toMatch(/guide tones/i);
+    });
+
+    it("is unavailable without chord overlay, reason mentions overlay not guide tones", () => {
+      const ctx: LensAvailabilityContext = {
+        hasChordOverlay: false,
+        hasGuideTones: true,
+        hasColorNotes: false,
+        hasOutsideTones: false,
+      };
+      expect(entry.isAvailable(ctx)).toBe(false);
+      expect(entry.unavailableReason(ctx)).toMatch(/chord overlay/i);
+    });
+  });
+
+  describe("color lens", () => {
+    const entry = LENS_REGISTRY.find((e) => e.id === "color")!;
+
+    it("is available when chord overlay + color notes both present", () => {
+      const ctx: LensAvailabilityContext = {
+        hasChordOverlay: true,
+        hasGuideTones: false,
+        hasColorNotes: true,
+        hasOutsideTones: false,
+      };
+      expect(entry.isAvailable(ctx)).toBe(true);
+    });
+
+    it("is unavailable when scale has no color notes", () => {
+      const ctx: LensAvailabilityContext = {
+        hasChordOverlay: true,
+        hasGuideTones: false,
+        hasColorNotes: false,
+        hasOutsideTones: false,
+      };
+      expect(entry.isAvailable(ctx)).toBe(false);
+      expect(entry.unavailableReason(ctx)).toMatch(/color notes/i);
+    });
+  });
+
+  describe("tension lens", () => {
+    const entry = LENS_REGISTRY.find((e) => e.id === "tension")!;
+
+    it("is available when chord has outside tones", () => {
+      const ctx: LensAvailabilityContext = {
+        hasChordOverlay: true,
+        hasGuideTones: false,
+        hasColorNotes: false,
+        hasOutsideTones: true,
+      };
+      expect(entry.isAvailable(ctx)).toBe(true);
+    });
+
+    it("is unavailable when chord is fully in-scale", () => {
+      const ctx: LensAvailabilityContext = {
+        hasChordOverlay: true,
+        hasGuideTones: true,
+        hasColorNotes: false,
+        hasOutsideTones: false,
+      };
+      expect(entry.isAvailable(ctx)).toBe(false);
+      expect(entry.unavailableReason(ctx)).toMatch(/fully within the scale/i);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lensAvailabilityContextAtom — computes context from live atom state
+// ---------------------------------------------------------------------------
+
+describe("lensAvailabilityContextAtom", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("hasChordOverlay=false when no chord type", () => {
+    const store = makeStore();
+    store.set(chordTypeAtom, null);
+    const ctx = store.get(lensAvailabilityContextAtom);
+    expect(ctx.hasChordOverlay).toBe(false);
+  });
+
+  it("hasChordOverlay=true when chord type is set", () => {
+    const store = makeStore();
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    const ctx = store.get(lensAvailabilityContextAtom);
+    expect(ctx.hasChordOverlay).toBe(true);
+  });
+
+  it("hasGuideTones=true for seventh chords (Dominant 7th has 3rd + b7)", () => {
+    const store = makeStore();
+    store.set(chordRootAtom, "G");
+    store.set(chordTypeAtom, "Dominant 7th");
+    const ctx = store.get(lensAvailabilityContextAtom);
+    expect(ctx.hasGuideTones).toBe(true);
+  });
+
+  it("hasGuideTones=false for power chord (no 3rd or 7th)", () => {
+    const store = makeStore();
+    store.set(chordRootAtom, "A");
+    store.set(chordTypeAtom, "Power Chord (5)");
+    const ctx = store.get(lensAvailabilityContextAtom);
+    expect(ctx.hasGuideTones).toBe(false);
+  });
+
+  it("hasGuideTones=true for triad with 3rd (Major Triad)", () => {
+    const store = makeStore();
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    const ctx = store.get(lensAvailabilityContextAtom);
+    expect(ctx.hasGuideTones).toBe(true); // has major 3rd
+  });
+
+  it("hasColorNotes=false for C Major (reference scale, no divergent notes)", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    const ctx = store.get(lensAvailabilityContextAtom);
+    expect(ctx.hasColorNotes).toBe(false);
+  });
+
+  it("hasColorNotes=true for D Dorian (B♮ diverges from D Natural Minor)", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "D");
+    store.set(scaleNameAtom, "Dorian");
+    store.set(chordRootAtom, "D");
+    store.set(chordTypeAtom, "Minor 7th");
+    const ctx = store.get(lensAvailabilityContextAtom);
+    expect(ctx.hasColorNotes).toBe(true);
+  });
+
+  it("hasOutsideTones=true when chord root is outside scale", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C#");
+    store.set(chordTypeAtom, "Minor Triad");
+    const ctx = store.get(lensAvailabilityContextAtom);
+    expect(ctx.hasOutsideTones).toBe(true);
+  });
+
+  it("hasOutsideTones=false when chord is fully in-scale", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    const ctx = store.get(lensAvailabilityContextAtom);
+    expect(ctx.hasOutsideTones).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lensAvailabilityAtom — resolved registry entries with available + reason
+// ---------------------------------------------------------------------------
+
+describe("lensAvailabilityAtom", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns five entries matching LENS_REGISTRY ids", () => {
+    const store = makeStore();
+    const entries = store.get(lensAvailabilityAtom);
+    expect(entries).toHaveLength(5);
+    const ids = entries.map((e) => e.id);
+    expect(ids).toContain("targets");
+    expect(ids).toContain("tension");
+  });
+
+  it("all entries unavailable when no chord overlay", () => {
+    const store = makeStore();
+    store.set(chordTypeAtom, null);
+    const entries = store.get(lensAvailabilityAtom);
+    expect(entries.every((e) => !e.available)).toBe(true);
+  });
+
+  it("all entries have non-empty label and description", () => {
+    const store = makeStore();
+    const entries = store.get(lensAvailabilityAtom);
+    for (const e of entries) {
+      expect(e.label.length).toBeGreaterThan(0);
+      expect(e.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("tension lens unavailable when chord fully in-scale (C Major + CMaj triad)", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    const entries = store.get(lensAvailabilityAtom);
+    const tensionEntry = entries.find((e) => e.id === "tension");
+    expect(tensionEntry!.available).toBe(false);
+    expect(tensionEntry!.reason).toMatch(/fully within the scale/i);
+  });
+
+  it("tension lens available when chord has outside tones", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C#");
+    store.set(chordTypeAtom, "Minor Triad");
+    const entries = store.get(lensAvailabilityAtom);
+    const tensionEntry = entries.find((e) => e.id === "tension");
+    expect(tensionEntry!.available).toBe(true);
+    expect(tensionEntry!.reason).toBeNull();
+  });
+
+  it("guide-tones lens unavailable for power chord", () => {
+    const store = makeStore();
+    store.set(chordRootAtom, "E");
+    store.set(chordTypeAtom, "Power Chord (5)");
+    const entries = store.get(lensAvailabilityAtom);
+    const gtEntry = entries.find((e) => e.id === "guide-tones");
+    expect(gtEntry!.available).toBe(false);
+    expect(gtEntry!.reason).toMatch(/guide tones/i);
+  });
+
+  it("color lens unavailable for C Major (no color notes)", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    const entries = store.get(lensAvailabilityAtom);
+    const colorEntry = entries.find((e) => e.id === "color");
+    expect(colorEntry!.available).toBe(false);
+  });
+
+  it("color lens available for D Dorian (has color notes)", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "D");
+    store.set(scaleNameAtom, "Dorian");
+    store.set(chordRootAtom, "D");
+    store.set(chordTypeAtom, "Minor 7th");
+    const entries = store.get(lensAvailabilityAtom);
+    const colorEntry = entries.find((e) => e.id === "color");
+    expect(colorEntry!.available).toBe(true);
+  });
+
+  it("reason is null for available lenses", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    store.set(practiceLensAtom, "targets");
+    const entries = store.get(lensAvailabilityAtom);
+    const targetsEntry = entries.find((e) => e.id === "targets");
+    expect(targetsEntry!.available).toBe(true);
+    expect(targetsEntry!.reason).toBeNull();
+  });
+});

--- a/src/hooks/useFretboardState.ts
+++ b/src/hooks/useFretboardState.ts
@@ -8,6 +8,7 @@ import {
   displayFormatAtom,
   useFlatsAtom,
   noteRoleMapAtom,
+  noteSemanticMapAtom,
   shapeDataAtom,
   autoCenterTargetAtom,
   recenterKeyAtom,
@@ -30,6 +31,7 @@ export function useFretboardState() {
   const displayFormat = useAtomValue(displayFormatAtom);
   const useFlats = useAtomValue(useFlatsAtom);
   const noteRoleMap = useAtomValue(noteRoleMapAtom);
+  const noteSemanticMap = useAtomValue(noteSemanticMapAtom);
   const { highlightNotes, boxBounds, shapePolygons, wrappedNotes } =
     useAtomValue(shapeDataAtom);
   const autoCenterTarget = useAtomValue(autoCenterTargetAtom);
@@ -53,6 +55,7 @@ export function useFretboardState() {
     displayFormat,
     useFlats,
     noteRoleMap,
+    noteSemanticMap,
     highlightNotes,
     boxBounds,
     shapePolygons,

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -68,6 +68,7 @@ export {
   chordLabelAtom,
   chordSummaryNotesAtom,
   allChordMembersAtom,
+  chordMemberFactsAtom,
 } from "./chordOverlayAtoms";
 
 export {
@@ -80,6 +81,8 @@ export {
   practiceBarBadgeAtom,
   practiceBarSharedMembersAtom,
   practiceBarOutsideMembersAtom,
+  lensAvailabilityContextAtom,
+  lensAvailabilityAtom,
 } from "./practiceLensAtoms";
 
 export {

--- a/src/store/chordOverlayAtoms.ts
+++ b/src/store/chordOverlayAtoms.ts
@@ -14,6 +14,7 @@ import type {
   ViewMode,
   FocusPreset,
   ChordMemberName,
+  ChordMemberFact,
   ResolvedChordMember,
   PracticeLens,
   ChordRowEntry,
@@ -405,6 +406,36 @@ export const chordSummaryNotesAtom = atom((get) => {
 // allChordMembersAtom — ChordRowEntry list with scale-membership and roles
 // Used by practiceLensAtoms and atoms.ts summary atoms.
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// chordMemberFactsAtom — pure chord facts, no scale context
+//
+// Reads only chordRootAtom and chordTypeAtom. Does NOT read scaleNotesAtom,
+// rootNoteAtom, or scaleNameAtom. This is the scale-independent layer from
+// which scale-aware atoms (allChordMembersAtom) are built.
+// ---------------------------------------------------------------------------
+
+export const chordMemberFactsAtom = atom((get): ChordMemberFact[] => {
+  const chordRoot = get(chordRootAtom);
+  const chordType = get(chordTypeAtom);
+  if (!chordType) return [];
+  const def = CHORD_DEFINITIONS[chordType];
+  if (!def) return [];
+  const rootIndex = NOTES.indexOf(chordRoot);
+  if (rootIndex === -1) return [];
+  // displayNote uses chord-root-relative accidentals (FLAT_KEYS membership of
+  // chordRoot), NOT the scale-derived useFlats — keeping this atom scale-free.
+  return def.members.map((m): ChordMemberFact => {
+    const note = NOTES[(rootIndex + m.semitone) % 12];
+    return {
+      internalNote: note,
+      displayNote: formatAccidental(getNoteDisplay(note, chordRoot)),
+      memberName: m.name === "root" ? "1" : formatAccidental(m.name),
+      semitone: m.semitone,
+      isChordRoot: m.name === "root",
+    };
+  });
+});
 
 export const allChordMembersAtom = atom((get) => {
   const chordType = get(chordTypeAtom);

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -3,12 +3,14 @@ import {
   NOTES,
   ENHARMONICS,
   INTERVAL_NAMES,
+  LENS_REGISTRY,
   getScaleNotes,
   getNoteDisplay,
   formatAccidental,
 } from "../theory";
 import type {
   ChordMemberName,
+  LensAvailabilityContext,
   NoteSemantics,
   PracticeCue,
   PracticeCueNote,
@@ -332,3 +334,42 @@ export const practiceBarSharedMembersAtom = atom((get) =>
 export const practiceBarOutsideMembersAtom = atom((get) =>
   get(allChordMembersAtom).filter((e) => !e.inScale),
 );
+
+// ---------------------------------------------------------------------------
+// Lens availability — registry-backed availability context + resolved entries
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes the context inputs used by LENS_REGISTRY predicates.
+ * A single atom so callers can read just the context (e.g. for unit tests)
+ * without consuming the full resolved list.
+ */
+export const lensAvailabilityContextAtom = atom((get): LensAvailabilityContext => {
+  const chordType = get(chordTypeAtom);
+  const activeChordMembers = get(activeChordMembersAtom);
+  const colorNotes = get(colorNotesAtom);
+  const hasOutsideChordMembers = get(hasOutsideChordMembersAtom);
+
+  return {
+    hasChordOverlay: !!chordType,
+    hasGuideTones: activeChordMembers.some((m) => GUIDE_TONE_RAW.has(m.name)),
+    hasColorNotes: colorNotes.length > 0,
+    hasOutsideTones: hasOutsideChordMembers,
+  };
+});
+
+/**
+ * Maps every LENS_REGISTRY entry against the current state to produce a list
+ * of lenses annotated with runtime availability and reason strings. Consumers
+ * use this to render lens pickers with disabled states and tooltip explanations.
+ */
+export const lensAvailabilityAtom = atom((get) => {
+  const ctx = get(lensAvailabilityContextAtom);
+  return LENS_REGISTRY.map((entry) => ({
+    id: entry.id,
+    label: entry.label,
+    description: entry.description,
+    available: entry.isAvailable(ctx),
+    reason: entry.unavailableReason(ctx),
+  }));
+});

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -145,6 +145,93 @@ export interface NoteSemantics {
   memberName?: ChordMemberName;
 }
 
+// Pure chord member fact — no scale context.
+// Separates what the chord defines (notes, intervals, root) from what the scale
+// adds (in-scale membership, tension roles).
+export interface ChordMemberFact {
+  internalNote: string;
+  /** Formatted using chord-root-relative accidentals — scale-independent. */
+  displayNote: string;
+  /** "1", "♭3", "3", "♭5", "5", "♭7", "7" */
+  memberName: string;
+  semitone: number;
+  isChordRoot: boolean;
+}
+
+// Context supplied to lens availability predicates.
+export interface LensAvailabilityContext {
+  hasChordOverlay: boolean;
+  /** Chord definition includes a 3rd or 7th member. */
+  hasGuideTones: boolean;
+  /** Scale has characteristic/divergent color notes. */
+  hasColorNotes: boolean;
+  /** At least one active chord tone falls outside the scale. */
+  hasOutsideTones: boolean;
+}
+
+// Registry entry for a practice lens: description + availability contract.
+export interface LensRegistryEntry {
+  id: PracticeLens;
+  label: string;
+  description: string;
+  isAvailable: (ctx: LensAvailabilityContext) => boolean;
+  /** Returns a human-readable reason when the lens is unavailable, or null. */
+  unavailableReason: (ctx: LensAvailabilityContext) => string | null;
+}
+
+export const LENS_REGISTRY: readonly LensRegistryEntry[] = [
+  {
+    id: "targets",
+    label: "Chord tones",
+    description: "Shows only chord root and active chord tones — for landing and outlining harmony",
+    isAvailable: (ctx) => ctx.hasChordOverlay,
+    unavailableReason: (ctx) =>
+      ctx.hasChordOverlay ? null : "Requires an active chord overlay",
+  },
+  {
+    id: "guide-tones",
+    label: "Guide tones",
+    description: "Highlights 3rd and 7th — the voice-leading tones that define chord quality",
+    isAvailable: (ctx) => ctx.hasChordOverlay && ctx.hasGuideTones,
+    unavailableReason: (ctx) => {
+      if (!ctx.hasChordOverlay) return "Requires an active chord overlay";
+      if (!ctx.hasGuideTones) return "Chord has no guide tones (3rd or 7th)";
+      return null;
+    },
+  },
+  {
+    id: "color",
+    label: "Color notes",
+    description: "Shows characteristic modal or blue notes that give the scale its flavor",
+    isAvailable: (ctx) => ctx.hasChordOverlay && ctx.hasColorNotes,
+    unavailableReason: (ctx) => {
+      if (!ctx.hasChordOverlay) return "Requires an active chord overlay";
+      if (!ctx.hasColorNotes) return "Scale has no characteristic color notes";
+      return null;
+    },
+  },
+  {
+    id: "targets-color",
+    label: "Targets + color",
+    description: "Combines chord tones with characteristic scale color notes — best for general-purpose soloing",
+    isAvailable: (ctx) => ctx.hasChordOverlay,
+    unavailableReason: (ctx) =>
+      ctx.hasChordOverlay ? null : "Requires an active chord overlay",
+  },
+  {
+    id: "tension",
+    label: "Tension notes",
+    description: "Highlights chord tones outside the scale — tones that create tension and need resolution",
+    isAvailable: (ctx) => ctx.hasChordOverlay && ctx.hasOutsideTones,
+    unavailableReason: (ctx) => {
+      if (!ctx.hasChordOverlay) return "Requires an active chord overlay";
+      if (!ctx.hasOutsideTones)
+        return "Chord is fully within the scale — no outside tones";
+      return null;
+    },
+  },
+];
+
 // Practice bar coaching cue types
 export type PracticeCueKind = "land-on" | "guide-tones" | "color-note" | "tension";
 

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -214,9 +214,12 @@ export const LENS_REGISTRY: readonly LensRegistryEntry[] = [
     id: "targets-color",
     label: "Targets + color",
     description: "Combines chord tones with characteristic scale color notes — best for general-purpose soloing",
-    isAvailable: (ctx) => ctx.hasChordOverlay,
-    unavailableReason: (ctx) =>
-      ctx.hasChordOverlay ? null : "Requires an active chord overlay",
+    isAvailable: (ctx) => ctx.hasChordOverlay && ctx.hasColorNotes,
+    unavailableReason: (ctx) => {
+      if (!ctx.hasChordOverlay) return "Requires an active chord overlay";
+      if (!ctx.hasColorNotes) return "Scale has no characteristic color notes";
+      return null;
+    },
   },
   {
     id: "tension",


### PR DESCRIPTION
## Summary

- **Chord facts independent of scale**: `chordMemberFactsAtom` reads only `chordRootAtom` + `chordTypeAtom`, never `scaleNotesAtom` or `rootNoteAtom`. Returns `ChordMemberFact[]` with `internalNote`, `semitone`, `isChordRoot`, and `memberName` — no `inScale` or `role`.
- **Lens registry/availability model**: `LENS_REGISTRY` in `theory.ts` — five entries each with `label`, `description`, `isAvailable(ctx)`, and `unavailableReason(ctx)`. `lensAvailabilityContextAtom` computes the context; `lensAvailabilityAtom` resolves the full list with runtime `available` + `reason` strings for UI consumers (disabled states, tooltips).
- **Composable renderer contract**: `FretboardSVG` gains a `noteSemantics?: Map<string, NoteSemantics>` prop. When present, each rendered note element gets `data-note-tension` and `data-note-guide-tone` attributes alongside the primary `data-note-role` class — a chord root outside the scale carries both `class="chord-root"` and `data-note-tension="true"` simultaneously. Wired through `useFretboardState` → `Fretboard`.

## New types / atoms

| Symbol | Location | Description |
|--------|----------|-------------|
| `ChordMemberFact` | `theory.ts` | Pure chord member — no scale context |
| `LensAvailabilityContext` | `theory.ts` | Context inputs for availability predicates |
| `LensRegistryEntry` | `theory.ts` | Registry entry: label, description, predicates |
| `LENS_REGISTRY` | `theory.ts` | Immutable registry of all five practice lenses |
| `chordMemberFactsAtom` | `chordOverlayAtoms.ts` | Scale-independent chord facts atom |
| `lensAvailabilityContextAtom` | `practiceLensAtoms.ts` | Live context from atom state |
| `lensAvailabilityAtom` | `practiceLensAtoms.ts` | Resolved registry entries with available + reason |

## Test plan

- [ ] `chordDomainSplit.test.ts` — `chordMemberFactsAtom`: returns same chord notes regardless of `rootNoteAtom`/`scaleNameAtom`; correct semitones, member names, `isChordRoot` flags
- [ ] `chordDomainSplit.test.ts` — `LENS_REGISTRY`: pure unit tests on predicates with explicit `LensAvailabilityContext` values (no atoms needed)
- [ ] `chordDomainSplit.test.ts` — `lensAvailabilityContextAtom` / `lensAvailabilityAtom`: guide-tones unavailable for power chords, tension unavailable when fully in-scale, color unavailable for C Major, etc.
- [ ] `FretboardSVG.test.tsx` composable-renderer suite: outside chord root gets `data-note-tension="true"` AND `.chord-root` class; in-scale root does not; guide tone gets `data-note-guide-tone="true"`; no attributes when `noteSemantics` is not provided
- [ ] Scale strip visuals unchanged (no CSS or rendering changes in this PR)

https://claude.ai/code/session_01HsNxhJa1kRV94AGDFQ9JTH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notes can now be marked as tensions and guide-tones, with semantic attributes added to rendered elements for styling and display purposes.
  * Added a lens availability system that determines which visualization options are contextually available based on the current chord and scale context.

* **Tests**
  * Added comprehensive test coverage for note semantic attributes and lens availability logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->