### PR TITLE
feat(components): add keyboard navigation to NoteGrid

### DIFF
--- a/src/components/NoteGrid.tsx
+++ b/src/components/NoteGrid.tsx
@@ -1,3 +1,4 @@
+import { useRef, useEffect } from "react";
 import clsx from "clsx";
 import { formatAccidental, getNoteDisplay } from "../theory";
 import "./NoteGrid.css";
@@ -10,21 +11,93 @@ interface NoteGridProps {
   useFlats: boolean;
 }
 
+const GRID_COLS = 4;
+
 export function NoteGrid({
   notes,
   selected,
   onSelect,
   useFlats,
 }: NoteGridProps) {
+  const selectedIndex = notes.indexOf(selected);
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const keyboardDrivenRef = useRef(false);
+
+  useEffect(() => {
+    if (keyboardDrivenRef.current) {
+      buttonRefs.current[selectedIndex]?.focus();
+      keyboardDrivenRef.current = false;
+    }
+  }, [selectedIndex]);
+
+  const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
+    const cols = GRID_COLS;
+
+    switch (e.key) {
+      case "ArrowRight": {
+        e.preventDefault();
+        keyboardDrivenRef.current = true;
+        const nextIndex = index < notes.length - 1 ? index + 1 : 0;
+        onSelect(notes[nextIndex]);
+        break;
+      }
+      case "ArrowLeft": {
+        e.preventDefault();
+        keyboardDrivenRef.current = true;
+        const prevIndex = index > 0 ? index - 1 : notes.length - 1;
+        onSelect(notes[prevIndex]);
+        break;
+      }
+      case "ArrowDown": {
+        e.preventDefault();
+        keyboardDrivenRef.current = true;
+        const nextIndex = index + cols;
+        if (nextIndex < notes.length) {
+          onSelect(notes[nextIndex]);
+        } else {
+          onSelect(notes[index % cols]);
+        }
+        break;
+      }
+      case "ArrowUp": {
+        e.preventDefault();
+        keyboardDrivenRef.current = true;
+        const prevIndex = index - cols;
+        if (prevIndex >= 0) {
+          onSelect(notes[prevIndex]);
+        } else {
+          onSelect(notes[notes.length - 1]);
+        }
+        break;
+      }
+      case "Home": {
+        e.preventDefault();
+        keyboardDrivenRef.current = true;
+        onSelect(notes[0]);
+        break;
+      }
+      case "End": {
+        e.preventDefault();
+        keyboardDrivenRef.current = true;
+        onSelect(notes[notes.length - 1]);
+        break;
+      }
+    }
+  };
+
   return (
     <div className={shared["note-grid"]} role="group" aria-label="Note selector">
-      {notes.map((n) => (
+      {notes.map((n, index) => (
         <button
           key={n}
+          ref={(el) => {
+            buttonRefs.current[index] = el;
+          }}
           type="button"
           className={clsx(shared["note-btn"], selected === n && shared.active)}
           aria-pressed={selected === n}
           onClick={() => onSelect(n)}
+          onKeyDown={(e) => handleKeyDown(e, index)}
         >
           <span className={shared["note-btn-label"]}>
             {formatAccidental(getNoteDisplay(n, n, useFlats))}

--- a/src/hooks/useFocusTrap.test.ts
+++ b/src/hooks/useFocusTrap.test.ts
@@ -59,7 +59,11 @@ describe("useFocusTrap", () => {
       useFocusTrap({ containerRef, active: true, onEscape })
     );
 
-    // Move focus into the trap
+    // Wait for initial RAF focus to complete before manually focusing
+    await act(async () => {
+      await new Promise(requestAnimationFrame);
+    });
+
     button1.focus();
     expect(document.activeElement).toBe(button1);
 
@@ -110,7 +114,7 @@ describe("useFocusTrap", () => {
 
     // Wait for initial RAF focus to complete before manually focusing
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 50));
+      await new Promise(requestAnimationFrame);
     });
 
     button1.focus();


### PR DESCRIPTION
## Summary
- Add arrow key navigation (Up/Down/Left/Right) to NoteGrid component
- Add Home/End keys to jump to first/last note in grid
- Auto-focus selected note on selection change
- Fix flaky useFocusTrap test by waiting for RAF before focusing

## Testing
- All 874 tests pass
- Lint passes
- Build passes