### PR TITLE
fix(NoteGrid): correct grid column count for up/down arrow key navigation

### DIFF
--- a/src/components/NoteGrid.tsx
+++ b/src/components/NoteGrid.tsx
@@ -11,7 +11,7 @@ interface NoteGridProps {
   useFlats: boolean;
 }
 
-const GRID_COLS = 4;
+const GRID_COLS = 6;
 
 export function NoteGrid({
   notes,
@@ -55,7 +55,7 @@ export function NoteGrid({
         if (nextIndex < notes.length) {
           onSelect(notes[nextIndex]);
         } else {
-          onSelect(notes[index % cols]);
+          onSelect(notes[nextIndex - notes.length]);
         }
         break;
       }
@@ -66,7 +66,7 @@ export function NoteGrid({
         if (prevIndex >= 0) {
           onSelect(notes[prevIndex]);
         } else {
-          onSelect(notes[notes.length - 1]);
+          onSelect(notes[prevIndex + notes.length]);
         }
         break;
       }


### PR DESCRIPTION
## Summary

- Fix  from 4 to 6 to match actual 2×6 grid layout
- Fix wrapping at edges to wrap to correct column index instead of random positions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased grid layout to display more notes per row
  * Enhanced keyboard navigation behavior when moving up or down past the note grid edges

<!-- end of auto-generated comment: release notes by coderabbit.ai -->