### PR TITLE
fix(overlay): shape leak, lens leakage, squircle, tension cues, color lenses

### DIFF
--- a/src/FretboardSVG.css
+++ b/src/FretboardSVG.css
@@ -154,6 +154,15 @@
   filter: var(--glow-violet);
 }
 
+/* Scale-owned color notes use a rounder squircle than chord-owned squircles.
+   CSS rx/ry override the SVG attribute (rx = r * 0.38 ≈ 19% of width) to 28%,
+   which gives the characteristic cushion shape at both small and large radii. */
+.fretboard-note[data-note-role="note-blue"] rect,
+.fretboard-note[data-note-role="color-tone"] rect {
+  rx: 28%;
+  ry: 28%;
+}
+
 /* ==========================================================================
    Outside chord root: squircle shape signals root identity; dashed stroke
    signals the root falls outside the active scale (tension note). Both roles
@@ -218,48 +227,6 @@
   filter: none;
 }
 /* scale-only notes intentionally left at base brightness */
-
-/* --- color lens ---------------------------------------------------------- */
-
-/* Color tones: bold stroke, vivid violet fill, explicit violet glow. */
-[data-practice-lens="color"] .fretboard-note.color-tone circle,
-[data-practice-lens="color"] .fretboard-note.color-tone rect,
-[data-practice-lens="color"] .fretboard-note.color-tone polygon {
-  stroke-width: 3.8;
-  fill: rgb(72 32 130 / 0.99);
-  stroke: var(--neon-violet);
-}
-[data-practice-lens="color"] .fretboard-note.color-tone {
-  filter: var(--glow-violet);
-}
-
-/* Chord root: semi-recede so color tones lead. */
-[data-practice-lens="color"] .fretboard-note.chord-root rect:last-of-type {
-  stroke-width: 1.8;
-  fill: rgb(55 35 18 / 0.65);
-  stroke: rgb(255 154 77 / 0.72);
-}
-[data-practice-lens="color"] .fretboard-note.chord-root {
-  filter: none;
-}
-
-/* Other chord tones recede: thin stroke, dim fill, no glow. */
-[data-practice-lens="color"] .fretboard-note.chord-tone-in-scale circle,
-[data-practice-lens="color"] .fretboard-note.chord-tone-in-scale rect,
-[data-practice-lens="color"] .fretboard-note.chord-tone-in-scale polygon {
-  stroke-width: 1.4;
-  fill: rgb(20 30 40 / 0.52);
-  stroke: rgb(200 110 40 / 0.62);
-}
-[data-practice-lens="color"] .fretboard-note.chord-tone-in-scale {
-  filter: none;
-}
-/* scale-only notes intentionally left at base brightness */
-
-/* --- targets-color lens -------------------------------------------------- */
-/* No recession rules — chord tones (squircles) and color tones (hexagons)
-   already distinguish themselves from scale-only circles via shape alone.
-   This lens is the balanced default; all notes show at full base brightness. */
 
 /* --- tension lens -------------------------------------------------------- */
 

