### PR TITLE
feat(fretboard): add master scale visibility control (all/custom/off)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -114,7 +114,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -124,7 +124,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -155,7 +155,7 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -172,7 +172,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -189,7 +189,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -199,7 +199,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -213,7 +213,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -231,7 +231,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -241,7 +241,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -251,7 +251,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -261,7 +261,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -275,7 +275,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -301,7 +301,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -316,7 +316,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -335,7 +335,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1116,7 +1116,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1127,7 +1127,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1138,7 +1138,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1148,14 +1148,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1660,7 +1660,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2440,7 +2440,7 @@
       "version": "2.10.15",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.15.tgz",
       "integrity": "sha512-1nfKCq9wuAZFTkA2ey/3OXXx7GzFjLdkTiFVNwlJ9WqdI706CZRIhEqjuwanjMIja+84jDLa9rcyZDPDiVkASQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2474,7 +2474,7 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2568,7 +2568,7 @@
       "version": "1.0.30001786",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001786.tgz",
       "integrity": "sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2846,7 +2846,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -2934,7 +2934,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3016,7 +3016,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3139,7 +3139,7 @@
       "version": "1.5.331",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
       "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -3355,7 +3355,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3852,7 +3852,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4772,7 +4772,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4843,7 +4843,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -4884,7 +4884,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -5389,7 +5389,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -5586,7 +5586,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5619,7 +5619,7 @@
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/object-inspect": {
@@ -5875,7 +5875,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -6284,7 +6284,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6980,7 +6980,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7476,7 +7476,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fretboard-app",
-  "version": "1.10.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fretboard-app",
-      "version": "1.10.0",
+      "version": "1.9.0",
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -21,7 +21,6 @@
         "@commitlint/config-conventional": "^20.5.0",
         "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.59.1",
-        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1513,6 +1512,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1612,7 +1612,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -5410,6 +5411,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5993,6 +5995,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6008,6 +6011,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6051,7 +6055,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redent": {
       "version": "3.0.0",

--- a/src/__tests__/DegreeChipStrip.test.tsx
+++ b/src/__tests__/DegreeChipStrip.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { DegreeChipStrip, type DegreeChip } from '../components/DegreeChipStrip';
 import { axe } from '../test-utils/a11y';
@@ -149,5 +149,93 @@ describe('DegreeChipStrip', () => {
       />
     );
     expect(container.querySelector('.degree-chip-strip-header')).toBeTruthy();
+  });
+
+  describe('mode prop', () => {
+    it("default mode 'all' renders chip list", () => {
+      const { container } = render(
+        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} />
+      );
+      expect(container.querySelector('.degree-chip-strip-list')).toBeTruthy();
+    });
+
+    it("mode 'off' hides chip list", () => {
+      const { container } = render(
+        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} mode="off" />
+      );
+      expect(container.querySelector('.degree-chip-strip-list')).toBeNull();
+    });
+
+    it("mode 'off' sets data-visibility-mode=off on section", () => {
+      const { container } = render(
+        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} mode="off" />
+      );
+      expect(container.querySelector('.degree-chip-strip')?.getAttribute('data-visibility-mode')).toBe('off');
+    });
+
+    it("mode 'all' disables chip buttons when no onChipToggle provided", () => {
+      const { getAllByRole } = render(
+        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} mode="all" />
+      );
+      const buttons = getAllByRole('button');
+      expect(buttons.every((b) => b.hasAttribute('disabled'))).toBe(true);
+    });
+
+    it("mode 'custom' enables chip buttons when onChipToggle provided", () => {
+      const toggle = vi.fn();
+      const { getAllByRole } = render(
+        <DegreeChipStrip
+          scaleName="A Natural Minor"
+          chips={aMinorChips}
+          mode="custom"
+          onChipToggle={toggle}
+        />
+      );
+      const buttons = getAllByRole('button');
+      expect(buttons.every((b) => !b.hasAttribute('disabled'))).toBe(true);
+    });
+
+    it("headerAction renders inside the strip", () => {
+      const { getByTestId } = render(
+        <DegreeChipStrip
+          scaleName="A Natural Minor"
+          chips={aMinorChips}
+          headerAction={<span data-testid="action-slot">ctrl</span>}
+        />
+      );
+      expect(getByTestId('action-slot')).toBeTruthy();
+    });
+
+    it("mode 'off' still renders headerAction", () => {
+      const { getByTestId } = render(
+        <DegreeChipStrip
+          scaleName="A Natural Minor"
+          chips={aMinorChips}
+          mode="off"
+          headerAction={<span data-testid="action-slot">ctrl</span>}
+        />
+      );
+      expect(getByTestId('action-slot')).toBeTruthy();
+    });
+
+    it("hidden chips show data-hidden in 'custom' mode", () => {
+      const { container } = render(
+        <DegreeChipStrip
+          scaleName="A Natural Minor"
+          chips={aMinorChips}
+          mode="custom"
+          hiddenNotes={new Set(['B'])}
+          onChipToggle={() => {}}
+        />
+      );
+      expect(container.querySelectorAll('[data-hidden="true"]').length).toBe(1);
+    });
+
+    it("no data-hidden chips rendered in 'all' mode (no hiddenNotes passed)", () => {
+      const { container } = render(
+        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} mode="all" />
+      );
+      expect(container.querySelectorAll('[data-hidden="true"]').length).toBe(0);
+    });
   });
 });

