### PR TITLE
feat(tension): separate resolution cue row in tension lens

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -484,7 +484,7 @@ describe("App", () => {
       localStorage.setItem(k("chordRoot"), "C");
       // Dominant 7th has Bb which is outside C Major → bar is non-trivial and shown
       localStorage.setItem(k("chordType"), "Dominant 7th");
-      localStorage.setItem(k("practiceLens"), "targets-color");
+      localStorage.setItem(k("practiceLens"), "targets");
       render(<App />);
       await waitFor(() => {
         expect(document.querySelector(".chord-practice-bar")).toBeTruthy();

--- a/src/__tests__/ChordPracticeBar.test.tsx
+++ b/src/__tests__/ChordPracticeBar.test.tsx
@@ -64,6 +64,15 @@ const tensionCue: PracticeCue = {
   ],
 };
 
+const resolutionCue: PracticeCue = {
+  kind: "resolution",
+  label: "Resolve to",
+  notes: [
+    { internalNote: "D", displayNote: "D", role: "chord-tone-in-scale" },
+    { internalNote: "A", displayNote: "A", role: "chord-tone-in-scale" },
+  ],
+};
+
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("ChordPracticeBar", () => {
@@ -223,16 +232,12 @@ describe("ChordPracticeBar", () => {
       expect(pills.length).toBe(2);
     });
 
-    it("renders resolution arrows for tension notes with resolvesTo", () => {
+    it("does not render inline resolution arrows on tension pills", () => {
       render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />);
-      const resolves = screen.getAllByText(/→/);
-      expect(resolves.length).toBe(2);
-      expect(resolves[0]!.textContent).toBe("→D");
-      expect(resolves[1]!.textContent).toBe("→A");
+      expect(screen.queryByText(/→/)).toBeNull();
     });
 
     it("outside chord root appears in tension cue (semantic fix)", () => {
-      // A chord root that is outside the scale should appear in a tension cue
       const outsideRootTension: PracticeCue = {
         kind: "tension",
         label: "Tension",
@@ -241,7 +246,7 @@ describe("ChordPracticeBar", () => {
             internalNote: "C#",
             displayNote: "C♯",
             intervalName: "1",
-            role: "chord-root",  // root role, but also tension
+            role: "chord-root",
             resolvesTo: { internalNote: "D", displayNote: "D" },
           },
         ],
@@ -249,7 +254,40 @@ describe("ChordPracticeBar", () => {
       render(<ChordPracticeBar title="C# Minor" cues={[outsideRootTension]} />);
       expect(screen.getByText("Tension:")).toBeTruthy();
       expect(screen.getByText("C♯")).toBeTruthy();
-      expect(screen.getByText("→D")).toBeTruthy();
+    });
+  });
+
+  describe("Resolution cue row", () => {
+    it("renders 'Resolve to:' label", () => {
+      render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue, resolutionCue]} />);
+      expect(screen.getByText("Resolve to:")).toBeTruthy();
+    });
+
+    it("renders resolution target note names", () => {
+      render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue, resolutionCue]} />);
+      expect(screen.getByText("D")).toBeTruthy();
+      expect(screen.getByText("A")).toBeTruthy();
+    });
+
+    it("resolution pills have data-role=chord-tone-in-scale", () => {
+      const { container } = render(
+        <ChordPracticeBar title="C# Minor Triad" cues={[tensionCue, resolutionCue]} />
+      );
+      const resolvePills = container.querySelectorAll(
+        '.practice-bar-pill-list[aria-label="Resolve to"] [data-role="chord-tone-in-scale"]'
+      );
+      expect(resolvePills.length).toBe(2);
+    });
+
+    it("does not render resolution row when no resolution cue is provided", () => {
+      render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />);
+      expect(screen.queryByText("Resolve to:")).toBeNull();
+    });
+
+    it("renders tension and resolution rows together", () => {
+      render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue, resolutionCue]} />);
+      expect(screen.getByText("Tension:")).toBeTruthy();
+      expect(screen.getByText("Resolve to:")).toBeTruthy();
     });
   });
 
@@ -379,9 +417,9 @@ describe("ChordPracticeBar", () => {
       expect(await axe(container)).toHaveNoViolations();
     });
 
