### PR TITLE
feat(fretboard): lens-specific behavior via semantic note model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -114,7 +114,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -124,7 +124,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -155,7 +155,7 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -172,7 +172,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -189,7 +189,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -199,7 +199,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -213,7 +213,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -231,7 +231,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -241,7 +241,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -251,7 +251,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -261,7 +261,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -275,7 +275,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -301,7 +301,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -316,7 +316,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -335,7 +335,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1116,7 +1116,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1127,7 +1127,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1138,7 +1138,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1148,14 +1148,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1660,7 +1660,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2440,7 +2440,7 @@
       "version": "2.10.15",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.15.tgz",
       "integrity": "sha512-1nfKCq9wuAZFTkA2ey/3OXXx7GzFjLdkTiFVNwlJ9WqdI706CZRIhEqjuwanjMIja+84jDLa9rcyZDPDiVkASQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2474,7 +2474,7 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2568,7 +2568,7 @@
       "version": "1.0.30001786",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001786.tgz",
       "integrity": "sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2846,7 +2846,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -2934,7 +2934,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3016,7 +3016,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3139,7 +3139,7 @@
       "version": "1.5.331",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
       "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -3355,7 +3355,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3852,7 +3852,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4772,7 +4772,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4843,7 +4843,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -4884,7 +4884,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -5389,7 +5389,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -5586,7 +5586,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5619,7 +5619,7 @@
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/object-inspect": {
@@ -5875,7 +5875,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -6284,7 +6284,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6980,7 +6980,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7476,7 +7476,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/src/FretboardSVG.css
+++ b/src/FretboardSVG.css
@@ -147,30 +147,43 @@
 /* ==========================================================================
    Outside chord root: squircle shape signals root identity; dashed stroke
    signals the root falls outside the active scale (tension note). Both roles
-   coexist — something the old single-role enum couldn't represent.
+   coexist — the old single-role enum couldn't represent this.
+   The outer halo rect uses inline style (see FretboardSVG.tsx) so CSS can't
+   override fill:none there; this rule targets only the inner fill rect.
    ========================================================================== */
 .fretboard-note.chord-root[data-note-tension] rect:last-of-type {
   stroke-dasharray: 6 3;
-  fill: rgb(80 28 0 / 0.95);
+  fill: rgb(90 28 0 / 0.97);
+  stroke: var(--neon-orange);
+  stroke-width: 2.8;
 }
 
 /* ==========================================================================
-   Lens emphasis — .fretboard-board[data-practice-lens] surfaces the active
-   lens so child notes can be selectively promoted or receded. Scale notes are
-   never globally dimmed; only non-focal notes within each lens recede.
+   Lens emphasis — [data-practice-lens] on .fretboard-board surfaces the active
+   lens so child notes can be selectively promoted or receded.
+
+   Design principle: scale notes (scale-only class) are NEVER globally dimmed.
+   Emphasis is additive — focal notes get bolder stroke, vivid fill, and explicit
+   glow. Non-focal chord tones recede within their own role hierarchy, but plain
+   scale notes always stay at base brightness so players keep the full scale
+   context visible.
    ========================================================================== */
 
 /* --- guide-tones lens ---------------------------------------------------- */
 
-/* Guide tones (3rd / 7th) pop: bolder stroke + richer fill. */
+/* Guide tones (3rd / 7th): bold stroke, vivid fill, explicit orange glow. */
 [data-practice-lens="guide-tones"] .fretboard-note[data-note-guide-tone] circle,
 [data-practice-lens="guide-tones"] .fretboard-note[data-note-guide-tone] rect,
 [data-practice-lens="guide-tones"] .fretboard-note[data-note-guide-tone] polygon {
-  stroke-width: 3.2;
-  fill: rgb(85 46 6 / 0.97);
+  stroke-width: 3.8;
+  fill: rgb(95 52 8 / 0.99);
+  stroke: var(--neon-orange);
+}
+[data-practice-lens="guide-tones"] .fretboard-note[data-note-guide-tone] {
+  filter: var(--glow-orange);
 }
 
-/* Non-guide chord tones (including root) recede: thin stroke, dim fill, glow removed. */
+/* Non-guide chord tones (including root) recede: thin stroke, dim fill, no glow. */
 [data-practice-lens="guide-tones"] .fretboard-note.chord-root:not([data-note-guide-tone]) rect:last-of-type,
 [data-practice-lens="guide-tones"] .fretboard-note.chord-tone-in-scale:not([data-note-guide-tone]) circle,
 [data-practice-lens="guide-tones"] .fretboard-note.chord-tone-in-scale:not([data-note-guide-tone]) rect,
