### PR TITLE
refactor(store): tech debt audit — remove dead noteRoleMap hook subscription

### DIFF
--- a/src/hooks/useFretboardState.ts
+++ b/src/hooks/useFretboardState.ts
@@ -7,7 +7,6 @@ import {
   fretEndAtom,
   displayFormatAtom,
   useFlatsAtom,
-  noteRoleMapAtom,
   noteSemanticMapAtom,
   shapeDataAtom,
   autoCenterTargetAtom,
@@ -30,7 +29,6 @@ export function useFretboardState() {
   const endFret = useAtomValue(fretEndAtom);
   const displayFormat = useAtomValue(displayFormatAtom);
   const useFlats = useAtomValue(useFlatsAtom);
-  const noteRoleMap = useAtomValue(noteRoleMapAtom);
   const noteSemanticMap = useAtomValue(noteSemanticMapAtom);
   const { highlightNotes, boxBounds, shapePolygons, wrappedNotes } =
     useAtomValue(shapeDataAtom);
@@ -54,7 +52,6 @@ export function useFretboardState() {
     endFret,
     displayFormat,
     useFlats,
-    noteRoleMap,
     noteSemanticMap,
     highlightNotes,
     boxBounds,


### PR DESCRIPTION
## Summary

Tech debt audit of the full codebase. One code fix shipped; all remaining items tracked as GitHub issues.

**Fix included:**
- Remove `noteRoleMap` / `noteRoleMapAtom` subscription from `useFretboardState` hook — the atom is alive and used by `summaryLegendItemsAtom`, but the hook was also subscribing to it and returning `noteRoleMap` in its return object, which no consumer (`Fretboard.tsx`) ever reads. Drops a dead reactive subscription.

## Issues filed (28 items — #191–#218)

| Priority | Issues |
|---|---|
| **HIGH** | #191 FretboardSVG god component split, #192 note classification test coverage |
| **MEDIUM** | #193 atoms.ts barrel store, #194 magic coordinate strings, #195 shapeDataAtom full recompute, #196 missing memo() on overlays, #197 DegreeChipStrip color-only a11y, #198 focus trap untested, #199 ~8 untested components, #200 shapeDataAtom service layer, #201 audio singleton → effect atom, #202 DEGREE_COLORS → CSS tokens, #205 theory.ts split, #206 silent storage failures, #215 BottomTabBar ARIA tab pattern, #216 neon glow contrast audit, #217 breakpoint single source of truth |
| **LOW** | #203 App.css magic values, #204 CSS module strategy, #207 degrees.ts tests, #208 audio test (synth as any) casts, #209 storage unsafe cast, #210 wood grain texture memoization, #211 BrandMark SVG title/desc, #212 bundle size analysis, #213 invalid tuning UX, #214 circular import audit, #218 practiceBarColorNotesAtom equality |

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run test` — 874 tests pass
- [x] `npm run build` — verified clean (pre-push hook)