--- a/src/__tests__/FretboardSVG.test.tsx
+++ b/src/__tests__/FretboardSVG.test.tsx
@@ -363,6 +363,61 @@ describe("FretboardSVG", () => {
     });
   });
 
+  describe("scale visibility 'off' mode — empty highlightNotes with chord overlay", () => {
+    it("chord root still renders when highlightNotes is empty", () => {
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          highlightNotes={[]}
+          chordTones={["C", "E", "G"]}
+          chordRoot="C"
+          rootNote="C"
+        />
+      );
+      expect(container.querySelectorAll(".chord-root").length).toBeGreaterThan(0);
+    });
+
+    it("chord tones render as chord-tone-outside-scale when highlightNotes is empty", () => {
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          highlightNotes={[]}
+          chordTones={["C", "E", "G"]}
+          chordRoot="C"
+          rootNote="C"
+        />
+      );
+      // E and G are chord tones but not "in scale" (no highlightNotes) → outside-scale
+      expect(container.querySelectorAll(".chord-tone-outside-scale").length).toBeGreaterThan(0);
+    });
+
+    it("no scale-only or note-active notes rendered when highlightNotes is empty", () => {
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          highlightNotes={[]}
+          chordTones={["C", "E", "G"]}
+          chordRoot="C"
+          rootNote="C"
+        />
+      );
+      expect(container.querySelectorAll(".scale-only").length).toBe(0);
+      expect(container.querySelectorAll(".note-active").length).toBe(0);
+    });
+
+    it("no note-active rendered when highlightNotes is empty and no chord overlay", () => {
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          highlightNotes={[]}
+          rootNote="C"
+        />
+      );
+      expect(container.querySelectorAll(".note-active").length).toBe(0);
+      expect(container.querySelectorAll(".key-tonic").length).toBe(0);
+    });
+  });
+
   describe("composable renderer contract — noteSemantics", () => {
     it("outside chord root gets data-note-tension when noteSemantics provided", () => {
       // C# is the chord root but is outside C Major scale (C,E,G highlights)

--- a/src/__tests__/SummaryRibbon.test.tsx
+++ b/src/__tests__/SummaryRibbon.test.tsx
@@ -7,6 +7,7 @@ import {
   scaleNameAtom,
   chordTypeAtom,
   chordRootAtom,
+  scaleVisibilityModeAtom,
 } from "../store/atoms";
 import { renderWithAtoms } from "./utils/renderWithAtoms";
 
@@ -34,5 +35,61 @@ describe("SummaryRibbon", () => {
     ]);
     expect(screen.getByRole("group", { name: "Scale degrees" })).toBeInTheDocument();
     expect(screen.getByRole("group", { name: /Practice cues/i })).toBeInTheDocument();
+  });
+
+  describe("scale visibility mode control", () => {
+    it("renders visibility toggle group with All/Custom/Off options", () => {
+      renderWithAtoms(<SummaryRibbon />, [...BASE_SEEDS]);
+      const group = screen.getByRole("group", { name: "Scale visibility" });
+      expect(group).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Custom" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Off" })).toBeInTheDocument();
+    });
+
+    it("mode 'all' shows chip list (default)", () => {
+      renderWithAtoms(<SummaryRibbon />, [
+        ...BASE_SEEDS,
+        [scaleVisibilityModeAtom, "all"],
+      ]);
+      // 7 chips for C Major
+      expect(screen.getAllByRole("listitem").length).toBe(7);
+    });
+
+    it("mode 'custom' shows chip list with toggleable chips", () => {
+      renderWithAtoms(<SummaryRibbon />, [
+        ...BASE_SEEDS,
+        [scaleVisibilityModeAtom, "custom"],
+      ]);
+      expect(screen.getAllByRole("listitem").length).toBe(7);
+      // Chips should be enabled (custom mode passes onChipToggle)
+      const hideButtons = screen.getAllByRole("button", { name: /Hide|Show/ });
+      expect(hideButtons.every((b) => !b.hasAttribute("disabled"))).toBe(true);
+    });
+
+    it("mode 'off' hides the chip list", () => {
+      renderWithAtoms(<SummaryRibbon />, [
+        ...BASE_SEEDS,
+        [scaleVisibilityModeAtom, "off"],
+      ]);
+      expect(screen.queryAllByRole("listitem").length).toBe(0);
+    });
+
+    it("mode 'off' still shows the scale degrees group (for visibility control)", () => {
+      renderWithAtoms(<SummaryRibbon />, [
+        ...BASE_SEEDS,
+        [scaleVisibilityModeAtom, "off"],
+      ]);
+      expect(screen.getByRole("group", { name: "Scale degrees" })).toBeInTheDocument();
+    });
+
+    it("mode 'all' disables chip toggle buttons", () => {
+      renderWithAtoms(<SummaryRibbon />, [
+        ...BASE_SEEDS,
+        [scaleVisibilityModeAtom, "all"],
+      ]);
+      const chipButtons = screen.getAllByRole("button", { name: /Hide|Show/ });
+      expect(chipButtons.every((b) => b.hasAttribute("disabled"))).toBe(true);
+    });
   });
 });