-    it("has no a11y violations with tension cue and resolution arrows", async () => {
+    it("has no a11y violations with tension cue and resolution row", async () => {
       const { container } = render(
-        <ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />
+        <ChordPracticeBar title="C# Minor Triad" cues={[tensionCue, resolutionCue]} />
       );
       expect(await axe(container)).toHaveNoViolations();
     });

--- a/src/__tests__/practiceLens.test.ts
+++ b/src/__tests__/practiceLens.test.ts
@@ -313,12 +313,15 @@ describe("practiceCuesAtom", () => {
         store.set(chordTypeAtom, "Major Triad"); // C#, F, G#
         store.set(practiceLensAtom, "tension");
         const cues = store.get(practiceCuesAtom);
+        const tensionCue = cues.find((c) => c.kind === "tension");
         const resCue = cues.find((c) => c.kind === "resolution");
+        expect(tensionCue).toBeDefined();
         expect(resCue).toBeDefined();
-        // No duplicate internalNote values
-        const noteNames = resCue!.notes.map((n) => n.internalNote);
-        const uniqueNames = new Set(noteNames);
-        expect(noteNames.length).toBe(uniqueNames.size);
+        const rawTargets = tensionCue!.notes
+          .flatMap((n) => (n.resolvesTo ? [n.resolvesTo.internalNote] : []));
+        const expectedDeduped = [...new Set(rawTargets)];
+        const actualTargets = resCue!.notes.map((n) => n.internalNote);
+        expect(actualTargets).toEqual(expectedDeduped);
       });
 
       it("does not emit a resolution cue when chord is fully in-scale", () => {
@@ -337,9 +340,7 @@ describe("practiceCuesAtom", () => {
         store.set(practiceLensAtom, "tension");
         const cues = store.get(practiceCuesAtom);
         const kinds = cues.map((c) => c.kind);
-        expect(kinds[0]).toBe("land-on");
-        expect(kinds[1]).toBe("tension");
-        expect(kinds[2]).toBe("resolution");
+        expect(kinds).toEqual(["land-on", "tension", "resolution"]);
       });
     });
   });

--- a/src/__tests__/practiceLens.test.ts
+++ b/src/__tests__/practiceLens.test.ts
@@ -250,6 +250,98 @@ describe("practiceCuesAtom", () => {
       const dTension = tensionCue!.notes.find((n) => n.internalNote === "D");
       expect(dTension?.resolvesTo).toBeDefined();
     });
