### PR TITLE
refactor(fretboard): make viewMode, autoCenterTarget, recenterKey prop-overridable

### DIFF
--- a/src/Fretboard.tsx
+++ b/src/Fretboard.tsx
@@ -49,6 +49,7 @@ interface FretboardProps {
   chordRoot?: string;
   chordFretSpread?: number;
   hideNonChordNotes?: boolean;
+  viewMode?: import("./theory").ViewMode;
   colorNotes?: string[];
   shapePolygons?: import("./shapes").ShapePolygon[];
   wrappedNotes?: Set<string>;
@@ -56,6 +57,8 @@ interface FretboardProps {
   useFlats?: boolean;
   scaleName?: string;
   stringRowPx?: number;
+  autoCenterTarget?: number;
+  recenterKey?: number;
   onFretClick?: (
     stringIndex: number,
     fretIndex: number,
@@ -80,14 +83,14 @@ export function Fretboard(props: FretboardProps) {
   const atomBoxBounds = shapeData.boxBounds;
   const atomShapePolygons = shapeData.shapePolygons;
   const atomWrappedNotes = shapeData.wrappedNotes;
-  const autoCenterTarget = useAtomValue(autoCenterTargetAtom);
-  const recenterKey = useAtomValue(recenterKeyAtom);
-  
+  const atomAutoCenterTarget = useAtomValue(autoCenterTargetAtom);
+  const atomRecenterKey = useAtomValue(recenterKeyAtom);
+
   const atomChordTones = useAtomValue(activeChordTonesAtom);
   const atomChordRoot = useAtomValue(chordRootAtom);
   const atomChordFretSpread = useAtomValue(chordFretSpreadAtom);
   const atomHideNonChordNotes = useAtomValue(hideNonChordNotesAtom);
-  const viewMode = useAtomValue(viewModeAtom);
+  const atomViewMode = useAtomValue(viewModeAtom);
   const practiceLens = useAtomValue(practiceLensAtom);
   const atomColorNotes = useAtomValue(colorNotesAtom);
   const atomHiddenNotes = useAtomValue(hiddenNotesAtom);
@@ -105,6 +108,9 @@ export function Fretboard(props: FretboardProps) {
   const chordRoot = props.chordRoot ?? atomChordRoot;
   const chordFretSpread = props.chordFretSpread ?? atomChordFretSpread;
   const hideNonChordNotes = props.hideNonChordNotes ?? atomHideNonChordNotes;
+  const viewMode = props.viewMode ?? atomViewMode;
+  const autoCenterTarget = props.autoCenterTarget ?? atomAutoCenterTarget;
+  const recenterKey = props.recenterKey ?? atomRecenterKey;
   const colorNotes = props.colorNotes ?? atomColorNotes;
   const shapePolygons = props.shapePolygons ?? atomShapePolygons;
   const wrappedNotes = props.wrappedNotes ?? atomWrappedNotes;


### PR DESCRIPTION
## Summary

- Rename `autoCenterTarget` / `recenterKey` / `viewMode` atom reads to use the `atom` prefix (consistent with all other atom-read variables in the component)
- Add `viewMode`, `autoCenterTarget`, and `recenterKey` to `FretboardProps` interface
- Add prop-override merges so props take precedence over atoms, matching the existing pattern for test compatibility

## Test plan

- [ ] TypeScript type-check passes (`tsc --noEmit`)
- [ ] No behaviour change — runtime values are identical when props are not supplied

https://claude.ai/code/session_0195Vtmv1H3wFMFx665bTvU1