### PR TITLE
feat(lens): improve lens UX with inline descriptions and unified availability

### DIFF
--- a/src/components/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls.tsx
@@ -38,6 +38,15 @@ const LENS_LABELS: Record<PracticeLens, string> = {
   tension: "Tension",
 };
 
+// Display order for the lens ToggleBar (targets-color is the default and shown first).
+const LENS_UI_ORDER: readonly PracticeLens[] = [
+  "targets-color",
+  "targets",
+  "guide-tones",
+  "color",
+  "tension",
+];
+
 const FOCUS_PRESET_LABELS: Record<FocusPreset, string> = {
   all: "All",
   triad: "Triad",
@@ -87,21 +96,29 @@ export function ChordOverlayControls() {
     })),
   ];
 
-  const lensOptions = lensAvailability.map((entry) => ({
-    value: entry.id,
-    label: LENS_LABELS[entry.id],
-    disabled: !entry.available,
-    title: entry.reason ?? undefined,
-  }));
+  const lensOptions = LENS_UI_ORDER.map((id) => {
+    const entry = lensAvailability.find((l) => l.id === id)!;
+    return {
+      value: entry.id,
+      label: LENS_LABELS[entry.id],
+      disabled: !entry.available,
+      title: entry.reason ?? undefined,
+    };
+  });
 
   const currentLensEntry = lensAvailability.find((l) => l.id === practiceLens);
 