+
+    describe("resolution cue row", () => {
+      it("emits a separate resolution cue when tension notes have resolution targets", () => {
+        const store = makeStore();
+        store.set(rootNoteAtom, "C");
+        store.set(scaleNameAtom, "Major");
+        store.set(chordRootAtom, "C#");
+        store.set(chordTypeAtom, "Minor Triad");
+        store.set(practiceLensAtom, "tension");
+        const cues = store.get(practiceCuesAtom);
+        const kinds = cues.map((c) => c.kind);
+        expect(kinds).toContain("resolution");
+      });
+
+      it("resolution cue has label 'Resolve to'", () => {
+        const store = makeStore();
+        store.set(rootNoteAtom, "C");
+        store.set(scaleNameAtom, "Major");
+        store.set(chordRootAtom, "C#");
+        store.set(chordTypeAtom, "Minor Triad");
+        store.set(practiceLensAtom, "tension");
+        const cues = store.get(practiceCuesAtom);
+        const resCue = cues.find((c) => c.kind === "resolution");
+        expect(resCue?.label).toBe("Resolve to");
+      });
+
+      it("resolution cue notes have role chord-tone-in-scale", () => {
+        const store = makeStore();
+        store.set(rootNoteAtom, "C");
+        store.set(scaleNameAtom, "Major");
+        store.set(chordRootAtom, "C#");
+        store.set(chordTypeAtom, "Minor Triad");
+        store.set(practiceLensAtom, "tension");
+        const cues = store.get(practiceCuesAtom);
+        const resCue = cues.find((c) => c.kind === "resolution");
+        expect(resCue).toBeDefined();
+        expect(resCue!.notes.every((n) => n.role === "chord-tone-in-scale")).toBe(true);
+      });
+
+      it("resolution cue target notes are all in the active scale", () => {
+        const store = makeStore();
+        store.set(rootNoteAtom, "C");
+        store.set(scaleNameAtom, "Major");
+        store.set(chordRootAtom, "C#");
+        store.set(chordTypeAtom, "Minor Triad");
+        store.set(practiceLensAtom, "tension");
+        const cues = store.get(practiceCuesAtom);
+        const resCue = cues.find((c) => c.kind === "resolution");
+        // C Major scale notes: C D E F G A B
+        const cMajor = new Set(["C", "D", "E", "F", "G", "A", "B"]);
+        expect(resCue!.notes.every((n) => cMajor.has(n.internalNote))).toBe(true);
+      });
+
+      it("resolution targets are deduped when multiple tension notes share the same target", () => {
+        // Two tension notes both resolve to the same in-scale note
+        // Use C# Major Triad (C#, F, G#) in C Major — C# and G# are outside; both may resolve to D or G/A
+        const store = makeStore();
+        store.set(rootNoteAtom, "C");
+        store.set(scaleNameAtom, "Major");
+        store.set(chordRootAtom, "C#");
+        store.set(chordTypeAtom, "Major Triad"); // C#, F, G#
+        store.set(practiceLensAtom, "tension");
+        const cues = store.get(practiceCuesAtom);
+        const resCue = cues.find((c) => c.kind === "resolution");
+        expect(resCue).toBeDefined();
+        // No duplicate internalNote values
+        const noteNames = resCue!.notes.map((n) => n.internalNote);
+        const uniqueNames = new Set(noteNames);
+        expect(noteNames.length).toBe(uniqueNames.size);
+      });
+
+      it("does not emit a resolution cue when chord is fully in-scale", () => {
+        const store = makeChordStore("Major", "C", "Major Triad", "tension");
+        const cues = store.get(practiceCuesAtom);
+        const kinds = cues.map((c) => c.kind);
+        expect(kinds).not.toContain("resolution");
+      });
+
+      it("tension, resolution, and land-on cues appear together in correct order", () => {
+        const store = makeStore();
+        store.set(rootNoteAtom, "C");
+        store.set(scaleNameAtom, "Major");
+        store.set(chordRootAtom, "C#");
+        store.set(chordTypeAtom, "Minor Triad");
+        store.set(practiceLensAtom, "tension");
+        const cues = store.get(practiceCuesAtom);
+        const kinds = cues.map((c) => c.kind);
+        expect(kinds[0]).toBe("land-on");
+        expect(kinds[1]).toBe("tension");
+        expect(kinds[2]).toBe("resolution");
+      });
+    });
   });
 
   describe("LENS_REGISTRY — chord-overlay lens model", () => {

--- a/src/components/ChordPracticeBar.css
+++ b/src/components/ChordPracticeBar.css
@@ -202,15 +202,6 @@
   letter-spacing: 0.02em;
 }
 
-/* Resolution arrow shown after tension notes: "→D" */
-.practice-bar-pill-resolve {
-  font-family: var(--font-sans);
-  font-size: calc(var(--pill-font) - 0.06rem);
-  font-weight: var(--font-weight-medium);
-  color: rgb(167 139 250 / 0.8);
-  line-height: 1;
-  letter-spacing: 0.01em;
-}
 
 /* Responsive — mobile */
 .app-container[data-layout-tier="mobile"] .chord-practice-bar {

--- a/src/components/ChordPracticeBar.tsx
+++ b/src/components/ChordPracticeBar.tsx
@@ -7,6 +7,7 @@ function cueKindDefaultRole(kind: PracticeCue["kind"]): string {
     case "guide-tones": return "guide-tone";
     case "color-note": return "color-tone";
     case "tension": return "chord-tone-outside-scale";
+    case "resolution": return "chord-tone-in-scale";
     default: return "chord-tone-in-scale";
   }
 }
@@ -30,11 +31,6 @@ function CueLine({ cue }: CueLineProps) {
             <span className="practice-bar-pill-note">{note.displayNote}</span>
             {note.intervalName && (
               <span className="practice-bar-pill-interval">{note.intervalName}</span>
-            )}
-            {note.resolvesTo && (
-              <span className="practice-bar-pill-resolve" aria-label={`resolves to ${note.resolvesTo.displayNote}`}>
-                →{note.resolvesTo.displayNote}
-              </span>
             )}
           </li>
         ))}

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -225,15 +225,37 @@ export const practiceCuesAtom = atom((get) => {
       }
       const tensionMembers = allChordMembers.filter((e) => !e.inScale);
       if (tensionMembers.length > 0) {
+        const tensionNotes = tensionMembers.map((e) => ({
+          ...toCueNote(e),
+          role: "chord-tone-outside-scale" as const,
+          resolvesTo: findResolution(e.internalNote),
+        }));
         cues.push({
           kind: "tension",
           label: "Tension",
-          notes: tensionMembers.map((e) => ({
-            ...toCueNote(e),
-            role: "chord-tone-outside-scale" as const,
-            resolvesTo: findResolution(e.internalNote),
-          })),
+          notes: tensionNotes,
         });
+        // Separate "Resolve to" row — deduped resolution targets
+        const seen = new Set<string>();
+        const resolutionNotes: PracticeCueNote[] = [];
+        for (const note of tensionNotes) {
+          const target = note.resolvesTo;
+          if (target && !seen.has(target.internalNote)) {
+            seen.add(target.internalNote);
+            resolutionNotes.push({
+              internalNote: target.internalNote,
+              displayNote: target.displayNote,
+              role: "chord-tone-in-scale" as const,
+            });
+          }
+        }
+        if (resolutionNotes.length > 0) {
+          cues.push({
+            kind: "resolution",
+            label: "Resolve to",
+            notes: resolutionNotes,
+          });
+        }
       }
       break;
     }

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -207,7 +207,7 @@ export const LENS_REGISTRY: readonly LensRegistryEntry[] = [
 ];
 
 // Practice bar coaching cue types
