### PR TITLE
feat(practice-bar): always show chord-note Land on row in practice bar

### DIFF
--- a/src/__tests__/ChordPracticeBar.test.tsx
+++ b/src/__tests__/ChordPracticeBar.test.tsx
@@ -254,6 +254,58 @@ describe("ChordPracticeBar", () => {
     });
   });
 
+  describe("Stacked Land on + Guide tones (guide-tones lens)", () => {
+    it("renders both 'Land on:' and 'Guide tones:' labels when stacked", () => {
+      render(
+        <ChordPracticeBar
+          title="G7"
+          lensLabel="Guide Tones"
+          cues={[landOnCue, guideToneCue]}
+        />
+      );
+      expect(screen.getByText("Land on:")).toBeTruthy();
+      expect(screen.getByText("Guide tones:")).toBeTruthy();
+    });
+
+    it("renders chord tones in land-on row and guide tones in guide-tones row", () => {
+      render(
+        <ChordPracticeBar
+          title="G7"
+          lensLabel="Guide Tones"
+          cues={[landOnCue, guideToneCue]}
+        />
+      );
+      // Land on row has chord tones (from landOnCue fixture: D, F, A, C)
+      expect(screen.getByText("F")).toBeTruthy();
+      // Guide tones row has guide tone notes (from guideToneCue fixture: E, B♭)
+      expect(screen.getByText("E")).toBeTruthy();
+      expect(screen.getByText("B♭")).toBeTruthy();
+    });
+
+    it("land-on pills have chord-root / chord-tone-in-scale roles; guide-tone pills have guide-tone role", () => {
+      const { container } = render(
+        <ChordPracticeBar
+          title="G7"
+          lensLabel="Guide Tones"
+          cues={[landOnCue, guideToneCue]}
+        />
+      );
+      expect(container.querySelector('[data-role="chord-root"]')).toBeTruthy();
+      expect(container.querySelectorAll('[data-role="guide-tone"]').length).toBe(2);
+    });
+
+    it("has no a11y violations with stacked Land on + Guide tones", async () => {
+      const { container } = render(
+        <ChordPracticeBar
+          title="G7"
+          lensLabel="Guide Tones"
+          cues={[landOnCue, guideToneCue]}
+        />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
   describe("Targets + Color (default lens)", () => {
     it("renders both Land on and Color note cues", () => {
       render(

--- a/src/__tests__/practiceLens.test.ts
+++ b/src/__tests__/practiceLens.test.ts
@@ -133,36 +133,43 @@ describe("practiceCuesAtom", () => {
   });
 
   describe("guide-tones lens", () => {
-    it("returns guide tones cue for a seventh chord (3rd + 7th)", () => {
+    it("returns land-on + guide-tones cues for a seventh chord (3rd + 7th)", () => {
       const store = makeChordStore("Major", "G", "Dominant 7th", "guide-tones");
       const cues = store.get(practiceCuesAtom);
-      expect(cues.length).toBe(1);
-      expect(cues[0]!.kind).toBe("guide-tones");
-      expect(cues[0]!.label).toBe("Guide tones");
+      expect(cues.length).toBe(2);
+      expect(cues[0]!.kind).toBe("land-on");
+      expect(cues[0]!.label).toBe("Land on");
+      expect(cues[1]!.kind).toBe("guide-tones");
+      expect(cues[1]!.label).toBe("Guide tones");
       // G7 = G B D F; guide tones = B (3) and F (b7)
-      const noteNames = cues[0]!.notes.map((n) => n.internalNote);
+      const noteNames = cues[1]!.notes.map((n) => n.internalNote);
       expect(noteNames).toContain("B");
       expect(noteNames).toContain("F");
     });
 
-    it("guide tones for a triad returns the 3rd", () => {
+    it("guide tones for a triad returns land-on first, then guide-tones with the 3rd", () => {
       const store = makeChordStore("Major", "C", "Major Triad", "guide-tones");
       const cues = store.get(practiceCuesAtom);
-      expect(cues[0]!.kind).toBe("guide-tones");
-      const noteNames = cues[0]!.notes.map((n) => n.internalNote);
+      expect(cues.length).toBe(2);
+      expect(cues[0]!.kind).toBe("land-on");
+      expect(cues[1]!.kind).toBe("guide-tones");
+      const noteNames = cues[1]!.notes.map((n) => n.internalNote);
       expect(noteNames).toContain("E"); // major 3rd
     });
 
-    it("falls back to land-on for power chord (no 3rd/7th)", () => {
+    it("shows only land-on for power chord (no 3rd/7th)", () => {
       const store = makeChordStore("Major", "G", "Power Chord (5)", "guide-tones");
       const cues = store.get(practiceCuesAtom);
+      expect(cues.length).toBe(1);
       expect(cues[0]!.kind).toBe("land-on");
     });
 
     it("guide tone notes have role=guide-tone", () => {
       const store = makeChordStore("Major", "G", "Dominant 7th", "guide-tones");
       const cues = store.get(practiceCuesAtom);
-      expect(cues[0]!.notes.every((n) => n.role === "guide-tone")).toBe(true);
+      const guideToneCue = cues.find((c) => c.kind === "guide-tones");
+      expect(guideToneCue).toBeDefined();
+      expect(guideToneCue!.notes.every((n) => n.role === "guide-tone")).toBe(true);
     });
   });
 

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -176,21 +176,26 @@ export const practiceCuesAtom = atom((get) => {
     return undefined;
   };
 
+  const buildLandOnCue = (): PracticeCue => ({
+    kind: "land-on",
+    label: "Land on",
+    notes: allChordMembers.map(toCueNote),
+  });
+
   const cues: PracticeCue[] = [];
 
   switch (practiceLens) {
     case "targets": {
       if (allChordMembers.length > 0) {
-        cues.push({
-          kind: "land-on",
-          label: "Land on",
-          notes: allChordMembers.map(toCueNote),
-        });
+        cues.push(buildLandOnCue());
       }
       break;
     }
 
     case "guide-tones": {
+      if (allChordMembers.length > 0) {
+        cues.push(buildLandOnCue());
+      }
       const guideNotes = allChordMembers.filter((e) =>
         GUIDE_TONE_FORMATTED.has(e.memberName),
       );
@@ -203,24 +208,14 @@ export const practiceCuesAtom = atom((get) => {
             role: "guide-tone" as const,
           })),
         });
-      } else {
-        // Fallback for power chords (no 3rd/7th): show all chord tones.
-        cues.push({
-          kind: "land-on",
-          label: "Land on",
-          notes: allChordMembers.map(toCueNote),
-        });
       }
+      // Power chords / no-guide-tone chords: land-on already pushed, nothing more.
       break;
     }
 
     case "tension": {
       if (allChordMembers.length > 0) {
-        cues.push({
-          kind: "land-on",
-          label: "Land on",
-          notes: allChordMembers.map(toCueNote),
-        });
+        cues.push(buildLandOnCue());
       }
       const tensionMembers = allChordMembers.filter((e) => !e.inScale);
       if (tensionMembers.length > 0) {


### PR DESCRIPTION
## Summary

- `guide-tones` lens now always prepends a **Land on** cue so chord tones are visible regardless of which lens is selected
- Power chords / chords with no 3rd or 7th show only the Land on row (unchanged fallback behaviour, just now consistent with other lenses)
- `tension` and `targets` lenses are unchanged
- Extracted a `buildLandOnCue` helper inside `practiceCuesAtom` to eliminate the repeated land-on construction across `targets`, `guide-tones`, and `tension` cases
- No changes to fretboard lens behaviour or lens availability; this is a practice-bar-only change

## Test plan

- [x] `practiceLens.test.ts` — updated guide-tones cases to expect `[land-on, guide-tones]` for seventh chords and triads; power chord still expects `[land-on]` only
- [x] `ChordPracticeBar.test.tsx` — new **Stacked Land on + Guide tones** describe block covering label rendering, note/role correctness, and a11y
- [x] Full test suite (926 tests) passes
- [x] Lint passes
- [x] Type-check passes

https://claude.ai/code/session_01BpdNZvo5wUBwrMvfXGtSpp