--- a/src/__tests__/atoms.test.ts
+++ b/src/__tests__/atoms.test.ts
@@ -35,6 +35,11 @@ import {
   chordTonesAtom,
   colorNotesAtom,
   clickedShapeAtom,
+  scaleVisibilityModeAtom,
+  effectiveHiddenNotesAtom,
+  effectiveColorNotesAtom,
+  hiddenNotesAtom,
+  toggleHiddenNoteAtom,
 } from "../store/atoms";
 import { STANDARD_TUNING, TUNINGS } from "../guitar";
 import { CAGED_SHAPES } from "../shapes";
@@ -638,6 +643,117 @@ describe("atoms", () => {
       expect(store.get(clickedShapeAtom)).toBe("E");
       store.set(clickedShapeAtom, null);
       expect(store.get(clickedShapeAtom)).toBeNull();
+    });
+  });
+
+  describe("scaleVisibilityModeAtom", () => {
+    it("defaults to 'all'", () => {
+      const store = makeStore();
+      const unsub = mount(store, scaleVisibilityModeAtom);
+      expect(store.get(scaleVisibilityModeAtom)).toBe("all");
+      unsub();
+    });
+
+    it("reads valid stored value from localStorage", () => {
+      localStorage.setItem(k("scaleVisibilityMode"), "custom");
+      const store = makeStore();
+      const unsub = mount(store, scaleVisibilityModeAtom);
+      expect(store.get(scaleVisibilityModeAtom)).toBe("custom");
+      unsub();
+    });
+
+    it("falls back to 'all' for invalid stored value", () => {
+      localStorage.setItem(k("scaleVisibilityMode"), "invalid");
+      const store = makeStore();
+      const unsub = mount(store, scaleVisibilityModeAtom);
+      expect(store.get(scaleVisibilityModeAtom)).toBe("all");
+      unsub();
+    });
+
+    it("persists written value to localStorage", () => {
+      const store = makeStore();
+      store.set(scaleVisibilityModeAtom, "off");
+      expect(localStorage.getItem(k("scaleVisibilityMode"))).toBe("off");
+    });
+
+    it("resetAtom resets scaleVisibilityModeAtom to 'all'", () => {
+      const store = makeStore();
+      store.set(scaleVisibilityModeAtom, "off");
+      store.set(resetAtom);
+      expect(store.get(scaleVisibilityModeAtom)).toBe("all");
+    });
+  });
+
+  describe("effectiveHiddenNotesAtom", () => {
+    it("returns empty set in 'all' mode regardless of hidden notes", () => {
+      const store = makeStore();
+      store.set(scaleVisibilityModeAtom, "all");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(toggleHiddenNoteAtom, "E");
+      expect(store.get(effectiveHiddenNotesAtom).size).toBe(0);
+    });
+
+    it("returns empty set in 'off' mode", () => {
+      const store = makeStore();
+      store.set(scaleVisibilityModeAtom, "off");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(toggleHiddenNoteAtom, "E");
+      expect(store.get(effectiveHiddenNotesAtom).size).toBe(0);
+    });
+
+    it("returns hiddenNotesAtom value in 'custom' mode", () => {
+      const store = makeStore();
+      store.set(scaleVisibilityModeAtom, "custom");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(toggleHiddenNoteAtom, "E");
+      const effective = store.get(effectiveHiddenNotesAtom);
+      expect(effective.has("E")).toBe(true);
+      expect(effective.size).toBe(1);
+    });
+
+    it("hidden notes persist through mode switches back to custom", () => {
+      const store = makeStore();
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(scaleVisibilityModeAtom, "custom");
+      store.set(toggleHiddenNoteAtom, "G");
+
+      store.set(scaleVisibilityModeAtom, "all");
+      expect(store.get(effectiveHiddenNotesAtom).size).toBe(0);
+
+      store.set(scaleVisibilityModeAtom, "custom");
+      // Hidden notes preserved in underlying hiddenNotesAtom
+      expect(store.get(hiddenNotesAtom).has("G")).toBe(true);
+      expect(store.get(effectiveHiddenNotesAtom).has("G")).toBe(true);
+    });
+  });
+
+  describe("effectiveColorNotesAtom", () => {
+    it("returns color notes normally in 'all' mode", () => {
+      const store = makeStore();
+      store.set(scaleVisibilityModeAtom, "all");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Minor Blues");
+      expect(store.get(effectiveColorNotesAtom)).toEqual(["F#"]);
+    });
+
+    it("returns empty array in 'off' mode", () => {
+      const store = makeStore();
+      store.set(scaleVisibilityModeAtom, "off");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Minor Blues");
+      expect(store.get(effectiveColorNotesAtom)).toEqual([]);
+    });
+
+    it("returns color notes in 'custom' mode", () => {
+      const store = makeStore();
+      store.set(scaleVisibilityModeAtom, "custom");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Minor Blues");
+      expect(store.get(effectiveColorNotesAtom)).toEqual(["F#"]);
     });
   });
 });

