### PR TITLE
feat(chord): chord practice dock pass 2 — independent surface + lens label

### DIFF
--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -770,8 +770,14 @@ export const FretboardSVG = memo(function FretboardSVG({
   const noteData = useMemo(() => {
     // practiceLens is the source of truth when provided; hideNonChordNotes is the
     // legacy fallback for callers that haven't migrated yet.
+    // "targets" lens explicitly hides non-chord notes; other defined lenses
+    // use the semantic model instead of this flag.
     const effectiveHideNonChordNotes =
-      practiceLens !== undefined ? false : hideNonChordNotes;
+      practiceLens === "targets"
+        ? true
+        : practiceLens !== undefined
+          ? false
+          : hideNonChordNotes;
     const notes = [];
     const scale = SCALES[scaleName] || [];
     const normRoot = rootNote && (ENHARMONICS[rootNote]?.includes("b") ? ENHARMONICS[rootNote] : rootNote);

--- a/src/__tests__/ChordPracticeBar.test.tsx
+++ b/src/__tests__/ChordPracticeBar.test.tsx
@@ -95,6 +95,38 @@ describe("ChordPracticeBar", () => {
     expect(container.querySelector(".chord-practice-bar-badge")).toBeNull();
   });
 
+  describe("lensLabel prop", () => {
+    it("renders lensLabel text when provided", () => {
+      render(
+        <ChordPracticeBar title="D Minor 7" lensLabel="Chord + Color" cues={[landOnCue]} />
+      );
+      expect(screen.getByText("Chord + Color")).toBeTruthy();
+    });
+
+    it("renders lensLabel in the .chord-practice-bar-lens-label element", () => {
+      const { container } = render(
+        <ChordPracticeBar title="D Minor 7" lensLabel="Guide Tones" cues={[landOnCue]} />
+      );
+      const el = container.querySelector(".chord-practice-bar-lens-label");
+      expect(el).toBeTruthy();
+      expect(el!.textContent).toBe("Guide Tones");
+    });
+
+    it("does not render lens-label element when lensLabel is null", () => {
+      const { container } = render(
+        <ChordPracticeBar title="D Minor 7" lensLabel={null} cues={[landOnCue]} />
+      );
+      expect(container.querySelector(".chord-practice-bar-lens-label")).toBeNull();
+    });
+
+    it("does not render lens-label element when lensLabel is omitted", () => {
+      const { container } = render(
+        <ChordPracticeBar title="D Minor 7" cues={[landOnCue]} />
+      );
+      expect(container.querySelector(".chord-practice-bar-lens-label")).toBeNull();
+    });
+  });
+
   it("returns null when cues array is empty", () => {
     const { container } = render(
       <ChordPracticeBar title="Empty" cues={[]} />

--- a/src/__tests__/practiceLens.test.ts
+++ b/src/__tests__/practiceLens.test.ts
@@ -9,9 +9,11 @@ import {
   shapeLocalPracticeCuesAtom,
   hideNonChordNotesAtom,
   showChordPracticeBarAtom,
+  practiceBarLensLabelAtom,
   noteSemanticMapAtom,
   rootNoteAtom,
   scaleNameAtom,
+  scaleVisibilityModeAtom,
   chordRootAtom,
   chordTypeAtom,
   fingeringPatternAtom,
@@ -394,5 +396,100 @@ describe("shapeLocalPracticeCuesAtom", () => {
     store.set(practiceLensAtom, "targets");
     store.set(fingeringPatternAtom, "all");
     expect(store.get(shapeLocalPracticeCuesAtom)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// practiceBarLensLabelAtom — sourced from LENS_REGISTRY labels
+// ---------------------------------------------------------------------------
+
+describe("practiceBarLensLabelAtom", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns null when no chord is active", () => {
+    const store = makeStore();
+    store.set(chordTypeAtom, null);
+    expect(store.get(practiceBarLensLabelAtom)).toBeNull();
+  });
+
+  it("returns the LENS_REGISTRY label for the active lens", () => {
+    const store = makeStore();
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    store.set(practiceLensAtom, "targets-color");
+    expect(store.get(practiceBarLensLabelAtom)).toBe("Chord + Color");
+  });
+
+  it("returns correct labels for every lens", () => {
+    const store = makeStore();
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+
+    const expected: Record<string, string> = {
+      "targets-color": "Chord + Color",
+      targets: "Chord Tones",
+      "guide-tones": "Guide Tones",
+      color: "Color Notes",
+      tension: "Tension",
+    };
+    for (const [lens, label] of Object.entries(expected)) {
+      store.set(practiceLensAtom, lens as PracticeLens);
+      expect(store.get(practiceBarLensLabelAtom)).toBe(label);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// showChordPracticeBarAtom — independent of scale visibility
+// ---------------------------------------------------------------------------
+
+describe("showChordPracticeBarAtom — scale visibility independence", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("shows the dock when scale visibility is off (targets lens)", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    store.set(practiceLensAtom, "targets");
+    store.set(scaleVisibilityModeAtom, "off");
+    expect(store.get(showChordPracticeBarAtom)).toBe(true);
+  });
+
+  it("shows the dock when scale visibility is off (targets-color with outside tones)", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C#");
+    store.set(chordTypeAtom, "Minor Triad");
+    store.set(practiceLensAtom, "targets-color");
+    store.set(scaleVisibilityModeAtom, "off");
+    expect(store.get(showChordPracticeBarAtom)).toBe(true);
+  });
+
+  it("dock visibility does not change when toggling scaleVisibilityMode", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Dominant 7th"); // Bb outside C Major
+    store.set(practiceLensAtom, "targets-color");
+
+    store.set(scaleVisibilityModeAtom, "all");
+    const visibleAll = store.get(showChordPracticeBarAtom);
+
+    store.set(scaleVisibilityModeAtom, "off");
+    const visibleOff = store.get(showChordPracticeBarAtom);
+
+    store.set(scaleVisibilityModeAtom, "custom");
+    const visibleCustom = store.get(showChordPracticeBarAtom);
+
+    expect(visibleAll).toBe(visibleOff);
+    expect(visibleAll).toBe(visibleCustom);
   });
 });

--- a/src/__tests__/practiceLens.test.ts
+++ b/src/__tests__/practiceLens.test.ts
@@ -13,7 +13,7 @@ import {
   noteSemanticMapAtom,
   rootNoteAtom,
   scaleNameAtom,
-  scaleVisibilityModeAtom,
+  scaleVisibleAtom,
   chordRootAtom,
   chordTypeAtom,
   fingeringPatternAtom,
@@ -457,7 +457,7 @@ describe("showChordPracticeBarAtom — scale visibility independence", () => {
     store.set(chordRootAtom, "C");
     store.set(chordTypeAtom, "Major Triad");
     store.set(practiceLensAtom, "targets");
-    store.set(scaleVisibilityModeAtom, "off");
+    store.set(scaleVisibleAtom, false);
     expect(store.get(showChordPracticeBarAtom)).toBe(true);
   });
 
@@ -468,11 +468,11 @@ describe("showChordPracticeBarAtom — scale visibility independence", () => {
     store.set(chordRootAtom, "C#");
     store.set(chordTypeAtom, "Minor Triad");
     store.set(practiceLensAtom, "targets-color");
-    store.set(scaleVisibilityModeAtom, "off");
+    store.set(scaleVisibleAtom, false);
     expect(store.get(showChordPracticeBarAtom)).toBe(true);
   });
 
-  it("dock visibility does not change when toggling scaleVisibilityMode", () => {
+  it("dock visibility does not change when toggling scaleVisibleAtom", () => {
     const store = makeStore();
     store.set(rootNoteAtom, "C");
     store.set(scaleNameAtom, "Major");
@@ -480,16 +480,12 @@ describe("showChordPracticeBarAtom — scale visibility independence", () => {
     store.set(chordTypeAtom, "Dominant 7th"); // Bb outside C Major
     store.set(practiceLensAtom, "targets-color");
 
-    store.set(scaleVisibilityModeAtom, "all");
-    const visibleAll = store.get(showChordPracticeBarAtom);
+    store.set(scaleVisibleAtom, true);
+    const visibleOn = store.get(showChordPracticeBarAtom);
 
-    store.set(scaleVisibilityModeAtom, "off");
+    store.set(scaleVisibleAtom, false);
     const visibleOff = store.get(showChordPracticeBarAtom);
 
-    store.set(scaleVisibilityModeAtom, "custom");
-    const visibleCustom = store.get(showChordPracticeBarAtom);
-
-    expect(visibleAll).toBe(visibleOff);
-    expect(visibleAll).toBe(visibleCustom);
+    expect(visibleOn).toBe(visibleOff);
   });
 });

--- a/src/components/ChordOverlayDock.tsx
+++ b/src/components/ChordOverlayDock.tsx
@@ -1,12 +1,13 @@
 import { usePracticeBarState } from "../hooks/usePracticeBarState";
 import { ChordPracticeBar } from "./ChordPracticeBar";
 
-/** Chord overlay surface: practice bar when a chord with outside members is active. */
+/** Independent chord practice dock — shows coaching cues for the active lens. */
 export function ChordOverlayDock() {
   const {
     showChordPracticeBar,
     practiceBarTitle,
     practiceBarBadge,
+    practiceBarLensLabel,
     isShapeLocalContext,
     shapeContextLabel,
     practiceCues,
@@ -19,6 +20,7 @@ export function ChordOverlayDock() {
     <ChordPracticeBar
       title={practiceBarTitle}
       badge={practiceBarBadge}
+      lensLabel={practiceBarLensLabel}
       cues={practiceCues}
       isShapeLocal={isShapeLocalContext}
       shapeContextLabel={shapeContextLabel}

--- a/src/components/ChordPracticeBar.css
+++ b/src/components/ChordPracticeBar.css
@@ -1,6 +1,6 @@
-/* Chord practice bar — compact analysis cue strip shown below the scale strip
-   when a chord overlay is active. Uses pills/capsules instead of circular chips
-   to read as "analysis" rather than "another note strip". */
+/* Chord practice bar — independent practice surface that shows coaching cues
+   for the active lens. Uses pills/capsules rather than circular chips so it
+   reads as "practice analysis" rather than "another note strip". */
 
 .chord-practice-bar {
   --pill-h: 1.55rem;
@@ -36,6 +36,21 @@
   color: var(--text-soft-white);
   line-height: 1.2;
   letter-spacing: 0.01em;
+}
+
+/* Lens label — small registry-sourced tag identifying the active practice lens. */
+.chord-practice-bar-lens-label {
+  font-family: var(--font-sans);
+  font-size: 0.68rem;
+  font-weight: var(--font-weight-medium);
+  color: rgb(255 255 255 / 0.5);
+  line-height: 1;
+  letter-spacing: 0.03em;
+  background: rgb(255 255 255 / 0.06);
+  border: 1px solid rgb(255 255 255 / 0.1);
+  border-radius: 0.3rem;
+  padding: 0.15rem 0.35rem;
+  white-space: nowrap;
 }
 
 .chord-practice-bar-badge {

--- a/src/components/ChordPracticeBar.tsx
+++ b/src/components/ChordPracticeBar.tsx
@@ -46,6 +46,8 @@ function CueLine({ cue }: CueLineProps) {
 export interface ChordPracticeBarProps {
   title: string;
   badge?: string | null;
+  /** Active lens label sourced from LENS_REGISTRY — shown as a small indicator in the dock header. */
+  lensLabel?: string | null;
   cues: PracticeCue[];
   isShapeLocal?: boolean;
   shapeContextLabel?: string | null;
@@ -57,6 +59,7 @@ export interface ChordPracticeBarProps {
 export function ChordPracticeBar({
   title,
   badge,
+  lensLabel,
   cues,
   isShapeLocal = false,
   shapeContextLabel = null,
@@ -78,6 +81,9 @@ export function ChordPracticeBar({
     >
       <div className="chord-practice-bar-header">
         <span className="chord-practice-bar-title">{title}</span>
+        {lensLabel && (
+          <span className="chord-practice-bar-lens-label">{lensLabel}</span>
+        )}
         {badge && <span className="chord-practice-bar-badge">{badge}</span>}
       </div>
       {shapeContextLabel && (

--- a/src/components/HelpModal.test.tsx
+++ b/src/components/HelpModal.test.tsx
@@ -42,6 +42,26 @@ describe("HelpModal", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("does not contain stale Focus-era control section", () => {
+    render(<HelpModal isOpen={true} onClose={vi.fn()} />);
+    // The old "Focus" UI section should not appear as a section heading or strong label
+    // that describes chord-tone narrowing controls (Triad, Shell, Rootless, Custom).
+    const allStrong = document.querySelectorAll("strong");
+    const focusLabels = Array.from(allStrong).filter(
+      (el) => el.textContent === "Focus",
+    );
+    expect(focusLabels).toHaveLength(0);
+  });
+
+  it("lists current lens names matching LENS_REGISTRY labels", () => {
+    render(<HelpModal isOpen={true} onClose={vi.fn()} />);
+    expect(screen.getByText("Chord + Color")).toBeTruthy();
+    expect(screen.getByText("Chord Tones")).toBeTruthy();
+    expect(screen.getByText("Guide Tones")).toBeTruthy();
+    expect(screen.getByText("Color Notes")).toBeTruthy();
+    expect(screen.getByText("Tension")).toBeTruthy();
+  });
+
   it("restores focus to trigger button when modal closes", () => {
     const onClose = vi.fn();
     const { rerender } = render(

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -122,35 +122,30 @@ export function HelpModal({ isOpen, onClose, triggerRef }: HelpModalProps) {
                   in sync with the scale root automatically.
                 </li>
                 <li>
-                  <strong>Lens</strong> controls which notes are emphasized:
+                  <strong>Lens</strong> controls which notes the practice dock
+                  coaches you toward:
                   <ul>
                     <li>
-                      <strong>Targets + Color</strong> — chord tones plus
+                      <strong>Chord + Color</strong> — chord tones plus
                       characteristic scale color notes (default).
                     </li>
                     <li>
-                      <strong>Targets</strong> — chord tones only; hides all
-                      other scale notes so you can focus on playable voicings.
+                      <strong>Chord Tones</strong> — chord tones only; for
+                      landing and outlining the harmony.
                     </li>
                     <li>
                       <strong>Guide Tones</strong> — 3rd and 7th only; the
                       tones that most strongly define chord quality.
                     </li>
                     <li>
-                      <strong>Color</strong> — characteristic modal or blue
-                      notes that give the scale its flavor.
+                      <strong>Color Notes</strong> — characteristic modal or
+                      blue notes that give the scale its flavor.
                     </li>
                     <li>
-                      <strong>Tension</strong> — chord tones that fall outside
-                      the scale and need resolution. Only available when the
-                      chord contains notes outside the scale.
+                      <strong>Tension</strong> — chord tones outside the scale
+                      that need resolution. Only shown when such tones exist.
                     </li>
                   </ul>
-                </li>
-                <li>
-                  <strong>Focus</strong> narrows which chord tones appear —
-                  useful for isolating roots, fifths, guide tones, or specific
-                  voicings (Triad, Shell, Rootless, Custom).
                 </li>
               </ul>
 

--- a/src/hooks/useFretboardState.ts
+++ b/src/hooks/useFretboardState.ts
@@ -59,12 +59,16 @@ export function useFretboardState() {
   let activeShape: ActiveShapeType;
   let shapeScope: ShapeScope = "global";
 
-  if (fingeringPattern === "all" || cagedShapes.size === 0) {
+  if (fingeringPattern === "all") {
     activePattern = "all";
     activeShape = undefined;
     shapeScope = "global";
   } else if (fingeringPattern === "caged") {
-    if (cagedShapes.size === 1) {
+    if (cagedShapes.size === 0) {
+      activePattern = "all";
+      activeShape = undefined;
+      shapeScope = "global";
+    } else if (cagedShapes.size === 1) {
       activePattern = "caged";
       activeShape = Array.from(cagedShapes)[0] as CagedShape;
       shapeScope = "single";

--- a/src/hooks/usePracticeBarState.ts
+++ b/src/hooks/usePracticeBarState.ts
@@ -3,6 +3,7 @@ import {
   showChordPracticeBarAtom,
   practiceBarTitleAtom,
   practiceBarBadgeAtom,
+  practiceBarLensLabelAtom,
   isShapeLocalContextAtom,
   shapeContextLabelAtom,
   practiceLensAtom,
@@ -14,6 +15,7 @@ export function usePracticeBarState() {
   const showChordPracticeBar = useAtomValue(showChordPracticeBarAtom);
   const practiceBarTitle = useAtomValue(practiceBarTitleAtom);
   const practiceBarBadge = useAtomValue(practiceBarBadgeAtom);
+  const practiceBarLensLabel = useAtomValue(practiceBarLensLabelAtom);
   const isShapeLocalContext = useAtomValue(isShapeLocalContextAtom);
   const shapeContextLabel = useAtomValue(shapeContextLabelAtom);
   const practiceLens = useAtomValue(practiceLensAtom);
@@ -24,6 +26,7 @@ export function usePracticeBarState() {
     showChordPracticeBar,
     practiceBarTitle,
     practiceBarBadge,
+    practiceBarLensLabel,
     isShapeLocalContext,
     shapeContextLabel,
     practiceLens,

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -75,6 +75,7 @@ export {
   showChordPracticeBarAtom,
   practiceBarTitleAtom,
   practiceBarBadgeAtom,
+  practiceBarLensLabelAtom,
   practiceBarSharedMembersAtom,
   practiceBarOutsideMembersAtom,
   lensAvailabilityContextAtom,

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -317,8 +317,18 @@ export const practiceBarTitleAtom = atom((get) => {
   return chordLabel ?? "";
 });
 
-// Badge is now minimal — always null (lens context shown via title + shape subtitle).
+// Badge is now minimal — always null (lens context shown via lensLabel in dock header).
 export const practiceBarBadgeAtom = atom(() => null as string | null);
+
+// Active lens label sourced from LENS_REGISTRY — used by the dock header so the
+// practice surface identifies its own focus without needing the controls open.
+export const practiceBarLensLabelAtom = atom((get): string | null => {
+  const chordType = get(chordTypeAtom);
+  if (!chordType) return null;
+  const lens = get(practiceLensAtom);
+  const entry = LENS_REGISTRY.find((e) => e.id === lens);
+  return entry?.label ?? null;
+});
 
 // ---------------------------------------------------------------------------
 // Practice bar member rows (shared/outside split)


### PR DESCRIPTION
## Summary

- **Lens label in dock header**: `practiceBarLensLabelAtom` derives the active lens name from `LENS_REGISTRY` and the dock now passes it to `ChordPracticeBar` as a `lensLabel` prop, rendered as a small inline tag so the practice surface identifies its focus without opening the controls panel.
- **Dock decoupled from scale strip**: Updated `ChordOverlayDock` comment and `ChordPracticeBar.css` header comment to reflect that the dock is an independent practice surface, not an extension of the scale strip.
- **Stale Focus-era UI removed**: Deleted the `<strong>Focus</strong>` section from `HelpModal.tsx` (old chord-tone narrowing UI: Triad, Shell, Rootless, Custom). Updated lens names in the help text to match current `LENS_REGISTRY` labels (`Chord + Color`, `Chord Tones`, `Color Notes`).
- **Tests**: `lensLabel` prop rendering, `practiceBarLensLabelAtom` for all five lenses, dock visibility independence from `scaleVisibilityMode` (3 new cases), HelpModal no stale Focus label, HelpModal lists all current lens names.

## Test plan

- [x] 917 tests pass (`npm run test`)
- [x] TypeScript builds clean (`npm run build`)
- [x] `practiceBarLensLabelAtom` returns correct label for every `PracticeLens` value
- [x] `ChordPracticeBar` renders `.chord-practice-bar-lens-label` when `lensLabel` is provided; absent when `null`/omitted
- [x] `showChordPracticeBarAtom` unchanged by toggling `scaleVisibilityMode` between `all`/`off`/`custom`
- [x] No `<strong>Focus</strong>` element in rendered HelpModal
- [x] HelpModal lists all five current lens names

## Cleanup left for stream 6

- The `practiceBarBadgeAtom` always returns `null` and its comment could be removed along with the `badge` prop if no future use is planned.
- `ChordOverlayControls` lens hint still shows the full `description` from `LENS_REGISTRY`; could be replaced with a shorter `shortDescription` field if further brevity is desired.

https://claude.ai/code/session_016RNDgxnCY9BAH1VDiXEZvL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shape-scoped chord tone visualization: CAGED patterns, 3NPS positions, and all-shape modes now dynamically filter chord tones for focused practice
  * Chord practice dock now displays an active lens label badge for clarity
  * Enhanced note rendering with lens-based visual emphasis effects

* **Documentation**
  * Updated help text with clearer descriptions of practice lens modes and functionality

* **Tests**
  * Added test coverage for shape scope membership and lens label display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->