### PR TITLE
feat(fretboard): render color notes as hexagons on fretboard and scale strip

### DIFF
--- a/src/FretboardSVG.css
+++ b/src/FretboardSVG.css
@@ -89,13 +89,13 @@
   stroke-width: 1.9;
 }
 
-/* Scale color notes (squircle — scale-owned characteristic tone, no chord overlay) */
+/* Scale color notes (hexagon — scale-owned characteristic tone, no chord overlay) */
 .fretboard-note.note-blue circle,
 .fretboard-note.note-blue rect,
 .fretboard-note.note-blue polygon {
   stroke: var(--note-ring-color-tone);
-  fill: rgb(30 18 55 / 0.82);
-  stroke-width: 1.8;
+  fill: rgb(20 30 40 / 0.92);
+  stroke-width: 1.9;
 }
 .fretboard-note.note-blue text {
   fill: #e8d8ff;
@@ -110,13 +110,13 @@
   stroke-width: 1.7;
 }
 
-/* Color Tone (Characteristic) */
+/* Color Tone (Characteristic) — hexagon, violet ring, matches note-active fill weight */
 .fretboard-note.color-tone circle,
 .fretboard-note.color-tone rect,
 .fretboard-note.color-tone polygon {
   stroke: var(--note-ring-color-tone);
-  fill: rgb(30 18 55 / 0.82);
-  stroke-width: 1.8;
+  fill: rgb(20 30 40 / 0.92);
+  stroke-width: 1.9;
 }
 .fretboard-note.color-tone text {
   fill: #e8d8ff;

--- a/src/FretboardSVG.css
+++ b/src/FretboardSVG.css
@@ -154,14 +154,7 @@
   filter: var(--glow-violet);
 }
 
