### PR TITLE
docs(help): update lens section to reflect current 3-lens system

### DIFF
--- a/src/components/HelpModal.test.tsx
+++ b/src/components/HelpModal.test.tsx
@@ -55,11 +55,12 @@ describe("HelpModal", () => {
 
   it("lists current lens names matching LENS_REGISTRY labels", () => {
     render(<HelpModal isOpen={true} onClose={vi.fn()} />);
-    expect(screen.getByText("Chord + Color")).toBeTruthy();
     expect(screen.getByText("Chord Tones")).toBeTruthy();
     expect(screen.getByText("Guide Tones")).toBeTruthy();
-    expect(screen.getByText("Color Notes")).toBeTruthy();
     expect(screen.getByText("Tension")).toBeTruthy();
+    // Removed lenses — must not appear
+    expect(screen.queryByText("Chord + Color")).toBeNull();
+    expect(screen.queryByText("Color Notes")).toBeNull();
   });
 
   it("restores focus to trigger button when modal closes", () => {

--- a/src/components/HelpModal.test.tsx
+++ b/src/components/HelpModal.test.tsx
@@ -55,9 +55,10 @@ describe("HelpModal", () => {
 
   it("lists current lens names matching LENS_REGISTRY labels", () => {
     render(<HelpModal isOpen={true} onClose={vi.fn()} />);
-    expect(screen.getByText("Chord Tones")).toBeTruthy();
-    expect(screen.getByText("Guide Tones")).toBeTruthy();
-    expect(screen.getByText("Tension")).toBeTruthy();
+    expect(screen.getAllByText("Chord Tones").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Guide Tones").length).toBeGreaterThan(0);
+    // "Tension" appears as both <strong> and <em> in the description
+    expect(screen.getAllByText("Tension").length).toBeGreaterThan(0);
     // Removed lenses — must not appear
     expect(screen.queryByText("Chord + Color")).toBeNull();
     expect(screen.queryByText("Color Notes")).toBeNull();

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -121,31 +121,43 @@ export function HelpModal({ isOpen, onClose, triggerRef }: HelpModalProps) {
                   <strong>Link chord root to scale</strong> keeps the chord root
                   in sync with the scale root automatically.
                 </li>
+              </ul>
+
+              <h3>Practice Lenses</h3>
+              <p>
+                When a chord overlay is active, a <strong>Lens</strong> selector
+                appears below it. Lenses focus the practice bar coaching cues at
+                the bottom of the screen — they do not hide fretboard notes.
+                Three lenses are available:
+              </p>
+              <ul>
                 <li>
-                  <strong>Lens</strong> controls which notes the practice dock
-                  coaches you toward:
-                  <ul>
-                    <li>
-                      <strong>Chord + Color</strong> — chord tones plus
-                      characteristic scale color notes (default).
-                    </li>
-                    <li>
-                      <strong>Chord Tones</strong> — chord tones only; for
-                      landing and outlining the harmony.
-                    </li>
-                    <li>
-                      <strong>Guide Tones</strong> — 3rd and 7th only; the
-                      tones that most strongly define chord quality.
-                    </li>
-                    <li>
-                      <strong>Color Notes</strong> — characteristic modal or
-                      blue notes that give the scale its flavor.
-                    </li>
-                    <li>
-                      <strong>Tension</strong> — chord tones outside the scale
-                      that need resolution. Only shown when such tones exist.
-                    </li>
-                  </ul>
+                  <strong>Chord Tones</strong> — the default lens. Highlights
+                  every chord member (root, 3rd, 5th, 7th, etc.) and shows a{" "}
+                  <em>Land on</em> cue in the practice bar listing all of them.
+                  Use this to learn the shape of a chord across the neck and
+                  practice landing phrases on strong harmonic tones.
+                </li>
+                <li>
+                  <strong>Guide Tones</strong> — narrows focus to the 3rd and
+                  7th only. These two intervals define chord quality more than
+                  any others, and moving smoothly between them across chord
+                  changes is the core of jazz voice-leading. The practice bar
+                  shows a <em>Guide tones</em> cue with just those two notes
+                  marked. Only available for chords that contain a 3rd or 7th
+                  (not power chords).
+                </li>
+                <li>
+                  <strong>Tension</strong> — surfaces chord tones that fall
+                  outside the active scale. These are the &ldquo;altered&rdquo;
+                  or &ldquo;outside&rdquo; tones that create tension and need
+                  resolution back into the scale. The practice bar shows three
+                  cue rows: <em>Land on</em> (all chord tones),{" "}
+                  <em>Tension</em> (the outside tones), and{" "}
+                  <em>Resolve to</em> (the nearest in-scale neighbors for each
+                  tension note). This lens is hidden automatically when the
+                  chord is fully within the scale — no outside tones, no
+                  tension to show.
                 </li>
               </ul>
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes outdated "Chord + Color" and "Color Notes" lens entries that no longer exist in the codebase
- Splits the old "Chord Overlay" section — chord overlay settings stay there, lenses get their own dedicated "Practice Lenses" section
- Adds accurate, detailed descriptions for all three current lenses: **Chord Tones**, **Guide Tones**, and **Tension**, including availability constraints (e.g. Guide Tones unavailable for power chords, Tension hidden when chord is fully in-scale) and how each drives the practice bar coaching cues

## Test plan

- [ ] Open the help modal and verify the "Practice Lenses" section appears with three entries
- [ ] Confirm "Chord + Color" and "Color Notes" are no longer mentioned
- [ ] Verify the Tension lens description matches runtime behavior (hidden when chord fully in-scale)
- [ ] Check Guide Tones description matches (unavailable for power chords)

https://claude.ai/code/session_01WgrXJiCk9oMmQAodqAbPg5
EOF
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated "Practice Lenses" help content with simplified lens descriptions — Chord Tones, Guide Tones, and Tension — clarifying what each cue shows (default chord member cues; guide-tone restrictions and dedicated cue; multi-row tension cues with automatic hiding when the chord fits the active scale) and clearer availability/behavior guidance for practice use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->