### PR TITLE
feat(fretboard): scroll to show entire shape, not just center point

### DIFF
--- a/src/Fretboard.tsx
+++ b/src/Fretboard.tsx
@@ -7,7 +7,7 @@ import {
   getNoteFrequency,
 } from "./guitar";
 import { synth } from "./audio";
-import { fretZoomAtom } from "./store/atoms";
+import { fretZoomAtom, type AutoCenterTarget } from "./store/atoms";
 import { FretboardSVG } from "./FretboardSVG";
 import { useFretboardState, type ShapeScope, type ActiveShapeType } from "./hooks/useFretboardState";
 import { 
@@ -42,7 +42,7 @@ interface FretboardProps {
   useFlats?: boolean;
   scaleName?: string;
   stringRowPx?: number;
-  autoCenterTarget?: number;
+  autoCenterTarget?: AutoCenterTarget;
   recenterKey?: number;
   activePattern?: "caged" | "3nps" | "all";
   activeShape?: ActiveShapeType;
@@ -134,14 +134,26 @@ export function Fretboard(props: FretboardProps) {
   }, [effectiveZoom]);
 
   useEffect(() => {
-    if (autoCenterTarget === undefined) return;
+    if (!autoCenterTarget) return;
     const el = scrollRef.current;
     if (!el) return;
     const zoom = effectiveZoomRef.current;
-    const targetOffset = (autoCenterTarget - startFret) * zoom;
     const containerW = el.clientWidth;
-    const centerOffset = targetOffset - containerW / 2 + zoom / 2;
-    el.scrollTo({ left: Math.max(0, centerOffset), behavior: "smooth" });
+    const buffer = zoom * 0.5;
+
+    const shapeMinPx = (autoCenterTarget.minFret - startFret) * zoom;
+    const shapeMaxPx = (autoCenterTarget.maxFret - startFret) * zoom;
+    const shapeWidth = shapeMaxPx - shapeMinPx;
+
+    let scrollLeft: number;
+    if (shapeWidth <= containerW - buffer * 2) {
+      const centerPx = (shapeMinPx + shapeMaxPx) / 2;
+      scrollLeft = centerPx - containerW / 2 + zoom / 2;
+    } else {
+      scrollLeft = shapeMinPx - buffer;
+    }
+
+    el.scrollTo({ left: Math.max(0, scrollLeft), behavior: "smooth" });
   }, [autoCenterTarget, recenterKey, startFret]);
 
   const updateCursor = useCallback((dragging: boolean) => {

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -249,6 +249,12 @@ export const effectiveColorNotesAtom = atom((get) => {
   return get(colorNotesAtom);
 });
 
+export interface AutoCenterTarget {
+  centerFret: number;
+  minFret: number;
+  maxFret: number;
+}
+
 export const autoCenterTargetAtom = atom((get) => {
   const fingeringPattern = get(fingeringPatternAtom);
   const { shapePolygons, boxBounds, wrappedNotes } = get(shapeDataAtom);
@@ -256,13 +262,17 @@ export const autoCenterTargetAtom = atom((get) => {
   const startFret = get(fretStartAtom);
   const endFret = get(fretEndAtom);
 
-  let target: number | undefined;
+  let target: AutoCenterTarget | undefined;
 
   if (fingeringPattern === "caged" && shapePolygons.length > 0) {
     if (clickedShape) {
       const clickedPoly = shapePolygons.find((p) => p.shape === clickedShape);
       if (clickedPoly && !clickedPoly.truncated) {
-        target = getShapeCenterFret(clickedPoly);
+        target = {
+          centerFret: getShapeCenterFret(clickedPoly),
+          minFret: clickedPoly.intendedMin,
+          maxFret: clickedPoly.intendedMax,
+        };
       }
     }
     if (target === undefined) {
@@ -273,14 +283,22 @@ export const autoCenterTargetAtom = atom((get) => {
         endFret,
       );
       if (mainShape) {
-        target = getShapeCenterFret(mainShape);
+        target = {
+          centerFret: getShapeCenterFret(mainShape),
+          minFret: mainShape.intendedMin,
+          maxFret: mainShape.intendedMax,
+        };
       }
     }
   } else if (fingeringPattern === "3nps" && boxBounds.length > 0) {
     const lowestBounds = boxBounds.reduce((a, b) =>
       a.minFret <= b.minFret ? a : b,
     );
-    target = lowestBounds.minFret;
+    target = {
+      centerFret: lowestBounds.minFret,
+      minFret: lowestBounds.minFret,
+      maxFret: lowestBounds.maxFret,
+    };
   }
 
   return target;

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -295,7 +295,7 @@ export const autoCenterTargetAtom = atom((get) => {
       a.minFret <= b.minFret ? a : b,
     );
     target = {
-      centerFret: lowestBounds.minFret,
+      centerFret: (lowestBounds.minFret + lowestBounds.maxFret) / 2,
       minFret: lowestBounds.minFret,
       maxFret: lowestBounds.maxFret,
     };


### PR DESCRIPTION
## Summary
- Add `AutoCenterTarget` interface with `minFret`/`maxFret` bounds to track full shape range
- Update `autoCenterTargetAtom` to return full shape bounds instead of a single center point
- Modify Fretboard scroll logic to fit entire shape in viewport, not just center on the middle note
- For shapes wider than viewport, scroll to left edge with 0.5 fret buffer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved fretboard auto-centering to intelligently position entire fret ranges when shapes are selected, providing better visual focus and display of the selected pattern.
* **Bug Fixes**
  * Fixed edge cases where certain selections previously failed to trigger centering, ensuring consistent behavior for all selected shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->