### PR TITLE
style(shape-hint): reset margin on shape hint labels

### DIFF
--- a/src/components/shared.module.css
+++ b/src/components/shared.module.css
@@ -201,7 +201,7 @@
   color: rgb(188 200 214 / 0.45);
   text-align: center;
   line-height: 1;
-  margin: -0.3rem 0 0;
+  margin: 0;
   user-select: none;
 }
 


### PR DESCRIPTION
Removes a negative top margin from the shape hint label in `shared.module.css`. This centers the label vertically within its container by relying on the existing `line-height: 1` instead of manual offset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted vertical spacing alignment for improved visual presentation of UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->