--- a/src/components/DegreeChipStrip.css
+++ b/src/components/DegreeChipStrip.css
@@ -28,14 +28,6 @@
   text-align: center;
 }
 
-.degree-chip-strip-header-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  width: 100%;
-}
-
 .degree-chip-strip-header {
   font-family: var(--font-sans);
   font-size: clamp(0.92rem, 1.5vw, 1.05rem);
@@ -45,8 +37,14 @@
   letter-spacing: 0.01em;
 }
 
-.degree-chip-strip-header-action {
-  flex-shrink: 0;
+/* When the header contains an action slot, lay it out as a flex row. */
+.degree-chip-strip-header[data-has-action] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
+  line-height: initial;
 }
 
 .degree-chip-strip-list {

--- a/src/components/DegreeChipStrip.css
+++ b/src/components/DegreeChipStrip.css
@@ -28,6 +28,14 @@
   text-align: center;
 }
 
+.degree-chip-strip-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
+}
+
 .degree-chip-strip-header {
   font-family: var(--font-sans);
   font-size: clamp(0.92rem, 1.5vw, 1.05rem);
@@ -35,6 +43,10 @@
   color: var(--text-soft-white);
   line-height: 1.2;
   letter-spacing: 0.01em;
+}
+
+.degree-chip-strip-header-action {
+  flex-shrink: 0;
 }
 
 .degree-chip-strip-list {

--- a/src/components/DegreeChipStrip.tsx
+++ b/src/components/DegreeChipStrip.tsx
@@ -21,7 +21,7 @@ export interface DegreeChipStripProps {
   hideHeader?: boolean;
   /** Controls chip interactivity and list visibility. */
   mode?: ScaleVisibilityMode;
-  /** Rendered inside the header row, to the right of the scale name. */
+  /** Rendered inside the header landmark, to the right of the scale name. */
   headerAction?: ReactNode;
 }
 
@@ -47,14 +47,13 @@ export function DegreeChipStrip({
       data-visibility-mode={mode}
     >
       {(!hideHeader || headerAction) && (
-        <div className="degree-chip-strip-header-row">
-          {!hideHeader && (
-            <span className="degree-chip-strip-header">{scaleName}</span>
-          )}
-          {headerAction && (
-            <div className="degree-chip-strip-header-action">{headerAction}</div>
-          )}
-        </div>
+        <header
+          className="degree-chip-strip-header"
+          data-has-action={headerAction ? 'true' : undefined}
+        >
+          {!hideHeader && scaleName}
+          {headerAction}
+        </header>
       )}
       {showChips && (
         <ul className="degree-chip-strip-list">

--- a/src/components/DegreeChipStrip.tsx
+++ b/src/components/DegreeChipStrip.tsx
@@ -1,4 +1,6 @@
+import type { ReactNode } from 'react';
 import clsx from 'clsx';
+import type { ScaleVisibilityMode } from '../store/atoms';
 import './DegreeChipStrip.css';
 
 export interface DegreeChip {
@@ -17,6 +19,10 @@ export interface DegreeChipStripProps {
   className?: string;
   'aria-label'?: string;
   hideHeader?: boolean;
+  /** Controls chip interactivity and list visibility. */
+  mode?: ScaleVisibilityMode;
+  /** Rendered inside the header row, to the right of the scale name. */
+  headerAction?: ReactNode;
 }
 
 export function DegreeChipStrip({
@@ -27,43 +33,57 @@ export function DegreeChipStrip({
   className,
   'aria-label': ariaLabel,
   hideHeader,
+  mode = 'all',
+  headerAction,
 }: DegreeChipStripProps) {
   const label = ariaLabel ?? `Scale degrees for ${scaleName}`;
+  const showChips = mode !== 'off';
 
   return (
     <section
       role="group"
       aria-label={label}
       className={clsx('degree-chip-strip', className)}
+      data-visibility-mode={mode}
     >
-      {!hideHeader && (
-        <header className="degree-chip-strip-header">{scaleName}</header>
+      {(!hideHeader || headerAction) && (
+        <div className="degree-chip-strip-header-row">
+          {!hideHeader && (
+            <span className="degree-chip-strip-header">{scaleName}</span>
+          )}
+          {headerAction && (
+            <div className="degree-chip-strip-header-action">{headerAction}</div>
+          )}
+        </div>
       )}
-      <ul className="degree-chip-strip-list">
-        {chips.map((chip, i) => {
-          const isHidden = hiddenNotes?.has(chip.internalNote) ?? false;
-          return (
-            <li
-              key={`${chip.note}-${i}`}
-              className="degree-chip-item"
-              data-in-scale={chip.inScale ? 'true' : undefined}
-              data-is-tonic={chip.isTonic ? 'true' : undefined}
-              data-hidden={isHidden ? 'true' : undefined}
-            >
-              <button
-                type="button"
-                className="degree-chip"
-                aria-pressed={isHidden}
-                aria-label={`${isHidden ? 'Show' : 'Hide'} ${chip.note}`}
-                onClick={() => onChipToggle?.(chip.internalNote)}
+      {showChips && (
+        <ul className="degree-chip-strip-list">
+          {chips.map((chip, i) => {
+            const isHidden = hiddenNotes?.has(chip.internalNote) ?? false;
+            return (
+              <li
+                key={`${chip.note}-${i}`}
+                className="degree-chip-item"
+                data-in-scale={chip.inScale ? 'true' : undefined}
+                data-is-tonic={chip.isTonic ? 'true' : undefined}
+                data-hidden={isHidden ? 'true' : undefined}
               >
-                <span className="degree-chip-note">{chip.note}</span>
-              </button>
-              <span className="degree-chip-interval">{chip.interval}</span>
-            </li>
-          );
-        })}
-      </ul>
+                <button
+                  type="button"
+                  className="degree-chip"
+                  aria-pressed={isHidden}
+                  aria-label={`${isHidden ? 'Show' : 'Hide'} ${chip.note}`}
+                  onClick={() => onChipToggle?.(chip.internalNote)}
+                  disabled={!onChipToggle}
+                >
+                  <span className="degree-chip-note">{chip.note}</span>
+                </button>
+                <span className="degree-chip-interval">{chip.interval}</span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </section>
   );
 }

--- a/src/components/SummaryRibbon.tsx
+++ b/src/components/SummaryRibbon.tsx
@@ -1,8 +1,18 @@
+import { useAtom } from "jotai";
 import { useScaleState } from "../hooks/useScaleState";
 import { useChordState } from "../hooks/useChordState";
 import { usePracticeBarState } from "../hooks/usePracticeBarState";
 import { DegreeChipStrip } from "./DegreeChipStrip";
 import { ChordPracticeBar } from "./ChordPracticeBar";
+import { ToggleBar } from "./ToggleBar";
+import { scaleVisibilityModeAtom, type ScaleVisibilityMode } from "../store/atoms";
+
+const VISIBILITY_OPTIONS: readonly { value: ScaleVisibilityMode; label: string }[] =
+  [
+    { value: "all", label: "All" },
+    { value: "custom", label: "Custom" },
+    { value: "off", label: "Off" },
+  ] as const;
 
 export function SummaryRibbon() {
   const {
@@ -11,6 +21,8 @@ export function SummaryRibbon() {
     toggleHiddenNote,
     degreeChips,
   } = useScaleState();
+
+  const [scaleVisibilityMode, setScaleVisibilityMode] = useAtom(scaleVisibilityModeAtom);
 
   const { chordType } = useChordState();
 
@@ -24,13 +36,24 @@ export function SummaryRibbon() {
     shapeLocalPracticeCues,
   } = usePracticeBarState();
 
+  const visibilityControl = (
+    <ToggleBar
+      options={VISIBILITY_OPTIONS}
+      value={scaleVisibilityMode}
+      onChange={setScaleVisibilityMode}
+      label="Scale visibility"
+    />
+  );
+
   const scaleStrip = (
     <DegreeChipStrip
       scaleName={scaleLabel}
       chips={degreeChips}
-      hiddenNotes={hiddenNotes}
-      onChipToggle={toggleHiddenNote}
+      hiddenNotes={scaleVisibilityMode === "custom" ? hiddenNotes : undefined}
+      onChipToggle={scaleVisibilityMode === "custom" ? toggleHiddenNote : undefined}
       aria-label="Scale degrees"
+      mode={scaleVisibilityMode}
+      headerAction={visibilityControl}
     />
   );
 

--- a/src/hooks/useFretboardState.ts
+++ b/src/hooks/useFretboardState.ts
@@ -8,7 +8,7 @@ import {
   displayFormatAtom,
   useFlatsAtom,
   noteSemanticMapAtom,
-  shapeDataAtom,
+  effectiveShapeDataAtom,
   autoCenterTargetAtom,
   recenterKeyAtom,
   activeChordTonesAtom,
@@ -17,8 +17,8 @@ import {
   hideNonChordNotesAtom,
   viewModeAtom,
   practiceLensAtom,
-  colorNotesAtom,
-  hiddenNotesAtom,
+  effectiveColorNotesAtom,
+  effectiveHiddenNotesAtom,
 } from "../store/atoms";
 
 export function useFretboardState() {
@@ -31,18 +31,18 @@ export function useFretboardState() {
   const useFlats = useAtomValue(useFlatsAtom);
   const noteSemanticMap = useAtomValue(noteSemanticMapAtom);
   const { highlightNotes, boxBounds, shapePolygons, wrappedNotes } =
-    useAtomValue(shapeDataAtom);
+    useAtomValue(effectiveShapeDataAtom);
   const autoCenterTarget = useAtomValue(autoCenterTargetAtom);
   const recenterKey = useAtomValue(recenterKeyAtom);
-  
+
   const chordTones = useAtomValue(activeChordTonesAtom);
   const chordRoot = useAtomValue(chordRootAtom);
   const chordFretSpread = useAtomValue(chordFretSpreadAtom);
   const hideNonChordNotes = useAtomValue(hideNonChordNotesAtom);
   const viewMode = useAtomValue(viewModeAtom);
   const practiceLens = useAtomValue(practiceLensAtom);
-  const colorNotes = useAtomValue(colorNotesAtom);
-  const hiddenNotes = useAtomValue(hiddenNotesAtom);
+  const colorNotes = useAtomValue(effectiveColorNotesAtom);
+  const hiddenNotes = useAtomValue(effectiveHiddenNotesAtom);
 
   return {
     currentTuning,

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -33,6 +33,7 @@ export {
   recenterKeyAtom,
 } from "./fingeringAtoms";
 
+export type { ScaleVisibilityMode } from "./scaleAtoms";
 export {
   rootNoteAtom,
   baseScaleNameAtom,
@@ -47,6 +48,7 @@ export {
   degreeChipsAtom,
   hiddenNotesAtom,
   toggleHiddenNoteAtom,
+  scaleVisibilityModeAtom,
 } from "./scaleAtoms";
 
 export {
@@ -126,6 +128,9 @@ import {
   scaleLabelAtom,
   baseScaleNameAtom,
   scaleBrowseModeAtom,
+  hiddenNotesAtom,
+  colorNotesAtom,
+  scaleVisibilityModeAtom,
 } from "./scaleAtoms";
 import {
   chordRootAtom,
@@ -226,6 +231,30 @@ export const shapeDataAtom = atom((get) => {
     shapePolygons: polygons,
     wrappedNotes: mergedWrappedNotes,
   };
+});
+
+// Effective shape data: 'off' mode returns empty highlightNotes so the fretboard
+// renders no scale notes, while chord overlay continues to work via chordTones.
+export const effectiveShapeDataAtom = atom((get) => {
+  const mode = get(scaleVisibilityModeAtom);
+  const data = get(shapeDataAtom);
+  if (mode === "off") return { ...data, highlightNotes: [] as string[] };
+  return data;
+});
+
+// Effective hidden notes: only non-empty in 'custom' mode.
+export const effectiveHiddenNotesAtom = atom((get) => {
+  const mode = get(scaleVisibilityModeAtom);
+  if (mode !== "custom") return new Set<string>();
+  return get(hiddenNotesAtom);
+});
+
+// Effective color notes: cleared in 'off' mode since color notes are part of
+// the scale (blue notes, modal characteristic tones).
+export const effectiveColorNotesAtom = atom((get) => {
+  const mode = get(scaleVisibilityModeAtom);
+  if (mode === "off") return [] as string[];
+  return get(colorNotesAtom);
 });
 
 export const autoCenterTargetAtom = atom((get) => {
@@ -514,6 +543,7 @@ export const resetAtom = atom(null, (_get, set) => {
   set(rootNoteAtom, RESET);
   set(baseScaleNameAtom, RESET);
   set(scaleBrowseModeAtom, RESET);
+  set(scaleVisibilityModeAtom, RESET);
   set(chordRootAtom, RESET);
   set(chordTypeAtom, RESET);
   set(linkChordRootAtom, RESET);

--- a/src/store/scaleAtoms.ts
+++ b/src/store/scaleAtoms.ts
@@ -267,3 +267,55 @@ export const toggleHiddenNoteAtom = atom(null, (_get, set, note: string) => {
     return next;
   });
 });
+
+// ---------------------------------------------------------------------------
+// Scale visibility mode — master switch for scale note display
+// ---------------------------------------------------------------------------
+
+export type ScaleVisibilityMode = "all" | "custom" | "off";
+
+const SCALE_VISIBILITY_MODES: readonly ScaleVisibilityMode[] = [
+  "all",
+  "custom",
+  "off",
+];
+
+const scaleVisibilityModeStorage = {
+  getItem(key: string, initialValue: ScaleVisibilityMode): ScaleVisibilityMode {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        localStorage.setItem(key, initialValue);
+        return initialValue;
+      }
+      if ((SCALE_VISIBILITY_MODES as readonly string[]).includes(stored)) {
+        return stored as ScaleVisibilityMode;
+      }
+      localStorage.setItem(key, initialValue);
+      return initialValue;
+    } catch {
+      return initialValue;
+    }
+  },
+  setItem(key: string, value: ScaleVisibilityMode): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Storage blocked or unavailable; ignore.
+    }
+  },
+};
+
+export const scaleVisibilityModeAtom = atomWithStorage<ScaleVisibilityMode>(
+  k("scaleVisibilityMode"),
+  "all",
+  scaleVisibilityModeStorage,
+  GET_ON_INIT,
+);


### PR DESCRIPTION
## Summary

- Adds a `scaleVisibilityModeAtom` (`all` | `custom` | `off`) persisted to localStorage, with self-healing storage and reset support
- `off` mode empties `highlightNotes` and `colorNotes` fed to the fretboard so all scale notes vanish; chord overlay (chord tones, chord root) continues to render independently via `chordTones` — the two surfaces are not coupled
- `custom` mode preserves the existing per-note toggle behaviour (`hiddenNotesAtom`); switching away and back preserves the hidden-note set
- `all` mode (default) restores previous behaviour — all scale notes visible, no individual toggles

## Implementation

- **`scaleAtoms.ts`**: `ScaleVisibilityMode` type + `scaleVisibilityModeAtom`
- **`atoms.ts`**: `effectiveShapeDataAtom`, `effectiveHiddenNotesAtom`, `effectiveColorNotesAtom` — derived atoms consumed by `useFretboardState`; `resetAtom` resets visibility mode to `"all"`
- **`useFretboardState.ts`**: uses the three effective atoms instead of the raw ones
- **`DegreeChipStrip`**: new `mode` prop gates chip-list rendering; new `headerAction` slot renders the `ToggleBar` inline in the strip header
- **`SummaryRibbon`**: wires the mode atom and conditionally passes `hiddenNotes`/`onChipToggle` so only `custom` mode enables per-chip toggles

## Test plan

- [ ] `scaleVisibilityModeAtom`: default `"all"`, valid/invalid storage, persist, reset
- [ ] `effectiveHiddenNotesAtom`: empty in `all`/`off`, populated in `custom`, preserved across mode switches
- [ ] `effectiveColorNotesAtom`: cleared in `off`, normal in `all`/`custom`
- [ ] `DegreeChipStrip` `mode` prop: `off` hides list, `all` disables buttons, `custom` enables buttons; `headerAction` renders in all modes
- [ ] `FretboardSVG` off-mode: empty `highlightNotes` + `chordTones` → chord root and outside-scale tones render; no `note-active`/`scale-only`
- [ ] `SummaryRibbon`: visibility toggle rendered; all three modes produce correct chip-list state

https://claude.ai/code/session_019Sa6pM8BQT8SPWse3yXePU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Scale visibility" mode control with three options: "All" (shows all scale degrees with controls disabled), "Custom" (enables individual degree toggles), and "Off" (hides the degree list). Selection persists across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->