-  // Auto-exit any lens that becomes unavailable (e.g. chord removed, scale changed).
+  // Switch away from unavailable lenses when state changes (e.g. chord becomes diatonic,
+  // scale changes). Only switch if at least one lens is available — when chord overlay is
+  // removed, no lens is available and we preserve the stored value for when it returns.
   useEffect(() => {
     if (currentLensEntry && !currentLensEntry.available) {
-      setPracticeLens("targets-color");
+      const fallback = lensAvailability.find((l) => l.available);
+      if (fallback) {
+        setPracticeLens(fallback.id);
+      }
     }
-  }, [currentLensEntry, setPracticeLens]);
+  }, [currentLensEntry, lensAvailability, setPracticeLens]);
 
   const focusPresetOptions = availableFocusPresets.map((preset) => ({
     value: preset,

--- a/src/components/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls.tsx
@@ -108,14 +108,19 @@ export function ChordOverlayControls() {
 
   const currentLensEntry = lensAvailability.find((l) => l.id === practiceLens);
 
-  // Switch away from unavailable lenses when state changes (e.g. chord becomes diatonic,
-  // scale changes). Only switch if at least one lens is available — when chord overlay is
-  // removed, no lens is available and we preserve the stored value for when it returns.
+  // Auto-exit unavailable lenses back to targets-color (the permanent fallback).
+  // Exemptions: (a) targets-color itself — it degrades gracefully when color notes are
+  // absent, so it is never auto-exited; (b) when chord overlay is inactive, all lenses
+  // are unavailable and we preserve the stored value for when the overlay returns.
   useEffect(() => {
-    if (currentLensEntry && !currentLensEntry.available) {
-      const fallback = lensAvailability.find((l) => l.available);
-      if (fallback) {
-        setPracticeLens(fallback.id);
+    if (
+      currentLensEntry &&
+      !currentLensEntry.available &&
+      currentLensEntry.id !== "targets-color"
+    ) {
+      const targetsColor = lensAvailability.find((l) => l.id === "targets-color");
+      if (targetsColor?.available) {
+        setPracticeLens("targets-color");
       }
     }
   }, [currentLensEntry, lensAvailability, setPracticeLens]);

--- a/src/components/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls.tsx
@@ -1,4 +1,5 @@
 import { startTransition, useEffect, useId, useState } from "react";
+import { useAtomValue } from "jotai";
 import clsx from "clsx";
 import {
   NOTES,
@@ -6,6 +7,7 @@ import {
   type FocusPreset,
   type ChordMemberName,
 } from "../theory";
+import { lensAvailabilityAtom } from "../store/atoms";
 import { LabeledSelect, type LabeledSelectOption } from "./LabeledSelect";
 import { NoteGrid } from "./NoteGrid";
 import { ToggleBar } from "./ToggleBar";
@@ -28,13 +30,13 @@ const CHORD_OPTIONS: (string | { divider: string })[] = [
 
 const CHORD_NONE_VALUE = "__none__";
 
-const PRACTICE_LENS_OPTIONS: { value: PracticeLens; label: string }[] = [
-  { value: "targets-color", label: "Targets + Color" },
-  { value: "targets", label: "Targets" },
-  { value: "guide-tones", label: "Guide Tones" },
-  { value: "color", label: "Color" },
-  { value: "tension", label: "Tension" },
-];
+const LENS_LABELS: Record<PracticeLens, string> = {
+  "targets-color": "Targets + Color",
+  targets: "Targets",
+  "guide-tones": "Guide Tones",
+  color: "Color",
+  tension: "Tension",
+};
 
 const FOCUS_PRESET_LABELS: Record<FocusPreset, string> = {
   all: "All",
@@ -67,10 +69,10 @@ export function ChordOverlayControls() {
     setCustomMembers,
     availableFocusPresets,
     chordMembers,
-    hasOutsideChordMembers,
   } = useChordState();
 
   const { useFlats } = useScaleState();
+  const lensAvailability = useAtomValue(lensAvailabilityAtom);
 
   const [isChordOverlayOpen, setChordOverlayOpen] = useState(Boolean(chordType));
   const linkChordRootId = useId();
@@ -85,18 +87,21 @@ export function ChordOverlayControls() {
     })),
   ];
 
-  // Tension lens requires outside chord members to be meaningful.
-  const lensOptions = PRACTICE_LENS_OPTIONS.map((opt) => ({
-    ...opt,
-    disabled: opt.value === "tension" && !hasOutsideChordMembers,
+  const lensOptions = lensAvailability.map((entry) => ({
+    value: entry.id,
+    label: LENS_LABELS[entry.id],
+    disabled: !entry.available,
+    title: entry.reason ?? undefined,
   }));
 
-  // Auto-exit tension lens when chord becomes fully diatonic.
+  const currentLensEntry = lensAvailability.find((l) => l.id === practiceLens);
+
+  // Auto-exit any lens that becomes unavailable (e.g. chord removed, scale changed).
   useEffect(() => {
-    if (practiceLens === "tension" && !hasOutsideChordMembers) {
+    if (currentLensEntry && !currentLensEntry.available) {
       setPracticeLens("targets-color");
     }
-  }, [practiceLens, hasOutsideChordMembers, setPracticeLens]);
+  }, [currentLensEntry, setPracticeLens]);
 
   const focusPresetOptions = availableFocusPresets.map((preset) => ({
     value: preset,
@@ -184,6 +189,9 @@ export function ChordOverlayControls() {
                   onChange={setPracticeLens}
                   label="Practice lens"
                 />
+                {currentLensEntry?.description ? (
+                  <p className={shared["lens-hint"]}>{currentLensEntry.description}</p>
+                ) : null}
               </div>
 
               <div className={shared["control-section"]}>

--- a/src/components/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls.tsx
@@ -112,7 +112,7 @@ export function ChordOverlayControls() {
       label: LENS_LABELS[id],
       disabled: !isActive && unavailable,
       title: !isActive && reason ? reason : undefined,
-      ariaLabel: !isActive && reason ? `${LENS_LABELS[id]}: ${reason}` : undefined,
+      description: !isActive && reason ? reason : undefined,
     };
   });
 

--- a/src/components/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls.tsx
@@ -96,31 +96,38 @@ export function ChordOverlayControls() {
     })),
   ];
 
+  // lensAvailabilityAtom emits one entry per LENS_REGISTRY member (same 5 ids as
+  // LENS_UI_ORDER), so find() will always succeed. Defensive fallback avoids the
+  // non-null assertion and makes the assumption explicit.
   const lensOptions = LENS_UI_ORDER.map((id) => {
-    const entry = lensAvailability.find((l) => l.id === id)!;
+    const entry = lensAvailability.find((l) => l.id === id);
     return {
-      value: entry.id,
-      label: LENS_LABELS[entry.id],
-      disabled: !entry.available,
-      title: entry.reason ?? undefined,
+      value: id,
+      label: LENS_LABELS[id],
+      disabled: entry ? !entry.available : true,
+      title: entry?.reason ?? undefined,
     };
   });
 
   const currentLensEntry = lensAvailability.find((l) => l.id === practiceLens);
 
-  // Auto-exit unavailable lenses back to targets-color (the permanent fallback).
-  // Exemptions: (a) targets-color itself — it degrades gracefully when color notes are
-  // absent, so it is never auto-exited; (b) when chord overlay is inactive, all lenses
-  // are unavailable and we preserve the stored value for when the overlay returns.
+  // Auto-exit unavailable lenses. targets-color is exempt — it degrades gracefully
+  // (shows chord tones, omits color highlights) when no color notes are present, so
+  // it is never auto-exited and serves as the primary fallback.
+  // Fallback chain: targets-color → targets (targets requires only an active chord
+  // overlay and is always available when another lens becomes unavailable mid-session).
+  // When no lens is available (chord overlay removed), preserve the stored value.
   useEffect(() => {
     if (
       currentLensEntry &&
       !currentLensEntry.available &&
       currentLensEntry.id !== "targets-color"
     ) {
-      const targetsColor = lensAvailability.find((l) => l.id === "targets-color");
-      if (targetsColor?.available) {
-        setPracticeLens("targets-color");
+      const tcAvailable = lensAvailability.find((l) => l.id === "targets-color")?.available;
+      const tAvailable = lensAvailability.find((l) => l.id === "targets")?.available;
+      const fallback = tcAvailable ? "targets-color" : tAvailable ? "targets" : null;
+      if (fallback) {
+        setPracticeLens(fallback);
       }
     }
   }, [currentLensEntry, lensAvailability, setPracticeLens]);

--- a/src/components/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls.tsx
@@ -99,13 +99,20 @@ export function ChordOverlayControls() {
   // lensAvailabilityAtom emits one entry per LENS_REGISTRY member (same 5 ids as
   // LENS_UI_ORDER), so find() will always succeed. Defensive fallback avoids the
   // non-null assertion and makes the assumption explicit.
+  // The active lens is never rendered disabled — it must remain focusable and visually
+  // active even when the registry marks it unavailable (e.g. targets-color with no color
+  // notes degrades gracefully and is exempt from auto-exit).
   const lensOptions = LENS_UI_ORDER.map((id) => {
     const entry = lensAvailability.find((l) => l.id === id);
+    const isActive = id === practiceLens;
+    const unavailable = entry ? !entry.available : true;
+    const reason = entry?.reason ?? undefined;
     return {
       value: id,
       label: LENS_LABELS[id],
-      disabled: entry ? !entry.available : true,
-      title: entry?.reason ?? undefined,
+      disabled: !isActive && unavailable,
+      title: !isActive && reason ? reason : undefined,
+      ariaLabel: !isActive && reason ? `${LENS_LABELS[id]}: ${reason}` : undefined,
     };
   });
 

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -122,13 +122,35 @@ export function HelpModal({ isOpen, onClose, triggerRef }: HelpModalProps) {
                   in sync with the scale root automatically.
                 </li>
                 <li>
-                  <strong>Chord only (hide scale)</strong> dims non-chord notes
-                  so you can focus on playable voicings.
+                  <strong>Lens</strong> controls which notes are emphasized:
+                  <ul>
+                    <li>
+                      <strong>Targets + Color</strong> — chord tones plus
+                      characteristic scale color notes (default).
+                    </li>
+                    <li>
+                      <strong>Targets</strong> — chord tones only; hides all
+                      other scale notes so you can focus on playable voicings.
+                    </li>
+                    <li>
+                      <strong>Guide Tones</strong> — 3rd and 7th only; the
+                      tones that most strongly define chord quality.
+                    </li>
+                    <li>
+                      <strong>Color</strong> — characteristic modal or blue
+                      notes that give the scale its flavor.
+                    </li>
+                    <li>
+                      <strong>Tension</strong> — chord tones that fall outside
+                      the scale and need resolution. Only available when the
+                      chord contains notes outside the scale.
+                    </li>
+                  </ul>
                 </li>
                 <li>
-                  <strong>Interval Filter</strong> narrows which chord tones
-                  appear — useful for isolating roots, fifths, or specific
-                  intervals.
+                  <strong>Focus</strong> narrows which chord tones appear —
+                  useful for isolating roots, fifths, guide tones, or specific
+                  voicings (Triad, Shell, Rootless, Custom).
                 </li>
               </ul>
 

--- a/src/components/ToggleBar.tsx
+++ b/src/components/ToggleBar.tsx
@@ -35,6 +35,7 @@ type ToggleBarOption<Value extends string | number> = {
   value: Value;
   label: string;
   disabled?: boolean;
+  title?: string;
 };
 
 interface ToggleBarProps<Value extends string | number> extends VariantProps<
@@ -73,6 +74,7 @@ export function ToggleBar<Value extends string | number>({
             className={toggleButtonVariants({ variant, isActive })}
             onClick={() => onChange(option.value)}
             disabled={option.disabled}
+            title={option.title}
           >
             {option.label}
           </button>

--- a/src/components/ToggleBar.tsx
+++ b/src/components/ToggleBar.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import "./ToggleBar.css";
 import shared from "./shared.module.css";
@@ -36,7 +37,8 @@ type ToggleBarOption<Value extends string | number> = {
   label: string;
   disabled?: boolean;
   title?: string;
-  ariaLabel?: string;
+  /** Accessible description announced after the button name by screen readers. */
+  description?: string;
 };
 
 interface ToggleBarProps<Value extends string | number> extends VariantProps<
@@ -57,6 +59,7 @@ export function ToggleBar<Value extends string | number>({
   label,
 }: ToggleBarProps<Value>) {
   const isTabs = variant === "tabs";
+  const descPrefix = useId();
   return (
     <div
       className={toggleBarVariants({ variant })}
@@ -65,6 +68,7 @@ export function ToggleBar<Value extends string | number>({
     >
       {options.map((option) => {
         const isActive = value === option.value;
+        const descId = option.description ? `${descPrefix}-${option.value}` : undefined;
         return (
           <button
             key={option.value}
@@ -76,12 +80,23 @@ export function ToggleBar<Value extends string | number>({
             onClick={() => onChange(option.value)}
             disabled={option.disabled}
             title={option.title}
-            aria-label={option.ariaLabel}
+            aria-describedby={descId}
           >
             {option.label}
           </button>
         );
       })}
+      {options.map((option) =>
+        option.description ? (
+          <span
+            key={`desc-${option.value}`}
+            id={`${descPrefix}-${option.value}`}
+            className={shared["sr-only"]}
+          >
+            {option.description}
+          </span>
+        ) : null,
+      )}
     </div>
   );
 }

--- a/src/components/ToggleBar.tsx
+++ b/src/components/ToggleBar.tsx
@@ -36,6 +36,7 @@ type ToggleBarOption<Value extends string | number> = {
   label: string;
   disabled?: boolean;
   title?: string;
+  ariaLabel?: string;
 };
 
 interface ToggleBarProps<Value extends string | number> extends VariantProps<
@@ -75,6 +76,7 @@ export function ToggleBar<Value extends string | number>({
             onClick={() => onChange(option.value)}
             disabled={option.disabled}
             title={option.title}
+            aria-label={option.ariaLabel}
           >
             {option.label}
           </button>

--- a/src/components/shared.module.css
+++ b/src/components/shared.module.css
@@ -206,8 +206,8 @@
 }
 
 .lens-hint {
-  font-size: 0.72rem;
-  color: rgb(188 200 214 / 0.55);
+  font-size: 0.75rem;
+  color: rgb(188 200 214 / 0.72);
   line-height: 1.4;
   margin: 0;
   user-select: none;

--- a/src/components/shared.module.css
+++ b/src/components/shared.module.css
@@ -210,7 +210,6 @@
   color: rgb(188 200 214 / 0.72);
   line-height: 1.4;
   margin: 0;
-  user-select: none;
 }
 
 .sr-only {

--- a/src/components/shared.module.css
+++ b/src/components/shared.module.css
@@ -205,6 +205,14 @@
   user-select: none;
 }
 
+.lens-hint {
+  font-size: 0.72rem;
+  color: rgb(188 200 214 / 0.55);
+  line-height: 1.4;
+  margin: 0;
+  user-select: none;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
## Summary

- **Inline descriptions**: A concise one-line description now appears below the Lens ToggleBar for the active lens (e.g. "Combines chord tones with characteristic scale color notes — best for general-purpose soloing").
- **Unified availability**: Replaced the ad-hoc tension-only `disabled` check and `useEffect` auto-exit with `lensAvailabilityAtom`, which derives availability for all five lenses consistently. The generalized auto-exit now handles any unavailable lens (not just tension).
- **Disabled tooltips**: Disabled lens buttons now carry a `title` attribute surfacing the unavailable reason on hover (e.g. "Chord is fully within the scale — no outside tones").
- **HelpModal update**: Removed stale "Chord only (hide scale)" and "Interval Filter" references. Added a Lens sub-section listing all five lenses with one-line descriptions, and updated the Focus bullet to reflect the actual preset names (Triad, Shell, Rootless, Custom).

## Test plan

- [ ] Open Chord Overlay with a chord active — confirm the selected Lens shows its description below the toggle bar
- [ ] Switch lenses — confirm description updates on each selection
- [ ] Change scale so color notes disappear — confirm Color / Targets + Color disable and auto-exit back to Targets + Color
- [ ] Use a fully diatonic chord — confirm Tension is disabled with tooltip "Chord is fully within the scale — no outside tones"
- [ ] Use a chord with non-diatonic tones — confirm Tension enables
- [ ] Hover a disabled lens button — confirm tooltip shows the unavailable reason
- [ ] Open Help modal → Chord Overlay section — confirm updated copy with Lens and Focus subsections, no stale references

https://claude.ai/code/session_018KJnaZBfVHXdvxnR7n8zBp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic Lens availability and descriptions shown in Chord Overlay controls
  * Auto-switches to an available fallback Lens when the selected Lens becomes unavailable

* **Documentation**
  * Help modal updated to describe five Lens emphasis modes (Targets + Color, Targets, Guide Tones, Color, Tension) and the Focus feature

* **Improvements**
  * Toggle buttons now surface per-option titles for tooltips
  * Added compact Lens hint styling under controls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->