### PR TITLE
fix(tension): restore inline →Target arrows on tension pills

### DIFF
--- a/src/__tests__/ChordPracticeBar.test.tsx
+++ b/src/__tests__/ChordPracticeBar.test.tsx
@@ -64,15 +64,6 @@ const tensionCue: PracticeCue = {
   ],
 };
 
-const resolutionCue: PracticeCue = {
-  kind: "resolution",
-  label: "Resolve to",
-  notes: [
-    { internalNote: "D", displayNote: "D", role: "chord-tone-in-scale" },
-    { internalNote: "A", displayNote: "A", role: "chord-tone-in-scale" },
-  ],
-};
-
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("ChordPracticeBar", () => {
@@ -232,9 +223,15 @@ describe("ChordPracticeBar", () => {
       expect(pills.length).toBe(2);
     });
 
-    it("does not render inline resolution arrows on tension pills", () => {
+    it("renders inline resolution arrows on tension pills", () => {
       render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />);
-      expect(screen.queryByText(/→/)).toBeNull();
+      expect(screen.getAllByText(/→/).length).toBeGreaterThan(0);
+    });
+
+    it("resolution arrow shows the target note name", () => {
+      render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />);
+      expect(screen.getByText("→D")).toBeTruthy();
+      expect(screen.getByText("→A")).toBeTruthy();
     });
 
     it("outside chord root appears in tension cue (semantic fix)", () => {
@@ -254,40 +251,6 @@ describe("ChordPracticeBar", () => {
       render(<ChordPracticeBar title="C# Minor" cues={[outsideRootTension]} />);
       expect(screen.getByText("Tension:")).toBeTruthy();
       expect(screen.getByText("C♯")).toBeTruthy();
-    });
-  });
-
-  describe("Resolution cue row", () => {
-    it("renders 'Resolve to:' label", () => {
-      render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue, resolutionCue]} />);
-      expect(screen.getByText("Resolve to:")).toBeTruthy();
-    });
-
-    it("renders resolution target note names", () => {
-      render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue, resolutionCue]} />);
-      expect(screen.getByText("D")).toBeTruthy();
-      expect(screen.getByText("A")).toBeTruthy();
-    });
-
-    it("resolution pills have data-role=chord-tone-in-scale", () => {
-      const { container } = render(
-        <ChordPracticeBar title="C# Minor Triad" cues={[tensionCue, resolutionCue]} />
-      );
-      const resolvePills = container.querySelectorAll(
-        '.practice-bar-pill-list[aria-label="Resolve to"] [data-role="chord-tone-in-scale"]'
-      );
-      expect(resolvePills.length).toBe(2);
-    });
-
-    it("does not render resolution row when no resolution cue is provided", () => {
-      render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />);
-      expect(screen.queryByText("Resolve to:")).toBeNull();
-    });
-
-    it("renders tension and resolution rows together", () => {
-      render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue, resolutionCue]} />);
-      expect(screen.getByText("Tension:")).toBeTruthy();
-      expect(screen.getByText("Resolve to:")).toBeTruthy();
     });
   });
 
@@ -417,9 +380,9 @@ describe("ChordPracticeBar", () => {
       expect(await axe(container)).toHaveNoViolations();
     });
 
