### PR TITLE
refactor(ownership): correct scale/chord surface separation — stream 6

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1194,20 +1194,16 @@
   justify-content: center;
 }
 
-/* Single adaptive ribbon card — replaces the old two-card summary-overlay-stack.
-   Wraps the scale strip + optional compact chord rail in one unified card. */
+/* Layout wrapper for scale strip + chord dock as independent sibling cards.
+   No card chrome here — each child (degree-chip-strip, chord-practice-bar)
+   carries its own background, border, and shadow. */
 .summary-ribbon {
   display: flex;
   flex-direction: column;
-  gap: 0.28rem;
+  gap: 0.5rem;
   width: min(100%, 30rem);
   margin: 0 auto;
-  padding: 0.5rem 0.9rem 0.55rem;
-  border-radius: 1rem;
-  background: rgb(22 27 38);
-  border: 1px solid rgb(255 255 255 / 0.06);
-  box-shadow: 0 6px 18px rgb(0 0 0 / 0.22);
-  align-items: center;
+  align-items: stretch;
 }
 
 /* Two-column header: scale label left, chord label + members right */
@@ -1245,40 +1241,6 @@
   flex-shrink: 0;
 }
 
-/* Strip card chrome is suppressed inside the ribbon — the ribbon IS the card.
-   Specificity (.app-container … .degree-chip-strip) beats desktop tier override. */
-.app-container .summary-ribbon .degree-chip-strip {
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  width: 100%;
-  margin: 0;
-  padding: 0.08rem 0 0;
-  border-radius: 0;
-  gap: 0.22rem;
-}
-
-.app-container .summary-ribbon .chord-row-strip {
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  width: 100%;
-  margin: 0;
-  padding: 0.1rem 0 0;
-  border-radius: 0;
-}
-
-/* Suppress per-strip headers inside the ribbon — the ribbon header covers them */
-.app-container .summary-ribbon .chord-row-strip-header {
-  display: none;
-}
-
-/* Separator between primary scale strip and secondary compact chord rail */
-.app-container .summary-ribbon .chord-row-strip--compact {
-  border-top: 1px solid rgb(255 255 255 / 0.07);
-  padding-top: 0.18rem;
-}
-
 /* Relationship row sits flush inside the ribbon — no extra card chrome */
 .app-container .summary-ribbon .relationship-row {
   width: 100%;
@@ -1293,9 +1255,7 @@
 /* Mobile ribbon */
 .app-container[data-layout-tier="mobile"] .summary-ribbon {
   width: 100%;
-  border-radius: 0.85rem;
-  padding: 0.45rem 0.7rem 0.5rem;
-  gap: 0.22rem;
+  gap: 0.4rem;
 }
 
 .app-container[data-layout-tier="mobile"] .summary-ribbon-header-left {
@@ -1309,8 +1269,7 @@
 /* Desktop ribbon */
 .app-container[data-layout-tier="desktop"] .summary-ribbon {
   width: min(100%, 32rem);
-  padding: 0.34rem 0.78rem 0.38rem;
-  gap: 0.18rem;
+  gap: 0.4rem;
 }
 
 .app-container[data-layout-tier="desktop"] .summary-ribbon-header-left {

--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -768,16 +768,10 @@ export const FretboardSVG = memo(function FretboardSVG({
   }, [totalColumns, startFret, stringRowPx, svgDefUrl, fretCenterX, inlayYAt, inlayYBottomAt, inlayYTopAt]);
 
   const noteData = useMemo(() => {
-    // practiceLens is the source of truth when provided; hideNonChordNotes is the
-    // legacy fallback for callers that haven't migrated yet.
-    // "targets" lens explicitly hides non-chord notes; other defined lenses
-    // use the semantic model instead of this flag.
+    // Lenses control coaching cues only — no lens hides scale notes.
+    // hideNonChordNotes is the legacy prop fallback for callers without practiceLens.
     const effectiveHideNonChordNotes =
-      practiceLens === "targets"
-        ? true
-        : practiceLens !== undefined
-          ? false
-          : hideNonChordNotes;
+      practiceLens !== undefined ? false : hideNonChordNotes;
     const notes = [];
     const scale = SCALES[scaleName] || [];
     const normRoot = rootNote && (ENHARMONICS[rootNote]?.includes("b") ? ENHARMONICS[rootNote] : rootNote);
@@ -950,9 +944,9 @@ export const FretboardSVG = memo(function FretboardSVG({
         );
 
         const isHidden = (() => {
-          // Targets lens: hide all non-chord scale notes, including color tones.
+          // Legacy hideNonChordNotes prop: hides scale-only and color-tone notes.
+          // With practiceLens set, effectiveHideNonChordNotes is always false.
           if (effectiveHideNonChordNotes && (noteClass === "scale-only" || noteClass === "color-tone")) return true;
-          // All other lenses show all notes; tension lens emphasizes through the practice bar.
           return false;
         })();
 

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -498,6 +498,51 @@ describe("App", () => {
       expect(title.textContent).toContain("C");
       expect(title.textContent).toContain("Dominant 7th");
     });
+
+    it("chord dock and scale strip are sibling cards — not nested inside each other", async () => {
+      localStorage.setItem(k("rootNote"), "C");
+      localStorage.setItem(k("chordRoot"), "D");
+      localStorage.setItem(k("chordType"), "Dominant 7th");
+      localStorage.setItem(k("practiceLens"), "tension");
+      render(<App />);
+      await waitFor(() => {
+        expect(document.querySelector(".summary-ribbon .chord-practice-bar")).toBeTruthy();
+      });
+      // The chord-practice-bar must NOT be nested inside degree-chip-strip
+      expect(
+        document.querySelector(".degree-chip-strip .chord-practice-bar")
+      ).toBeNull();
+      // Both surfaces exist as direct children of summary-ribbon
+      const ribbon = document.querySelector(".summary-ribbon")!;
+      const strip = ribbon.querySelector(":scope > .degree-chip-strip, :scope > section");
+      expect(strip).toBeTruthy();
+    });
+
+    it("chord dock remains visible when scale is hidden (eye-off)", async () => {
+      localStorage.setItem(k("rootNote"), "C");
+      localStorage.setItem(k("chordRoot"), "C");
+      localStorage.setItem(k("chordType"), "Dominant 7th");
+      localStorage.setItem(k("practiceLens"), "tension");
+      localStorage.setItem(k("scaleVisible"), "false");
+      render(<App />);
+      await waitFor(() => {
+        expect(document.querySelector(".chord-practice-bar")).toBeTruthy();
+      });
+    });
+
+    it("eye toggle button appears before the scale name text in the strip header", async () => {
+      render(<App />);
+      await waitFor(() => {
+        expect(document.querySelector(".degree-chip-strip-header")).toBeTruthy();
+      });
+      const header = document.querySelector(".degree-chip-strip-header")!;
+      const children = Array.from(header.childNodes).filter(
+        (n) => n.nodeType === Node.ELEMENT_NODE || (n.nodeType === Node.TEXT_NODE && n.textContent?.trim())
+      );
+      // First meaningful child should be the eye toggle button
+      const firstEl = children.find((n) => n.nodeType === Node.ELEMENT_NODE) as Element;
+      expect(firstEl?.tagName.toLowerCase()).toBe("button");
+    });
   });
 
   describe("Chord overlay", () => {

--- a/src/__tests__/atoms.test.ts
+++ b/src/__tests__/atoms.test.ts
@@ -463,7 +463,7 @@ describe("atoms", () => {
       const store = makeStore();
       store.set(chordRootAtom, "G");
       store.set(linkChordRootAtom, false);
-      store.set(practiceLensAtom, "targets"); // targets lens → hideNonChordNotesAtom = true
+      store.set(practiceLensAtom, "targets");
       store.set(chordFretSpreadAtom, 5);
       store.set(fingeringPatternAtom, "caged");
       store.set(npsPositionAtom, 3);
@@ -475,13 +475,14 @@ describe("atoms", () => {
       store.set(mobileTabAtom, "view");
       store.set(landscapeNarrowTabAtom, "key");
 
-      expect(store.get(hideNonChordNotesAtom)).toBe(true);
+      // hideNonChordNotesAtom is always false — lenses never hide scale notes
+      expect(store.get(hideNonChordNotesAtom)).toBe(false);
 
       store.set(resetAtom);
 
       expect(store.get(chordRootAtom)).toBe("C");
       expect(store.get(linkChordRootAtom)).toBe(true);
-      expect(store.get(hideNonChordNotesAtom)).toBe(false); // targets-color lens → false
+      expect(store.get(hideNonChordNotesAtom)).toBe(false);
       expect(store.get(chordFretSpreadAtom)).toBe(0);
       expect(store.get(fingeringPatternAtom)).toBe("all");
       expect(store.get(npsPositionAtom)).toBe(1);

--- a/src/__tests__/practiceLens.test.ts
+++ b/src/__tests__/practiceLens.test.ts
@@ -75,18 +75,17 @@ describe("practiceLensAtom", () => {
 });
 
 describe("hideNonChordNotesAtom", () => {
-  it("is true when lens is targets", () => {
+  it("is always false — lenses never hide scale notes", () => {
     const store = makeStore();
-    store.set(practiceLensAtom, "targets");
-    expect(store.get(hideNonChordNotesAtom)).toBe(true);
-  });
-
-  it("is false for all other lenses", () => {
-    const store = makeStore();
-    for (const lens of ["guide-tones", "color", "targets-color", "tension"] as const) {
+    for (const lens of ["targets", "guide-tones", "color", "targets-color", "tension"] as const) {
       store.set(practiceLensAtom, lens);
       expect(store.get(hideNonChordNotesAtom)).toBe(false);
     }
+  });
+
+  it("is false when no chord is set", () => {
+    const store = makeStore();
+    expect(store.get(hideNonChordNotesAtom)).toBe(false);
   });
 });
 
@@ -487,5 +486,124 @@ describe("showChordPracticeBarAtom — scale visibility independence", () => {
     const visibleOff = store.get(showChordPracticeBarAtom);
 
     expect(visibleOn).toBe(visibleOff);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ownership model — scale/chord separation contracts
+// ---------------------------------------------------------------------------
+
+import {
+  colorNotesAtom,
+  effectiveColorNotesAtom,
+  effectiveShapeDataAtom,
+  toggleScaleVisibleAtom,
+} from "../store/atoms";
+
+describe("chord overlay does not control scale visibility", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("enabling chord overlay does not change effectiveShapeDataAtom highlightNotes count", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(scaleVisibleAtom, true);
+
+    const before = store.get(effectiveShapeDataAtom).highlightNotes.length;
+
+    store.set(chordTypeAtom, "Major Triad");
+
+    const after = store.get(effectiveShapeDataAtom).highlightNotes.length;
+
+    expect(after).toBe(before);
+  });
+
+  it("disabling chord overlay does not change scale highlight notes", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(scaleVisibleAtom, true);
+    store.set(chordTypeAtom, "Major Triad");
+
+    const before = store.get(effectiveShapeDataAtom).highlightNotes.length;
+
+    store.set(chordTypeAtom, null);
+
+    const after = store.get(effectiveShapeDataAtom).highlightNotes.length;
+
+    expect(after).toBe(before);
+  });
+});
+
+describe("Chord Tones lens does not hide scale notes", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("hideNonChordNotesAtom is false when targets lens is active", () => {
+    const store = makeStore();
+    store.set(chordTypeAtom, "Major Triad");
+    store.set(practiceLensAtom, "targets");
+    expect(store.get(hideNonChordNotesAtom)).toBe(false);
+  });
+
+  it("effectiveShapeDataAtom highlightNotes unchanged when switching to targets lens", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(scaleVisibleAtom, true);
+    store.set(chordTypeAtom, "Major Triad");
+    store.set(practiceLensAtom, "targets-color");
+
+    const before = store.get(effectiveShapeDataAtom).highlightNotes.length;
+
+    store.set(practiceLensAtom, "targets");
+
+    const after = store.get(effectiveShapeDataAtom).highlightNotes.length;
+
+    expect(after).toBe(before);
+  });
+});
+
+describe("color notes are scale-owned — independent of chord overlay", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("colorNotesAtom returns color notes for Minor Blues scale without chord overlay", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Minor Blues");
+    // Minor Blues has a flat-5 blue note (Gb/F#)
+    expect(store.get(colorNotesAtom).length).toBeGreaterThan(0);
+  });
+
+  it("colorNotesAtom is unaffected by chord type changes", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Minor Blues");
+
+    const before = store.get(colorNotesAtom);
+
+    store.set(chordTypeAtom, "Dominant 7th");
+    const after = store.get(colorNotesAtom);
+
+    expect(after).toEqual(before);
+  });
+
+  it("effectiveColorNotesAtom is cleared by scaleVisible=false, not by chord overlay", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Minor Blues");
+    store.set(chordTypeAtom, "Dominant 7th");
+    store.set(scaleVisibleAtom, true);
+
+    expect(store.get(effectiveColorNotesAtom).length).toBeGreaterThan(0);
+
+    store.set(toggleScaleVisibleAtom);
+
+    expect(store.get(effectiveColorNotesAtom)).toHaveLength(0);
   });
 });

--- a/src/components/DegreeChipStrip.css
+++ b/src/components/DegreeChipStrip.css
@@ -37,11 +37,13 @@
   letter-spacing: 0.01em;
 }
 
-/* When the header contains an action slot, lay it out as a flex row. */
+/* When the header contains an action slot, lay it out as a flex row.
+   Action renders before the title so the eye toggle sits left-aligned
+   inline with the scale name rather than isolated at the far edge. */
 .degree-chip-strip-header[data-has-action] {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 0.5rem;
   width: 100%;
   line-height: initial;

--- a/src/components/DegreeChipStrip.tsx
+++ b/src/components/DegreeChipStrip.tsx
@@ -52,8 +52,8 @@ export function DegreeChipStrip({
           className="degree-chip-strip-header"
           data-has-action={headerAction ? 'true' : undefined}
         >
-          {!hideHeader && scaleName}
           {headerAction}
+          {!hideHeader && scaleName}
         </header>
       )}
       {visible && (

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -429,7 +429,6 @@ export const summaryLegendItemsAtom = atom((get) => {
   if (!chordType) return [] as LegendItem[];
 
   const summaryChordRow = get(summaryChordRowAtom);
-  const practiceLens = get(practiceLensAtom);
   const noteRoleMap = get(noteRoleMapAtom);
 
   const rolesPresent = new Set(summaryChordRow.map((e) => e.role));
@@ -440,9 +439,9 @@ export const summaryLegendItemsAtom = atom((get) => {
     items.push({ role: "chord-tone-in-scale", label: "Chord tone" });
   if (rolesPresent.has("chord-tone-outside-scale"))
     items.push({ role: "chord-tone-outside-scale", label: "Outside scale" });
-  // Show scale-only legend entry when the lens is not targets (which hides them).
+  // Scale-only notes are always visible — no lens hides them.
   const hasScaleOnly = Array.from(noteRoleMap.values()).includes("scale-only");
-  if (practiceLens !== "targets" && hasScaleOnly) {
+  if (hasScaleOnly) {
     items.push({ role: "scale-only", label: "Scale only" });
   }
   return items;
@@ -450,14 +449,12 @@ export const summaryLegendItemsAtom = atom((get) => {
 
 export const showRelationshipRowAtom = atom((get) => {
   const chordType = get(chordTypeAtom);
-  const practiceLens = get(practiceLensAtom);
   const chordRoot = get(chordRootAtom);
   const rootNote = get(rootNoteAtom);
   const hasOutsideChordMembers = get(hasOutsideChordMembersAtom);
 
   return !!(
     chordType &&
-    practiceLens !== "targets" &&
     (chordRoot !== rootNote || hasOutsideChordMembers)
   );
 });
@@ -471,33 +468,21 @@ export const chordMemberLabelsAtom = atom((get) =>
 );
 
 export const summaryHeaderLeftAtom = atom((get) => {
-  const chordType = get(chordTypeAtom);
-  const practiceLens = get(practiceLensAtom);
   const scaleLabel = get(scaleLabelAtom);
-  const chordLabel = get(chordLabelAtom);
-
-  if (!chordType) return scaleLabel;
-  // Targets lens is chord-focused: show the chord name as the primary header.
-  if (practiceLens === "targets") return chordLabel ?? scaleLabel;
   return scaleLabel;
 });
 
 export const summaryHeaderRightAtom = atom((get) => {
   const chordType = get(chordTypeAtom);
   const chordLabel = get(chordLabelAtom);
-  const practiceLens = get(practiceLensAtom);
 
   if (!chordType || !chordLabel) return null;
-  // Targets lens already shows the chord in the left header.
-  if (practiceLens === "targets") return null;
   return chordLabel;
 });
 
 export const summaryPrimaryModeAtom = atom((get) => {
   const chordType = get(chordTypeAtom);
-  const practiceLens = get(practiceLensAtom);
   if (!chordType) return "scale";
-  if (practiceLens === "targets") return "chord";
   return "scale";
 });
 

--- a/src/store/chordOverlayAtoms.ts
+++ b/src/store/chordOverlayAtoms.ts
@@ -176,10 +176,9 @@ export const practiceLensAtom = atomWithStorage<PracticeLens>(
 // Overlay semantics — lens availability + derived flags
 // ---------------------------------------------------------------------------
 
-// Targets lens hides scale-only notes so only chord tones are shown.
-export const hideNonChordNotesAtom = atom(
-  (get) => get(practiceLensAtom) === "targets",
-);
+// Lenses control coaching cues only — no lens hides scale notes.
+// Kept as a stable export for legacy callers; always returns false.
+export const hideNonChordNotesAtom = atom(() => false);
 
 // ---------------------------------------------------------------------------
 // Chord derived atoms


### PR DESCRIPTION
## Summary

- **`Chord Tones` lens no longer hides scale notes.** `hideNonChordNotesAtom` always returns `false`; `FretboardSVG` no longer force-hides `scale-only` / `color-tone` notes when `practiceLens === "targets"`. Lenses now control coaching cues only.
- **Scale owns its header.** Removed `practiceLens === "targets"` special-casing from `summaryHeaderLeftAtom`, `summaryHeaderRightAtom`, `summaryPrimaryModeAtom`, `summaryLegendItemsAtom`, and `showRelationshipRowAtom`. The scale label always leads; scale-only legend entries always appear.
- **Eye toggle moved inline with scale name.** `DegreeChipStrip` renders `headerAction` before the title text. CSS changed from `justify-content: space-between` to `flex-start` so the eye button sits left-aligned next to the scale name rather than isolated at the far right edge.
- **Scale strip and chord dock are visually independent cards.** `.summary-ribbon` is now a layout-only flex column (no background, border, or shadow of its own). The CSS block that suppressed `degree-chip-strip` card chrome inside the ribbon was removed — each surface now renders its own independent card.

## Files changed

| File | What changed |
|---|---|
| `src/store/chordOverlayAtoms.ts` | `hideNonChordNotesAtom` → always `false` |
| `src/FretboardSVG.tsx` | Remove `targets` lens hiding from `effectiveHideNonChordNotes` |
| `src/store/atoms.ts` | Remove lens-dependent branching from 5 summary atoms |
| `src/components/DegreeChipStrip.tsx` | Render `headerAction` before title text |
| `src/components/DegreeChipStrip.css` | `justify-content: flex-start` for action header |
| `src/App.css` | Strip card chrome from `.summary-ribbon`; remove `.degree-chip-strip` chrome suppression |
| `src/__tests__/practiceLens.test.ts` | Updated `hideNonChordNotesAtom` tests; new ownership suites |
| `src/__tests__/App.test.tsx` | New tests: sibling card structure, dock visible when scale hidden, eye toggle position |
| `src/__tests__/atoms.test.ts` | Updated reset-atom test comment/assertion |

## Test plan

- [x] All 935 tests pass (`npm run test`)
- [x] Lint clean (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] New atom tests: chord overlay toggle doesn't affect `effectiveShapeDataAtom` highlights
- [x] New atom tests: `targets` lens leaves `hideNonChordNotesAtom` false
- [x] New atom tests: color notes are scale-owned (unaffected by chord changes)
- [x] New App tests: chord dock and scale strip are sibling elements, not nested
- [x] New App test: dock visible when `scaleVisible=false`
- [x] New App test: eye toggle button is the first element in the strip header

## What remains for the next phase

- `data-chord-active="true"` CSS dims `.note-scale-only` to `0.45` opacity — a residual chord-over-scale influence not addressed in this pass.
- `summaryHeaderLeftAtom` / `summaryPrimaryModeAtom` are now exported but unused by any component; candidate for removal.
- Legacy dead `.summary-ribbon .chord-row-strip` CSS rules from the old architecture can be pruned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "targets" practice lens no longer hides non-chord scale and tone notes, allowing full visibility of the scale context.

* **UI Improvements**
  * Simplified the summary ribbon with cleaner visual styling and improved spacing.
  * Reordered header elements for better usability.
  * Enhanced legend to consistently display scale-only notes when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->