### PR TITLE
feat(a11y): add :focus-visible glow styles for keyboard navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -74,6 +74,7 @@
 .header-btn:focus-visible {
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-glow);
 }
 
 .header-btn .icon {
@@ -233,6 +234,7 @@
 .help-modal-close:focus-visible {
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-glow);
 }
 
 .help-modal-close .icon {
@@ -495,6 +497,7 @@
 .note-bubble:focus-visible {
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-glow);
 }
 
 @keyframes note-ping {

--- a/src/DrawerSelector.module.css
+++ b/src/DrawerSelector.module.css
@@ -43,6 +43,7 @@
 .drawer-trigger:focus-visible {
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-glow);
 }
 
 .drawer-label {
@@ -125,6 +126,7 @@
 .drawer-option:focus-visible {
   outline: var(--focus-ring);
   outline-offset: -2px;
+  box-shadow: var(--focus-ring-glow);
 }
 
 .drawer-option.active {

--- a/src/components/BottomTabBar.css
+++ b/src/components/BottomTabBar.css
@@ -56,6 +56,7 @@
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
   border-radius: var(--radius-sm);
+  box-shadow: var(--focus-ring-glow);
 }
 
 .bottom-tab-bar-btn:disabled {

--- a/src/components/FretRangeControl.css
+++ b/src/components/FretRangeControl.css
@@ -40,6 +40,7 @@
 .fret-btn:focus-visible {
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-glow);
 }
 
 .fret-value {

--- a/src/components/LabeledSelect.css
+++ b/src/components/LabeledSelect.css
@@ -48,7 +48,7 @@
 .labeled-select-native:focus-visible {
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
-  box-shadow: 0 0 0 4px rgb(77 228 255 / 0.12);
+  box-shadow: var(--focus-ring-glow);
 }
 
 .labeled-select-native:hover:not(:disabled) {

--- a/src/components/SettingsOverlay.css
+++ b/src/components/SettingsOverlay.css
@@ -73,6 +73,7 @@
 .settings-overlay-close:focus-visible {
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-glow);
 }
 
 .settings-overlay-close .icon {
@@ -186,6 +187,7 @@
 .overlay-help-trigger:focus-visible {
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-glow);
 }
 
 .overlay-help-trigger .icon {
@@ -247,6 +249,7 @@
 .overlay-reset-btn:focus-visible {
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-glow);
 }
 
 @media (max-width: 480px) {

--- a/src/components/StepperControl.css
+++ b/src/components/StepperControl.css
@@ -33,6 +33,7 @@
 .stepper-btn:focus-visible:not(:disabled) {
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-glow);
 }
 
 .stepper-btn:disabled {

--- a/src/components/TheoryControls.css
+++ b/src/components/TheoryControls.css
@@ -118,6 +118,7 @@
 .theory-disclosure-btn:focus-visible {
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-glow);
 }
 
 .theory-chord-section,

--- a/src/components/ToggleBar.css
+++ b/src/components/ToggleBar.css
@@ -48,6 +48,6 @@
 .mobile-tab-bar .mobile-tab:focus-visible {
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
-  box-shadow: 0 0 0 3px rgb(77 228 255 / 0.2);
+  box-shadow: var(--focus-ring-glow);
   color: var(--text-on-accent);
 }

--- a/src/components/shared.module.css
+++ b/src/components/shared.module.css
@@ -99,7 +99,7 @@
   outline-offset: var(--focus-ring-offset);
   color: var(--text-on-accent);
   border-color: var(--neon-cyan);
-  box-shadow: 0 0 0 3px rgb(77 228 255 / 0.2);
+  box-shadow: var(--focus-ring-glow);
 }
 
 .chord-root-row {
@@ -238,7 +238,7 @@
   outline: var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
   border-radius: 2px;
-  box-shadow: 0 0 0 3px rgb(77 228 255 / 0.2);
+  box-shadow: var(--focus-ring-glow);
 }
 
 /* stylelint-disable selector-pseudo-class-no-unknown */

--- a/src/semantic.css
+++ b/src/semantic.css
@@ -52,9 +52,10 @@
   --panel-surface-pad: var(--space-4);
   --panel-surface-pad-compact: var(--space-3) var(--space-4);
 
-  /* FOCUS-RING TOKEN — neon-cyan matches all active-state indicators in the UI */
+  /* FOCUS-RING TOKEN — neon-cyan glow for keyboard nav visibility against dark theme */
   --focus-ring: 2px solid var(--neon-cyan);
   --focus-ring-offset: 2px;
+  --focus-ring-glow: 0 0 8px rgb(77 228 255 / 0.6), 0 0 16px rgb(77 228 255 / 0.35);
 
   /* Z-INDEX SEMANTIC ALIASES (primitives in tokens.css) */
   --z-note: var(--token-z-note);


### PR DESCRIPTION
## Summary
- Add `--focus-ring-glow` CSS variable with cyan glow effect for keyboard navigation visibility
- Apply glow to all interactive elements with `:focus-visible` states across the app
- Improves accessibility UX by providing clear visual indicators against the dark theme