-    it("has no a11y violations with tension cue and resolution row", async () => {
+    it("has no a11y violations with tension cue", async () => {
       const { container } = render(
-        <ChordPracticeBar title="C# Minor Triad" cues={[tensionCue, resolutionCue]} />
+        <ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />
       );
       expect(await axe(container)).toHaveNoViolations();
     });

--- a/src/__tests__/practiceLens.test.ts
+++ b/src/__tests__/practiceLens.test.ts
@@ -251,97 +251,16 @@ describe("practiceCuesAtom", () => {
       expect(dTension?.resolvesTo).toBeDefined();
     });
 
-    describe("resolution cue row", () => {
-      it("emits a separate resolution cue when tension notes have resolution targets", () => {
-        const store = makeStore();
-        store.set(rootNoteAtom, "C");
-        store.set(scaleNameAtom, "Major");
-        store.set(chordRootAtom, "C#");
-        store.set(chordTypeAtom, "Minor Triad");
-        store.set(practiceLensAtom, "tension");
-        const cues = store.get(practiceCuesAtom);
-        const kinds = cues.map((c) => c.kind);
-        expect(kinds).toContain("resolution");
-      });
-
-      it("resolution cue has label 'Resolve to'", () => {
-        const store = makeStore();
-        store.set(rootNoteAtom, "C");
-        store.set(scaleNameAtom, "Major");
-        store.set(chordRootAtom, "C#");
-        store.set(chordTypeAtom, "Minor Triad");
-        store.set(practiceLensAtom, "tension");
-        const cues = store.get(practiceCuesAtom);
-        const resCue = cues.find((c) => c.kind === "resolution");
-        expect(resCue?.label).toBe("Resolve to");
-      });
-
-      it("resolution cue notes have role chord-tone-in-scale", () => {
-        const store = makeStore();
-        store.set(rootNoteAtom, "C");
-        store.set(scaleNameAtom, "Major");
-        store.set(chordRootAtom, "C#");
-        store.set(chordTypeAtom, "Minor Triad");
-        store.set(practiceLensAtom, "tension");
-        const cues = store.get(practiceCuesAtom);
-        const resCue = cues.find((c) => c.kind === "resolution");
-        expect(resCue).toBeDefined();
-        expect(resCue!.notes.every((n) => n.role === "chord-tone-in-scale")).toBe(true);
-      });
-
-      it("resolution cue target notes are all in the active scale", () => {
-        const store = makeStore();
-        store.set(rootNoteAtom, "C");
-        store.set(scaleNameAtom, "Major");
-        store.set(chordRootAtom, "C#");
-        store.set(chordTypeAtom, "Minor Triad");
-        store.set(practiceLensAtom, "tension");
-        const cues = store.get(practiceCuesAtom);
-        const resCue = cues.find((c) => c.kind === "resolution");
-        // C Major scale notes: C D E F G A B
-        const cMajor = new Set(["C", "D", "E", "F", "G", "A", "B"]);
-        expect(resCue!.notes.every((n) => cMajor.has(n.internalNote))).toBe(true);
-      });
-
-      it("resolution targets are deduped when multiple tension notes share the same target", () => {
-        // Two tension notes both resolve to the same in-scale note
-        // Use C# Major Triad (C#, F, G#) in C Major — C# and G# are outside; both may resolve to D or G/A
-        const store = makeStore();
-        store.set(rootNoteAtom, "C");
-        store.set(scaleNameAtom, "Major");
-        store.set(chordRootAtom, "C#");
-        store.set(chordTypeAtom, "Major Triad"); // C#, F, G#
-        store.set(practiceLensAtom, "tension");
-        const cues = store.get(practiceCuesAtom);
-        const tensionCue = cues.find((c) => c.kind === "tension");
-        const resCue = cues.find((c) => c.kind === "resolution");
-        expect(tensionCue).toBeDefined();
-        expect(resCue).toBeDefined();
-        const rawTargets = tensionCue!.notes
-          .flatMap((n) => (n.resolvesTo ? [n.resolvesTo.internalNote] : []));
-        const expectedDeduped = [...new Set(rawTargets)];
-        const actualTargets = resCue!.notes.map((n) => n.internalNote);
-        expect(actualTargets).toEqual(expectedDeduped);
-      });
-
-      it("does not emit a resolution cue when chord is fully in-scale", () => {
-        const store = makeChordStore("Major", "C", "Major Triad", "tension");
-        const cues = store.get(practiceCuesAtom);
-        const kinds = cues.map((c) => c.kind);
-        expect(kinds).not.toContain("resolution");
-      });
-
-      it("tension, resolution, and land-on cues appear together in correct order", () => {
-        const store = makeStore();
-        store.set(rootNoteAtom, "C");
-        store.set(scaleNameAtom, "Major");
-        store.set(chordRootAtom, "C#");
-        store.set(chordTypeAtom, "Minor Triad");
-        store.set(practiceLensAtom, "tension");
-        const cues = store.get(practiceCuesAtom);
-        const kinds = cues.map((c) => c.kind);
-        expect(kinds).toEqual(["land-on", "tension", "resolution"]);
-      });
+    it("tension and land-on cues appear together in correct order", () => {
+      const store = makeStore();
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(chordRootAtom, "C#");
+      store.set(chordTypeAtom, "Minor Triad");
+      store.set(practiceLensAtom, "tension");
+      const cues = store.get(practiceCuesAtom);
+      const kinds = cues.map((c) => c.kind);
+      expect(kinds).toEqual(["land-on", "tension"]);
     });
   });
 

--- a/src/components/ChordPracticeBar.css
+++ b/src/components/ChordPracticeBar.css
@@ -202,6 +202,15 @@
   letter-spacing: 0.02em;
 }
 
+/* Resolution arrow shown after tension notes: "→D" */
+.practice-bar-pill-resolve {
+  font-family: var(--font-sans);
+  font-size: calc(var(--pill-font) - 0.06rem);
+  font-weight: var(--font-weight-medium);
+  color: rgb(167 139 250 / 0.8);
+  line-height: 1;
+  letter-spacing: 0.01em;
+}
 
 /* Responsive — mobile */
 .app-container[data-layout-tier="mobile"] .chord-practice-bar {

--- a/src/components/ChordPracticeBar.tsx
+++ b/src/components/ChordPracticeBar.tsx
@@ -7,7 +7,6 @@ function cueKindDefaultRole(kind: PracticeCue["kind"]): string {
     case "guide-tones": return "guide-tone";
     case "color-note": return "color-tone";
     case "tension": return "chord-tone-outside-scale";
-    case "resolution": return "chord-tone-in-scale";
     default: return "chord-tone-in-scale";
   }
 }
@@ -31,6 +30,11 @@ function CueLine({ cue }: CueLineProps) {
             <span className="practice-bar-pill-note">{note.displayNote}</span>
             {note.intervalName && (
               <span className="practice-bar-pill-interval">{note.intervalName}</span>
+            )}
+            {note.resolvesTo && (
+              <span className="practice-bar-pill-resolve" aria-label={`resolves to ${note.resolvesTo.displayNote}`}>
+                →{note.resolvesTo.displayNote}
+              </span>
             )}
           </li>
         ))}

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -235,27 +235,6 @@ export const practiceCuesAtom = atom((get) => {
           label: "Tension",
           notes: tensionNotes,
         });