--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -106,7 +106,6 @@ function getLensEmphasis(
   noteClass: string,
   practiceLens: PracticeLens | undefined,
   isGuideTone: boolean,
-  isColorTone: boolean,
   isTension: boolean,
 ): LensEmphasis {
   const defaultEmphasis: LensEmphasis = { radiusBoost: 1, opacityBoost: 1 };
@@ -120,18 +119,6 @@ function getLensEmphasis(
       }
       if (noteClass.includes("chord-") || noteClass.includes("color-")) {
         return { radiusBoost: 0.85, opacityBoost: 0.7 };
-      }
-      return defaultEmphasis;
-
-    case "color":
-      if (isColorTone) {
-        return { glowColor: "violet", radiusBoost: 1.15, opacityBoost: 1 };
-      }
-      return { radiusBoost: 0.9, opacityBoost: 0.75 };
-
-    case "targets-color":
-      if (isColorTone) {
-        return { glowColor: "violet", radiusBoost: 1.1, opacityBoost: 1 };
       }
       return defaultEmphasis;
 
@@ -198,6 +185,7 @@ function classifyNoteFromSemantics(
   isChordInRange: boolean,
   isInActiveShape: boolean,
   hasChordOverlay: boolean,
+  isHighlighted: boolean,
   shapePolygons: ShapePolygon[],
   boxBounds: BoxBound[],
   fretIndex: number,
@@ -214,14 +202,14 @@ function classifyNoteFromSemantics(
   if (sem.isChordRoot && sem.isChordTone && isChordInRange && isInActiveShape) return "chord-root";
   // In-scale chord tones.
   if (sem.isInScale && sem.isChordTone && isChordInRange && isInActiveShape) return "chord-tone-in-scale";
-  // Color/characteristic tone: scale note not covered by a chord role.
-  if (sem.isInScale && sem.isColorTone) return "color-tone";
-  // Other in-scale notes.
-  if (sem.isInScale) return "scale-only";
+  // Color/characteristic tone: must also be shape-highlighted to stay shape-contained.
+  if (sem.isInScale && sem.isColorTone && isHighlighted) return "color-tone";
+  // Other in-scale notes: shape-aware gate prevents leakage outside active shape.
+  if (sem.isInScale && isHighlighted) return "scale-only";
   // Out-of-scale chord tones (tension, non-root).
   if (sem.isChordTone && isChordInRange && isInActiveShape) return "chord-tone-outside-scale";
-  // Outside active shape chord tones become scale-only (visible but not emphasized)
-  if (sem.isChordTone && !isInActiveShape && sem.isInScale) return "scale-only";
+  // Outside active shape chord tones become scale-only only when highlighted.
+  if (sem.isChordTone && !isInActiveShape && sem.isInScale && isHighlighted) return "scale-only";
   return "note-inactive";
 }
 
@@ -832,6 +820,7 @@ export const FretboardSVG = memo(function FretboardSVG({
                 isChordInRange,
                 isInActiveShape,
                 hasChordOverlay,
+                isHighlighted,
                 shapePolygons,
                 boxBounds,
                 fretIndex,
@@ -886,12 +875,12 @@ export const FretboardSVG = memo(function FretboardSVG({
               noteClass === "key-tonic")) ||
           (isWrapped && isHighlighted);
 
-        // Lens-specific emphasis for visual distinction
+        // Lens emphasis only applies when chord overlay is active.
+        // Without an overlay, no lens-driven dimming or emphasis should alter scale notes.
         const lensEmphasis = getLensEmphasis(
           noteClass,
-          practiceLens,
+          hasChordOverlay ? practiceLens : undefined,
           semantics?.isGuideTone ?? false,
-          semantics?.isColorTone ?? isColorNote,
           semantics?.isTension ?? false,
         );
 
@@ -920,7 +909,7 @@ export const FretboardSVG = memo(function FretboardSVG({
   }, [numStrings, fretboardLayout, totalColumns, startFret, maxFret, hiddenNotes, highlightNotes, hasChordOverlay, chordTones, rootNote, chordRoot, colorNotes, shapePolygons, boxBounds, chordFretSpread, scaleName, useFlats, displayFormat, wrappedNotes, hideNonChordNotes, practiceLens, tuning, noteSemantics, activePattern, activeShape, shapeScope]);
 
   return (
-    <div role="group" aria-label={ariaLabel} className="fretboard-board" data-practice-lens={practiceLens}>
+    <div role="group" aria-label={ariaLabel} className="fretboard-board" data-practice-lens={hasChordOverlay ? practiceLens : undefined}>
       <div
         className="fretboard-neck"
         style={

--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -169,13 +169,12 @@ function classifyNote(
   // With pattern-aware rendering, skip chord notes outside the active shape.
   if (isChordRootNote && isChordTone && isChordInRange && isInActiveShape) return "chord-root";
   if (isHighlighted && isChordTone && isChordInRange && isInActiveShape) return "chord-tone-in-scale";
-  // Color/characteristic tone: scale note not covered by chord role → hexagon.
-  if (isHighlighted && isColorNote) return "color-tone";
-  if (isHighlighted) return "scale-only";
+  // Color/characteristic tone: shape-aware gate prevents leakage outside active shape.
+  if (isHighlighted && isColorNote && isInActiveShape) return "color-tone";
+  // In-scale notes: shape-aware gate — outside the active shape → note-inactive.
+  if (isHighlighted && isInActiveShape) return "scale-only";
   if (!isHighlighted && isChordTone && isChordInRange && isInActiveShape)
     return "chord-tone-outside-scale";
-  // Outside active shape chord tones become scale-only (visible but not emphasized)
-  if (isChordTone && !isInActiveShape && isHighlighted) return "scale-only";
   return "note-inactive";
 }
 
@@ -192,8 +191,9 @@ function classifyNoteFromSemantics(
 ): string {
   if (!hasChordOverlay) {
     // Delegate to classifyNote to avoid duplicating the no-overlay logic.
+    // isHighlighted (position/shape-aware) must be passed, not sem.isInScale (pitch-only).
     return classifyNote(
-      sem.isScaleRoot, sem.isChordRoot, sem.isColorTone, sem.isInScale,
+      sem.isScaleRoot, sem.isChordRoot, sem.isColorTone, isHighlighted,
       sem.isChordTone, hasChordOverlay, isChordInRange, isInActiveShape, shapePolygons, boxBounds, fretIndex,
     );
   }

--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -202,14 +202,13 @@ function classifyNoteFromSemantics(
   if (sem.isChordRoot && sem.isChordTone && isChordInRange && isInActiveShape) return "chord-root";
   // In-scale chord tones.
   if (sem.isInScale && sem.isChordTone && isChordInRange && isInActiveShape) return "chord-tone-in-scale";
-  // Color/characteristic tone: must also be shape-highlighted to stay shape-contained.
-  if (sem.isInScale && sem.isColorTone && isHighlighted) return "color-tone";
-  // Other in-scale notes: shape-aware gate prevents leakage outside active shape.
-  if (sem.isInScale && isHighlighted) return "scale-only";
-  // Out-of-scale chord tones (tension, non-root).
+  // Color/characteristic tone: isInActiveShape (shape-aware) gates containment.
+  if (sem.isInScale && sem.isColorTone && isInActiveShape && isHighlighted) return "color-tone";
+  // Other in-scale notes: shape-aware gate — outside the active shape → note-inactive.
+  if (sem.isInScale && isInActiveShape && isHighlighted) return "scale-only";
+  // Out-of-scale chord tones (tension, non-root) within the shape.
   if (sem.isChordTone && isChordInRange && isInActiveShape) return "chord-tone-outside-scale";
-  // Outside active shape chord tones become scale-only only when highlighted.
-  if (sem.isChordTone && !isInActiveShape && sem.isInScale && isHighlighted) return "scale-only";
+  // Everything else outside the active shape: suppress entirely.
   return "note-inactive";
 }
 

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -408,22 +408,21 @@ describe("App", () => {
       expect(document.querySelector(".summary-shell .chord-practice-bar")).toBeNull();
     });
 
-    it("targets-color lens: scale strip always in summary-shell", async () => {
+    it("targets lens: scale strip always in summary-shell", async () => {
       localStorage.setItem(k("chordType"), "Major Triad");
-      localStorage.setItem(k("practiceLens"), "targets-color");
+      localStorage.setItem(k("practiceLens"), "targets");
       render(<App />);
       await waitFor(() => {
         expect(document.querySelector(".summary-shell .degree-chip-strip")).toBeTruthy();
       });
     });
 
-    it("targets-color lens: chord practice bar hidden in simple diatonic case (same root, all preset, all in scale, C Major)", async () => {
+    it("targets lens: chord practice bar hidden in simple diatonic case (same root, all preset, all in scale, C Major)", async () => {
       localStorage.setItem(k("rootNote"), "C");
       localStorage.setItem(k("scaleName"), "Major");
       localStorage.setItem(k("chordRoot"), "C");
       localStorage.setItem(k("chordType"), "Major Triad");
-      localStorage.setItem(k("focusPreset"), "all");
-      localStorage.setItem(k("practiceLens"), "targets-color");
+      localStorage.setItem(k("practiceLens"), "targets");
       render(<App />);
       await waitFor(() => {
         expect(document.querySelector(".degree-chip-strip")).toBeTruthy();
@@ -433,20 +432,22 @@ describe("App", () => {
       expect(document.querySelector(".relationship-row")).toBeNull();
     });
 
-    it("targets-color lens: shows chord practice bar when chordRoot differs from scale root", async () => {
+    it("targets lens: shows chord practice bar when chordRoot differs from scale root", async () => {
       localStorage.setItem(k("rootNote"), "C");
       localStorage.setItem(k("chordRoot"), "G");
       localStorage.setItem(k("chordType"), "Major Triad");
-      localStorage.setItem(k("focusPreset"), "all");
-      localStorage.setItem(k("practiceLens"), "targets-color");
+      localStorage.setItem(k("practiceLens"), "targets");
       render(<App />);
       await waitFor(() => {
         expect(document.querySelector(".chord-practice-bar")).toBeTruthy();
       });
     });
 
-    it("targets lens: renders chord practice bar in dock shell and scale strip in summary shell", async () => {
-      localStorage.setItem(k("chordType"), "Major Triad");
+    it("targets lens: renders chord practice bar in dock shell and scale strip in summary shell (outside tones)", async () => {
+      // Use Dominant 7th which has Bb outside C Major — forces practice bar to show
+      localStorage.setItem(k("rootNote"), "C");
+      localStorage.setItem(k("chordRoot"), "C");
+      localStorage.setItem(k("chordType"), "Dominant 7th");
       localStorage.setItem(k("practiceLens"), "targets");
       render(<App />);
       await waitFor(() => {
@@ -467,22 +468,12 @@ describe("App", () => {
       });
     });
 
-    it("no legend row is rendered in targets-color lens", async () => {
+    it("no legend row is rendered in targets lens (Dominant 7th — outside tones force bar visible)", async () => {
       localStorage.setItem(k("chordType"), "Dominant 7th");
-      localStorage.setItem(k("practiceLens"), "targets-color");
-      render(<App />);
-      await waitFor(() => {
-        expect(document.querySelector(".chord-dock-shell")).toBeTruthy();
-      });
-      expect(document.querySelector(".chord-row-legend")).toBeNull();
-    });
-
-    it("no legend row is rendered in targets lens", async () => {
-      localStorage.setItem(k("chordType"), "Major Triad");
       localStorage.setItem(k("practiceLens"), "targets");
       render(<App />);
       await waitFor(() => {
-        expect(document.querySelector(".chord-dock-shell .chord-practice-bar")).toBeTruthy();
+        expect(document.querySelector(".chord-dock-shell")).toBeTruthy();
       });
       expect(document.querySelector(".chord-row-legend")).toBeNull();
     });

--- a/src/__tests__/FretboardSVG.test.tsx
+++ b/src/__tests__/FretboardSVG.test.tsx
@@ -953,5 +953,193 @@ describe("FretboardSVG", () => {
         expect(el.getAttribute("data-note-shape")).toBe("squircle");
       });
     });
+
+    describe("overlay-on shape containment — noteSemantics path (regression)", () => {
+      // When noteSemantics is provided (chord overlay active), in-scale notes outside
+      // the active shape must NOT render as scale-only or color-tone.
+      // Previously, sem.isInScale alone would classify them — ignoring shape membership.
+
+      const tinyShape: ShapePolygon = {
+        shape: "E" as CagedShape,
+        color: "rgba(99,102,241,0.3)",
+        cagedLabel: "E",
+        modalLabel: "Ionian",
+        truncated: false,
+        intendedMin: 0,
+        intendedMax: 1,
+        vertices: [
+          { fret: 0, string: 0 },
+          { fret: 0, string: 1 },
+          { fret: 0, string: 2 },
+          { fret: 0, string: 3 },
+          { fret: 0, string: 4 },
+          { fret: 0, string: 5 },
+          { fret: 1, string: 5 },
+          { fret: 1, string: 4 },
+          { fret: 1, string: 3 },
+          { fret: 1, string: 2 },
+          { fret: 1, string: 1 },
+          { fret: 1, string: 0 },
+        ],
+      };
+
+      it("scale-only note outside active shape is note-inactive (not scale-only) with noteSemantics", () => {
+        // E is in scale (highlightNotes) and noteSemantics.isInScale=true,
+        // but E at fret 9 is outside the tiny shape (frets 0-1).
+        // With the fix, classifyNoteFromSemantics must use isHighlighted (shape-aware),
+        // so the out-of-shape E becomes note-inactive rather than scale-only.
+        const semantics = new Map<string, NoteSemantics>([
+          [
+            "C",
+            {
+              isScaleRoot: true,
+              isChordRoot: true,
+              isChordTone: true,
+              isInScale: true,
+              isColorTone: false,
+              isGuideTone: false,
+              isTension: false,
+              memberName: "root",
+            },
+          ],
+          [
+            "E",
+            {
+              isScaleRoot: false,
+              isChordRoot: false,
+              isChordTone: false,
+              isInScale: true,
+              isColorTone: false,
+              isGuideTone: false,
+              isTension: false,
+            },
+          ],
+        ]);
+        const { container } = render(
+          <FretboardSVG
+            {...BASE_PROPS}
+            startFret={0}
+            endFret={12}
+            chordTones={["C"]}
+            chordRoot="C"
+            highlightNotes={["C", "E"]}
+            shapePolygons={[tinyShape]}
+            activePattern="caged"
+            activeShape="E"
+            shapeScope="single"
+            chordFretSpread={0}
+            noteSemantics={semantics}
+          />
+        );
+        // All scale-only notes must be within frets 0-1 (inside tiny shape)
+        const scaleOnly = container.querySelectorAll('.fretboard-note.scale-only');
+        scaleOnly.forEach((el) => {
+          const btn = el.closest('.note-bubble') ?? el.querySelector('button');
+          const label = btn?.getAttribute('aria-label') ?? '';
+          // Fret 2+ is outside the shape — no scale-only should appear there
+          expect(label).not.toMatch(/fret [2-9]/);
+        });
+      });
+
+      it("color-tone note outside active shape is note-inactive with noteSemantics", () => {
+        // B is a color note AND in scale, but outside the tiny shape.
+        // Must not appear as color-tone when outside the shape.
+        const semantics = new Map<string, NoteSemantics>([
+          [
+            "C",
+            {
+              isScaleRoot: true,
+              isChordRoot: true,
+              isChordTone: true,
+              isInScale: true,
+              isColorTone: false,
+              isGuideTone: false,
+              isTension: false,
+              memberName: "root",
+            },
+          ],
+          [
+            "B",
+            {
+              isScaleRoot: false,
+              isChordRoot: false,
+              isChordTone: false,
+              isInScale: true,
+              isColorTone: true,
+              isGuideTone: false,
+              isTension: false,
+            },
+          ],
+        ]);
+        const { container } = render(
+          <FretboardSVG
+            {...BASE_PROPS}
+            startFret={0}
+            endFret={12}
+            chordTones={["C"]}
+            chordRoot="C"
+            highlightNotes={["C", "B"]}
+            colorNotes={["B"]}
+            shapePolygons={[tinyShape]}
+            activePattern="caged"
+            activeShape="E"
+            shapeScope="single"
+            chordFretSpread={0}
+            noteSemantics={semantics}
+          />
+        );
+        // All color-tone notes must be within frets 0-1 (inside the shape)
+        const colorTones = container.querySelectorAll('.fretboard-note.color-tone');
+        colorTones.forEach((el) => {
+          const btn = el.closest('.note-bubble') ?? el.querySelector('button');
+          const label = btn?.getAttribute('aria-label') ?? '';
+          expect(label).not.toMatch(/fret [2-9]/);
+        });
+      });
+    });
+  });
+
+  describe("lens leakage — no lens effect when chord overlay is off", () => {
+    it("fretboard-board has no data-practice-lens attribute when no chord overlay", () => {
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          practiceLens="guide-tones"
+        />
+      );
+      const board = container.querySelector('.fretboard-board');
+      expect(board?.getAttribute('data-practice-lens')).toBeNull();
+    });
+
+    it("fretboard-board has data-practice-lens when chord overlay is active", () => {
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          chordTones={["C", "E", "G"]}
+          chordRoot="C"
+          practiceLens="guide-tones"
+        />
+      );
+      const board = container.querySelector('.fretboard-board');
+      expect(board?.getAttribute('data-practice-lens')).toBe('guide-tones');
+    });
+
+    it("scale notes have normal opacity with no chord overlay regardless of practiceLens", () => {
+      const { container } = render(
+        <FretboardSVG
+          {...BASE_PROPS}
+          practiceLens="guide-tones"
+          highlightNotes={["C", "E", "G"]}
+        />
+      );
+      const noteElements = container.querySelectorAll('.fretboard-note:not(.hidden)');
+      noteElements.forEach((el) => {
+        const opacity = (el as HTMLElement).style.opacity;
+        // No lens dimming: opacity should be 1 or unset (not reduced)
+        if (opacity) {
+          expect(parseFloat(opacity)).toBeGreaterThanOrEqual(1);
+        }
+      });
+    });
   });
 });

--- a/src/__tests__/FretboardSVG.test.tsx
+++ b/src/__tests__/FretboardSVG.test.tsx
@@ -1031,13 +1031,15 @@ describe("FretboardSVG", () => {
             noteSemantics={semantics}
           />
         );
-        // All scale-only notes must be within frets 0-1 (inside tiny shape)
-        const scaleOnly = container.querySelectorAll('.fretboard-note.scale-only');
+        // aria-label lives on .note-bubble buttons (a11y layer), not on .fretboard-note SVG elements.
+        // Query buttons directly — they share the same noteClass as the SVG peers.
+        const scaleOnly = container.querySelectorAll('.note-bubble.scale-only');
         scaleOnly.forEach((el) => {
-          const btn = el.closest('.note-bubble') ?? el.querySelector('button');
-          const label = btn?.getAttribute('aria-label') ?? '';
-          // Fret 2+ is outside the shape — no scale-only should appear there
-          expect(label).not.toMatch(/fret [2-9]/);
+          const label = el.getAttribute("aria-label") ?? "";
+          // Each button must carry a fret label — empty means lookup failed.
+          expect(label).toMatch(/fret \d+/i);
+          // Fret 2+ (including 10-12) is outside the tiny shape.
+          expect(label).not.toMatch(/fret (?:[2-9]|1[0-2])\b/i);
         });
       });
 
@@ -1089,11 +1091,11 @@ describe("FretboardSVG", () => {
           />
         );
         // All color-tone notes must be within frets 0-1 (inside the shape)
-        const colorTones = container.querySelectorAll('.fretboard-note.color-tone');
+        const colorTones = container.querySelectorAll('.note-bubble.color-tone');
         colorTones.forEach((el) => {
-          const btn = el.closest('.note-bubble') ?? el.querySelector('button');
-          const label = btn?.getAttribute('aria-label') ?? '';
-          expect(label).not.toMatch(/fret [2-9]/);
+          const label = el.getAttribute("aria-label") ?? "";
+          expect(label).toMatch(/fret \d+/i);
+          expect(label).not.toMatch(/fret (?:[2-9]|1[0-2])\b/i);
         });
       });
     });
@@ -1134,11 +1136,9 @@ describe("FretboardSVG", () => {
       );
       const noteElements = container.querySelectorAll('.fretboard-note:not(.hidden)');
       noteElements.forEach((el) => {
-        const opacity = (el as HTMLElement).style.opacity;
-        // No lens dimming: opacity should be 1 or unset (not reduced)
-        if (opacity) {
-          expect(parseFloat(opacity)).toBeGreaterThanOrEqual(1);
-        }
+        // Use computed style — inline style misses stylesheet-applied opacity.
+        const opacity = parseFloat(getComputedStyle(el as Element).opacity);
+        expect(opacity).toBeGreaterThanOrEqual(1);
       });
     });
   });

--- a/src/__tests__/FretboardSVG.test.tsx
+++ b/src/__tests__/FretboardSVG.test.tsx
@@ -646,7 +646,9 @@ describe("FretboardSVG", () => {
       expect(inScaleTone.length).toBeGreaterThan(0);
     });
 
-    it("single CAGED shape membership - chord tone outside shape falls back to scale-only when in scale", () => {
+    it("single CAGED shape membership - chord tone outside shape is suppressed (not scale-only)", () => {
+      // activeShape="C" but polygon is shape "E" — no polygon matches active shape,
+      // so isInActiveShape=false everywhere. All notes should be note-inactive.
       const { container } = render(
         <FretboardSVG
           {...BASE_PROPS}
@@ -660,7 +662,7 @@ describe("FretboardSVG", () => {
         />,
       );
       const scaleOnlyNotes = container.querySelectorAll(".scale-only");
-      expect(scaleOnlyNotes.length).toBeGreaterThan(0);
+      expect(scaleOnlyNotes.length).toBe(0);
     });
 
     it("global scope shows chord overlay across all visible shapes", () => {
@@ -741,7 +743,10 @@ describe("FretboardSVG", () => {
       expect(chordRootInShape.length).toBe(0);
     });
 
-    it("in-scale chord tone outside active shape renders as scale-only", () => {
+    it("in-scale chord tone outside active shape is suppressed (not scale-only)", () => {
+      // shapeScope="single" + activeShape="E" — only the E polygon is active.
+      // Notes in the E shape → chord-tone-in-scale. Notes outside → note-inactive.
+      // The C-shape polygon (fullShapePolygon) is visible but not the active shape.
       const { container } = render(
         <FretboardSVG
           {...BASE_PROPS}
@@ -755,7 +760,10 @@ describe("FretboardSVG", () => {
         />,
       );
       const scaleOnlyNotes = container.querySelectorAll(".scale-only");
-      expect(scaleOnlyNotes.length).toBeGreaterThan(0);
+      expect(scaleOnlyNotes.length).toBe(0);
+      // In-shape chord tones must still render correctly.
+      const chordTonesInShape = container.querySelectorAll(".chord-tone-in-scale");
+      expect(chordTonesInShape.length).toBeGreaterThan(0);
     });
 
     it("REGRESSION: multi-shape without shapeScope would fail membership check", () => {

--- a/src/__tests__/chordDomainSplit.test.ts
+++ b/src/__tests__/chordDomainSplit.test.ts
@@ -170,13 +170,14 @@ describe("Focus removal", () => {
 // ---------------------------------------------------------------------------
 
 describe("LENS_REGISTRY", () => {
-  it("contains all five practice lenses", () => {
+  it("contains exactly three chord-overlay lenses (color and targets-color removed)", () => {
     const ids = LENS_REGISTRY.map((e) => e.id);
     expect(ids).toContain("targets");
     expect(ids).toContain("guide-tones");
-    expect(ids).toContain("color");
-    expect(ids).toContain("targets-color");
     expect(ids).toContain("tension");
+    expect(ids).not.toContain("color");
+    expect(ids).not.toContain("targets-color");
+    expect(ids).toHaveLength(3);
   });
 
   it("every entry has a non-empty label and description", () => {
@@ -188,11 +189,12 @@ describe("LENS_REGISTRY", () => {
 
   it("uses correct labels matching the target visible names", () => {
     const byId = Object.fromEntries(LENS_REGISTRY.map((e) => [e.id, e.label]));
-    expect(byId["targets-color"]).toBe("Chord + Color");
     expect(byId["targets"]).toBe("Chord Tones");
     expect(byId["guide-tones"]).toBe("Guide Tones");
-    expect(byId["color"]).toBe("Color Notes");
     expect(byId["tension"]).toBe("Tension");
+    // Removed lenses should not exist
+    expect(byId["targets-color"]).toBeUndefined();
+    expect(byId["color"]).toBeUndefined();
   });
 
   it("tension is the only lens with hideWhenUnavailable=true", () => {
@@ -204,8 +206,8 @@ describe("LENS_REGISTRY", () => {
     }
   });
 
-  it("targets-color is available with chord overlay only (no color notes required)", () => {
-    const entry = LENS_REGISTRY.find((e) => e.id === "targets-color")!;
+  it("targets lens is available with chord overlay only (no color notes required)", () => {
+    const entry = LENS_REGISTRY.find((e) => e.id === "targets")!;
     const ctx: LensAvailabilityContext = {
       hasChordOverlay: true,
       hasGuideTones: false,
@@ -277,28 +279,15 @@ describe("LENS_REGISTRY", () => {
     });
   });
 
-  describe("color lens", () => {
-    const entry = LENS_REGISTRY.find((e) => e.id === "color")!;
-
-    it("is available when chord overlay + color notes both present", () => {
-      const ctx: LensAvailabilityContext = {
-        hasChordOverlay: true,
-        hasGuideTones: false,
-        hasColorNotes: true,
-        hasOutsideTones: false,
-      };
-      expect(entry.isAvailable(ctx)).toBe(true);
+  describe("color lens (removed)", () => {
+    it("color lens id does not exist in LENS_REGISTRY", () => {
+      const entry = LENS_REGISTRY.find((e) => (e.id as string) === "color");
+      expect(entry).toBeUndefined();
     });
 
-    it("is unavailable when scale has no color notes", () => {
-      const ctx: LensAvailabilityContext = {
-        hasChordOverlay: true,
-        hasGuideTones: false,
-        hasColorNotes: false,
-        hasOutsideTones: false,
-      };
-      expect(entry.isAvailable(ctx)).toBe(false);
-      expect(entry.unavailableReason(ctx)).toMatch(/color notes/i);
+    it("targets-color lens id does not exist in LENS_REGISTRY", () => {
+      const entry = LENS_REGISTRY.find((e) => (e.id as string) === "targets-color");
+      expect(entry).toBeUndefined();
     });
   });
 
@@ -426,12 +415,13 @@ describe("lensAvailabilityAtom", () => {
     localStorage.clear();
   });
 
-  it("returns five entries matching LENS_REGISTRY ids", () => {
+  it("returns three entries matching LENS_REGISTRY ids", () => {
     const store = makeStore();
     const entries = store.get(lensAvailabilityAtom);
-    expect(entries).toHaveLength(5);
+    expect(entries).toHaveLength(3);
     const ids = entries.map((e) => e.id);
     expect(ids).toContain("targets");
+    expect(ids).toContain("guide-tones");
     expect(ids).toContain("tension");
   });
 
@@ -485,26 +475,15 @@ describe("lensAvailabilityAtom", () => {
     expect(gtEntry!.reason).toMatch(/guide tones/i);
   });
 
-  it("color lens unavailable for C Major (no color notes)", () => {
-    const store = makeStore();
-    store.set(rootNoteAtom, "C");
-    store.set(scaleNameAtom, "Major");
-    store.set(chordRootAtom, "C");
-    store.set(chordTypeAtom, "Major Triad");
-    const entries = store.get(lensAvailabilityAtom);
-    const colorEntry = entries.find((e) => e.id === "color");
-    expect(colorEntry!.available).toBe(false);
-  });
-
-  it("color lens available for D Dorian (has color notes)", () => {
+  it("color and targets-color lenses are absent from resolved availability", () => {
     const store = makeStore();
     store.set(rootNoteAtom, "D");
     store.set(scaleNameAtom, "Dorian");
     store.set(chordRootAtom, "D");
     store.set(chordTypeAtom, "Minor 7th");
     const entries = store.get(lensAvailabilityAtom);
-    const colorEntry = entries.find((e) => e.id === "color");
-    expect(colorEntry!.available).toBe(true);
+    expect(entries.find((e) => (e.id as string) === "color")).toBeUndefined();
+    expect(entries.find((e) => (e.id as string) === "targets-color")).toBeUndefined();
   });
 
   it("reason is null for available lenses", () => {
@@ -520,16 +499,16 @@ describe("lensAvailabilityAtom", () => {
     expect(targetsEntry!.reason).toBeNull();
   });
 
-  it("targets-color lens available for C Major (chord overlay is all that's required)", () => {
+  it("targets lens available for C Major (chord overlay is all that's required)", () => {
     const store = makeStore();
     store.set(rootNoteAtom, "C");
     store.set(scaleNameAtom, "Major");
     store.set(chordRootAtom, "C");
     store.set(chordTypeAtom, "Major Triad");
     const entries = store.get(lensAvailabilityAtom);
-    const tcEntry = entries.find((e) => e.id === "targets-color");
-    expect(tcEntry!.available).toBe(true);
-    expect(tcEntry!.reason).toBeNull();
+    const tEntry = entries.find((e) => e.id === "targets");
+    expect(tEntry!.available).toBe(true);
+    expect(tEntry!.reason).toBeNull();
   });
 
   it("tension entry has hideWhenUnavailable=true in resolved availability", () => {

--- a/src/__tests__/practiceLens.test.ts
+++ b/src/__tests__/practiceLens.test.ts
@@ -10,6 +10,7 @@ import {
   hideNonChordNotesAtom,
   showChordPracticeBarAtom,
   practiceBarLensLabelAtom,
+  lensAvailabilityAtom,
   noteSemanticMapAtom,
   rootNoteAtom,
   scaleNameAtom,
@@ -28,9 +29,9 @@ describe("practiceLensAtom", () => {
     localStorage.clear();
   });
 
-  it("defaults to targets-color", () => {
+  it("defaults to targets", () => {
     const store = makeStore();
-    expect(store.get(practiceLensAtom)).toBe("targets-color");
+    expect(store.get(practiceLensAtom)).toBe("targets");
   });
 
   it("reads stored value", () => {
@@ -57,11 +58,28 @@ describe("practiceLensAtom", () => {
     unsub();
   });
 
-  it("migrates old viewMode=compare to targets-color lens", () => {
+  it("migrates old viewMode=compare to targets lens (default)", () => {
     localStorage.setItem(k("viewMode"), "compare");
     const store = makeStore();
     const unsub = store.sub(practiceLensAtom, () => {});
-    expect(store.get(practiceLensAtom)).toBe("targets-color");
+    expect(store.get(practiceLensAtom)).toBe("targets");
+    unsub();
+  });
+
+  it("migrates stored targets-color to targets (removed lens)", () => {
+    localStorage.setItem(k("practiceLens"), "targets-color");
+    const store = makeStore();
+    const unsub = store.sub(practiceLensAtom, () => {});
+    // targets-color is no longer a valid lens — storage adapter falls back to default
+    expect(store.get(practiceLensAtom)).toBe("targets");
+    unsub();
+  });
+
+  it("migrates stored color to targets (removed lens)", () => {
+    localStorage.setItem(k("practiceLens"), "color");
+    const store = makeStore();
+    const unsub = store.sub(practiceLensAtom, () => {});
+    expect(store.get(practiceLensAtom)).toBe("targets");
     unsub();
   });
 
@@ -69,7 +87,7 @@ describe("practiceLensAtom", () => {
     localStorage.setItem(k("practiceLens"), "invalid-lens");
     const store = makeStore();
     const unsub = store.sub(practiceLensAtom, () => {});
-    expect(store.get(practiceLensAtom)).toBe("targets-color");
+    expect(store.get(practiceLensAtom)).toBe("targets");
     unsub();
   });
 });
@@ -77,7 +95,7 @@ describe("practiceLensAtom", () => {
 describe("hideNonChordNotesAtom", () => {
   it("is always false — lenses never hide scale notes", () => {
     const store = makeStore();
-    for (const lens of ["targets", "guide-tones", "color", "targets-color", "tension"] as const) {
+    for (const lens of ["targets", "guide-tones", "tension"] as const) {
       store.set(practiceLensAtom, lens);
       expect(store.get(hideNonChordNotesAtom)).toBe(false);
     }
@@ -164,69 +182,6 @@ describe("practiceCuesAtom", () => {
     });
   });
 
-  describe("color lens", () => {
-    it("returns a color-note cue for a modal scale with divergent notes", () => {
-      // D Dorian has B♮ as its color note (diverges from D Natural Minor)
-      const store = makeChordStore("Dorian", "D", "Minor 7th", "color");
-      const cues = store.get(practiceCuesAtom);
-      expect(cues.some((c) => c.kind === "color-note")).toBe(true);
-    });
-
-    it("returns empty cues when scale has no color tones", () => {
-      // C Major has no divergent notes (reference scale)
-      const store = makeChordStore("Major", "C", "Major Triad", "color");
-      const cues = store.get(practiceCuesAtom);
-      expect(cues.length).toBe(0);
-    });
-
-    it("color notes already in chord tones are filtered out", () => {
-      // G Mixolydian: color note is F (the b7). G7 chord includes F.
-      // F should be filtered from color cue (covered by land-on in targets-color).
-      const store = makeChordStore("Mixolydian", "G", "Dominant 7th", "color");
-      const cues = store.get(practiceCuesAtom);
-      // Color lens: if F is in chord tones, it's filtered → no color cue at all
-      const colorCues = cues.filter((c) => c.kind === "color-note");
-      if (colorCues.length > 0) {
-        const colorNotes = colorCues[0]!.notes.map((n) => n.internalNote);
-        expect(colorNotes).not.toContain("F");
-      }
-    });
-  });
-
-  describe("targets-color lens (default)", () => {
-    it("returns land-on + color-note cues for Dorian + Dm7", () => {
-      const store = makeChordStore("Dorian", "D", "Minor 7th", "targets-color");
-      const cues = store.get(practiceCuesAtom);
-      const kinds = cues.map((c) => c.kind);
-      expect(kinds).toContain("land-on");
-      expect(kinds).toContain("color-note");
-    });
-
-    it("returns only land-on when scale has no color tones (C Major + C Major Triad)", () => {
-      const store = makeChordStore("Major", "C", "Major Triad", "targets-color");
-      const cues = store.get(practiceCuesAtom);
-      const kinds = cues.map((c) => c.kind);
-      expect(kinds).toContain("land-on");
-      expect(kinds).not.toContain("color-note");
-    });
-
-    it("does not duplicate notes already in land-on as color notes", () => {
-      // G Mixolydian + G7: F is in both chord and scale divergence
-      const store = makeChordStore("Mixolydian", "G", "Dominant 7th", "targets-color");
-      const cues = store.get(practiceCuesAtom);
-      const colorCues = cues.filter((c) => c.kind === "color-note");
-      if (colorCues.length > 0) {
-        const landOnNotes = cues
-          .filter((c) => c.kind === "land-on")
-          .flatMap((c) => c.notes.map((n) => n.internalNote));
-        const colorNotes = colorCues[0]!.notes.map((n) => n.internalNote);
-        for (const note of colorNotes) {
-          expect(landOnNotes).not.toContain(note);
-        }
-      }
-    });
-  });
-
   describe("tension lens", () => {
     it("returns land-on + tension cues when chord has outside-scale tones", () => {
       // C Major + C# Minor Triad: C#, E, G# — C# and G# are outside C Major
@@ -277,6 +232,49 @@ describe("practiceCuesAtom", () => {
       const kinds = cues.map((c) => c.kind);
       expect(kinds).toContain("land-on");
       expect(kinds).not.toContain("tension");
+    });
+
+    it("finds resolution target within 2 semitones for pentatonic scale", () => {
+      // C Minor Pentatonic (C Eb F G Bb) + D Minor Triad (D F A)
+      // D is outside the pentatonic. Nearest scale neighbor: Eb (1 step up) or C (2 steps down).
+      const store = makeStore();
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Minor Pentatonic");
+      store.set(chordRootAtom, "D");
+      store.set(chordTypeAtom, "Minor Triad");
+      store.set(practiceLensAtom, "tension");
+      const cues = store.get(practiceCuesAtom);
+      const tensionCue = cues.find((c) => c.kind === "tension");
+      expect(tensionCue).toBeDefined();
+      // D (tension) should resolve to D# / Eb (1 step up, in pentatonic as Eb)
+      const dTension = tensionCue!.notes.find((n) => n.internalNote === "D");
+      expect(dTension?.resolvesTo).toBeDefined();
+    });
+  });
+
+  describe("LENS_REGISTRY — chord-overlay lens model", () => {
+    it("does not include targets-color or color lenses", () => {
+      const store = makeStore();
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major Triad");
+      const availability = store.get(lensAvailabilityAtom);
+      const ids = availability.map((l) => l.id);
+      expect(ids).not.toContain("targets-color");
+      expect(ids).not.toContain("color");
+    });
+
+    it("contains exactly Chord Tones, Guide Tones, and Tension", () => {
+      const store = makeStore();
+      store.set(chordRootAtom, "C");
+      store.set(chordTypeAtom, "Major 7th"); // has guide tones
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      const availability = store.get(lensAvailabilityAtom);
+      const ids = availability.map((l) => l.id);
+      expect(ids).toContain("targets");
+      expect(ids).toContain("guide-tones");
+      expect(ids).toContain("tension");
+      expect(ids).toHaveLength(3);
     });
   });
 });
@@ -358,29 +356,29 @@ describe("showChordPracticeBarAtom", () => {
     store.set(scaleNameAtom, "Major");
     store.set(chordRootAtom, "C");
     store.set(chordTypeAtom, "Major Triad");
-    // Diatonic simple case but lens is not targets-color
-    store.set(practiceLensAtom, "targets");
+    // Diatonic simple case but lens is not targets (guide-tones)
+    store.set(practiceLensAtom, "guide-tones");
     expect(store.get(showChordPracticeBarAtom)).toBe(true);
   });
 
-  it("returns false for targets-color lens in diatonic simple case", () => {
+  it("returns false for targets lens in diatonic simple case (root linked, chord in-scale)", () => {
     const store = makeStore();
     store.set(rootNoteAtom, "C");
     store.set(scaleNameAtom, "Major");
     store.set(chordRootAtom, "C");
     store.set(chordTypeAtom, "Major Triad");
-    store.set(practiceLensAtom, "targets-color");
-    // C Major + C Major Triad — diatonic simple case (chord root == scale root, fully in-scale, no color notes)
+    store.set(practiceLensAtom, "targets");
+    // C Major + C Major Triad — diatonic simple case (chord root == scale root, fully in-scale)
     expect(store.get(showChordPracticeBarAtom)).toBe(false);
   });
 
-  it("returns true for targets-color when there are outside chord members", () => {
+  it("returns true for targets when there are outside chord members", () => {
     const store = makeStore();
     store.set(rootNoteAtom, "C");
     store.set(scaleNameAtom, "Major");
     store.set(chordRootAtom, "C");
     store.set(chordTypeAtom, "Dominant 7th"); // Bb is outside C Major
-    store.set(practiceLensAtom, "targets-color");
+    store.set(practiceLensAtom, "targets");
     expect(store.get(showChordPracticeBarAtom)).toBe(true);
   });
 });
@@ -417,20 +415,18 @@ describe("practiceBarLensLabelAtom", () => {
     const store = makeStore();
     store.set(chordRootAtom, "C");
     store.set(chordTypeAtom, "Major Triad");
-    store.set(practiceLensAtom, "targets-color");
-    expect(store.get(practiceBarLensLabelAtom)).toBe("Chord + Color");
+    store.set(practiceLensAtom, "targets");
+    expect(store.get(practiceBarLensLabelAtom)).toBe("Chord Tones");
   });
 
-  it("returns correct labels for every lens", () => {
+  it("returns correct labels for every active lens", () => {
     const store = makeStore();
     store.set(chordRootAtom, "C");
     store.set(chordTypeAtom, "Major Triad");
 
     const expected: Record<string, string> = {
-      "targets-color": "Chord + Color",
       targets: "Chord Tones",
       "guide-tones": "Guide Tones",
-      color: "Color Notes",
       tension: "Tension",
     };
     for (const [lens, label] of Object.entries(expected)) {
@@ -460,13 +456,13 @@ describe("showChordPracticeBarAtom — scale visibility independence", () => {
     expect(store.get(showChordPracticeBarAtom)).toBe(true);
   });
 
-  it("shows the dock when scale visibility is off (targets-color with outside tones)", () => {
+  it("shows the dock when scale visibility is off (targets with outside tones)", () => {
     const store = makeStore();
     store.set(rootNoteAtom, "C");
     store.set(scaleNameAtom, "Major");
     store.set(chordRootAtom, "C#");
     store.set(chordTypeAtom, "Minor Triad");
-    store.set(practiceLensAtom, "targets-color");
+    store.set(practiceLensAtom, "targets");
     store.set(scaleVisibleAtom, false);
     expect(store.get(showChordPracticeBarAtom)).toBe(true);
   });
@@ -477,7 +473,7 @@ describe("showChordPracticeBarAtom — scale visibility independence", () => {
     store.set(scaleNameAtom, "Major");
     store.set(chordRootAtom, "C");
     store.set(chordTypeAtom, "Dominant 7th"); // Bb outside C Major
-    store.set(practiceLensAtom, "targets-color");
+    store.set(practiceLensAtom, "targets");
 
     store.set(scaleVisibleAtom, true);
     const visibleOn = store.get(showChordPracticeBarAtom);
@@ -549,17 +545,17 @@ describe("Chord Tones lens does not hide scale notes", () => {
     expect(store.get(hideNonChordNotesAtom)).toBe(false);
   });
 
-  it("effectiveShapeDataAtom highlightNotes unchanged when switching to targets lens", () => {
+  it("effectiveShapeDataAtom highlightNotes unchanged when switching between lenses", () => {
     const store = makeStore();
     store.set(rootNoteAtom, "C");
     store.set(scaleNameAtom, "Major");
     store.set(scaleVisibleAtom, true);
     store.set(chordTypeAtom, "Major Triad");
-    store.set(practiceLensAtom, "targets-color");
+    store.set(practiceLensAtom, "targets");
 
     const before = store.get(effectiveShapeDataAtom).highlightNotes.length;
 
-    store.set(practiceLensAtom, "targets");
+    store.set(practiceLensAtom, "guide-tones");
 
     const after = store.get(effectiveShapeDataAtom).highlightNotes.length;
 

--- a/src/components/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls.tsx
@@ -26,12 +26,10 @@ const CHORD_OPTIONS: (string | { divider: string })[] = [
 
 const CHORD_NONE_VALUE = "__none__";
 
-// Display order for the lens ToggleBar (targets-color is the default and shown first).
+// Display order for the lens ToggleBar.
 const LENS_UI_ORDER: readonly PracticeLens[] = [
-  "targets-color",
   "targets",
   "guide-tones",
-  "color",
   "tension",
 ];
 
@@ -88,23 +86,18 @@ export function ChordOverlayControls() {
 
   const currentLensEntry = lensAvailability.find((l) => l.id === practiceLens);
 
-  // Auto-exit unavailable lenses. targets-color is exempt — it degrades gracefully
-  // (shows chord tones, omits color highlights) when no color notes are present, so
-  // it is never auto-exited and serves as the primary fallback.
-  // Fallback chain: targets-color → targets (targets requires only an active chord
-  // overlay and is always available when another lens becomes unavailable mid-session).
+  // Auto-exit unavailable lenses. "targets" is exempt — it requires only an active
+  // chord overlay and is always available when any other lens becomes unavailable.
   // When no lens is available (chord overlay removed), preserve the stored value.
   useEffect(() => {
     if (
       currentLensEntry &&
       !currentLensEntry.available &&
-      currentLensEntry.id !== "targets-color"
+      currentLensEntry.id !== "targets"
     ) {
-      const tcAvailable = lensAvailability.find((l) => l.id === "targets-color")?.available;
       const tAvailable = lensAvailability.find((l) => l.id === "targets")?.available;
-      const fallback = tcAvailable ? "targets-color" : tAvailable ? "targets" : null;
-      if (fallback) {
-        setPracticeLens(fallback);
+      if (tAvailable) {
+        setPracticeLens("targets");
       }
     }
   }, [currentLensEntry, lensAvailability, setPracticeLens]);

--- a/src/components/DegreeChipStrip.css
+++ b/src/components/DegreeChipStrip.css
@@ -152,12 +152,13 @@
 }
 
 /* Color note (blue note / modal characteristic tone) — squircle geometry + violet glow.
-   border-radius: 38% matches the SVG squircle rx/ry = r * 0.38 on the fretboard. */
+   border-radius: 28% matches the CSS rx: 28% override on the SVG fretboard rects,
+   giving the characteristic cushion shape rather than a near-circular appearance. */
 .degree-chip-item[data-is-color-note='true'] .degree-chip {
   border-color: var(--glow-violet-border);
   box-shadow: var(--glow-violet-sm);
   opacity: 1;
-  border-radius: 38%;
+  border-radius: 28%;
 }
 
 /* Hidden state overrides all active states — connector line grey glow. */

--- a/src/components/TheoryControls.test.tsx
+++ b/src/components/TheoryControls.test.tsx
@@ -79,12 +79,13 @@ describe("TheoryControls", () => {
 
     expect(screen.getByText("Lens")).toBeInTheDocument();
     expect(screen.queryByText("Focus")).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Chord + Color" }),
-    ).toBeInTheDocument();
+    // Chord + Color and Color Notes lenses are removed from the chord overlay
+    expect(screen.queryByRole("button", { name: "Chord + Color" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Color Notes" })).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Chord Tones" }),
     ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Guide Tones" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "All" })).not.toBeInTheDocument();
   });
 

--- a/src/store/chordOverlayAtoms.ts
+++ b/src/store/chordOverlayAtoms.ts
@@ -71,8 +71,6 @@ const chordFretSpreadStorage = constrainedNumberStorage({ min: 0, max: 4, intege
 const PRACTICE_LENS_VALUES: PracticeLens[] = [
   "targets",
   "guide-tones",
-  "color",
-  "targets-color",
   "tension",
 ];
 
@@ -80,7 +78,7 @@ function migrateViewModeToLens(viewMode: string): PracticeLens {
   switch (viewMode) {
     case "chord": return "targets";
     case "outside": return "tension";
-    default: return "targets-color";
+    default: return "targets";
   }
 }
 
@@ -167,7 +165,7 @@ export const chordFretSpreadAtom = atomWithStorage(
 // Migrates from legacy viewMode value on first access (handled by practiceLensStorage).
 export const practiceLensAtom = atomWithStorage<PracticeLens>(
   k("practiceLens"),
-  "targets-color",
+  "targets",
   practiceLensStorage,
   GET_ON_INIT,
 );

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -23,6 +23,7 @@ import {
   scaleNotesAtom,
   colorNotesAtom,
   useFlatsAtom,
+  scaleVisibleAtom,
 } from "./scaleAtoms";
 import {
   chordRootAtom,
@@ -146,7 +147,6 @@ export const practiceCuesAtom = atom((get) => {
   const chordRoot = get(chordRootAtom);
   const useFlats = get(useFlatsAtom);
   const allChordMembers = get(allChordMembersAtom);
-  const colorNotesFiltered = get(practiceBarColorNotesFilteredAtom);
   const scaleNotes = get(scaleNotesAtom);
 
   const displayNote = (note: string) =>
@@ -159,22 +159,22 @@ export const practiceCuesAtom = atom((get) => {
     role: e.role,
   });
 
-  // Find the nearest in-scale note (half-step up or down) as a resolution target.
+  // Find the nearest in-scale note (up to 2 semitones in each direction).
+  // Prefers 1-step up, then 1-step down, then 2-step up, then 2-step down.
+  // The 2-step radius ensures coverage for pentatonic scales with wider gaps.
   const findResolution = (
     note: string,
   ): { internalNote: string; displayNote: string } | undefined => {
     const noteIdx = NOTES.indexOf(note);
     if (noteIdx === -1) return undefined;
     const scaleNoteSet = new Set(scaleNotes);
-    const up = NOTES[(noteIdx + 1) % 12];
-    const down = NOTES[(noteIdx + 11) % 12];
-    const resolved = scaleNoteSet.has(up)
-      ? up
-      : scaleNoteSet.has(down)
-        ? down
-        : undefined;
-    if (!resolved) return undefined;
-    return { internalNote: resolved, displayNote: displayNote(resolved) };
+    for (let step = 1; step <= 2; step++) {
+      const up = NOTES[(noteIdx + step) % 12];
+      const down = NOTES[(noteIdx - step + 12) % 12];
+      if (scaleNoteSet.has(up)) return { internalNote: up, displayNote: displayNote(up) };
+      if (scaleNoteSet.has(down)) return { internalNote: down, displayNote: displayNote(down) };
+    }
+    return undefined;
   };
 
   const cues: PracticeCue[] = [];
@@ -210,45 +210,6 @@ export const practiceCuesAtom = atom((get) => {
           kind: "land-on",
           label: "Land on",
           notes: allChordMembers.map(toCueNote),
-        });
-      }
-      break;
-    }
-
-    case "color": {
-      if (colorNotesFiltered.length > 0) {
-        cues.push({
-          kind: "color-note",
-          label: colorNotesFiltered.length === 1 ? "Color note" : "Color notes",
-          notes: colorNotesFiltered.map((n) => ({
-            internalNote: n.internalNote,
-            displayNote: n.displayNote,
-            intervalName: n.intervalName,
-            role: "color-tone" as const,
-          })),
-        });
-      }
-      break;
-    }
-
-    case "targets-color": {
-      if (allChordMembers.length > 0) {
-        cues.push({
-          kind: "land-on",
-          label: "Land on",
-          notes: allChordMembers.map(toCueNote),
-        });
-      }
-      if (colorNotesFiltered.length > 0) {
-        cues.push({
-          kind: "color-note",
-          label: colorNotesFiltered.length === 1 ? "Color note" : "Color notes",
-          notes: colorNotesFiltered.map((n) => ({
-            internalNote: n.internalNote,
-            displayNote: n.displayNote,
-            intervalName: n.intervalName,
-            role: "color-tone" as const,
-          })),
         });
       }
       break;
@@ -292,19 +253,22 @@ export const showChordPracticeBarAtom = atom((get) => {
   const practiceLens = get(practiceLensAtom);
 
   // Non-default lenses always show — user explicitly chose a practice focus.
-  if (practiceLens !== "targets-color") return true;
+  if (practiceLens !== "targets") return true;
 
-  // For targets-color (default): suppress the bar for the diatonic simple case
-  // where the chord is fully in-scale, root is linked, and no color tones exist
-  // (nothing interesting to coach about).
+  // When the scale is hidden, always show the bar — the user needs chord-tone
+  // coaching even if the scale isn't visible on the fretboard.
+  const scaleVisible = get(scaleVisibleAtom);
+  if (!scaleVisible) return true;
+
+  // For targets (default): suppress the bar for the diatonic simple case
+  // where the chord is fully in-scale and the root is linked
+  // (nothing interesting to coach about beyond what the fretboard already shows).
   const hasOutsideChordMembers = get(hasOutsideChordMembersAtom);
-  const colorNotes = get(colorNotesAtom);
   const chordRoot = get(chordRootAtom);
   const rootNote = get(rootNoteAtom);
 
   const isDiatonicSimpleCase =
     !hasOutsideChordMembers &&
-    colorNotes.length === 0 &&
     chordRoot === rootNote;
 
   return !isDiatonicSimpleCase;

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -119,8 +119,6 @@ export interface LegendItem {
 export type PracticeLens =
   | "targets"       // chord root + active chord tones — for landing and outlining harmony
   | "guide-tones"   // 3rd/7th — for voice-leading and strong chord definition
-  | "color"         // characteristic modal/blue notes — for hearing why the scale sounds like itself
-  | "targets-color" // targets + color (best general-purpose soloing practice view)
   | "tension";      // outside/altered tones — secondary/advanced lens
 
 // Composable note semantics — multiple properties can coexist on one note.
@@ -175,17 +173,9 @@ export interface LensRegistryEntry {
 
 export const LENS_REGISTRY: readonly LensRegistryEntry[] = [
   {
-    id: "targets-color",
-    label: "Chord + Color",
-    description: "Combines chord tones with characteristic scale color notes — best for general-purpose soloing",
-    isAvailable: (ctx) => ctx.hasChordOverlay,
-    unavailableReason: (ctx) =>
-      ctx.hasChordOverlay ? null : "Requires an active chord overlay",
-  },
-  {
     id: "targets",
     label: "Chord Tones",
-    description: "Shows only chord tones — for landing and outlining harmony",
+    description: "Shows chord tones — for landing and outlining harmony",
     isAvailable: (ctx) => ctx.hasChordOverlay,
     unavailableReason: (ctx) =>
       ctx.hasChordOverlay ? null : "Requires an active chord overlay",
@@ -198,17 +188,6 @@ export const LENS_REGISTRY: readonly LensRegistryEntry[] = [
     unavailableReason: (ctx) => {
       if (!ctx.hasChordOverlay) return "Requires an active chord overlay";
       if (!ctx.hasGuideTones) return "Chord has no guide tones (3rd or 7th)";
-      return null;
-    },
-  },
-  {
-    id: "color",
-    label: "Color Notes",
-    description: "Shows characteristic modal or blue notes that give the scale its flavor",
-    isAvailable: (ctx) => ctx.hasChordOverlay && ctx.hasColorNotes,
-    unavailableReason: (ctx) => {
-      if (!ctx.hasChordOverlay) return "Requires an active chord overlay";
-      if (!ctx.hasColorNotes) return "Scale has no characteristic color notes";
       return null;
     },
   },


### PR DESCRIPTION
## Summary

Five interconnected chord-overlay regressions fixed in a single focused correction pass.

- **Overlay-on shape leak** — `classifyNoteFromSemantics` used `sem.isInScale` (pitch-only) to gate `scale-only` / `color-tone` rendering, ignoring shape position. Notes inside the scale but outside the active CAGED/3NPS pattern rendered incorrectly when the chord overlay was on. Fixed by passing `isHighlighted` (shape-aware, from `effectiveShapeDataAtom`) to `classifyNoteFromSemantics` and gating both `color-tone` and `scale-only` branches through it — same gate the overlay-off path already used.

- **Remove color-note lenses** — `"color"` and `"targets-color"` removed from `PracticeLens`, `LENS_REGISTRY`, `practiceCuesAtom`, `ChordOverlayControls`, and all tests. Color notes are scale-owned semantics; they were never correct as chord-overlay lenses. Remaining lenses: **Chord Tones**, **Guide Tones**, **Tension**.

- **Squircle geometry** — Two independent mismatches corrected. SVG fretboard: CSS `rx`/`ry: 28%` on color/blue note `<rect>` elements (was `rx = r * 0.38` ≈ 19% of width — too rectangular). Scale strip chips: `border-radius: 28%` (was `38%` — nearly circular). Both now read as proper squircles.

- **Lens leakage when overlay off** — `practiceLens` and `data-practice-lens` were passed/set unconditionally on `FretboardSVG`. CSS `[data-practice-lens]` opacity rules fired even without a chord overlay, dimming scale notes the user never asked to dim. Both now gated on `hasChordOverlay`.

- **Tension resolution cue** — `findResolution` searched only ±1 semitone; pentatonic scales have gaps up to 3 semitones, so the nearest in-scale resolution was frequently missed and the cue appeared empty. Now searches ±2 semitones, covering all pentatonic cases. Also: `showChordPracticeBarAtom` now always shows the bar when `scaleVisible` is false (scale hidden → chord-tone coaching still needed even for diatonic simple case).

## Test plan

- [ ] Overlay-on shape containment: scale notes stay inside the active shape when chord overlay is enabled
- [ ] Overlay-off shape containment: unchanged (pre-existing behavior confirmed by existing tests)
- [ ] `Chord + Color` and `Color Notes` do not appear in the lens picker
- [ ] `Chord Tones`, `Guide Tones`, `Tension` remain in the lens picker
- [ ] Color notes render on strip and fretboard without chord overlay active
- [ ] Color/blue notes on fretboard read as squircles (not squares or circles)
- [ ] Scale strip color chips read as squircles
- [ ] No lens-driven dimming applies when chord overlay is off
- [ ] Tension practice cues include a named resolution-note target
- [ ] Tension cues work for pentatonic scales (C Minor Pentatonic + Major Triad tested)
- [ ] Practice bar shows when scale is hidden, even for fully-diatonic chords
- [ ] `npm run lint && npm run test && npm run build` all pass (41 files, 926 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented practice-lens UI effects from appearing when chord overlay is disabled.
  * Notes outside an active shape are now shown as inactive rather than scale-highlighted.

* **Updates**
  * Removed "Color Notes" and "Chord + Color" lenses; selector now shows "Chord Tones", "Guide Tones", and "Tension".
  * Default practice lens changed to "Chord Tones".
  * Slightly reduced corner rounding on chord/note chips and fretboard color notes.

* **Tests**
  * Added and updated tests covering lens availability, overlay containment, and rendering regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->