### PR TITLE
fix(shapes): show single 3NPS diagonal per position

### DIFF
--- a/src/shapes/threeNPS.ts
+++ b/src/shapes/threeNPS.ts
@@ -23,58 +23,43 @@ export function get3NPSCoordinates(
 
   if (currentFretFocus === -1) return { coordinates: [], bounds: [], polygons: [], wrappedNotes: new Set() };
 
-  const boundingBoxes: { minFret: number; maxFret: number }[] = [];
-  const allCoords = [];
+  const coords: string[] = [];
+  let scaleIndex = scaleNotes.indexOf(startNote);
+  let aggregateMinFret = 99;
+  let aggregateMaxFret = -1;
+  let localFocus = currentFretFocus;
 
-  const focusFrets = [];
-  let sFret = currentFretFocus;
-  while (sFret <= frets) {
-    focusFrets.push(sFret);
-    sFret += 12;
-  }
+  for (let s = startString; s >= 0; s--) {
+    let notesFound = 0;
+    const searchMin = Math.max(0, localFocus - 4);
+    const searchMax = Math.min(frets, localFocus + 6);
 
-  for (const focus of focusFrets) {
-    const coords: string[] = [];
-    let scaleIndex = scaleNotes.indexOf(startNote);
-    let aggregateMinFret = 99;
-    let aggregateMaxFret = -1;
-    let localFocus = focus;
+    let lastFretAdded = -1;
 
-    for (let s = startString; s >= 0; s--) {
-      let notesFound = 0;
-      const searchMin = Math.max(0, localFocus - 4);
-      const searchMax = Math.min(frets, localFocus + 6);
-
-      let lastFretAdded = -1;
-
-      for (let f = searchMin; f <= searchMax && notesFound < 3; f++) {
-        const expectedNote = scaleNotes[scaleIndex % scaleNotes.length];
-        if (layout[s][f] === expectedNote) {
-          coords.push(`${s}-${f}`);
-          notesFound++;
-          scaleIndex++;
-          aggregateMinFret = Math.min(aggregateMinFret, f);
-          aggregateMaxFret = Math.max(aggregateMaxFret, f);
-          lastFretAdded = f;
-        }
-      }
-      if (lastFretAdded !== -1) {
-        localFocus = lastFretAdded - 1;
+    for (let f = searchMin; f <= searchMax && notesFound < 3; f++) {
+      const expectedNote = scaleNotes[scaleIndex % scaleNotes.length];
+      if (layout[s][f] === expectedNote) {
+        coords.push(`${s}-${f}`);
+        notesFound++;
+        scaleIndex++;
+        aggregateMinFret = Math.min(aggregateMinFret, f);
+        aggregateMaxFret = Math.max(aggregateMaxFret, f);
+        lastFretAdded = f;
       }
     }
-
-    if (coords.length > 0) {
-      allCoords.push(...coords);
-      boundingBoxes.push({
-        minFret: aggregateMinFret,
-        maxFret: aggregateMaxFret,
-      });
+    if (lastFretAdded !== -1) {
+      localFocus = lastFretAdded - 1;
     }
   }
+
+  const bounds =
+    coords.length > 0
+      ? [{ minFret: aggregateMinFret, maxFret: aggregateMaxFret }]
+      : [];
 
   return {
-    coordinates: allCoords,
-    bounds: boundingBoxes,
+    coordinates: coords,
+    bounds,
     polygons: [],
     wrappedNotes: new Set(),
   };


### PR DESCRIPTION
## Summary

- `get3NPSCoordinates` was iterating over all octave occurrences of the start note on the low-E string (e.g. frets 5 and 17 for A), generating one full long-diagonal per octave and merging them all into `allCoords`
- The merged result gave every position 2+ overlapping diagonals spanning the full fretboard, making adjacent positions look identical (positions 1 and 7 showed the same thing)
- Fix: use only the first (lowest-fret) occurrence of the start note to generate exactly one diagonal per position; return a single bounding box entry accordingly

## Test plan

- [ ] Switch to 3NPS fingering pattern and step through positions 1–7 — each should display a distinct diagonal at a different fret region
- [ ] Positions 1 and 7 should no longer look identical
- [ ] All 928 existing tests pass (`npm run test`)
- [ ] Lint clean (`npm run lint`)

https://claude.ai/code/session_01H1QTXEQcreTZZMaCRRpHyc