-        // Separate "Resolve to" row — deduped resolution targets
-        const seen = new Set<string>();
-        const resolutionNotes: PracticeCueNote[] = [];
-        for (const note of tensionNotes) {
-          const target = note.resolvesTo;
-          if (target && !seen.has(target.internalNote)) {
-            seen.add(target.internalNote);
-            resolutionNotes.push({
-              internalNote: target.internalNote,
-              displayNote: target.displayNote,
-              role: "chord-tone-in-scale" as const,
-            });
-          }
-        }
-        if (resolutionNotes.length > 0) {
-          cues.push({
-            kind: "resolution",
-            label: "Resolve to",
-            notes: resolutionNotes,
-          });
-        }
       }
       break;
     }

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -207,7 +207,7 @@ export const LENS_REGISTRY: readonly LensRegistryEntry[] = [
 ];
 
 // Practice bar coaching cue types
-export type PracticeCueKind = "land-on" | "guide-tones" | "color-note" | "tension" | "resolution";
+export type PracticeCueKind = "land-on" | "guide-tones" | "color-note" | "tension";
 
 export interface PracticeCueNote {
   internalNote: string;


### PR DESCRIPTION
## Summary

- Restores the inline `→G` resolution arrow on each tension pill (e.g. `F# ♭7 →G`), which was removed in PR #240
- Drops the separate "Resolve to" cue row that replaced the arrows — the inline format keeps the tension-to-resolution pairing visible at a glance; the separate row lost that connection
- Removes `"resolution"` from `PracticeCueKind` since the kind is no longer emitted

## Test plan

- [ ] Tension lens with an outside-scale chord shows `Land on` + `Tension` rows; each tension pill displays `→<target>` inline
- [ ] Tension lens with a fully in-scale chord shows only `Land on` (no tension/resolution rows)
- [ ] No separate "Resolve to" row appears
- [ ] 928 tests pass; build clean