### PR TITLE
feat(animation): unify animation duration constants

### DIFF
--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -2,6 +2,10 @@ import { useEffect, useRef, type RefObject } from "react";
 import { X } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useFocusTrap } from "../hooks/useFocusTrap";
+import {
+  ANIMATION_DURATION_FAST,
+  ANIMATION_EASE,
+} from "../constants";
 
 interface HelpModalProps {
   isOpen: boolean;
@@ -39,7 +43,7 @@ export function HelpModal({ isOpen, onClose, triggerRef }: HelpModalProps) {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          transition={{ duration: 0.2, ease: "easeOut" }}
+          transition={{ duration: ANIMATION_DURATION_FAST, ease: ANIMATION_EASE }}
         >
           <motion.div
             ref={helpModalRef}
@@ -52,7 +56,7 @@ export function HelpModal({ isOpen, onClose, triggerRef }: HelpModalProps) {
             initial={{ opacity: 0, scale: 0.96 }}
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.96 }}
-            transition={{ duration: 0.2, ease: "easeOut" }}
+            transition={{ duration: ANIMATION_DURATION_FAST, ease: ANIMATION_EASE }}
           >
             <div className="help-modal-header">
               <h2 id="help-modal-title">FretFlow Help</h2>

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -27,9 +27,11 @@ import {
 } from "../layout/responsive";
 import { useFocusTrap } from "../hooks/useFocusTrap";
 import {
-  MAX_FRET, 
-  FRET_ZOOM_MIN, 
-  FRET_ZOOM_MAX 
+  MAX_FRET,
+  FRET_ZOOM_MIN,
+  FRET_ZOOM_MAX,
+  ANIMATION_DURATION_STANDARD,
+  ANIMATION_EASE,
 } from "../constants";
 import "./SettingsOverlay.css";
 
@@ -464,7 +466,7 @@ function SettingsOverlaySurface({
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
-        transition={{ duration: 0.24, ease: "easeOut" }}
+        transition={{ duration: ANIMATION_DURATION_STANDARD, ease: ANIMATION_EASE }}
       />
       <motion.div
         className="settings-overlay-drawer"
@@ -478,7 +480,7 @@ function SettingsOverlaySurface({
         initial={{ x: "100%" }}
         animate={{ x: 0 }}
         exit={{ x: "100%" }}
-        transition={{ duration: 0.24, ease: "easeOut" }}
+        transition={{ duration: ANIMATION_DURATION_STANDARD, ease: ANIMATION_EASE }}
       >
         <div className="settings-overlay-header">
           <span className="settings-overlay-title">Settings</span>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,11 @@ export const A4_ABS_DISTANCE = 57; // C0 is 0, A4 is 57
 // Components
 export const DRAWER_DROPUP_THRESHOLD = 260;
 
+// Animation transitions (motion/react)
+export const ANIMATION_DURATION_FAST = 0.2;
+export const ANIMATION_DURATION_STANDARD = 0.24;
+export const ANIMATION_EASE = "easeOut";
+
 // Settings / Atoms
 export const FRET_ZOOM_MIN = 50;
 export const FRET_ZOOM_MAX = 200;


### PR DESCRIPTION
## Summary
- Add shared animation constants to `constants.ts`: `ANIMATION_DURATION_FAST` (0.2), `ANIMATION_DURATION_STANDARD` (0.24), and `ANIMATION_EASE` ("easeOut")
- Update `SettingsOverlay` to use shared constants
- Update `HelpModal` to use shared constants