### PR TITLE
feat(practice): compact degree chip strip in chord dock + fix tension resolve arrows

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1201,6 +1201,15 @@
   justify-content: center;
 }
 
+/* Inner column wrapper — stacks practice bar + compact scale strip vertically. */
+.chord-overlay-dock {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  width: min(100%, 32rem);
+}
+
 /* Chord overlay active: scale-only fretboard notes dim further so chord tones lead */
 .app-container[data-chord-active="true"] .note-scale-only {
   opacity: 0.45;

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -491,7 +491,7 @@ describe("App", () => {
       expect(title.textContent).toContain("Dominant 7th");
     });
 
-    it("chord dock and scale strip are in separate shells — not nested inside each other", async () => {
+    it("chord dock and scale strip are in correct shells", async () => {
       localStorage.setItem(k("rootNote"), "C");
       localStorage.setItem(k("chordRoot"), "D");
       localStorage.setItem(k("chordType"), "Dominant 7th");
@@ -502,9 +502,9 @@ describe("App", () => {
       });
       // chord-practice-bar must NOT be nested inside degree-chip-strip
       expect(document.querySelector(".degree-chip-strip .chord-practice-bar")).toBeNull();
-      // scale strip must NOT be nested inside chord-dock-shell
-      expect(document.querySelector(".chord-dock-shell .degree-chip-strip")).toBeNull();
-      // each surface in its own shell
+      // chord dock includes a compact degree-chip-strip for scale context while practicing
+      expect(document.querySelector(".chord-dock-shell .degree-chip-strip")).toBeTruthy();
+      // scale strip (full interactive version) also present in summary-shell
       expect(document.querySelector(".summary-shell .degree-chip-strip")).toBeTruthy();
     });
 

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -503,9 +503,11 @@ describe("App", () => {
       // chord-practice-bar must NOT be nested inside degree-chip-strip
       expect(document.querySelector(".degree-chip-strip .chord-practice-bar")).toBeNull();
       // chord dock includes a compact degree-chip-strip for scale context while practicing
-      expect(document.querySelector(".chord-dock-shell .degree-chip-strip")).toBeTruthy();
-      // scale strip (full interactive version) also present in summary-shell
-      expect(document.querySelector(".summary-shell .degree-chip-strip")).toBeTruthy();
+      expect(document.querySelector(".chord-dock-shell .degree-chip-strip.degree-chip-strip--compact")).toBeTruthy();
+      // scale strip (full interactive version) in summary-shell is NOT compact
+      const summaryStrip = document.querySelector(".summary-shell .degree-chip-strip");
+      expect(summaryStrip).toBeTruthy();
+      expect(summaryStrip!.classList.contains("degree-chip-strip--compact")).toBe(false);
     });
 
     it("chord dock remains visible when scale is hidden (eye-off)", async () => {

--- a/src/__tests__/ChordPracticeBar.test.tsx
+++ b/src/__tests__/ChordPracticeBar.test.tsx
@@ -254,6 +254,58 @@ describe("ChordPracticeBar", () => {
     });
   });
 
+  describe("Stacked Land on + Guide tones (guide-tones lens)", () => {
+    it("renders both 'Land on:' and 'Guide tones:' labels when stacked", () => {
+      render(
+        <ChordPracticeBar
+          title="G7"
+          lensLabel="Guide Tones"
+          cues={[landOnCue, guideToneCue]}
+        />
+      );
+      expect(screen.getByText("Land on:")).toBeTruthy();
+      expect(screen.getByText("Guide tones:")).toBeTruthy();
+    });
+
+    it("renders chord tones in land-on row and guide tones in guide-tones row", () => {
+      render(
+        <ChordPracticeBar
+          title="G7"
+          lensLabel="Guide Tones"
+          cues={[landOnCue, guideToneCue]}
+        />
+      );
+      // Land on row has chord tones (from landOnCue fixture: D, F, A, C)
+      expect(screen.getByText("F")).toBeTruthy();
+      // Guide tones row has guide tone notes (from guideToneCue fixture: E, B♭)
+      expect(screen.getByText("E")).toBeTruthy();
+      expect(screen.getByText("B♭")).toBeTruthy();
+    });
+
+    it("land-on pills have chord-root / chord-tone-in-scale roles; guide-tone pills have guide-tone role", () => {
+      const { container } = render(
+        <ChordPracticeBar
+          title="G7"
+          lensLabel="Guide Tones"
+          cues={[landOnCue, guideToneCue]}
+        />
+      );
+      expect(container.querySelector('[data-role="chord-root"]')).toBeTruthy();
+      expect(container.querySelectorAll('[data-role="guide-tone"]').length).toBe(2);
+    });
+
+    it("has no a11y violations with stacked Land on + Guide tones", async () => {
+      const { container } = render(
+        <ChordPracticeBar
+          title="G7"
+          lensLabel="Guide Tones"
+          cues={[landOnCue, guideToneCue]}
+        />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
   describe("Targets + Color (default lens)", () => {
     it("renders both Land on and Color note cues", () => {
       render(

--- a/src/__tests__/practiceLens.test.ts
+++ b/src/__tests__/practiceLens.test.ts
@@ -133,36 +133,43 @@ describe("practiceCuesAtom", () => {
   });
 
   describe("guide-tones lens", () => {
-    it("returns guide tones cue for a seventh chord (3rd + 7th)", () => {
+    it("returns land-on + guide-tones cues for a seventh chord (3rd + 7th)", () => {
       const store = makeChordStore("Major", "G", "Dominant 7th", "guide-tones");
       const cues = store.get(practiceCuesAtom);
-      expect(cues.length).toBe(1);
-      expect(cues[0]!.kind).toBe("guide-tones");
-      expect(cues[0]!.label).toBe("Guide tones");
+      expect(cues.length).toBe(2);
+      expect(cues[0]!.kind).toBe("land-on");
+      expect(cues[0]!.label).toBe("Land on");
+      expect(cues[1]!.kind).toBe("guide-tones");
+      expect(cues[1]!.label).toBe("Guide tones");
       // G7 = G B D F; guide tones = B (3) and F (b7)
-      const noteNames = cues[0]!.notes.map((n) => n.internalNote);
+      const noteNames = cues[1]!.notes.map((n) => n.internalNote);
       expect(noteNames).toContain("B");
       expect(noteNames).toContain("F");
     });
 
-    it("guide tones for a triad returns the 3rd", () => {
+    it("guide tones for a triad returns land-on first, then guide-tones with the 3rd", () => {
       const store = makeChordStore("Major", "C", "Major Triad", "guide-tones");
       const cues = store.get(practiceCuesAtom);
-      expect(cues[0]!.kind).toBe("guide-tones");
-      const noteNames = cues[0]!.notes.map((n) => n.internalNote);
+      expect(cues.length).toBe(2);
+      expect(cues[0]!.kind).toBe("land-on");
+      expect(cues[1]!.kind).toBe("guide-tones");
+      const noteNames = cues[1]!.notes.map((n) => n.internalNote);
       expect(noteNames).toContain("E"); // major 3rd
     });
 
-    it("falls back to land-on for power chord (no 3rd/7th)", () => {
+    it("shows only land-on for power chord (no 3rd/7th)", () => {
       const store = makeChordStore("Major", "G", "Power Chord (5)", "guide-tones");
       const cues = store.get(practiceCuesAtom);
+      expect(cues.length).toBe(1);
       expect(cues[0]!.kind).toBe("land-on");
     });
 
     it("guide tone notes have role=guide-tone", () => {
       const store = makeChordStore("Major", "G", "Dominant 7th", "guide-tones");
       const cues = store.get(practiceCuesAtom);
-      expect(cues[0]!.notes.every((n) => n.role === "guide-tone")).toBe(true);
+      const guideToneCue = cues.find((c) => c.kind === "guide-tones");
+      expect(guideToneCue).toBeDefined();
+      expect(guideToneCue!.notes.every((n) => n.role === "guide-tone")).toBe(true);
     });
   });
 

--- a/src/components/ChordOverlayDock.tsx
+++ b/src/components/ChordOverlayDock.tsx
@@ -26,7 +26,7 @@ export function ChordOverlayDock() {
   const colorNoteSet = colorNotes.length > 0 ? new Set(colorNotes) : undefined;
 
   return (
-    <>
+    <div className="chord-overlay-dock">
       <ChordPracticeBar
         title={practiceBarTitle}
         badge={practiceBarBadge}
@@ -44,6 +44,6 @@ export function ChordOverlayDock() {
         hideHeader={false}
         aria-label="Scale degrees"
       />
-    </>
+    </div>
   );
 }

--- a/src/components/ChordOverlayDock.tsx
+++ b/src/components/ChordOverlayDock.tsx
@@ -1,5 +1,8 @@
+import { useAtomValue } from "jotai";
 import { usePracticeBarState } from "../hooks/usePracticeBarState";
 import { ChordPracticeBar } from "./ChordPracticeBar";
+import { DegreeChipStrip } from "./DegreeChipStrip";
+import { degreeChipsAtom, scaleLabelAtom, colorNotesAtom } from "../store/atoms";
 
 /** Independent chord practice dock — shows coaching cues for the active lens. */
 export function ChordOverlayDock() {
@@ -14,17 +17,33 @@ export function ChordOverlayDock() {
     shapeLocalPracticeCues,
   } = usePracticeBarState();
 
+  const degreeChips = useAtomValue(degreeChipsAtom);
+  const scaleLabel = useAtomValue(scaleLabelAtom);
+  const colorNotes = useAtomValue(colorNotesAtom);
+
   if (!showChordPracticeBar) return null;
 
+  const colorNoteSet = colorNotes.length > 0 ? new Set(colorNotes) : undefined;
+
   return (
-    <ChordPracticeBar
-      title={practiceBarTitle}
-      badge={practiceBarBadge}
-      lensLabel={practiceBarLensLabel}
-      cues={practiceCues}
-      isShapeLocal={isShapeLocalContext}
-      shapeContextLabel={shapeContextLabel}
-      shapeLocalCues={shapeLocalPracticeCues}
-    />
+    <>
+      <ChordPracticeBar
+        title={practiceBarTitle}
+        badge={practiceBarBadge}
+        lensLabel={practiceBarLensLabel}
+        cues={practiceCues}
+        isShapeLocal={isShapeLocalContext}
+        shapeContextLabel={shapeContextLabel}
+        shapeLocalCues={shapeLocalPracticeCues}
+      />
+      <DegreeChipStrip
+        scaleName={scaleLabel}
+        chips={degreeChips}
+        colorNotes={colorNoteSet}
+        compact
+        hideHeader={false}
+        aria-label="Scale degrees"
+      />
+    </>
   );
 }

--- a/src/components/DegreeChipStrip.css
+++ b/src/components/DegreeChipStrip.css
@@ -193,6 +193,28 @@
   letter-spacing: 0.02em;
 }
 
+/* Compact variant — smaller chips for secondary surfaces (e.g. inside the practice dock). */
+.degree-chip-strip--compact {
+  --chip-size: clamp(1.45rem, 2.1vw, 1.65rem);
+
+  padding: 0.28rem 0.65rem 0.3rem;
+  gap: 0.2rem;
+  border-radius: 0.75rem;
+}
+
+.degree-chip-strip--compact .degree-chip-strip-header {
+  font-size: 0.72rem;
+  color: rgb(255 255 255 / 0.45);
+}
+
+.degree-chip-strip--compact .degree-chip-note {
+  font-size: clamp(0.72rem, 1.2vw, 0.84rem);
+}
+
+.degree-chip-strip--compact .degree-chip-interval {
+  font-size: 0.62rem;
+}
+
 .app-container[data-layout-tier="mobile"] .degree-chip-strip {
   --chip-size: 2.15rem;
 

--- a/src/components/DegreeChipStrip.css
+++ b/src/components/DegreeChipStrip.css
@@ -193,8 +193,10 @@
   letter-spacing: 0.02em;
 }
 
-/* Compact variant — smaller chips for secondary surfaces (e.g. inside the practice dock). */
-.degree-chip-strip--compact {
+/* Compact variant — smaller chips for secondary surfaces (e.g. inside the practice dock).
+   Selectors include .degree-chip-strip base class so they out-specifify the layout-tier
+   rules below (which use .app-container[...] .degree-chip-strip). */
+.degree-chip-strip.degree-chip-strip--compact {
   --chip-size: clamp(1.45rem, 2.1vw, 1.65rem);
 
   padding: 0.28rem 0.65rem 0.3rem;
@@ -202,16 +204,16 @@
   border-radius: 0.75rem;
 }
 
-.degree-chip-strip--compact .degree-chip-strip-header {
+.degree-chip-strip.degree-chip-strip--compact .degree-chip-strip-header {
   font-size: 0.72rem;
   color: rgb(255 255 255 / 0.45);
 }
 
-.degree-chip-strip--compact .degree-chip-note {
+.degree-chip-strip.degree-chip-strip--compact .degree-chip-note {
   font-size: clamp(0.72rem, 1.2vw, 0.84rem);
 }
 
-.degree-chip-strip--compact .degree-chip-interval {
+.degree-chip-strip.degree-chip-strip--compact .degree-chip-interval {
   font-size: 0.62rem;
 }
 

--- a/src/components/DegreeChipStrip.tsx
+++ b/src/components/DegreeChipStrip.tsx
@@ -24,6 +24,8 @@ export interface DegreeChipStripProps {
   visible?: boolean;
   /** Rendered inside the header landmark, to the right of the scale name. */
   headerAction?: ReactNode;
+  /** Compact mode — smaller chips and tighter padding for secondary surfaces. */
+  compact?: boolean;
 }
 
 export function DegreeChipStrip({
@@ -37,6 +39,7 @@ export function DegreeChipStrip({
   hideHeader,
   visible = true,
   headerAction,
+  compact,
 }: DegreeChipStripProps) {
   const label = ariaLabel ?? `Scale degrees for ${scaleName}`;
 
@@ -44,7 +47,7 @@ export function DegreeChipStrip({
     <section
       role="group"
       aria-label={label}
-      className={clsx('degree-chip-strip', className)}
+      className={clsx('degree-chip-strip', compact && 'degree-chip-strip--compact', className)}
       data-scale-visible={visible ? 'true' : 'false'}
     >
       {(!hideHeader || headerAction) && (

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -398,9 +398,11 @@ export const shapeLocalPracticeCuesAtom = atom((get) => {
   return cues
     .map((cue) => ({
       ...cue,
-      notes: cue.notes.filter((n) =>
-        shapeHighlightedNoteSet.has(n.internalNote),
-      ),
+      // Tension cues are never filtered by shape — tension notes and their
+      // resolve targets must always be visible regardless of position context.
+      notes: cue.kind === "tension"
+        ? cue.notes
+        : cue.notes.filter((n) => shapeHighlightedNoteSet.has(n.internalNote)),
     }))
     .filter((cue) => cue.notes.length > 0);
 });

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -176,21 +176,26 @@ export const practiceCuesAtom = atom((get) => {
     return undefined;
   };
 
+  const buildLandOnCue = (): PracticeCue => ({
+    kind: "land-on",
+    label: "Land on",
+    notes: allChordMembers.map(toCueNote),
+  });
+
   const cues: PracticeCue[] = [];
 
   switch (practiceLens) {
     case "targets": {
       if (allChordMembers.length > 0) {
-        cues.push({
-          kind: "land-on",
-          label: "Land on",
-          notes: allChordMembers.map(toCueNote),
-        });
+        cues.push(buildLandOnCue());
       }
       break;
     }
 
     case "guide-tones": {
+      if (allChordMembers.length > 0) {
+        cues.push(buildLandOnCue());
+      }
       const guideNotes = allChordMembers.filter((e) =>
         GUIDE_TONE_FORMATTED.has(e.memberName),
       );
@@ -203,24 +208,14 @@ export const practiceCuesAtom = atom((get) => {
             role: "guide-tone" as const,
           })),
         });
-      } else {
-        // Fallback for power chords (no 3rd/7th): show all chord tones.
-        cues.push({
-          kind: "land-on",
-          label: "Land on",
-          notes: allChordMembers.map(toCueNote),
-        });
       }
+      // Power chords / no-guide-tone chords: land-on already pushed, nothing more.
       break;
     }
 
     case "tension": {
       if (allChordMembers.length > 0) {
-        cues.push({
-          kind: "land-on",
-          label: "Land on",
-          notes: allChordMembers.map(toCueNote),
-        });
+        cues.push(buildLandOnCue());
       }
       const tensionMembers = allChordMembers.filter((e) => !e.inScale);
       if (tensionMembers.length > 0) {


### PR DESCRIPTION
## Summary

- **Compact degree chip strip in chord dock**: `ChordOverlayDock` now renders a read-only `DegreeChipStrip` below the practice bar. Players can see scale context (which degree each note is) while focusing on chord practice. Uses a new `compact` prop on `DegreeChipStrip` that reduces chip size and padding for the secondary surface.

- **Fix tension lens resolve arrows in shape-local mode**: `shapeLocalPracticeCuesAtom` was filtering tension cue notes by shape membership, which could drop the entire "Tension" cue row when no tension notes happened to fall inside the current CAGED/3NPS position. Tension notes and their `→resolve` arrows now always appear regardless of shape context — that information is always relevant when practicing against a chord.

## What changed

**`src/components/DegreeChipStrip.tsx`** — added `compact?: boolean` prop that applies `degree-chip-strip--compact` class

**`src/components/DegreeChipStrip.css`** — added `.degree-chip-strip--compact` modifier: smaller `--chip-size` (~1.5rem), tighter padding, muted header text

**`src/components/ChordOverlayDock.tsx`** — renders compact `DegreeChipStrip` below `ChordPracticeBar`; reads `degreeChipsAtom`, `scaleLabelAtom`, `colorNotesAtom` directly

**`src/store/atoms.ts`** — `shapeLocalPracticeCuesAtom`: tension cues (`kind === "tension"`) bypass the shape-note filter so resolve arrows are always emitted

**`src/__tests__/App.test.tsx`** — updated surface-separation test to expect the compact strip inside `.chord-dock-shell`

## Test plan

- [ ] Select a chord — practice bar shows with compact degree chips below it
- [ ] Compact chips reflect the current scale (correct notes, color notes marked)
- [ ] Tension lens with CAGED single-shape or 3NPS — "Tension" cue row still appears with `→resolve` arrows even when tension notes are outside the current shape
- [ ] Tension lens with fully diatonic chord — no tension row (correct; nothing to resolve)
- [ ] All 922 tests pass; build clean

https://claude.ai/code/session_01Y5Txi83BPV2XfJo73QK53X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Degree chips added to the chord dock overlay for enhanced chord visualization and practice.

* **Improvements**
  * Compact layout mode for degree chips with tighter sizing and spacing.
  * Tension cues now include all relevant notes (no longer filtered out).

* **Tests**
  * Updated and added tests to validate degree-chip behaviors, cue ordering/composition, stacked cue rendering, and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->