### PR TITLE
refactor(summary): split SummaryRibbon into ScaleStripPanel + ChordOverlayDock siblings

### DIFF
--- a/src/components/ChordOverlayDock.tsx
+++ b/src/components/ChordOverlayDock.tsx
@@ -1,0 +1,28 @@
+import { usePracticeBarState } from "../hooks/usePracticeBarState";
+import { ChordPracticeBar } from "./ChordPracticeBar";
+
+/** Chord overlay surface: practice bar when a chord with outside members is active. */
+export function ChordOverlayDock() {
+  const {
+    showChordPracticeBar,
+    practiceBarTitle,
+    practiceBarBadge,
+    isShapeLocalContext,
+    shapeContextLabel,
+    practiceCues,
+    shapeLocalPracticeCues,
+  } = usePracticeBarState();
+
+  if (!showChordPracticeBar) return null;
+
+  return (
+    <ChordPracticeBar
+      title={practiceBarTitle}
+      badge={practiceBarBadge}
+      cues={practiceCues}
+      isShapeLocal={isShapeLocalContext}
+      shapeContextLabel={shapeContextLabel}
+      shapeLocalCues={shapeLocalPracticeCues}
+    />
+  );
+}

--- a/src/components/ScaleStripPanel.tsx
+++ b/src/components/ScaleStripPanel.tsx
@@ -1,0 +1,36 @@
+import { useAtom } from "jotai";
+import { useScaleState } from "../hooks/useScaleState";
+import { DegreeChipStrip } from "./DegreeChipStrip";
+import { ToggleBar } from "./ToggleBar";
+import { scaleVisibilityModeAtom, type ScaleVisibilityMode } from "../store/atoms";
+
+const VISIBILITY_OPTIONS: readonly { value: ScaleVisibilityMode; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "custom", label: "Custom" },
+  { value: "off", label: "Off" },
+] as const;
+
+/** Scale surface: degree chips + visibility toggle. No chord concerns. */
+export function ScaleStripPanel() {
+  const { scaleLabel, hiddenNotes, toggleHiddenNote, degreeChips } = useScaleState();
+  const [scaleVisibilityMode, setScaleVisibilityMode] = useAtom(scaleVisibilityModeAtom);
+
+  return (
+    <DegreeChipStrip
+      scaleName={scaleLabel}
+      chips={degreeChips}
+      hiddenNotes={scaleVisibilityMode === "custom" ? hiddenNotes : undefined}
+      onChipToggle={scaleVisibilityMode === "custom" ? toggleHiddenNote : undefined}
+      aria-label="Scale degrees"
+      mode={scaleVisibilityMode}
+      headerAction={
+        <ToggleBar
+          options={VISIBILITY_OPTIONS}
+          value={scaleVisibilityMode}
+          onChange={setScaleVisibilityMode}
+          label="Scale visibility"
+        />
+      }
+    />
+  );
+}

--- a/src/components/SummaryRibbon.tsx
+++ b/src/components/SummaryRibbon.tsx
@@ -1,79 +1,24 @@
-import { useAtom } from "jotai";
-import { useScaleState } from "../hooks/useScaleState";
-import { useChordState } from "../hooks/useChordState";
-import { usePracticeBarState } from "../hooks/usePracticeBarState";
-import { DegreeChipStrip } from "./DegreeChipStrip";
-import { ChordPracticeBar } from "./ChordPracticeBar";
-import { ToggleBar } from "./ToggleBar";
-import { scaleVisibilityModeAtom, type ScaleVisibilityMode } from "../store/atoms";
+import { useAtomValue } from "jotai";
+import { chordTypeAtom } from "../store/atoms";
+import { ScaleStripPanel } from "./ScaleStripPanel";
+import { ChordOverlayDock } from "./ChordOverlayDock";
 
-const VISIBILITY_OPTIONS: readonly { value: ScaleVisibilityMode; label: string }[] =
-  [
-    { value: "all", label: "All" },
-    { value: "custom", label: "Custom" },
-    { value: "off", label: "Off" },
-  ] as const;
-
+/**
+ * Orchestrates the top summary area.
+ * No chord → bare ScaleStripPanel.
+ * Chord active → .summary-ribbon shell with ScaleStripPanel + ChordOverlayDock as siblings.
+ */
 export function SummaryRibbon() {
-  const {
-    scaleLabel,
-    hiddenNotes,
-    toggleHiddenNote,
-    degreeChips,
-  } = useScaleState();
-
-  const [scaleVisibilityMode, setScaleVisibilityMode] = useAtom(scaleVisibilityModeAtom);
-
-  const { chordType } = useChordState();
-
-  const {
-    showChordPracticeBar,
-    practiceBarTitle,
-    practiceBarBadge,
-    isShapeLocalContext,
-    shapeContextLabel,
-    practiceCues,
-    shapeLocalPracticeCues,
-  } = usePracticeBarState();
-
-  const visibilityControl = (
-    <ToggleBar
-      options={VISIBILITY_OPTIONS}
-      value={scaleVisibilityMode}
-      onChange={setScaleVisibilityMode}
-      label="Scale visibility"
-    />
-  );
-
-  const scaleStrip = (
-    <DegreeChipStrip
-      scaleName={scaleLabel}
-      chips={degreeChips}
-      hiddenNotes={scaleVisibilityMode === "custom" ? hiddenNotes : undefined}
-      onChipToggle={scaleVisibilityMode === "custom" ? toggleHiddenNote : undefined}
-      aria-label="Scale degrees"
-      mode={scaleVisibilityMode}
-      headerAction={visibilityControl}
-    />
-  );
+  const chordType = useAtomValue(chordTypeAtom);
 
   if (!chordType) {
-    return scaleStrip;
+    return <ScaleStripPanel />;
   }
 
   return (
     <div className="summary-ribbon">
-      {scaleStrip}
-      {showChordPracticeBar && (
-        <ChordPracticeBar
-          title={practiceBarTitle}
-          badge={practiceBarBadge}
-          cues={practiceCues}
-          isShapeLocal={isShapeLocalContext}
-          shapeContextLabel={shapeContextLabel}
-          shapeLocalCues={shapeLocalPracticeCues}
-        />
-      )}
+      <ScaleStripPanel />
+      <ChordOverlayDock />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Extract `ScaleStripPanel` — owns scale state, visibility toggle (`ToggleBar`), and `DegreeChipStrip`. No chord concerns.
- Extract `ChordOverlayDock` — owns practice bar state and `ChordPracticeBar`. Returns `null` when the bar is suppressed.
- Slim down `SummaryRibbon` to a thin orchestrator: no chord → bare `<ScaleStripPanel>`; chord active → `.summary-ribbon` shell containing both siblings.

## Why

The original `SummaryRibbon` mixed scale state, visibility control, chord state, and practice bar state in one ~80-line component. This PR establishes clear component and layout ownership between the two surfaces — one per concern — without touching store logic, lens logic, fretboard rendering, or overlay semantics.

## Reviewer notes

- DOM output is structurally identical; the existing CSS selectors (`.summary-ribbon .degree-chip-strip` etc.) still resolve correctly.
- No CSS changes were needed.
- All 905 tests pass unchanged; the `SummaryRibbon` integration tests cover the composed behavior end-to-end.
- No store edits.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test` — 905/905 pass
- [x] `npm run build` — pre-push hook ran type-check + tests successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chord overlay dock component with chord practice bar state management
  * Added scale strip panel component with scale visibility toggle controls (all, custom, off modes)

* **Refactor**
  * Reorganized summary ribbon to use new specialized components, streamlining state management and component composition

<!-- end of auto-generated comment: release notes by coderabbit.ai -->