@@ -184,7 +197,7 @@
   filter: none;
 }
 
-/* Color tones recede: keep hexagon shape, dim the violet ring. */
+/* Color tones recede: keep hexagon shape, dim violet ring. */
 [data-practice-lens="guide-tones"] .fretboard-note.color-tone circle,
 [data-practice-lens="guide-tones"] .fretboard-note.color-tone rect,
 [data-practice-lens="guide-tones"] .fretboard-note.color-tone polygon {
@@ -194,31 +207,24 @@
 [data-practice-lens="guide-tones"] .fretboard-note.color-tone {
   filter: none;
 }
-
-/* Scale-only notes: dim the ring so guide tones read as the focal layer. */
-[data-practice-lens="guide-tones"] .fretboard-note.scale-only circle,
-[data-practice-lens="guide-tones"] .fretboard-note.scale-only rect,
-[data-practice-lens="guide-tones"] .fretboard-note.scale-only polygon {
-  stroke: rgb(77 228 255 / 0.38);
-}
-[data-practice-lens="guide-tones"] .fretboard-note.scale-only {
-  filter: none;
-}
+/* scale-only notes intentionally left at base brightness */
 
 /* --- color lens ---------------------------------------------------------- */
 
-/* Color tones pop: bolder stroke + richer violet fill. */
+/* Color tones: bold stroke, vivid violet fill, explicit violet glow. */
 [data-practice-lens="color"] .fretboard-note.color-tone circle,
 [data-practice-lens="color"] .fretboard-note.color-tone rect,
 [data-practice-lens="color"] .fretboard-note.color-tone polygon {
-  stroke-width: 3.2;
-  fill: rgb(62 32 115 / 0.97);
+  stroke-width: 3.8;
+  fill: rgb(72 32 130 / 0.99);
+  stroke: var(--neon-violet);
+}
+[data-practice-lens="color"] .fretboard-note.color-tone {
+  filter: var(--glow-violet);
 }
 
 /* Chord root: semi-recede so color tones lead. */
-[data-practice-lens="color"] .fretboard-note.chord-root circle,
-[data-practice-lens="color"] .fretboard-note.chord-root rect,
-[data-practice-lens="color"] .fretboard-note.chord-root polygon {
+[data-practice-lens="color"] .fretboard-note.chord-root rect:last-of-type {
   stroke-width: 1.8;
   fill: rgb(55 35 18 / 0.62);
   stroke: rgb(255 154 77 / 0.68);
@@ -227,7 +233,7 @@
   filter: none;
 }
 
-/* Other chord tones recede: thin stroke, dim fill, glow removed. */
+/* Other chord tones recede: thin stroke, dim fill, no glow. */
 [data-practice-lens="color"] .fretboard-note.chord-tone-in-scale circle,
 [data-practice-lens="color"] .fretboard-note.chord-tone-in-scale rect,
 [data-practice-lens="color"] .fretboard-note.chord-tone-in-scale polygon {
@@ -238,53 +244,38 @@
 [data-practice-lens="color"] .fretboard-note.chord-tone-in-scale {
   filter: none;
 }
-
-/* Scale-only notes: dim ring so color tones read as focal layer. */
-[data-practice-lens="color"] .fretboard-note.scale-only circle,
-[data-practice-lens="color"] .fretboard-note.scale-only rect,
-[data-practice-lens="color"] .fretboard-note.scale-only polygon {
-  stroke: rgb(77 228 255 / 0.38);
-}
-[data-practice-lens="color"] .fretboard-note.scale-only {
-  filter: none;
-}
+/* scale-only notes intentionally left at base brightness */
 
 /* --- targets-color lens -------------------------------------------------- */
-
-/* Scale-only: gentle recession so chord + color tones define the hierarchy. */
-[data-practice-lens="targets-color"] .fretboard-note.scale-only circle,
-[data-practice-lens="targets-color"] .fretboard-note.scale-only rect,
-[data-practice-lens="targets-color"] .fretboard-note.scale-only polygon {
-  stroke: rgb(77 228 255 / 0.55);
-}
-[data-practice-lens="targets-color"] .fretboard-note.scale-only {
-  filter: none;
-}
+/* No recession rules — chord tones (squircles) and color tones (hexagons)
+   already distinguish themselves from scale-only circles via shape alone.
+   This lens is the balanced default; all notes show at full base brightness. */
 
 /* --- tension lens -------------------------------------------------------- */
 
-/* Tension notes: vivid solid stroke (override dashed), bright fill. */
+/* Tension notes (chord tones outside scale): vivid solid orange, bold stroke. */
 [data-practice-lens="tension"] .fretboard-note.chord-tone-outside-scale circle,
 [data-practice-lens="tension"] .fretboard-note.chord-tone-outside-scale rect,
 [data-practice-lens="tension"] .fretboard-note.chord-tone-outside-scale polygon {
   stroke: var(--neon-orange);
   fill: rgb(95 22 0 / 0.97);
   stroke-dasharray: none;
-  stroke-width: 3.0;
+  stroke-width: 3.8;
+}
+[data-practice-lens="tension"] .fretboard-note.chord-tone-outside-scale {
+  filter: var(--glow-orange);
 }
 
-/* Tension chord root: squircle (root) + dashed vivid stroke (tension). */
+/* Tension chord root: squircle (root identity) + dashed vivid stroke (tension). */
 [data-practice-lens="tension"] .fretboard-note.chord-root[data-note-tension] rect:last-of-type {
   stroke: var(--neon-orange);
   fill: rgb(95 22 0 / 0.97);
   stroke-dasharray: 6 3;
-  stroke-width: 3.0;
+  stroke-width: 3.8;
 }
 
-/* Regular chord root (not tension): semi-recede so tension leads. */
-[data-practice-lens="tension"] .fretboard-note.chord-root:not([data-note-tension]) circle,
-[data-practice-lens="tension"] .fretboard-note.chord-root:not([data-note-tension]) rect,
-[data-practice-lens="tension"] .fretboard-note.chord-root:not([data-note-tension]) polygon {
+/* Regular chord root (not tension): semi-recede so tension notes lead. */
+[data-practice-lens="tension"] .fretboard-note.chord-root:not([data-note-tension]) rect:last-of-type {
   stroke-width: 1.8;
   fill: rgb(55 35 18 / 0.62);
   stroke: rgb(255 154 77 / 0.68);
@@ -293,7 +284,7 @@
   filter: none;
 }
 
-/* Chord tones in scale recede: thin stroke, dim fill, glow removed. */
+/* Chord tones in scale recede: thin stroke, dim fill, no glow. */
 [data-practice-lens="tension"] .fretboard-note.chord-tone-in-scale circle,
 [data-practice-lens="tension"] .fretboard-note.chord-tone-in-scale rect,
 [data-practice-lens="tension"] .fretboard-note.chord-tone-in-scale polygon {
@@ -302,16 +293,6 @@
   stroke: rgb(200 110 40 / 0.50);
 }
 [data-practice-lens="tension"] .fretboard-note.chord-tone-in-scale {
-  filter: none;
-}
-
-/* Scale-only: dim ring to push tension notes forward. */
-[data-practice-lens="tension"] .fretboard-note.scale-only circle,
-[data-practice-lens="tension"] .fretboard-note.scale-only rect,
-[data-practice-lens="tension"] .fretboard-note.scale-only polygon {
-  stroke: rgb(77 228 255 / 0.38);
-}
-[data-practice-lens="tension"] .fretboard-note.scale-only {
   filter: none;
 }
 
@@ -325,3 +306,4 @@
 [data-practice-lens="tension"] .fretboard-note.color-tone {
   filter: none;
 }
+/* scale-only notes intentionally left at base brightness */

--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -118,15 +118,7 @@ function classifyNote(
   return "note-inactive";
 }
 
-/**
- * Semantic-model classification: uses NoteSemantics (composable boolean flags)
- * instead of the legacy positional boolean list. Falls back to classifyNote when
- * semantics are unavailable (no chord overlay context).
- *
- * Key advantage: isChordRoot + isTension can coexist — the chord root that sits
- * outside the scale is still classified as "chord-root" (preserving squircle
- * shape / root identity) while isTension drives the supplementary data attribute.
- */
+// Chord-root + isTension can coexist: outside-scale root stays "chord-root" (squircle/identity).
 function classifyNoteFromSemantics(
   sem: NoteSemantics,
   isChordInRange: boolean,
@@ -136,18 +128,11 @@ function classifyNoteFromSemantics(
   fretIndex: number,
 ): string {
   if (!hasChordOverlay) {
-    if (sem.isColorTone && sem.isInScale) return "note-blue";
-    if (sem.isScaleRoot && sem.isInScale) return "key-tonic";
-    if (sem.isInScale) return "note-active";
-    if (
-      sem.isColorTone &&
-      shapePolygons.length > 0 &&
-      boxBounds.some(
-        (b) => fretIndex >= b.minFret - 1 && fretIndex <= b.maxFret + 1,
-      )
-    )
-      return "note-blue";
-    return "note-inactive";
+    // Delegate to classifyNote to avoid duplicating the no-overlay logic.
+    return classifyNote(
+      sem.isScaleRoot, sem.isChordRoot, sem.isColorTone, sem.isInScale,
+      sem.isChordTone, hasChordOverlay, isChordInRange, shapePolygons, boxBounds, fretIndex,
+    );
   }
   // Chord overlay active: chord-root takes absolute priority, even if outside scale.
   if (sem.isChordRoot && sem.isChordTone && isChordInRange) return "chord-root";
@@ -720,13 +705,9 @@ export const FretboardSVG = memo(function FretboardSVG({
               fretIndex <= b.maxFret + chordFretSpread,
           );
 
-        // Use the composable semantic model when available (chord overlay context).
-        // Falls back to the legacy boolean path for scale-only views.
-        const semantics =
-          noteSemantics?.get(noteName) ??
-          (ENHARMONICS[noteName]
-            ? noteSemantics?.get(ENHARMONICS[noteName]!)
-            : undefined);
+        // Use the composable semantic model when available; fall back to booleans.
+        // Keys are sharp-normalized (per project convention) so no enharmonic lookup needed.
+        const semantics = noteSemantics?.get(noteName);
 
         const noteClass = isNoteHidden
           ? "note-inactive"

--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -118,6 +118,50 @@ function classifyNote(
   return "note-inactive";
 }
 
+/**
+ * Semantic-model classification: uses NoteSemantics (composable boolean flags)
+ * instead of the legacy positional boolean list. Falls back to classifyNote when
+ * semantics are unavailable (no chord overlay context).
+ *
+ * Key advantage: isChordRoot + isTension can coexist — the chord root that sits
+ * outside the scale is still classified as "chord-root" (preserving squircle
+ * shape / root identity) while isTension drives the supplementary data attribute.
+ */
+function classifyNoteFromSemantics(
+  sem: NoteSemantics,
+  isChordInRange: boolean,
+  hasChordOverlay: boolean,
+  shapePolygons: ShapePolygon[],
+  boxBounds: BoxBound[],
+  fretIndex: number,
+): string {
+  if (!hasChordOverlay) {
+    if (sem.isColorTone && sem.isInScale) return "note-blue";
+    if (sem.isScaleRoot && sem.isInScale) return "key-tonic";
+    if (sem.isInScale) return "note-active";
+    if (
+      sem.isColorTone &&
+      shapePolygons.length > 0 &&
+      boxBounds.some(
+        (b) => fretIndex >= b.minFret - 1 && fretIndex <= b.maxFret + 1,
+      )
+    )
+      return "note-blue";
+    return "note-inactive";
+  }
+  // Chord overlay active: chord-root takes absolute priority, even if outside scale.
+  if (sem.isChordRoot && sem.isChordTone && isChordInRange) return "chord-root";
+  // In-scale chord tones.
+  if (sem.isInScale && sem.isChordTone) return "chord-tone-in-scale";
+  // Color/characteristic tone: scale note not covered by a chord role.
+  if (sem.isInScale && sem.isColorTone) return "color-tone";
+  // Other in-scale notes.
+  if (sem.isInScale) return "scale-only";
+  // Out-of-scale chord tones (tension, non-root).
+  if (sem.isChordTone && isChordInRange) return "chord-tone-outside-scale";
+  return "note-inactive";
+}
+
 type NoteShape = "circle" | "squircle" | "diamond" | "hexagon";
 
 type NoteVisuals = {
@@ -676,20 +720,37 @@ export const FretboardSVG = memo(function FretboardSVG({
               fretIndex <= b.maxFret + chordFretSpread,
           );
 
+        // Use the composable semantic model when available (chord overlay context).
+        // Falls back to the legacy boolean path for scale-only views.
+        const semantics =
+          noteSemantics?.get(noteName) ??
+          (ENHARMONICS[noteName]
+            ? noteSemantics?.get(ENHARMONICS[noteName]!)
+            : undefined);
+
         const noteClass = isNoteHidden
           ? "note-inactive"
-          : classifyNote(
-              isScaleRoot,
-              isChordRootNote,
-              isColorNote,
-              isHighlighted,
-              isChordTone,
-              hasChordOverlay,
-              isChordInRange,
-              shapePolygons,
-              boxBounds,
-              fretIndex,
-            );
+          : semantics
+            ? classifyNoteFromSemantics(
+                semantics,
+                isChordInRange,
+                hasChordOverlay,
+                shapePolygons,
+                boxBounds,
+                fretIndex,
+              )
+            : classifyNote(
+                isScaleRoot,
+                isChordRootNote,
+                isColorNote,
+                isHighlighted,
+                isChordTone,
+                hasChordOverlay,
+                isChordInRange,
+                shapePolygons,
+                boxBounds,
+                fretIndex,
+              );
 
         if (noteClass === "note-inactive") continue;
 
@@ -745,7 +806,6 @@ export const FretboardSVG = memo(function FretboardSVG({
           return false;
         })();
 
-        const semantics = noteSemantics?.get(noteName);
         notes.push({
           stringIndex,
           fretIndex,
@@ -1051,6 +1111,9 @@ export const FretboardSVG = memo(function FretboardSVG({
                   noteShape === "squircle" ? (
                     <>
                       {noteClass === "chord-root" && (
+                        /* Outer halo: inline style prevents CSS class rules from overriding
+                           fill/stroke so the halo remains a transparent ring (not a filled rect).
+                           When isTension, the halo echoes the dashed tension signal. */
                         <rect
                           x={cx - r - 3.5}
                           y={cy - r - 3.5}
@@ -1058,9 +1121,15 @@ export const FretboardSVG = memo(function FretboardSVG({
                           height={(r + 3.5) * 2}
                           rx={(r + 3.5) * 0.38}
                           ry={(r + 3.5) * 0.38}
-                          fill="none"
-                          stroke="rgb(255 154 77 / 0.22)"
-                          strokeWidth={1.5}
+                          style={{
+                            fill: "none",
+                            stroke: isTension
+                              ? "rgb(255 154 77 / 0.45)"
+                              : "rgb(255 154 77 / 0.22)",
+                            strokeWidth: isTension ? 1.8 : 1.5,
+                            strokeDasharray: isTension ? "6 3" : undefined,
+                            paintOrder: "stroke",
+                          }}
                         />
                       )}
                       <rect


### PR DESCRIPTION
## Summary

- **Semantic classification**: Add `classifyNoteFromSemantics()` that drives note roles from `NoteSemantics` (composable boolean flags) instead of the legacy positional bool list. A chord root outside the scale stays `chord-root` (squircle shape / root identity) while `isTension` flows through as a supplementary data attribute — the single-role enum couldn't represent this coexistence.
- **Fix outside-chord-root rendering**: The outer halo `<rect>` now uses React inline `style` for `fill`/`stroke`/`strokeWidth` so CSS class rules can no longer override `fill: none`. The halo is now a true transparent ring; when `isTension`, it echoes the dashed signal. The base `chord-root[data-note-tension]` CSS is updated to vivid `neon-orange` stroke + red-shifted fill so root identity (squircle shape) and tension status (dashed ring) are both clearly readable.
- **Remove global scale-note dimming**: All `scale-only` stroke-dimming rules are deleted from every lens section (guide-tones, color, tension, targets-color). Scale notes always render at base brightness regardless of active lens — only non-focal chord-tone roles recede within their own hierarchy.
- **Materially stronger focal emphasis per lens**: Guide tones get `stroke-width: 3.8`, `var(--neon-orange)` stroke, and an explicit `var(--glow-orange)` filter. Color tones get `stroke-width: 3.8`, `var(--neon-violet)` stroke, and `var(--glow-violet)`. Tension notes get `stroke-width: 3.8` and `var(--glow-orange)`. Each lens now reads distinctly from the others without needing to suppress scale context.
- **Targets-color lens cleanup**: All recession rules removed; shape contrast (squircles / hexagons vs circles) provides hierarchy without any dimming.

## Test plan

- [ ] Load app with a scale + chord overlay active; switch through all five lenses and verify each looks visually distinct
- [ ] Guide-tones lens: only 3rd/7th notes should be vivid orange with thick ring; chord root and other chord tones should be dim; scale-only notes should be at full base cyan brightness (not dimmed)
- [ ] Color lens: color tone hexagons should be vivid violet; chord tones should recede; scale-only notes at full base brightness
- [ ] Tension lens: tension notes (outside-scale chord tones) should be vivid orange with solid thick ring; in-scale chord tones recede; scale-only notes at full base brightness
- [ ] Outside chord root (chord root not in scale): confirm squircle shape is preserved AND a dashed orange ring is visible (both root identity + tension status)
- [ ] Targets-color (default): all note types show at full brightness; shapes alone differentiate chord tones from scale notes
- [ ] Targets lens: non-chord-tone scale notes still hidden (unchanged behavior)
- [ ] 874 tests pass, build succeeds

https://claude.ai/code/session_016Wn8fbkw1VPqrX21T1wdLB