-/* Scale-owned color notes use a rounder squircle than chord-owned squircles.
-   CSS rx/ry override the SVG attribute (rx = r * 0.38 ≈ 19% of width) to 28%,
-   which gives the characteristic cushion shape at both small and large radii. */
-.fretboard-note[data-note-role="note-blue"] rect,
-.fretboard-note[data-note-role="color-tone"] rect {
-  rx: 28%;
-  ry: 28%;
-}
+/* Color notes render as hexagon polygons — no rect override needed. */
 
 /* ==========================================================================
    Outside chord root: squircle shape signals root identity; dashed stroke

--- a/src/FretboardSVG.tsx
+++ b/src/FretboardSVG.tsx
@@ -246,7 +246,7 @@ function getNoteVisuals(
     case "note-blue":
       return {
         radiusScale: RADIUS_SCALE_NOTE_ACTIVE,
-        noteShape: "squircle",
+        noteShape: "hexagon",
       };
     case "scale-only":
       return {
@@ -256,7 +256,7 @@ function getNoteVisuals(
     case "color-tone":
       return {
         radiusScale: RADIUS_SCALE_COLOR_TONE,
-        noteShape: "squircle",
+        noteShape: "hexagon",
       };
     case "chord-tone-outside-scale":
       return {

--- a/src/__tests__/DegreeChipStrip.test.tsx
+++ b/src/__tests__/DegreeChipStrip.test.tsx
@@ -291,8 +291,8 @@ describe('DegreeChipStrip', () => {
       expect(container.querySelector('[data-chord-active]')).toBeNull();
     });
 
-    it("color note chip has data-is-color-note for squircle CSS targeting", () => {
-      // CSS applies border-radius: 28% (squircle geometry) to [data-is-color-note='true'].
+    it("color note chip has data-is-color-note for hexagon CSS targeting", () => {
+      // CSS applies clip-path hexagon geometry to [data-is-color-note='true'].
       // This test verifies the data attribute hook is present so CSS can target it.
       const { container } = render(
         <DegreeChipStrip

--- a/src/__tests__/DegreeChipStrip.test.tsx
+++ b/src/__tests__/DegreeChipStrip.test.tsx
@@ -292,7 +292,7 @@ describe('DegreeChipStrip', () => {
     });
 
     it("color note chip has data-is-color-note for squircle CSS targeting", () => {
-      // CSS applies border-radius: 38% (squircle geometry) to [data-is-color-note='true'].
+      // CSS applies border-radius: 28% (squircle geometry) to [data-is-color-note='true'].
       // This test verifies the data attribute hook is present so CSS can target it.
       const { container } = render(
         <DegreeChipStrip

--- a/src/__tests__/FretboardSVG.test.tsx
+++ b/src/__tests__/FretboardSVG.test.tsx
@@ -305,9 +305,9 @@ describe("FretboardSVG", () => {
       expect(activeNotes.length).toBeGreaterThan(0);
     });
 
-    it("color-tone notes have data-note-shape=squircle when chord overlay active", () => {
+    it("color-tone notes have data-note-shape=hexagon when chord overlay active", () => {
       // D Dorian scale: D E F G A B C. colorNote=B. chordTones=D F A (Dm triad).
-      // B is in scale, is a color note, NOT a chord tone → color-tone (squircle, scale-owned)
+      // B is in scale, is a color note, NOT a chord tone → color-tone (hexagon, scale-owned)
       const { container } = render(
         <FretboardSVG
           {...BASE_PROPS}
@@ -318,11 +318,11 @@ describe("FretboardSVG", () => {
           chordRoot="D"
         />
       );
-      const colorToneSquircles = container.querySelectorAll('.color-tone[data-note-shape="squircle"]');
-      expect(colorToneSquircles.length).toBeGreaterThan(0);
+      const colorToneHexagons = container.querySelectorAll('.color-tone[data-note-shape="hexagon"]');
+      expect(colorToneHexagons.length).toBeGreaterThan(0);
     });
 
-    it("note-blue notes (scale color notes, no chord overlay) have data-note-shape=squircle", () => {
+    it("note-blue notes (scale color notes, no chord overlay) have data-note-shape=hexagon", () => {
       const { container } = render(
         <FretboardSVG
           {...BASE_PROPS}
@@ -331,9 +331,9 @@ describe("FretboardSVG", () => {
           colorNotes={["B"]}
         />
       );
-      // No chord overlay: color notes → note-blue with squircle shape
-      const colorNoteSquircles = container.querySelectorAll('.note-blue[data-note-shape="squircle"]');
-      expect(colorNoteSquircles.length).toBeGreaterThan(0);
+      // No chord overlay: color notes → note-blue with hexagon shape
+      const colorNoteHexagons = container.querySelectorAll('.note-blue[data-note-shape="hexagon"]');
+      expect(colorNoteHexagons.length).toBeGreaterThan(0);
     });
 
     it("chord role wins over color-tone when a note is both", () => {

--- a/src/components/DegreeChipStrip.css
+++ b/src/components/DegreeChipStrip.css
@@ -151,14 +151,17 @@
   border-width: var(--chip-border-width);
 }
 
-/* Color note (blue note / modal characteristic tone) — squircle geometry + violet glow.
-   border-radius: 28% matches the CSS rx: 28% override on the SVG fretboard rects,
-   giving the characteristic cushion shape rather than a near-circular appearance. */
+/* Color note (blue note / modal characteristic tone) — hexagon geometry + violet glow.
+   clip-path clips the chip to a pointy-top hexagon matching the SVG fretboard hexagon.
+   filter: drop-shadow is used instead of box-shadow because box-shadow is clipped
+   by clip-path while filter is applied after clipping. */
 .degree-chip-item[data-is-color-note='true'] .degree-chip {
-  border-color: var(--glow-violet-border);
-  box-shadow: var(--glow-violet-sm);
+  clip-path: polygon(50% 0%, 93% 25%, 93% 75%, 50% 100%, 7% 75%, 7% 25%);
+  border-radius: 0;
+  border-color: transparent;
+  box-shadow: none;
+  filter: drop-shadow(0 0 5px rgb(167 139 250 / 0.75));
   opacity: 1;
-  border-radius: 28%;
 }
 
 /* Hidden state overrides all active states — connector line grey glow. */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,7 +35,7 @@ export const RADIUS_SCALE_KEY_TONIC = 0.82;
 export const RADIUS_SCALE_CHORD_ROOT = 0.86;
 export const RADIUS_SCALE_CHORD_TONE = 0.82;
 export const RADIUS_SCALE_NOTE_ACTIVE = 0.82;
-export const RADIUS_SCALE_COLOR_TONE = 0.80;
+export const RADIUS_SCALE_COLOR_TONE = 0.82;
 export const RADIUS_SCALE_DEFAULT = 0.8;
 
 // Fret markers


### PR DESCRIPTION
## Summary

- Color notes (`note-blue`, `color-tone`) now render as **hexagons** (matching the SVG hexagon polygon path) instead of squircles on the fretboard
- `DegreeChipStrip` color note chips use CSS `clip-path` hexagon + `filter: drop-shadow` for violet glow
- Fixed color note fill: was dark violet at 82% opacity, now matches `note-active` neutral dark fill at 92% opacity so color notes have the same visual weight as regular scale notes
- `RADIUS_SCALE_COLOR_TONE` bumped from 0.80 → 0.82 to match other scale note classes

## Dimming behavior
Color notes are only dimmed when a CAGED/3NPS shape is active AND the note falls outside the polygon boundary (`isInsideAnyPolygon` check). No dimming when no shape is active.

## Test plan
- [ ] Minor/Major Blues scale: blue note renders as hexagon on fretboard and chip strip
- [ ] Modal scale (e.g. Dorian): characteristic tones render as hexagons
- [ ] With chord overlay active: color-tone notes render as hexagons
- [ ] Color note hexagon inside CAGED shape: same visual weight as regular scale notes (no dimming)
- [ ] Color note outside active shape: dimmed at 80% opacity

https://claude.ai/code/session_01MHrrhzD1KCvcEs77gPHJbM