-export type PracticeCueKind = "land-on" | "guide-tones" | "color-note" | "tension";
+export type PracticeCueKind = "land-on" | "guide-tones" | "color-note" | "tension" | "resolution";
 
 export interface PracticeCueNote {
   internalNote: string;


### PR DESCRIPTION
## Summary

- Instead of inline `→Target` arrows embedded inside each tension pill, the tension lens now renders a dedicated **"Resolve to"** cue row showing the deduped set of in-scale resolution targets
- Tension pill row remains intact; the resolution row appears immediately below it when targets exist
- No resolution row rendered when the chord is fully in-scale (no tension notes)

## What changed

**`src/theory.ts`** — added `"resolution"` to `PracticeCueKind` union

**`src/store/practiceLensAtoms.ts`** — in the `tension` lens case, after building the tension cue, compute deduped resolution targets from the `resolvesTo` values already on each tension note and emit them as a separate `{ kind: "resolution", label: "Resolve to" }` cue row

**`src/components/ChordPracticeBar.tsx`** — added `"resolution"` to `cueKindDefaultRole` (maps to `chord-tone-in-scale` styling); removed inline `→Target` span rendering from tension pills

**`src/components/ChordPracticeBar.css`** — removed dead `.practice-bar-pill-resolve` rule

**`src/__tests__/ChordPracticeBar.test.tsx`** — added `resolutionCue` fixture and resolution row tests; replaced inline-arrow test with no-inline-arrow assertion

**`src/__tests__/practiceLens.test.ts`** — added 7 targeted tests covering: resolution cue present/absent, label, role, scale membership, deduplication, and cue order

## Test plan

- [ ] Tension lens with outside-scale chord shows three rows: `Land on` / `Tension` / `Resolve to`
- [ ] Tension lens with fully in-scale chord shows only `Land on` (no resolution row)
- [ ] Resolution target pills are styled as in-scale (orange border, no dash)
- [ ] No inline arrows visible on tension pills
- [ ] All 938 tests pass; build clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chord practice bar now displays a dedicated "Resolve to" section showing resolution target notes separately from tension notes.

* **Style**
  * Simplified resolution target visualization from inline arrow notation to organized, labeled section rows for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->