### PR TITLE
feat(scale): eye toggle + scale-owned color notes (stream 5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fretboard-app",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fretboard-app",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -21,6 +21,7 @@
         "@commitlint/config-conventional": "^20.5.0",
         "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.59.1",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1512,7 +1513,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1612,8 +1612,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -5411,7 +5410,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5995,7 +5993,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6011,7 +6008,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6055,8 +6051,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",

--- a/src/Fretboard.tsx
+++ b/src/Fretboard.tsx
@@ -73,6 +73,9 @@ export function Fretboard(props: FretboardProps) {
   const hiddenNotes = props.hiddenNotes ?? state.hiddenNotes;
   const useFlats = props.useFlats ?? state.useFlats;
   const scaleName = props.scaleName ?? state.scaleName;
+  const activePattern = props.activePattern ?? state.activePattern;
+  const activeShape = props.activeShape ?? state.activeShape;
+  const shapeScope = props.shapeScope ?? state.shapeScope;
   const noteSemantics = state.noteSemanticMap.size > 0 ? state.noteSemanticMap : undefined;
   const startFret = state.startFret;
   const endFret = state.endFret;
@@ -250,9 +253,9 @@ export function Fretboard(props: FretboardProps) {
           hiddenNotes={hiddenNotes}
           useFlats={useFlats}
           scaleName={scaleName}
-          activePattern={state.activePattern}
-          activeShape={state.activeShape}
-          shapeScope={state.shapeScope}
+          activePattern={activePattern}
+          activeShape={activeShape}
+          shapeScope={shapeScope}
           noteSemantics={noteSemantics}
           id={id}
           onNoteClick={handleFretClick}

--- a/src/__tests__/DegreeChipStrip.test.tsx
+++ b/src/__tests__/DegreeChipStrip.test.tsx
@@ -86,7 +86,6 @@ describe('DegreeChipStrip', () => {
   });
 
   it('scale strip does not render data-chord-active attribute even when chord is active externally', () => {
-    // DegreeChipStrip no longer accepts a chordActive prop — the section never has this attribute
     const { container } = render(
       <DegreeChipStrip
         scaleName="A Natural Minor"
@@ -151,48 +150,55 @@ describe('DegreeChipStrip', () => {
     expect(container.querySelector('.degree-chip-strip-header')).toBeTruthy();
   });
 
-  describe('mode prop', () => {
-    it("default mode 'all' renders chip list", () => {
+  describe('visible prop (eye toggle)', () => {
+    it("default visible=true renders chip list", () => {
       const { container } = render(
         <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} />
       );
       expect(container.querySelector('.degree-chip-strip-list')).toBeTruthy();
     });
 
-    it("mode 'off' hides chip list", () => {
+    it("visible=false hides chip list", () => {
       const { container } = render(
-        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} mode="off" />
+        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} visible={false} />
       );
       expect(container.querySelector('.degree-chip-strip-list')).toBeNull();
     });
 
-    it("mode 'off' sets data-visibility-mode=off on section", () => {
+    it("visible=false sets data-scale-visible=false on section", () => {
       const { container } = render(
-        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} mode="off" />
+        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} visible={false} />
       );
-      expect(container.querySelector('.degree-chip-strip')?.getAttribute('data-visibility-mode')).toBe('off');
+      expect(container.querySelector('.degree-chip-strip')?.getAttribute('data-scale-visible')).toBe('false');
     });
 
-    it("mode 'all' disables chip buttons when no onChipToggle provided", () => {
-      const { getAllByRole } = render(
-        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} mode="all" />
+    it("visible=true sets data-scale-visible=true on section", () => {
+      const { container } = render(
+        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} visible={true} />
       );
-      const buttons = getAllByRole('button');
-      expect(buttons.every((b) => b.hasAttribute('disabled'))).toBe(true);
+      expect(container.querySelector('.degree-chip-strip')?.getAttribute('data-scale-visible')).toBe('true');
     });
 
-    it("mode 'custom' enables chip buttons when onChipToggle provided", () => {
+    it("chip buttons are enabled when onChipToggle provided and visible", () => {
       const toggle = vi.fn();
       const { getAllByRole } = render(
         <DegreeChipStrip
           scaleName="A Natural Minor"
           chips={aMinorChips}
-          mode="custom"
           onChipToggle={toggle}
+          visible={true}
         />
       );
       const buttons = getAllByRole('button');
       expect(buttons.every((b) => !b.hasAttribute('disabled'))).toBe(true);
+    });
+
+    it("chip buttons are disabled when no onChipToggle provided", () => {
+      const { getAllByRole } = render(
+        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} visible={true} />
+      );
+      const buttons = getAllByRole('button');
+      expect(buttons.every((b) => b.hasAttribute('disabled'))).toBe(true);
     });
 
     it("headerAction renders inside the strip", () => {
@@ -206,24 +212,24 @@ describe('DegreeChipStrip', () => {
       expect(getByTestId('action-slot')).toBeTruthy();
     });
 
-    it("mode 'off' still renders headerAction", () => {
+    it("visible=false still renders headerAction", () => {
       const { getByTestId } = render(
         <DegreeChipStrip
           scaleName="A Natural Minor"
           chips={aMinorChips}
-          mode="off"
+          visible={false}
           headerAction={<span data-testid="action-slot">ctrl</span>}
         />
       );
       expect(getByTestId('action-slot')).toBeTruthy();
     });
 
-    it("hidden chips show data-hidden in 'custom' mode", () => {
+    it("hidden chips show data-hidden when visible", () => {
       const { container } = render(
         <DegreeChipStrip
           scaleName="A Natural Minor"
           chips={aMinorChips}
-          mode="custom"
+          visible={true}
           hiddenNotes={new Set(['B'])}
           onChipToggle={() => {}}
         />
@@ -231,11 +237,58 @@ describe('DegreeChipStrip', () => {
       expect(container.querySelectorAll('[data-hidden="true"]').length).toBe(1);
     });
 
-    it("no data-hidden chips rendered in 'all' mode (no hiddenNotes passed)", () => {
+    it("no data-hidden chips rendered when no hiddenNotes passed", () => {
       const { container } = render(
-        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} mode="all" />
+        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} visible={true} />
       );
       expect(container.querySelectorAll('[data-hidden="true"]').length).toBe(0);
+    });
+  });
+
+  describe('colorNotes prop (scale-owned color-note rendering)', () => {
+    it("color note chips get data-is-color-note attribute", () => {
+      const { container } = render(
+        <DegreeChipStrip
+          scaleName="C Minor Blues"
+          chips={aMinorChips}
+          colorNotes={new Set(['E'])}
+          visible={true}
+        />
+      );
+      expect(container.querySelectorAll('[data-is-color-note="true"]').length).toBe(1);
+    });
+
+    it("color notes appear without chord overlay (pure scale feature)", () => {
+      const { container } = render(
+        <DegreeChipStrip
+          scaleName="C Minor Blues"
+          chips={aMinorChips}
+          colorNotes={new Set(['E', 'G'])}
+          visible={true}
+        />
+      );
+      expect(container.querySelectorAll('[data-is-color-note="true"]').length).toBe(2);
+    });
+
+    it("no data-is-color-note attributes when colorNotes not provided", () => {
+      const { container } = render(
+        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} visible={true} />
+      );
+      expect(container.querySelectorAll('[data-is-color-note="true"]').length).toBe(0);
+    });
+
+    it("chord overlay independence: DegreeChipStrip does not accept chord props", () => {
+      const { container } = render(
+        <DegreeChipStrip
+          scaleName="A Natural Minor"
+          chips={aMinorChips}
+          colorNotes={new Set(['E'])}
+        />
+      );
+      // The strip should have no chord-specific data attributes
+      expect(container.querySelector('[data-in-chord]')).toBeNull();
+      expect(container.querySelector('[data-is-chord-root]')).toBeNull();
+      expect(container.querySelector('[data-chord-active]')).toBeNull();
     });
   });
 });

--- a/src/__tests__/SummaryRibbon.test.tsx
+++ b/src/__tests__/SummaryRibbon.test.tsx
@@ -7,7 +7,7 @@ import {
   scaleNameAtom,
   chordTypeAtom,
   chordRootAtom,
-  scaleVisibilityModeAtom,
+  scaleVisibleAtom,
 } from "../store/atoms";
 import { renderWithAtoms } from "./utils/renderWithAtoms";
 
@@ -37,59 +37,61 @@ describe("SummaryRibbon", () => {
     expect(screen.getByRole("group", { name: /Practice cues/i })).toBeInTheDocument();
   });
 
-  describe("scale visibility mode control", () => {
-    it("renders visibility toggle group with All/Custom/Off options", () => {
+  describe("eye toggle scale visibility", () => {
+    it("renders eye toggle button", () => {
       renderWithAtoms(<SummaryRibbon />, [...BASE_SEEDS]);
-      const group = screen.getByRole("group", { name: "Scale visibility" });
-      expect(group).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Custom" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Off" })).toBeInTheDocument();
+      const eyeButton = screen.getByRole("button", { name: /hide scale|show scale/i });
+      expect(eyeButton).toBeInTheDocument();
     });
 
-    it("mode 'all' shows chip list (default)", () => {
+    it("eye on (default) shows chip list with 7 chips for C Major", () => {
       renderWithAtoms(<SummaryRibbon />, [
         ...BASE_SEEDS,
-        [scaleVisibilityModeAtom, "all"],
-      ]);
-      // 7 chips for C Major
-      expect(screen.getAllByRole("listitem").length).toBe(7);
-    });
-
-    it("mode 'custom' shows chip list with toggleable chips", () => {
-      renderWithAtoms(<SummaryRibbon />, [
-        ...BASE_SEEDS,
-        [scaleVisibilityModeAtom, "custom"],
+        [scaleVisibleAtom, true],
       ]);
       expect(screen.getAllByRole("listitem").length).toBe(7);
-      // Chips should be enabled (custom mode passes onChipToggle)
-      const hideButtons = screen.getAllByRole("button", { name: /Hide|Show/ });
-      expect(hideButtons.every((b) => !b.hasAttribute("disabled"))).toBe(true);
     });
 
-    it("mode 'off' hides the chip list", () => {
+    it("eye off hides the chip list", () => {
       renderWithAtoms(<SummaryRibbon />, [
         ...BASE_SEEDS,
-        [scaleVisibilityModeAtom, "off"],
+        [scaleVisibleAtom, false],
       ]);
       expect(screen.queryAllByRole("listitem").length).toBe(0);
     });
 
-    it("mode 'off' still shows the scale degrees group (for visibility control)", () => {
+    it("eye off still shows the scale degrees group (for eye control)", () => {
       renderWithAtoms(<SummaryRibbon />, [
         ...BASE_SEEDS,
-        [scaleVisibilityModeAtom, "off"],
+        [scaleVisibleAtom, false],
       ]);
       expect(screen.getByRole("group", { name: "Scale degrees" })).toBeInTheDocument();
     });
 
-    it("mode 'all' disables chip toggle buttons", () => {
+    it("eye on shows chip toggle buttons as enabled", () => {
       renderWithAtoms(<SummaryRibbon />, [
         ...BASE_SEEDS,
-        [scaleVisibilityModeAtom, "all"],
+        [scaleVisibleAtom, true],
       ]);
-      const chipButtons = screen.getAllByRole("button", { name: /Hide|Show/ });
-      expect(chipButtons.every((b) => b.hasAttribute("disabled"))).toBe(true);
+      // Chips are enabled when scale is visible (onChipToggle is always passed)
+      const hideButtons = screen.getAllByRole("button", { name: /Hide|Show/ });
+      expect(hideButtons.every((b) => !b.hasAttribute("disabled"))).toBe(true);
+    });
+
+    it("chord overlay does not change scale-strip semantics", () => {
+      renderWithAtoms(<SummaryRibbon />, [
+        [rootNoteAtom, "C"],
+        [scaleNameAtom, "Major"],
+        [chordRootAtom, "C"],
+        [chordTypeAtom, "Major Triad"],
+        [scaleVisibleAtom, true],
+      ]);
+      // Scale strip still shows all 7 scale chips regardless of chord overlay
+      expect(screen.getAllByRole("listitem").length).toBe(7);
+      // No chord-specific attributes on scale strip
+      const scaleGroup = screen.getByRole("group", { name: "Scale degrees" });
+      expect(scaleGroup.getAttribute("data-chord-active")).toBeNull();
+      expect(scaleGroup.getAttribute("data-in-chord")).toBeNull();
     });
   });
 });

--- a/src/__tests__/atoms.test.ts
+++ b/src/__tests__/atoms.test.ts
@@ -32,7 +32,8 @@ import {
   chordTonesAtom,
   colorNotesAtom,
   clickedShapeAtom,
-  scaleVisibilityModeAtom,
+  scaleVisibleAtom,
+  toggleScaleVisibleAtom,
   effectiveHiddenNotesAtom,
   effectiveColorNotesAtom,
   hiddenNotesAtom,
@@ -638,113 +639,140 @@ describe("atoms", () => {
     });
   });
 
-  describe("scaleVisibilityModeAtom", () => {
-    it("defaults to 'all'", () => {
+  describe("scaleVisibleAtom", () => {
+    it("defaults to true", () => {
       const store = makeStore();
-      const unsub = mount(store, scaleVisibilityModeAtom);
-      expect(store.get(scaleVisibilityModeAtom)).toBe("all");
+      const unsub = mount(store, scaleVisibleAtom);
+      expect(store.get(scaleVisibleAtom)).toBe(true);
       unsub();
     });
 
-    it("reads valid stored value from localStorage", () => {
-      localStorage.setItem(k("scaleVisibilityMode"), "custom");
+    it("reads stored true from localStorage", () => {
+      localStorage.setItem(k("scaleVisible"), "true");
       const store = makeStore();
-      const unsub = mount(store, scaleVisibilityModeAtom);
-      expect(store.get(scaleVisibilityModeAtom)).toBe("custom");
+      const unsub = mount(store, scaleVisibleAtom);
+      expect(store.get(scaleVisibleAtom)).toBe(true);
       unsub();
     });
 
-    it("falls back to 'all' for invalid stored value", () => {
-      localStorage.setItem(k("scaleVisibilityMode"), "invalid");
+    it("reads stored false from localStorage", () => {
+      localStorage.setItem(k("scaleVisible"), "false");
       const store = makeStore();
-      const unsub = mount(store, scaleVisibilityModeAtom);
-      expect(store.get(scaleVisibilityModeAtom)).toBe("all");
+      const unsub = mount(store, scaleVisibleAtom);
+      expect(store.get(scaleVisibleAtom)).toBe(false);
       unsub();
     });
 
-    it("persists written value to localStorage", () => {
+    it("falls back to true for invalid stored value", () => {
+      localStorage.setItem(k("scaleVisible"), "invalid");
       const store = makeStore();
-      store.set(scaleVisibilityModeAtom, "off");
-      expect(localStorage.getItem(k("scaleVisibilityMode"))).toBe("off");
+      const unsub = mount(store, scaleVisibleAtom);
+      expect(store.get(scaleVisibleAtom)).toBe(true);
+      unsub();
     });
 
-    it("resetAtom resets scaleVisibilityModeAtom to 'all'", () => {
+    it("persists false to localStorage", () => {
       const store = makeStore();
-      store.set(scaleVisibilityModeAtom, "off");
+      store.set(scaleVisibleAtom, false);
+      expect(localStorage.getItem(k("scaleVisible"))).toBe("false");
+    });
+
+    it("resetAtom resets scaleVisibleAtom to true", () => {
+      const store = makeStore();
+      store.set(scaleVisibleAtom, false);
       store.set(resetAtom);
-      expect(store.get(scaleVisibilityModeAtom)).toBe("all");
+      expect(store.get(scaleVisibleAtom)).toBe(true);
+    });
+  });
+
+  describe("toggleScaleVisibleAtom", () => {
+    it("eye off hides the scale (visible false)", () => {
+      const store = makeStore();
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      expect(store.get(scaleVisibleAtom)).toBe(true);
+      store.set(toggleScaleVisibleAtom);
+      expect(store.get(scaleVisibleAtom)).toBe(false);
+    });
+
+    it("eye off clears individually hidden notes", () => {
+      const store = makeStore();
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(toggleHiddenNoteAtom, "E");
+      store.set(toggleHiddenNoteAtom, "G");
+      expect(store.get(hiddenNotesAtom).size).toBe(2);
+      store.set(toggleScaleVisibleAtom);
+      expect(store.get(hiddenNotesAtom).size).toBe(0);
+    });
+
+    it("eye on restores the full scale (no hidden notes)", () => {
+      const store = makeStore();
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(toggleHiddenNoteAtom, "E");
+      store.set(toggleScaleVisibleAtom); // off — clears hidden notes
+      store.set(toggleScaleVisibleAtom); // on
+      expect(store.get(scaleVisibleAtom)).toBe(true);
+      expect(store.get(hiddenNotesAtom).size).toBe(0);
+    });
+
+    it("individual note toggles only matter while scale is visible", () => {
+      const store = makeStore();
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      // Toggle note while visible — it is reflected in effectiveHiddenNotes
+      store.set(toggleHiddenNoteAtom, "B");
+      expect(store.get(effectiveHiddenNotesAtom).has("B")).toBe(true);
+      // Turn scale off — effectiveHiddenNotes returns empty
+      store.set(toggleScaleVisibleAtom);
+      expect(store.get(effectiveHiddenNotesAtom).size).toBe(0);
     });
   });
 
   describe("effectiveHiddenNotesAtom", () => {
-    it("returns empty set in 'all' mode regardless of hidden notes", () => {
+    it("returns hidden notes when scale is visible", () => {
       const store = makeStore();
-      store.set(scaleVisibilityModeAtom, "all");
       store.set(rootNoteAtom, "C");
       store.set(scaleNameAtom, "Major");
       store.set(toggleHiddenNoteAtom, "E");
-      expect(store.get(effectiveHiddenNotesAtom).size).toBe(0);
+      expect(store.get(effectiveHiddenNotesAtom).has("E")).toBe(true);
+      expect(store.get(effectiveHiddenNotesAtom).size).toBe(1);
     });
 
-    it("returns empty set in 'off' mode", () => {
+    it("returns empty set when scale is not visible", () => {
       const store = makeStore();
-      store.set(scaleVisibilityModeAtom, "off");
       store.set(rootNoteAtom, "C");
       store.set(scaleNameAtom, "Major");
       store.set(toggleHiddenNoteAtom, "E");
+      store.set(scaleVisibleAtom, false);
       expect(store.get(effectiveHiddenNotesAtom).size).toBe(0);
-    });
-
-    it("returns hiddenNotesAtom value in 'custom' mode", () => {
-      const store = makeStore();
-      store.set(scaleVisibilityModeAtom, "custom");
-      store.set(rootNoteAtom, "C");
-      store.set(scaleNameAtom, "Major");
-      store.set(toggleHiddenNoteAtom, "E");
-      const effective = store.get(effectiveHiddenNotesAtom);
-      expect(effective.has("E")).toBe(true);
-      expect(effective.size).toBe(1);
-    });
-
-    it("hidden notes persist through mode switches back to custom", () => {
-      const store = makeStore();
-      store.set(rootNoteAtom, "C");
-      store.set(scaleNameAtom, "Major");
-      store.set(scaleVisibilityModeAtom, "custom");
-      store.set(toggleHiddenNoteAtom, "G");
-
-      store.set(scaleVisibilityModeAtom, "all");
-      expect(store.get(effectiveHiddenNotesAtom).size).toBe(0);
-
-      store.set(scaleVisibilityModeAtom, "custom");
-      // Hidden notes preserved in underlying hiddenNotesAtom
-      expect(store.get(hiddenNotesAtom).has("G")).toBe(true);
-      expect(store.get(effectiveHiddenNotesAtom).has("G")).toBe(true);
     });
   });
 
   describe("effectiveColorNotesAtom", () => {
-    it("returns color notes normally in 'all' mode", () => {
+    it("returns color notes when scale is visible", () => {
       const store = makeStore();
-      store.set(scaleVisibilityModeAtom, "all");
+      store.set(scaleVisibleAtom, true);
       store.set(rootNoteAtom, "C");
       store.set(scaleNameAtom, "Minor Blues");
       expect(store.get(effectiveColorNotesAtom)).toEqual(["F#"]);
     });
 
-    it("returns empty array in 'off' mode", () => {
+    it("returns empty array when scale is not visible", () => {
       const store = makeStore();
-      store.set(scaleVisibilityModeAtom, "off");
+      store.set(scaleVisibleAtom, false);
       store.set(rootNoteAtom, "C");
       store.set(scaleNameAtom, "Minor Blues");
       expect(store.get(effectiveColorNotesAtom)).toEqual([]);
     });
 
-    it("returns color notes in 'custom' mode", () => {
+    it("color notes appear without chord overlay when scale is visible", () => {
       const store = makeStore();
-      store.set(scaleVisibilityModeAtom, "custom");
+      store.set(scaleVisibleAtom, true);
       store.set(rootNoteAtom, "C");
       store.set(scaleNameAtom, "Minor Blues");
+      // No chord overlay (chordType remains null by default)
       expect(store.get(effectiveColorNotesAtom)).toEqual(["F#"]);
     });
   });

--- a/src/__tests__/integration.test.tsx
+++ b/src/__tests__/integration.test.tsx
@@ -20,6 +20,34 @@ vi.mock("../audio", () => ({
   synth: mockSynth,
 }));
 
+// motion/react uses RAF-sequenced animations which never fire in jsdom, causing
+// AnimatePresence to defer rendering its children indefinitely and making any
+// waitFor that depends on animated content flaky. Replace with instant renders.
+vi.mock("motion/react", async () => {
+  const React = await import("react");
+  const ANIMATION_PROPS = new Set([
+    "initial", "animate", "exit", "transition", "variants",
+    "whileHover", "whileTap", "whileFocus", "whileDrag", "whileInView",
+    "layoutId", "layout",
+  ]);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const makeElement = (tag: string) => React.forwardRef<HTMLElement, any>(
+    ({ children, ...props }, ref) => {
+      const rest = Object.fromEntries(
+        Object.entries(props).filter(([k]) => !ANIMATION_PROPS.has(k)),
+      );
+      return React.createElement(tag, { ...rest, ref }, children);
+    },
+  );
+  return {
+    motion: new Proxy({} as Record<string, unknown>, {
+      get(_t, prop: string) { return makeElement(prop); },
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => children as any,
+  };
+});
+
 describe("Integration Tests - User Workflows", () => {
   beforeEach(() => {
     localStorage.clear();

--- a/src/components/DegreeChipStrip.css
+++ b/src/components/DegreeChipStrip.css
@@ -47,6 +47,36 @@
   line-height: initial;
 }
 
+/* Eye visibility toggle button */
+.scale-eye-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem;
+  border: none;
+  background: transparent;
+  color: var(--text-soft-white);
+  opacity: 0.6;
+  cursor: pointer;
+  border-radius: 0.3rem;
+  transition: opacity var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.scale-eye-toggle:hover {
+  opacity: 1;
+}
+
+.scale-eye-toggle:focus-visible {
+  outline: 2px solid rgb(77 228 255 / 0.7);
+  outline-offset: 2px;
+  opacity: 1;
+}
+
+.scale-eye-toggle[aria-pressed="true"] {
+  opacity: 0.4;
+}
+
 .degree-chip-strip-list {
   position: relative;
   display: flex;
@@ -117,6 +147,14 @@
   box-shadow: var(--chip-glow-orange);
   opacity: 1;
   border-width: var(--chip-border-width);
+}
+
+/* Color note (blue note / modal characteristic tone) — violet glow matching
+   the fretboard hexagon color-tone rendering (--neon-violet = #A78BFA). */
+.degree-chip-item[data-is-color-note='true'] .degree-chip {
+  border-color: rgb(167 139 250 / 0.85);
+  box-shadow: 0 0 6px rgb(167 139 250 / 0.65);
+  opacity: 1;
 }
 
 /* Hidden state overrides all active states — connector line grey glow. */

--- a/src/components/DegreeChipStrip.css
+++ b/src/components/DegreeChipStrip.css
@@ -152,8 +152,8 @@
 /* Color note (blue note / modal characteristic tone) — violet glow matching
    the fretboard hexagon color-tone rendering (--neon-violet = #A78BFA). */
 .degree-chip-item[data-is-color-note='true'] .degree-chip {
-  border-color: rgb(167 139 250 / 0.85);
-  box-shadow: 0 0 6px rgb(167 139 250 / 0.65);
+  border-color: var(--glow-violet-border);
+  box-shadow: var(--glow-violet-sm);
   opacity: 1;
 }
 

--- a/src/components/DegreeChipStrip.tsx
+++ b/src/components/DegreeChipStrip.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react';
 import clsx from 'clsx';
-import type { ScaleVisibilityMode } from '../store/atoms';
 import './DegreeChipStrip.css';
 
 export interface DegreeChip {
@@ -16,11 +15,13 @@ export interface DegreeChipStripProps {
   chips: DegreeChip[];
   hiddenNotes?: Set<string>;
   onChipToggle?: (internalNote: string) => void;
+  /** Scale-owned color notes (blue notes, modal characteristic tones). */
+  colorNotes?: Set<string>;
   className?: string;
   'aria-label'?: string;
   hideHeader?: boolean;
-  /** Controls chip interactivity and list visibility. */
-  mode?: ScaleVisibilityMode;
+  /** When false, hides the chip list. Default true. */
+  visible?: boolean;
   /** Rendered inside the header landmark, to the right of the scale name. */
   headerAction?: ReactNode;
 }
@@ -30,21 +31,21 @@ export function DegreeChipStrip({
   chips,
   hiddenNotes,
   onChipToggle,
+  colorNotes,
   className,
   'aria-label': ariaLabel,
   hideHeader,
-  mode = 'all',
+  visible = true,
   headerAction,
 }: DegreeChipStripProps) {
   const label = ariaLabel ?? `Scale degrees for ${scaleName}`;
-  const showChips = mode !== 'off';
 
   return (
     <section
       role="group"
       aria-label={label}
       className={clsx('degree-chip-strip', className)}
-      data-visibility-mode={mode}
+      data-scale-visible={visible ? 'true' : 'false'}
     >
       {(!hideHeader || headerAction) && (
         <header
@@ -55,10 +56,11 @@ export function DegreeChipStrip({
           {headerAction}
         </header>
       )}
-      {showChips && (
+      {visible && (
         <ul className="degree-chip-strip-list">
           {chips.map((chip, i) => {
             const isHidden = hiddenNotes?.has(chip.internalNote) ?? false;
+            const isColorNote = colorNotes?.has(chip.internalNote) ?? false;
             return (
               <li
                 key={`${chip.note}-${i}`}
@@ -66,6 +68,7 @@ export function DegreeChipStrip({
                 data-in-scale={chip.inScale ? 'true' : undefined}
                 data-is-tonic={chip.isTonic ? 'true' : undefined}
                 data-hidden={isHidden ? 'true' : undefined}
+                data-is-color-note={isColorNote ? 'true' : undefined}
               >
                 <button
                   type="button"

--- a/src/components/ScaleStripPanel.tsx
+++ b/src/components/ScaleStripPanel.tsx
@@ -1,35 +1,55 @@
-import { useAtom } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { useScaleState } from "../hooks/useScaleState";
 import { DegreeChipStrip } from "./DegreeChipStrip";
-import { ToggleBar } from "./ToggleBar";
-import { scaleVisibilityModeAtom, type ScaleVisibilityMode } from "../store/atoms";
+import { scaleVisibleAtom, toggleScaleVisibleAtom, colorNotesAtom } from "../store/atoms";
 
-const VISIBILITY_OPTIONS: readonly { value: ScaleVisibilityMode; label: string }[] = [
-  { value: "all", label: "All" },
-  { value: "custom", label: "Custom" },
-  { value: "off", label: "Off" },
-] as const;
+function EyeOpenIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+      <circle cx="12" cy="12" r="3"/>
+    </svg>
+  );
+}
 
-/** Scale surface: degree chips + visibility toggle. No chord concerns. */
+function EyeClosedIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/>
+      <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/>
+      <path d="m1 1 22 22"/>
+    </svg>
+  );
+}
+
+/** Scale surface: degree chips + eye visibility toggle. No chord concerns. */
 export function ScaleStripPanel() {
   const { scaleLabel, hiddenNotes, toggleHiddenNote, degreeChips } = useScaleState();
-  const [scaleVisibilityMode, setScaleVisibilityMode] = useAtom(scaleVisibilityModeAtom);
+  const scaleVisible = useAtomValue(scaleVisibleAtom);
+  const toggleScaleVisible = useSetAtom(toggleScaleVisibleAtom);
+  const colorNotes = useAtomValue(colorNotesAtom);
+
+  const colorNoteSet = colorNotes.length > 0 ? new Set(colorNotes) : undefined;
 
   return (
     <DegreeChipStrip
       scaleName={scaleLabel}
       chips={degreeChips}
-      hiddenNotes={scaleVisibilityMode === "custom" ? hiddenNotes : undefined}
-      onChipToggle={scaleVisibilityMode === "custom" ? toggleHiddenNote : undefined}
+      hiddenNotes={scaleVisible ? hiddenNotes : undefined}
+      onChipToggle={scaleVisible ? toggleHiddenNote : undefined}
+      colorNotes={colorNoteSet}
+      visible={scaleVisible}
       aria-label="Scale degrees"
-      mode={scaleVisibilityMode}
       headerAction={
-        <ToggleBar
-          options={VISIBILITY_OPTIONS}
-          value={scaleVisibilityMode}
-          onChange={setScaleVisibilityMode}
-          label="Scale visibility"
-        />
+        <button
+          type="button"
+          className="scale-eye-toggle"
+          aria-label={scaleVisible ? "Hide scale" : "Show scale"}
+          aria-pressed={!scaleVisible}
+          onClick={toggleScaleVisible}
+        >
+          {scaleVisible ? <EyeOpenIcon /> : <EyeClosedIcon />}
+        </button>
       }
     />
   );

--- a/src/components/ScaleStripPanel.tsx
+++ b/src/components/ScaleStripPanel.tsx
@@ -1,7 +1,5 @@
-import { useAtomValue, useSetAtom } from "jotai";
 import { useScaleState } from "../hooks/useScaleState";
 import { DegreeChipStrip } from "./DegreeChipStrip";
-import { scaleVisibleAtom, toggleScaleVisibleAtom, colorNotesAtom } from "../store/atoms";
 
 function EyeOpenIcon() {
   return (
@@ -24,10 +22,15 @@ function EyeClosedIcon() {
 
 /** Scale surface: degree chips + eye visibility toggle. No chord concerns. */
 export function ScaleStripPanel() {
-  const { scaleLabel, hiddenNotes, toggleHiddenNote, degreeChips } = useScaleState();
-  const scaleVisible = useAtomValue(scaleVisibleAtom);
-  const toggleScaleVisible = useSetAtom(toggleScaleVisibleAtom);
-  const colorNotes = useAtomValue(colorNotesAtom);
+  const {
+    scaleLabel,
+    hiddenNotes,
+    toggleHiddenNote,
+    degreeChips,
+    colorNotes,
+    scaleVisible,
+    toggleScaleVisible,
+  } = useScaleState();
 
   const colorNoteSet = colorNotes.length > 0 ? new Set(colorNotes) : undefined;
 

--- a/src/hooks/useScaleState.ts
+++ b/src/hooks/useScaleState.ts
@@ -12,6 +12,8 @@ import {
   hiddenNotesAtom,
   toggleHiddenNoteAtom,
   degreeChipsAtom,
+  scaleVisibleAtom,
+  toggleScaleVisibleAtom,
 } from "../store/atoms";
 
 export function useScaleState() {
@@ -28,6 +30,8 @@ export function useScaleState() {
   const [hiddenNotes, setHiddenNotes] = useAtom(hiddenNotesAtom);
   const toggleHiddenNote = useSetAtom(toggleHiddenNoteAtom);
   const degreeChips = useAtomValue(degreeChipsAtom);
+  const scaleVisible = useAtomValue(scaleVisibleAtom);
+  const toggleScaleVisible = useSetAtom(toggleScaleVisibleAtom);
 
   return {
     rootNote,
@@ -45,5 +49,7 @@ export function useScaleState() {
     setHiddenNotes,
     toggleHiddenNote,
     degreeChips,
+    scaleVisible,
+    toggleScaleVisible,
   };
 }

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -33,7 +33,6 @@ export {
   recenterKeyAtom,
 } from "./fingeringAtoms";
 
-export type { ScaleVisibilityMode } from "./scaleAtoms";
 export {
   rootNoteAtom,
   baseScaleNameAtom,
@@ -48,7 +47,8 @@ export {
   degreeChipsAtom,
   hiddenNotesAtom,
   toggleHiddenNoteAtom,
-  scaleVisibilityModeAtom,
+  scaleVisibleAtom,
+  toggleScaleVisibleAtom,
 } from "./scaleAtoms";
 
 export {
@@ -124,7 +124,7 @@ import {
   scaleBrowseModeAtom,
   hiddenNotesAtom,
   colorNotesAtom,
-  scaleVisibilityModeAtom,
+  scaleVisibleAtom,
 } from "./scaleAtoms";
 import {
   chordRootAtom,
@@ -224,27 +224,27 @@ export const shapeDataAtom = atom((get) => {
   };
 });
 
-// Effective shape data: 'off' mode returns empty highlightNotes so the fretboard
+// Effective shape data: eye-off returns empty highlightNotes so the fretboard
 // renders no scale notes, while chord overlay continues to work via chordTones.
 export const effectiveShapeDataAtom = atom((get) => {
-  const mode = get(scaleVisibilityModeAtom);
+  const visible = get(scaleVisibleAtom);
   const data = get(shapeDataAtom);
-  if (mode === "off") return { ...data, highlightNotes: [] as string[] };
+  if (!visible) return { ...data, highlightNotes: [] as string[] };
   return data;
 });
 
-// Effective hidden notes: only non-empty in 'custom' mode.
+// Effective hidden notes: returns actual hidden notes when scale is visible.
 export const effectiveHiddenNotesAtom = atom((get) => {
-  const mode = get(scaleVisibilityModeAtom);
-  if (mode !== "custom") return new Set<string>();
+  const visible = get(scaleVisibleAtom);
+  if (!visible) return new Set<string>();
   return get(hiddenNotesAtom);
 });
 
-// Effective color notes: cleared in 'off' mode since color notes are part of
-// the scale (blue notes, modal characteristic tones).
+// Effective color notes: cleared when scale is off since color notes are
+// part of the scale (blue notes, modal characteristic tones).
 export const effectiveColorNotesAtom = atom((get) => {
-  const mode = get(scaleVisibilityModeAtom);
-  if (mode === "off") return [] as string[];
+  const visible = get(scaleVisibleAtom);
+  if (!visible) return [] as string[];
   return get(colorNotesAtom);
 });
 
@@ -533,7 +533,7 @@ export const resetAtom = atom(null, (_get, set) => {
   set(rootNoteAtom, RESET);
   set(baseScaleNameAtom, RESET);
   set(scaleBrowseModeAtom, RESET);
-  set(scaleVisibilityModeAtom, RESET);
+  set(scaleVisibleAtom, RESET);
   set(chordRootAtom, RESET);
   set(chordTypeAtom, RESET);
   set(linkChordRootAtom, RESET);

--- a/src/store/scaleAtoms.ts
+++ b/src/store/scaleAtoms.ts
@@ -15,7 +15,7 @@ import {
   getDivergentNotes,
   formatAccidental,
 } from "../theory";
-import { k, rawStringStorage, GET_ON_INIT } from "../utils/storage";
+import { k, rawStringStorage, booleanStorage, GET_ON_INIT } from "../utils/storage";
 import { fingeringPatternAtom, cagedShapesAtom } from "./fingeringAtoms";
 import type { CagedShape } from "../shapes";
 
@@ -269,53 +269,26 @@ export const toggleHiddenNoteAtom = atom(null, (_get, set, note: string) => {
 });
 
 // ---------------------------------------------------------------------------
-// Scale visibility mode — master switch for scale note display
+// Scale visibility — boolean eye toggle (replaces tri-state All/Custom/Off)
 // ---------------------------------------------------------------------------
 
-export type ScaleVisibilityMode = "all" | "custom" | "off";
-
-const SCALE_VISIBILITY_MODES: readonly ScaleVisibilityMode[] = [
-  "all",
-  "custom",
-  "off",
-];
-
-const scaleVisibilityModeStorage = {
-  getItem(key: string, initialValue: ScaleVisibilityMode): ScaleVisibilityMode {
-    try {
-      const stored = localStorage.getItem(key);
-      if (stored === null) {
-        localStorage.setItem(key, initialValue);
-        return initialValue;
-      }
-      if ((SCALE_VISIBILITY_MODES as readonly string[]).includes(stored)) {
-        return stored as ScaleVisibilityMode;
-      }
-      localStorage.setItem(key, initialValue);
-      return initialValue;
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: ScaleVisibilityMode): void {
-    try {
-      localStorage.setItem(key, value);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-  removeItem(key: string): void {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      // Storage blocked or unavailable; ignore.
-    }
-  },
-};
-
-export const scaleVisibilityModeAtom = atomWithStorage<ScaleVisibilityMode>(
-  k("scaleVisibilityMode"),
-  "all",
-  scaleVisibilityModeStorage,
+// Persisted so users don't lose their preference on refresh.
+// Turning the scale off also clears hidden notes (see toggleScaleVisibleAtom).
+export const scaleVisibleAtom = atomWithStorage<boolean>(
+  k("scaleVisible"),
+  true,
+  booleanStorage,
   GET_ON_INIT,
 );
+
+// Write atom: turns scale on/off. Turning off also clears any per-note hidden
+// state so that turning back on always shows the full scale.
+export const toggleScaleVisibleAtom = atom(null, (get, set) => {
+  const visible = get(scaleVisibleAtom);
+  if (visible) {
+    set(hiddenNotesAtom, new Set<string>());
+    set(scaleVisibleAtom, false);
+  } else {
+    set(scaleVisibleAtom, true);
+  }
+});

--- a/src/store/scaleAtoms.ts
+++ b/src/store/scaleAtoms.ts
@@ -272,11 +272,24 @@ export const toggleHiddenNoteAtom = atom(null, (_get, set, note: string) => {
 // Scale visibility — boolean eye toggle (replaces tri-state All/Custom/Off)
 // ---------------------------------------------------------------------------
 
+// One-time migration: if the old tri-state key exists, map "off" → false and
+// remove the stale key so subsequent boots use the new boolean key directly.
+function readLegacyScaleVisibility(): boolean {
+  try {
+    const legacy = localStorage.getItem(k("scaleVisibilityMode"));
+    if (legacy === null) return true;
+    localStorage.removeItem(k("scaleVisibilityMode"));
+    return legacy !== "off";
+  } catch {
+    return true;
+  }
+}
+
 // Persisted so users don't lose their preference on refresh.
 // Turning the scale off also clears hidden notes (see toggleScaleVisibleAtom).
 export const scaleVisibleAtom = atomWithStorage<boolean>(
   k("scaleVisible"),
-  true,
+  readLegacyScaleVisibility(),
   booleanStorage,
   GET_ON_INIT,
 );

--- a/src/tokens.css
+++ b/src/tokens.css
@@ -101,6 +101,8 @@
   --glow-orange-sm: 0 0 6px rgb(255 154 77 / 0.5);
   --glow-orange-md: 0 0 12px rgb(255 154 77 / 0.6);
   --glow-orange-lg: 0 0 24px rgb(255 154 77 / 0.5);
+  --glow-violet-sm: 0 0 6px rgb(167 139 250 / 0.65);
+  --glow-violet-border: rgb(167 139 250 / 0.85);
 
   /* filter drop-shadows for SVG glyphs (brand icon) */
   --glow-filter-cyan: drop-shadow(0 0 6px rgb(77 228 255 / 0.65));


### PR DESCRIPTION
## Summary

- **Eye toggle replaces All/Custom/Off**: `scaleVisibleAtom` (boolean, persisted) replaces the tri-state `scaleVisibilityModeAtom`. The header action is now an open/closed eye SVG button instead of the ToggleBar.
- **Eye-off clears hidden notes**: `toggleScaleVisibleAtom` clears `hiddenNotesAtom` before setting visible=false, so eye-on always restores the full scale with no hidden subset carried over.
- **Per-note toggles always available**: Chip buttons are enabled whenever the scale is visible — no more "custom mode" gate. Hidden notes are transient scale-surface state, not a visibility mode.
- **Scale-owned color notes on the strip**: `DegreeChipStrip` gains a `colorNotes?: Set<string>` prop; chips gain `data-is-color-note="true"` and a violet glow (`#A78BFA`) matching the fretboard hexagon rendering. Color notes appear without a chord overlay.
- **Chord overlay independence preserved**: `DegreeChipStrip` accepts no chord props; the strip carries no `data-chord-active` or `data-in-chord` attributes regardless of chord state.

## Changed files

| File | What changed |
|---|---|
| `src/store/scaleAtoms.ts` | Remove `ScaleVisibilityMode` tri-state; add `scaleVisibleAtom` + `toggleScaleVisibleAtom` |
| `src/store/atoms.ts` | Update effective atoms + `resetAtom` to use `scaleVisibleAtom` |
| `src/components/DegreeChipStrip.tsx` | Replace `mode` prop with `visible` boolean; add `colorNotes` prop |
| `src/components/DegreeChipStrip.css` | Color note violet glow + eye toggle button styles |
| `src/components/ScaleStripPanel.tsx` | Eye icon button; always-enabled chip toggles; passes `colorNotes` |
| `src/hooks/useScaleState.ts` | Expose `scaleVisible` + `toggleScaleVisible` |
| `src/__tests__/atoms.test.ts` | Updated for boolean model; new eye toggle + color note tests |
| `src/__tests__/DegreeChipStrip.test.tsx` | Updated for `visible` prop; new color note + chord independence tests |
| `src/__tests__/SummaryRibbon.test.tsx` | Updated for eye toggle; chord independence assertion |

## Test plan

- [x] Eye toggle hides scale completely (chip list gone, eye button remains)
- [x] Eye toggle clears individually hidden notes on off
- [x] Eye toggle restores full scale (no hidden subset) on on
- [x] Individual note toggles available only while scale is visible
- [x] Color notes appear on scale strip without chord overlay
- [x] Color notes appear with correct violet glow (`data-is-color-note`)
- [x] Chord overlay does not restyle or control scale strip
- [x] TypeScript clean (`tsc --noEmit`)
- [x] All 913 tests pass (pre-push hook verified)

## Follow-up (stream 6)

- Snapshot tests may need updating once the eye button HTML is captured
- The old `scaleVisibilityMode` localStorage key (`fretflow:scaleVisibilityMode`) from existing user sessions will be ignored (new key is `fretflow:scaleVisible`); a one-time migration shim could be added if needed
- Color note interval label could be annotated (e.g. "♭5" in a distinct color) in a follow-up styling pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fingering pattern visualization (CAGED, 3NPS) with shape-based highlighting for targeted practice
  * Introduced note emphasis lens to highlight guide tones and color tones during practice sessions
  * Added color highlighting for specific scale degrees
  * Simplified scale visibility to a single eye toggle control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->