### PR TITLE
refactor(practice): two-group chord practice bar with composable semantics

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1201,12 +1201,21 @@
   justify-content: center;
 }
 
-/* Inner column wrapper — stacks practice bar + compact scale strip vertically. */
+/* Inner wrapper for the practice bar. Width is kept in lockstep with the
+   degree-chip-strip so the two surfaces line up vertically. See
+   `DegreeChipStrip.css` for the matching clamp values. */
 .chord-overlay-dock {
   display: flex;
   flex-direction: column;
-  align-items: center;
   gap: 0.35rem;
+  width: min(100%, 30rem);
+}
+
+.app-container[data-layout-tier="mobile"] .chord-overlay-dock {
+  width: 100%;
+}
+
+.app-container[data-layout-tier="desktop"] .chord-overlay-dock {
   width: min(100%, 32rem);
 }
 

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -502,12 +502,12 @@ describe("App", () => {
       });
       // chord-practice-bar must NOT be nested inside degree-chip-strip
       expect(document.querySelector(".degree-chip-strip .chord-practice-bar")).toBeNull();
-      // chord dock includes a compact degree-chip-strip for scale context while practicing
-      expect(document.querySelector(".chord-dock-shell .degree-chip-strip.degree-chip-strip--compact")).toBeTruthy();
-      // scale strip (full interactive version) in summary-shell is NOT compact
+      // chord dock does NOT include a duplicate degree-chip-strip — the scale
+      // strip is owned exclusively by the summary-shell.
+      expect(document.querySelector(".chord-dock-shell .degree-chip-strip")).toBeNull();
+      // scale strip lives in summary-shell.
       const summaryStrip = document.querySelector(".summary-shell .degree-chip-strip");
       expect(summaryStrip).toBeTruthy();
-      expect(summaryStrip!.classList.contains("degree-chip-strip--compact")).toBe(false);
     });
 
     it("chord dock remains visible when scale is hidden (eye-off)", async () => {

--- a/src/__tests__/ChordOverlayDock.test.tsx
+++ b/src/__tests__/ChordOverlayDock.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { ChordOverlayDock } from "../components/ChordOverlayDock";
+import {
+  rootNoteAtom,
+  scaleNameAtom,
+  chordTypeAtom,
+  chordRootAtom,
+} from "../store/atoms";
+import { renderWithAtoms } from "./utils/renderWithAtoms";
+
+describe("ChordOverlayDock", () => {
+  it("renders the practice bar when a chord is active", () => {
+    renderWithAtoms(<ChordOverlayDock />, [
+      [rootNoteAtom, "C"],
+      [scaleNameAtom, "Major"],
+      [chordRootAtom, "D"],
+      [chordTypeAtom, "Minor 7th"],
+    ]);
+    expect(screen.getByRole("group", { name: /Practice cues/i })).toBeTruthy();
+  });
+
+  it("does not render a DegreeChipStrip (scale strip is owned elsewhere)", () => {
+    const { container } = renderWithAtoms(<ChordOverlayDock />, [
+      [rootNoteAtom, "C"],
+      [scaleNameAtom, "Major"],
+      [chordRootAtom, "D"],
+      [chordTypeAtom, "Minor 7th"],
+    ]);
+    // The dock must not include a duplicate scale-degree chip strip.
+    expect(
+      container.querySelector('[aria-label="Scale degrees"]'),
+    ).toBeNull();
+    expect(screen.queryByRole("group", { name: "Scale degrees" })).toBeNull();
+  });
+
+  it("collapses to a single Land on group when the chord is fully in-scale (targets lens)", () => {
+    renderWithAtoms(<ChordOverlayDock />, [
+      [rootNoteAtom, "C"],
+      [scaleNameAtom, "Major"],
+      [chordRootAtom, "D"],
+      [chordTypeAtom, "Minor 7th"],
+    ]);
+    // targets lens + fully in-scale chord → Land on equals Chord, so only
+    // the Land on group is rendered.
+    expect(screen.queryByText("Chord:")).toBeNull();
+    expect(screen.getByText("Land on:")).toBeTruthy();
+  });
+});

--- a/src/__tests__/ChordOverlayDock.test.tsx
+++ b/src/__tests__/ChordOverlayDock.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { screen } from "@testing-library/react";
 import { ChordOverlayDock } from "../components/ChordOverlayDock";
 import {
@@ -7,16 +7,24 @@ import {
   scaleNameAtom,
   chordTypeAtom,
   chordRootAtom,
+  practiceLensAtom,
 } from "../store/atoms";
 import { renderWithAtoms } from "./utils/renderWithAtoms";
 
 describe("ChordOverlayDock", () => {
+  beforeEach(() => {
+    // practiceLensAtom is persisted via atomWithStorage — clear so prior
+    // tests can't bleed a non-default lens into this suite.
+    localStorage.clear();
+  });
+
   it("renders the practice bar when a chord is active", () => {
     renderWithAtoms(<ChordOverlayDock />, [
       [rootNoteAtom, "C"],
       [scaleNameAtom, "Major"],
       [chordRootAtom, "D"],
       [chordTypeAtom, "Minor 7th"],
+      [practiceLensAtom, "targets"],
     ]);
     expect(screen.getByRole("group", { name: /Practice cues/i })).toBeTruthy();
   });
@@ -27,6 +35,7 @@ describe("ChordOverlayDock", () => {
       [scaleNameAtom, "Major"],
       [chordRootAtom, "D"],
       [chordTypeAtom, "Minor 7th"],
+      [practiceLensAtom, "targets"],
     ]);
     // The dock must not include a duplicate scale-degree chip strip.
     expect(
@@ -41,6 +50,7 @@ describe("ChordOverlayDock", () => {
       [scaleNameAtom, "Major"],
       [chordRootAtom, "D"],
       [chordTypeAtom, "Minor 7th"],
+      [practiceLensAtom, "targets"],
     ]);
     // targets lens + fully in-scale chord → Land on equals Chord, so only
     // the Land on group is rendered.

--- a/src/__tests__/ChordPracticeBar.test.tsx
+++ b/src/__tests__/ChordPracticeBar.test.tsx
@@ -1,68 +1,99 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ChordPracticeBar } from "../components/ChordPracticeBar";
-import type { PracticeCue } from "../theory";
+import type { PracticeBarGroup, PracticeBarNote } from "../theory";
 import { axe } from "../test-utils/a11y";
 
-// ── Fixture cues ──────────────────────────────────────────────────────────────
+// ── Fixture notes ────────────────────────────────────────────────────────────
 
-const landOnCue: PracticeCue = {
-  kind: "land-on",
-  label: "Land on",
+const mkNote = (
+  overrides: Partial<PracticeBarNote> &
+    Pick<PracticeBarNote, "internalNote" | "displayNote">,
+): PracticeBarNote => ({
+  intervalName: "1",
+  isChordRoot: false,
+  isGuideTone: false,
+  isTension: false,
+  isInScale: true,
+  ...overrides,
+});
+
+// D Minor 7 — D F A C (fully in C Major scale; D is chord root)
+const dmin7ChordGroup: PracticeBarGroup = {
+  label: "Chord",
   notes: [
-    { internalNote: "D", displayNote: "D", intervalName: "1", role: "chord-root" },
-    { internalNote: "F", displayNote: "F", intervalName: "♭3", role: "chord-tone-in-scale" },
-    { internalNote: "A", displayNote: "A", intervalName: "5", role: "chord-tone-in-scale" },
-    { internalNote: "C", displayNote: "C", intervalName: "♭7", role: "chord-tone-in-scale" },
+    mkNote({ internalNote: "D", displayNote: "D", intervalName: "1", isChordRoot: true }),
+    mkNote({ internalNote: "F", displayNote: "F", intervalName: "♭3", isGuideTone: true }),
+    mkNote({ internalNote: "A", displayNote: "A", intervalName: "5" }),
+    mkNote({ internalNote: "C", displayNote: "C", intervalName: "♭7", isGuideTone: true }),
   ],
 };
 
-const colorCue: PracticeCue = {
-  kind: "color-note",
-  label: "Color note",
+// C# Minor Triad on C Major — C#, E, G#
+// C# = outside chord root (isChordRoot + isTension both set)
+// G# = outside non-root chord tone (tension only)
+// E  = in-scale chord tone
+const cSharpMinorChordGroup: PracticeBarGroup = {
+  label: "Chord",
   notes: [
-    { internalNote: "B", displayNote: "B", intervalName: "6", role: "color-tone" },
-  ],
-};
-
-const colorCuePlural: PracticeCue = {
-  kind: "color-note",
-  label: "Color notes",
-  notes: [
-    { internalNote: "B", displayNote: "B", intervalName: "6", role: "color-tone" },
-    { internalNote: "F#", displayNote: "F♯", intervalName: "♯4", role: "color-tone" },
-  ],
-};
-
-const guideToneCue: PracticeCue = {
-  kind: "guide-tones",
-  label: "Guide tones",
-  notes: [
-    { internalNote: "E", displayNote: "E", intervalName: "3", role: "guide-tone" },
-    { internalNote: "A#", displayNote: "B♭", intervalName: "♭7", role: "guide-tone" },
-  ],
-};
-
-const tensionCue: PracticeCue = {
-  kind: "tension",
-  label: "Tension",
-  notes: [
-    {
+    mkNote({
       internalNote: "C#",
       displayNote: "C♯",
       intervalName: "1",
-      role: "chord-tone-outside-scale",
-      resolvesTo: { internalNote: "D", displayNote: "D" },
-    },
-    {
+      isChordRoot: true,
+      isTension: true,
+      isInScale: false,
+    }),
+    mkNote({ internalNote: "E", displayNote: "E", intervalName: "♭3" }),
+    mkNote({
       internalNote: "G#",
       displayNote: "G♯",
       intervalName: "5",
-      role: "chord-tone-outside-scale",
-      resolvesTo: { internalNote: "A", displayNote: "A" },
-    },
+      isTension: true,
+      isInScale: false,
+    }),
   ],
 };
+
+const cSharpMinorTensionLandOn: PracticeBarGroup = {
+  label: "Land on",
+  notes: [
+    mkNote({
+      internalNote: "C#",
+      displayNote: "C♯",
+      intervalName: "1",
+      isChordRoot: true,
+      isTension: true,
+      isInScale: false,
+      resolvesTo: { internalNote: "D", displayNote: "D" },
+    }),
+    mkNote({
+      internalNote: "G#",
+      displayNote: "G♯",
+      intervalName: "5",
+      isTension: true,
+      isInScale: false,
+      resolvesTo: { internalNote: "A", displayNote: "A" },
+    }),
+  ],
+};
+
+const g7GuideToneLandOn: PracticeBarGroup = {
+  label: "Land on",
+  notes: [
+    mkNote({ internalNote: "B", displayNote: "B", intervalName: "3", isGuideTone: true }),
+    mkNote({ internalNote: "F", displayNote: "F", intervalName: "♭7", isGuideTone: true }),
+  ],
+};
+
+// Same notes as dmin7ChordGroup but labelled "Land on" — for the targets lens
+// where the Land on group mirrors the Chord group.
+const dmin7LandOnGroup: PracticeBarGroup = {
+  label: "Land on",
+  notes: dmin7ChordGroup.notes,
+};
+
+const emptyGroup: PracticeBarGroup = { label: "Land on", notes: [] };
 
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -71,383 +102,281 @@ describe("ChordPracticeBar", () => {
     render(
       <ChordPracticeBar
         title="D Minor 7"
-        cues={[landOnCue]}
-      />
+        chordGroup={dmin7ChordGroup}
+        landOnGroup={dmin7LandOnGroup}
+      />,
     );
-    const group = screen.getByRole("group", { name: "Practice cues: D Minor 7" });
-    expect(group).toBeTruthy();
+    expect(
+      screen.getByRole("group", { name: "Practice cues: D Minor 7" }),
+    ).toBeTruthy();
   });
 
   it("renders the title", () => {
-    render(<ChordPracticeBar title="D Minor 7" cues={[landOnCue]} />);
+    render(
+      <ChordPracticeBar
+        title="D Minor 7"
+        chordGroup={dmin7ChordGroup}
+        landOnGroup={dmin7LandOnGroup}
+      />,
+    );
     expect(screen.getByText("D Minor 7")).toBeTruthy();
   });
 
-  it("renders an optional badge when provided", () => {
-    render(<ChordPracticeBar title="D Minor 7" badge="Targets" cues={[landOnCue]} />);
+  it("renders optional badge when provided", () => {
+    render(
+      <ChordPracticeBar
+        title="D Minor 7"
+        badge="Targets"
+        chordGroup={dmin7ChordGroup}
+        landOnGroup={dmin7LandOnGroup}
+      />,
+    );
     expect(screen.getByText("Targets")).toBeTruthy();
   });
 
-  it("does not render a badge element when badge is null", () => {
-    const { container } = render(
-      <ChordPracticeBar title="D Minor 7" badge={null} cues={[landOnCue]} />
+  it("renders lensLabel when provided", () => {
+    render(
+      <ChordPracticeBar
+        title="G7"
+        lensLabel="Guide Tones"
+        chordGroup={dmin7ChordGroup}
+        landOnGroup={g7GuideToneLandOn}
+      />,
     );
-    expect(container.querySelector(".chord-practice-bar-badge")).toBeNull();
+    expect(screen.getByText("Guide Tones")).toBeTruthy();
   });
 
-  describe("lensLabel prop", () => {
-    it("renders lensLabel text when provided", () => {
-      render(
-        <ChordPracticeBar title="D Minor 7" lensLabel="Chord + Color" cues={[landOnCue]} />
-      );
-      expect(screen.getByText("Chord + Color")).toBeTruthy();
-    });
-
-    it("renders lensLabel in the .chord-practice-bar-lens-label element", () => {
-      const { container } = render(
-        <ChordPracticeBar title="D Minor 7" lensLabel="Guide Tones" cues={[landOnCue]} />
-      );
-      const el = container.querySelector(".chord-practice-bar-lens-label");
-      expect(el).toBeTruthy();
-      expect(el!.textContent).toBe("Guide Tones");
-    });
-
-    it("does not render lens-label element when lensLabel is null", () => {
-      const { container } = render(
-        <ChordPracticeBar title="D Minor 7" lensLabel={null} cues={[landOnCue]} />
-      );
-      expect(container.querySelector(".chord-practice-bar-lens-label")).toBeNull();
-    });
-
-    it("does not render lens-label element when lensLabel is omitted", () => {
-      const { container } = render(
-        <ChordPracticeBar title="D Minor 7" cues={[landOnCue]} />
-      );
-      expect(container.querySelector(".chord-practice-bar-lens-label")).toBeNull();
-    });
-  });
-
-  it("returns null when cues array is empty", () => {
+  it("does not render lens-label element when lensLabel is omitted", () => {
     const { container } = render(
-      <ChordPracticeBar title="Empty" cues={[]} />
+      <ChordPracticeBar
+        title="D Minor 7"
+        chordGroup={dmin7ChordGroup}
+        landOnGroup={dmin7LandOnGroup}
+      />,
+    );
+    expect(container.querySelector(".chord-practice-bar-lens-label")).toBeNull();
+  });
+
+  it("returns null when both groups are empty", () => {
+    const { container } = render(
+      <ChordPracticeBar
+        title="Empty"
+        chordGroup={{ label: "Chord", notes: [] }}
+        landOnGroup={emptyGroup}
+      />,
     );
     expect(container.firstChild).toBeNull();
   });
 
-  describe("Land on cue (targets / targets-color)", () => {
-    it("renders 'Land on:' cue label", () => {
-      render(<ChordPracticeBar title="D Minor 7" cues={[landOnCue]} />);
+  describe("two-group layout", () => {
+    it("renders Chord and Land on as separate labeled groups when Land on is a narrower subset", () => {
+      render(
+        <ChordPracticeBar
+          title="G7"
+          lensLabel="Guide Tones"
+          chordGroup={dmin7ChordGroup}
+          landOnGroup={g7GuideToneLandOn}
+        />,
+      );
+      expect(screen.getByText("Chord:")).toBeTruthy();
       expect(screen.getByText("Land on:")).toBeTruthy();
     });
 
-    it("renders all chord tone note names", () => {
-      render(<ChordPracticeBar title="D Minor 7" cues={[landOnCue]} />);
-      expect(screen.getByText("D")).toBeTruthy();
-      expect(screen.getByText("F")).toBeTruthy();
-      expect(screen.getByText("A")).toBeTruthy();
-      expect(screen.getByText("C")).toBeTruthy();
-    });
-
-    it("renders interval names alongside note names", () => {
-      render(<ChordPracticeBar title="D Minor 7" cues={[landOnCue]} />);
-      expect(screen.getByText("1")).toBeTruthy();
-      expect(screen.getByText("♭3")).toBeTruthy();
-    });
-
-    it("pills have correct data-role for chord root and chord tones", () => {
+    it("marks groups with data-group-variant for desktop side-by-side styling", () => {
       const { container } = render(
-        <ChordPracticeBar title="D Minor 7" cues={[landOnCue]} />
+        <ChordPracticeBar
+          title="G7"
+          lensLabel="Guide Tones"
+          chordGroup={dmin7ChordGroup}
+          landOnGroup={g7GuideToneLandOn}
+        />,
       );
-      expect(container.querySelector('[data-role="chord-root"]')).toBeTruthy();
-      expect(container.querySelectorAll('[data-role="chord-tone-in-scale"]').length).toBe(3);
+      expect(
+        container.querySelector('[data-group-variant="chord"]'),
+      ).toBeTruthy();
+      expect(
+        container.querySelector('[data-group-variant="land-on"]'),
+      ).toBeTruthy();
+    });
+
+    it("does not render a shape-context subtitle", () => {
+      const { container } = render(
+        <ChordPracticeBar
+          title="D Minor 7"
+          chordGroup={dmin7ChordGroup}
+          landOnGroup={dmin7LandOnGroup}
+        />,
+      );
+      expect(
+        container.querySelector(".chord-practice-bar-context"),
+      ).toBeNull();
     });
   });
 
-  describe("Color note cue", () => {
-    it("renders 'Color note:' label (singular)", () => {
-      render(<ChordPracticeBar title="D Dorian" cues={[colorCue]} />);
-      expect(screen.getByText("Color note:")).toBeTruthy();
-    });
-
-    it("renders 'Color notes:' label (plural)", () => {
-      render(<ChordPracticeBar title="C Lydian" cues={[colorCuePlural]} />);
-      expect(screen.getByText("Color notes:")).toBeTruthy();
-    });
-
-    it("pill has data-role=color-tone", () => {
+  describe("collapsed group rendering", () => {
+    it("renders only Land on when it is semantically identical to Chord", () => {
       const { container } = render(
-        <ChordPracticeBar title="D Dorian" cues={[colorCue]} />
+        <ChordPracticeBar
+          title="D Minor 7"
+          lensLabel="Chord Tones"
+          chordGroup={dmin7ChordGroup}
+          landOnGroup={dmin7LandOnGroup}
+        />,
       );
-      expect(container.querySelector('[data-role="color-tone"]')).toBeTruthy();
+      expect(screen.queryByText("Chord:")).toBeNull();
+      expect(screen.getByText("Land on:")).toBeTruthy();
+      expect(
+        container.querySelectorAll('[data-group-variant="chord"]').length,
+      ).toBe(0);
+      expect(
+        container.querySelectorAll('[data-group-variant="land-on"]').length,
+      ).toBe(1);
     });
 
-    it("renders color note name and interval", () => {
-      render(<ChordPracticeBar title="D Dorian" cues={[colorCue]} />);
-      expect(screen.getByText("B")).toBeTruthy();
-      expect(screen.getByText("6")).toBeTruthy();
+    it("renders both groups when Land on carries resolution data (tension)", () => {
+      render(
+        <ChordPracticeBar
+          title="C# Minor Triad"
+          lensLabel="Tension"
+          chordGroup={cSharpMinorChordGroup}
+          landOnGroup={cSharpMinorTensionLandOn}
+        />,
+      );
+      expect(screen.getByText("Chord:")).toBeTruthy();
+      expect(screen.getByText("Land on:")).toBeTruthy();
+    });
+
+    it("renders both groups when Land on is a narrower subset (guide tones)", () => {
+      render(
+        <ChordPracticeBar
+          title="G7"
+          lensLabel="Guide Tones"
+          chordGroup={dmin7ChordGroup}
+          landOnGroup={g7GuideToneLandOn}
+        />,
+      );
+      expect(screen.getByText("Chord:")).toBeTruthy();
+      expect(screen.getByText("Land on:")).toBeTruthy();
     });
   });
 
-  describe("Guide tones cue", () => {
-    it("renders 'Guide tones:' label", () => {
-      render(<ChordPracticeBar title="G7" cues={[guideToneCue]} />);
-      expect(screen.getByText("Guide tones:")).toBeTruthy();
-    });
-
-    it("pills have data-role=guide-tone", () => {
+  describe("composable semantic flags", () => {
+    it("chord root pill carries data-chord-root=true", () => {
       const { container } = render(
-        <ChordPracticeBar title="G7" cues={[guideToneCue]} />
+        <ChordPracticeBar
+          title="D Minor 7"
+          chordGroup={dmin7ChordGroup}
+          landOnGroup={dmin7LandOnGroup}
+        />,
       );
-      const pills = container.querySelectorAll('[data-role="guide-tone"]');
-      expect(pills.length).toBe(2);
+      expect(container.querySelector('[data-chord-root="true"]')).toBeTruthy();
     });
 
-    it("renders guide tone note names", () => {
-      render(<ChordPracticeBar title="G7" cues={[guideToneCue]} />);
-      expect(screen.getByText("E")).toBeTruthy();
-      expect(screen.getByText("B♭")).toBeTruthy();
-    });
-  });
-
-  describe("Tension cue", () => {
-    it("renders 'Tension:' label", () => {
-      render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />);
-      expect(screen.getByText("Tension:")).toBeTruthy();
-    });
-
-    it("pills have data-role=chord-tone-outside-scale", () => {
+    it("guide tones carry data-guide-tone=true and are distinct from ordinary chord tones", () => {
       const { container } = render(
-        <ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />
+        <ChordPracticeBar
+          title="G7"
+          lensLabel="Guide Tones"
+          chordGroup={dmin7ChordGroup}
+          landOnGroup={g7GuideToneLandOn}
+        />,
       );
-      const pills = container.querySelectorAll('[data-role="chord-tone-outside-scale"]');
-      expect(pills.length).toBe(2);
+      const guidePills = container.querySelectorAll(
+        '[data-group-variant="land-on"] [data-guide-tone="true"]',
+      );
+      expect(guidePills.length).toBe(2);
+      // Ordinary chord tone (A, the 5th) should not carry the guide-tone flag.
+      const chordPills = container.querySelectorAll(
+        '[data-group-variant="chord"] .practice-bar-pill',
+      );
+      const plainTone = Array.from(chordPills).find(
+        (el) => el.textContent?.includes("A"),
+      );
+      expect(plainTone?.getAttribute("data-guide-tone")).toBeNull();
     });
 
-    it("renders inline resolution arrows on tension pills", () => {
-      render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />);
-      expect(screen.getAllByText(/→/).length).toBeGreaterThan(0);
+    it("outside chord root carries BOTH data-chord-root AND data-tension", () => {
+      const { container } = render(
+        <ChordPracticeBar
+          title="C# Minor Triad"
+          lensLabel="Tension"
+          chordGroup={cSharpMinorChordGroup}
+          landOnGroup={cSharpMinorTensionLandOn}
+        />,
+      );
+      // Chord group's C♯ pill must preserve both root + tension identities.
+      const cSharpInChord = container.querySelector(
+        '[data-group-variant="chord"] [data-chord-root="true"][data-tension="true"]',
+      );
+      expect(cSharpInChord).toBeTruthy();
+      expect(cSharpInChord?.textContent).toContain("C♯");
     });
 
-    it("resolution arrow shows the target note name", () => {
-      render(<ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />);
+    it("outside non-root chord tones carry only data-tension", () => {
+      const { container } = render(
+        <ChordPracticeBar
+          title="C# Minor Triad"
+          lensLabel="Tension"
+          chordGroup={cSharpMinorChordGroup}
+          landOnGroup={cSharpMinorTensionLandOn}
+        />,
+      );
+      const gSharpPill = Array.from(
+        container.querySelectorAll(
+          '[data-group-variant="chord"] [data-tension="true"]',
+        ),
+      ).find((el) => el.textContent?.includes("G♯"));
+      expect(gSharpPill).toBeTruthy();
+      expect(gSharpPill?.getAttribute("data-chord-root")).toBeNull();
+    });
+
+    it("renders resolution arrows for tension land-on notes", () => {
+      render(
+        <ChordPracticeBar
+          title="C# Minor Triad"
+          lensLabel="Tension"
+          chordGroup={cSharpMinorChordGroup}
+          landOnGroup={cSharpMinorTensionLandOn}
+        />,
+      );
       expect(screen.getByText("→D")).toBeTruthy();
       expect(screen.getByText("→A")).toBeTruthy();
     });
-
-    it("outside chord root appears in tension cue (semantic fix)", () => {
-      const outsideRootTension: PracticeCue = {
-        kind: "tension",
-        label: "Tension",
-        notes: [
-          {
-            internalNote: "C#",
-            displayNote: "C♯",
-            intervalName: "1",
-            role: "chord-root",
-            resolvesTo: { internalNote: "D", displayNote: "D" },
-          },
-        ],
-      };
-      render(<ChordPracticeBar title="C# Minor" cues={[outsideRootTension]} />);
-      expect(screen.getByText("Tension:")).toBeTruthy();
-      expect(screen.getByText("C♯")).toBeTruthy();
-    });
   });
 
-  describe("Stacked Land on + Guide tones (guide-tones lens)", () => {
-    it("renders both 'Land on:' and 'Guide tones:' labels when stacked", () => {
-      render(
+  describe("accessibility", () => {
+    it("has no a11y violations (targets lens)", async () => {
+      const { container } = render(
         <ChordPracticeBar
-          title="G7"
-          lensLabel="Guide Tones"
-          cues={[landOnCue, guideToneCue]}
-        />
+          title="D Minor 7"
+          lensLabel="Chord Tones"
+          chordGroup={dmin7ChordGroup}
+          landOnGroup={dmin7LandOnGroup}
+        />,
       );
-      expect(screen.getByText("Land on:")).toBeTruthy();
-      expect(screen.getByText("Guide tones:")).toBeTruthy();
+      expect(await axe(container)).toHaveNoViolations();
     });
 
-    it("renders chord tones in land-on row and guide tones in guide-tones row", () => {
-      render(
-        <ChordPracticeBar
-          title="G7"
-          lensLabel="Guide Tones"
-          cues={[landOnCue, guideToneCue]}
-        />
-      );
-      // Land on row has chord tones (from landOnCue fixture: D, F, A, C)
-      expect(screen.getByText("F")).toBeTruthy();
-      // Guide tones row has guide tone notes (from guideToneCue fixture: E, B♭)
-      expect(screen.getByText("E")).toBeTruthy();
-      expect(screen.getByText("B♭")).toBeTruthy();
-    });
-
-    it("land-on pills have chord-root / chord-tone-in-scale roles; guide-tone pills have guide-tone role", () => {
+    it("has no a11y violations (guide-tones lens)", async () => {
       const { container } = render(
         <ChordPracticeBar
           title="G7"
           lensLabel="Guide Tones"
-          cues={[landOnCue, guideToneCue]}
-        />
-      );
-      expect(container.querySelector('[data-role="chord-root"]')).toBeTruthy();
-      expect(container.querySelectorAll('[data-role="guide-tone"]').length).toBe(2);
-    });
-
-    it("has no a11y violations with stacked Land on + Guide tones", async () => {
-      const { container } = render(
-        <ChordPracticeBar
-          title="G7"
-          lensLabel="Guide Tones"
-          cues={[landOnCue, guideToneCue]}
-        />
-      );
-      expect(await axe(container)).toHaveNoViolations();
-    });
-  });
-
-  describe("Targets + Color (default lens)", () => {
-    it("renders both Land on and Color note cues", () => {
-      render(
-        <ChordPracticeBar
-          title="D Minor 7"
-          cues={[landOnCue, colorCue]}
-        />
-      );
-      expect(screen.getByText("Land on:")).toBeTruthy();
-      expect(screen.getByText("Color note:")).toBeTruthy();
-    });
-
-    it("does not duplicate color note when it is already a chord tone (filtered upstream)", () => {
-      // colorCuePlural contains B and F# — if these were chord tones they'd be filtered
-      // out before reaching the component. This test just verifies the component renders
-      // them as-is (filtering is done in atoms).
-      render(
-        <ChordPracticeBar
-          title="G Mixolydian + G7"
-          cues={[landOnCue]}
-        />
-      );
-      // No color cue because it was filtered upstream; component just shows land-on.
-      expect(screen.queryByText("Color note:")).toBeNull();
-    });
-  });
-
-  describe("Shape-local context", () => {
-    it("renders shapeContextLabel as subtitle", () => {
-      render(
-        <ChordPracticeBar
-          title="D Minor 7"
-          cues={[landOnCue, colorCue]}
-          isShapeLocal
-          shapeContextLabel="In E shape"
-          shapeLocalCues={[landOnCue]}
-        />
-      );
-      expect(screen.getByText("In E shape")).toBeTruthy();
-    });
-
-    it("uses shapeLocalCues when isShapeLocal and shapeLocalCues is non-empty", () => {
-      const shapeLandOn: PracticeCue = {
-        kind: "land-on",
-        label: "Land on",
-        notes: [
-          { internalNote: "D", displayNote: "D", intervalName: "1", role: "chord-root" },
-        ],
-      };
-      render(
-        <ChordPracticeBar
-          title="D Minor 7"
-          cues={[landOnCue, colorCue]}
-          isShapeLocal
-          shapeContextLabel="In E shape"
-          shapeLocalCues={[shapeLandOn]}
-        />
-      );
-      // Shape-local cue shows only D (not F, A, C from global cue)
-      expect(screen.getByText("D")).toBeTruthy();
-      expect(screen.queryByText("Color note:")).toBeNull();
-    });
-
-    it("falls back to global cues when shapeLocalCues is empty", () => {
-      render(
-        <ChordPracticeBar
-          title="D Minor 7"
-          cues={[landOnCue]}
-          isShapeLocal
-          shapeContextLabel="In E shape"
-          shapeLocalCues={[]}
-        />
-      );
-      // Falls back to global; still shows global cue notes
-      expect(screen.getByText("Land on:")).toBeTruthy();
-    });
-
-    it("does not render context label when shapeContextLabel is null", () => {
-      render(
-        <ChordPracticeBar
-          title="D Minor 7"
-          cues={[landOnCue]}
-          isShapeLocal={false}
-          shapeContextLabel={null}
-        />
-      );
-      expect(screen.queryByText("In E shape")).toBeNull();
-    });
-
-    it("returns null when shapeLocalCues is non-empty array but all empty after lens filter (empty shapeLocalCues)", () => {
-      const { container } = render(
-        <ChordPracticeBar
-          title="D Minor 7"
-          cues={[landOnCue]}
-          isShapeLocal
-          shapeContextLabel="In E shape"
-          shapeLocalCues={[]}
-        />
-      );
-      // Falls back to global cues — not null
-      expect(container.firstChild).not.toBeNull();
-    });
-  });
-
-  describe("Accessibility", () => {
-    it("has no a11y violations with a land-on cue", async () => {
-      const { container } = render(
-        <ChordPracticeBar title="D Minor 7" cues={[landOnCue]} />
+          chordGroup={dmin7ChordGroup}
+          landOnGroup={g7GuideToneLandOn}
+        />,
       );
       expect(await axe(container)).toHaveNoViolations();
     });
 
-    it("has no a11y violations with targets+color cues", async () => {
-      const { container } = render(
-        <ChordPracticeBar title="D Dorian + Dm7" cues={[landOnCue, colorCue]} />
-      );
-      expect(await axe(container)).toHaveNoViolations();
-    });
-
-    it("has no a11y violations with guide-tones cue", async () => {
-      const { container } = render(
-        <ChordPracticeBar title="G7" cues={[guideToneCue]} />
-      );
-      expect(await axe(container)).toHaveNoViolations();
-    });
-
-    it("has no a11y violations with tension cue", async () => {
-      const { container } = render(
-        <ChordPracticeBar title="C# Minor Triad" cues={[tensionCue]} />
-      );
-      expect(await axe(container)).toHaveNoViolations();
-    });
-
-    it("has no a11y violations in shape-local context", async () => {
+    it("has no a11y violations (tension lens)", async () => {
       const { container } = render(
         <ChordPracticeBar
-          title="D Minor 7"
-          cues={[landOnCue, colorCue]}
-          isShapeLocal
-          shapeContextLabel="In E shape"
-          shapeLocalCues={[landOnCue]}
-        />
+          title="C# Minor Triad"
+          lensLabel="Tension"
+          chordGroup={cSharpMinorChordGroup}
+          landOnGroup={cSharpMinorTensionLandOn}
+        />,
       );
       expect(await axe(container)).toHaveNoViolations();
     });

--- a/src/__tests__/practiceLens.test.ts
+++ b/src/__tests__/practiceLens.test.ts
@@ -9,6 +9,8 @@ import {
   shapeLocalPracticeCuesAtom,
   showChordPracticeBarAtom,
   practiceBarLensLabelAtom,
+  practiceBarChordGroupAtom,
+  practiceBarLandOnGroupAtom,
   lensAvailabilityAtom,
   noteSemanticMapAtom,
   rootNoteAtom,
@@ -374,6 +376,140 @@ describe("showChordPracticeBarAtom", () => {
     store.set(chordTypeAtom, "Minor Triad");
     store.set(practiceLensAtom, "targets");
     expect(store.get(showChordPracticeBarAtom)).toBe(true);
+  });
+});
+
+describe("practiceBarChordGroupAtom", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("is lens-independent — same chord regardless of active lens", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Dominant 7th");
+
+    const notesByLens: Record<string, string[]> = {};
+    for (const lens of ["targets", "guide-tones", "tension"] as const) {
+      store.set(practiceLensAtom, lens);
+      notesByLens[lens] = store
+        .get(practiceBarChordGroupAtom)
+        .notes.map((n) => n.internalNote);
+    }
+    expect(notesByLens.targets).toEqual(notesByLens["guide-tones"]);
+    expect(notesByLens.targets).toEqual(notesByLens.tension);
+  });
+
+  it("always contains all chord members", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "G");
+    store.set(chordTypeAtom, "Dominant 7th"); // G B D F
+    const notes = store
+      .get(practiceBarChordGroupAtom)
+      .notes.map((n) => n.internalNote);
+    expect(notes).toEqual(expect.arrayContaining(["G", "B", "D", "F"]));
+  });
+
+  it("outside chord root carries both isChordRoot and isTension", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C#");
+    store.set(chordTypeAtom, "Minor Triad"); // C# E G#
+
+    const group = store.get(practiceBarChordGroupAtom);
+    const cSharp = group.notes.find((n) => n.internalNote === "C#");
+    expect(cSharp).toBeDefined();
+    expect(cSharp!.isChordRoot).toBe(true);
+    expect(cSharp!.isTension).toBe(true);
+    expect(cSharp!.isInScale).toBe(false);
+  });
+
+  it("guide tones carry isGuideTone, ordinary chord tones do not", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "G");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "G");
+    store.set(chordTypeAtom, "Dominant 7th"); // G B D F
+
+    const group = store.get(practiceBarChordGroupAtom);
+    const b = group.notes.find((n) => n.internalNote === "B"); // major 3rd
+    const f = group.notes.find((n) => n.internalNote === "F"); // ♭7
+    const d = group.notes.find((n) => n.internalNote === "D"); // 5th
+    expect(b?.isGuideTone).toBe(true);
+    expect(f?.isGuideTone).toBe(true);
+    expect(d?.isGuideTone).toBe(false);
+  });
+});
+
+describe("practiceBarLandOnGroupAtom", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  function mkStore(lens: "targets" | "guide-tones" | "tension") {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    return { store, lens };
+  }
+
+  it("targets lens — contains all chord members", () => {
+    const { store, lens } = mkStore("targets");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    store.set(practiceLensAtom, lens);
+    const notes = store
+      .get(practiceBarLandOnGroupAtom)
+      .notes.map((n) => n.internalNote);
+    expect(notes).toEqual(expect.arrayContaining(["C", "E", "G"]));
+  });
+
+  it("guide-tones lens — contains only 3rd/7th members", () => {
+    const { store, lens } = mkStore("guide-tones");
+    store.set(chordRootAtom, "G");
+    store.set(chordTypeAtom, "Dominant 7th"); // G B D F
+    store.set(practiceLensAtom, lens);
+    const notes = store
+      .get(practiceBarLandOnGroupAtom)
+      .notes.map((n) => n.internalNote);
+    expect(notes).toEqual(expect.arrayContaining(["B", "F"]));
+    expect(notes).not.toContain("D");
+    expect(notes).not.toContain("G");
+  });
+
+  it("tension lens — contains only outside-scale chord members with resolutions", () => {
+    const { store, lens } = mkStore("tension");
+    store.set(chordRootAtom, "C#");
+    store.set(chordTypeAtom, "Minor Triad"); // C# E G#
+    store.set(practiceLensAtom, lens);
+    const notes = store.get(practiceBarLandOnGroupAtom).notes;
+    const internals = notes.map((n) => n.internalNote);
+    expect(internals).toEqual(expect.arrayContaining(["C#", "G#"]));
+    expect(internals).not.toContain("E");
+    // Outside chord root still carries isChordRoot + isTension in land-on too.
+    const cSharp = notes.find((n) => n.internalNote === "C#");
+    expect(cSharp?.isChordRoot).toBe(true);
+    expect(cSharp?.isTension).toBe(true);
+    expect(cSharp?.resolvesTo).toBeDefined();
+  });
+
+  it("group label is always 'Land on' regardless of lens", () => {
+    const { store, lens } = mkStore("targets");
+    store.set(chordRootAtom, "C");
+    store.set(chordTypeAtom, "Major Triad");
+    store.set(practiceLensAtom, lens);
+    expect(store.get(practiceBarLandOnGroupAtom).label).toBe("Land on");
+
+    store.set(practiceLensAtom, "guide-tones");
+    expect(store.get(practiceBarLandOnGroupAtom).label).toBe("Land on");
+
+    store.set(practiceLensAtom, "tension");
+    expect(store.get(practiceBarLandOnGroupAtom).label).toBe("Land on");
   });
 });
 

--- a/src/components/ChordOverlayDock.tsx
+++ b/src/components/ChordOverlayDock.tsx
@@ -1,8 +1,5 @@
-import { useAtomValue } from "jotai";
 import { usePracticeBarState } from "../hooks/usePracticeBarState";
 import { ChordPracticeBar } from "./ChordPracticeBar";
-import { DegreeChipStrip } from "./DegreeChipStrip";
-import { degreeChipsAtom, scaleLabelAtom, colorNotesAtom } from "../store/atoms";
 
 /** Independent chord practice dock — shows coaching cues for the active lens. */
 export function ChordOverlayDock() {
@@ -11,19 +8,11 @@ export function ChordOverlayDock() {
     practiceBarTitle,
     practiceBarBadge,
     practiceBarLensLabel,
-    isShapeLocalContext,
-    shapeContextLabel,
-    practiceCues,
-    shapeLocalPracticeCues,
+    chordGroup,
+    landOnGroup,
   } = usePracticeBarState();
 
-  const degreeChips = useAtomValue(degreeChipsAtom);
-  const scaleLabel = useAtomValue(scaleLabelAtom);
-  const colorNotes = useAtomValue(colorNotesAtom);
-
   if (!showChordPracticeBar) return null;
-
-  const colorNoteSet = colorNotes.length > 0 ? new Set(colorNotes) : undefined;
 
   return (
     <div className="chord-overlay-dock">
@@ -31,18 +20,8 @@ export function ChordOverlayDock() {
         title={practiceBarTitle}
         badge={practiceBarBadge}
         lensLabel={practiceBarLensLabel}
-        cues={practiceCues}
-        isShapeLocal={isShapeLocalContext}
-        shapeContextLabel={shapeContextLabel}
-        shapeLocalCues={shapeLocalPracticeCues}
-      />
-      <DegreeChipStrip
-        scaleName={scaleLabel}
-        chips={degreeChips}
-        colorNotes={colorNoteSet}
-        compact
-        hideHeader={false}
-        aria-label="Scale degrees"
+        chordGroup={chordGroup}
+        landOnGroup={landOnGroup}
       />
     </div>
   );

--- a/src/components/ChordPracticeBar.css
+++ b/src/components/ChordPracticeBar.css
@@ -1,6 +1,7 @@
-/* Chord practice bar — independent practice surface that shows coaching cues
-   for the active lens. Uses pills/capsules rather than circular chips so it
-   reads as "practice analysis" rather than "another note strip". */
+/* Chord practice bar — two-group coaching surface (Chord + Land on).
+   Groups sit side-by-side on wide viewports and stack only when space is
+   tight. Pill styling uses composable data-flags so overlapping semantics
+   (e.g. outside chord root = root + tension) render correctly. */
 
 .chord-practice-bar {
   --pill-h: 1.55rem;
@@ -9,19 +10,25 @@
   --pill-gap: 0.3rem;
   --bar-fill: rgb(18 23 34);
 
+  --amber-strong: rgb(255 154 77);
+  --amber-soft: rgb(255 154 77 / 0.55);
+  --amber-bg-strong: rgb(255 154 77 / 0.22);
+  --amber-bg-soft: rgb(255 154 77 / 0.1);
+  --tension-border: rgb(255 122 61);
+  --guide-blue: rgb(96 165 250);
+  --guide-blue-bg: rgb(30 60 120 / 0.25);
+
   display: flex;
   flex-direction: column;
-  gap: 0.38rem;
-  width: min(100%, 30rem);
-  margin: 0 auto;
-  padding: 0.42rem 0.85rem 0.48rem;
+  gap: 0.3rem;
+  width: 100%;
+  padding: 0.38rem 0.85rem 0.42rem;
   border-radius: 0.85rem;
   background: var(--bar-fill);
   border: 1px solid rgb(255 255 255 / 0.07);
   box-shadow: 0 4px 14px rgb(0 0 0 / 0.2);
 }
 
-/* Header row: title + optional badge */
 .chord-practice-bar-header {
   display: flex;
   align-items: baseline;
@@ -38,7 +45,6 @@
   letter-spacing: 0.01em;
 }
 
-/* Lens label — small registry-sourced tag identifying the active practice lens. */
 .chord-practice-bar-lens-label {
   font-family: var(--font-sans);
   font-size: 0.68rem;
@@ -68,69 +74,38 @@
   white-space: nowrap;
 }
 
-/* Context line: shape/position label shown below the title row */
-.chord-practice-bar-context {
-  font-family: var(--font-sans);
-  font-size: 0.7rem;
-  font-weight: var(--font-weight-medium);
-  color: rgb(255 255 255 / 0.42);
-  letter-spacing: 0.04em;
-  line-height: 1;
-}
-
-/* Coaching cues — stacked rows, one cue per line */
-.chord-practice-bar-cues {
-  display: flex;
-  flex-direction: column;
-  gap: 0.32rem;
-}
-
-/* Individual cue row: label + pill list side by side */
-.practice-bar-cue {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  flex-wrap: wrap;
-}
-
-.practice-bar-cue-label {
-  font-family: var(--font-sans);
-  font-size: 0.68rem;
-  font-weight: var(--font-weight-medium);
-  color: rgb(255 255 255 / 0.38);
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-/* Legacy group layout kept for backward compat with any external CSS */
+/* Side-by-side group layout — only stacks on narrow viewports */
 .chord-practice-bar-groups {
   display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
+  flex-direction: row;
+  align-items: center;
+  gap: 1.25rem;
   flex-wrap: wrap;
 }
 
 .practice-bar-group {
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: 0.4rem;
   flex-wrap: wrap;
 }
 
 .practice-bar-group-label {
   font-family: var(--font-sans);
   font-size: 0.68rem;
-  font-weight: var(--font-weight-medium);
-  color: rgb(255 255 255 / 0.38);
-  letter-spacing: 0.05em;
+  font-weight: var(--font-weight-semibold);
+  color: rgb(255 255 255 / 0.42);
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   white-space: nowrap;
   flex-shrink: 0;
 }
 
-/* Pill list */
+/* Land-on group feels more active — it's the coaching focus */
+.practice-bar-group[data-group-variant="land-on"] .practice-bar-group-label {
+  color: rgb(255 255 255 / 0.66);
+}
+
 .practice-bar-pill-list {
   display: flex;
   align-items: center;
@@ -141,7 +116,7 @@
   padding: 0;
 }
 
-/* Base pill — capsule shape */
+/* Base pill — neutral capsule. Data-flags layer on identity + tension. */
 .practice-bar-pill {
   display: inline-flex;
   align-items: center;
@@ -154,34 +129,41 @@
   cursor: default;
 }
 
-/* Role-based pill variants */
-.practice-bar-pill[data-role="chord-root"] {
-  background: rgb(255 154 77 / 0.18);
-  border-color: rgb(255 154 77 / 0.85);
+/* In-scale chord tone — subtle amber outline. */
+.practice-bar-pill[data-in-scale="true"] {
+  background: var(--amber-bg-soft);
+  border-color: var(--amber-soft);
+}
+
+/* Guide tone — cool blue accent, distinct from ordinary chord tones. */
+.practice-bar-pill[data-guide-tone="true"] {
+  background: var(--guide-blue-bg);
+  border-color: rgb(96 165 250 / 0.75);
+  box-shadow: 0 0 5px rgb(96 165 250 / 0.28);
+}
+
+/* Chord root — solid amber emphasis. */
+.practice-bar-pill[data-chord-root="true"] {
+  background: var(--amber-bg-strong);
+  border-color: var(--amber-strong);
+  border-style: solid;
   box-shadow: 0 0 6px rgb(255 154 77 / 0.4);
 }
 
-.practice-bar-pill[data-role="chord-tone-in-scale"] {
-  background: rgb(255 154 77 / 0.08);
-  border-color: rgb(255 154 77 / 0.55);
-}
-
-.practice-bar-pill[data-role="chord-tone-outside-scale"] {
-  background: rgb(120 50 20 / 0.22);
-  border-color: rgb(204 122 61 / 0.7);
+/* Tension — dashed orange border. */
+.practice-bar-pill[data-tension="true"] {
+  border-color: var(--tension-border);
   border-style: dashed;
 }
 
-.practice-bar-pill[data-role="color-tone"] {
-  background: rgb(50 30 90 / 0.22);
-  border-color: rgb(167 139 250 / 0.75);
-  box-shadow: 0 0 5px rgb(167 139 250 / 0.3);
-}
-
-.practice-bar-pill[data-role="guide-tone"] {
-  background: rgb(30 60 120 / 0.22);
-  border-color: rgb(96 165 250 / 0.7);
-  box-shadow: 0 0 5px rgb(96 165 250 / 0.25);
+/* Outside chord root — amber root body PLUS dashed tension border.
+   This is the overlapping-semantic case that the old single-role model
+   could not represent. */
+.practice-bar-pill[data-chord-root="true"][data-tension="true"] {
+  background: var(--amber-bg-strong);
+  border-color: var(--tension-border);
+  border-style: dashed;
+  box-shadow: 0 0 6px rgb(255 154 77 / 0.4);
 }
 
 .practice-bar-pill-note {
@@ -202,39 +184,39 @@
   letter-spacing: 0.02em;
 }
 
-/* Resolution arrow shown after tension notes: "→D" */
 .practice-bar-pill-resolve {
   font-family: var(--font-sans);
   font-size: calc(var(--pill-font) - 0.06rem);
   font-weight: var(--font-weight-medium);
-  color: rgb(167 139 250 / 0.8);
+  color: rgb(167 139 250 / 0.85);
   line-height: 1;
   letter-spacing: 0.01em;
 }
 
-/* Responsive — mobile */
+/* Narrow viewports — stack groups vertically. */
+.app-container[data-layout-tier="mobile"] .chord-practice-bar-groups,
+.app-container[data-layout-variant="tablet-stacked"] .chord-practice-bar-groups {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.3rem;
+}
+
 .app-container[data-layout-tier="mobile"] .chord-practice-bar {
-  width: 100%;
   border-radius: 0.7rem;
   padding: 0.38rem 0.7rem 0.42rem;
-  gap: 0.32rem;
+  gap: 0.28rem;
 }
 
 .app-container[data-layout-tier="mobile"] .chord-practice-bar-title {
   font-size: 0.82rem;
 }
 
-.app-container[data-layout-tier="mobile"] .practice-bar-group-label {
-  font-size: 0.64rem;
-}
-
-/* Responsive — desktop */
+/* Desktop — compact vertically, full width used horizontally. */
 .app-container[data-layout-tier="desktop"] .chord-practice-bar {
-  width: min(100%, 32rem);
-  padding: 0.3rem 0.78rem 0.34rem;
-  gap: 0.28rem;
+  padding: 0.3rem 0.85rem 0.34rem;
+  gap: 0.25rem;
 }
 
 .app-container[data-layout-tier="desktop"] .chord-practice-bar-title {
-  font-size: clamp(0.76rem, 1.1vw, 0.88rem);
+  font-size: clamp(0.78rem, 1.1vw, 0.9rem);
 }

--- a/src/components/ChordPracticeBar.css
+++ b/src/components/ChordPracticeBar.css
@@ -31,7 +31,7 @@
 
 .chord-practice-bar-header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 0.45rem;
   flex-wrap: wrap;
 }
@@ -47,7 +47,7 @@
 
 .chord-practice-bar-lens-label {
   font-family: var(--font-sans);
-  font-size: 0.68rem;
+  font-size: 0.78rem;
   font-weight: var(--font-weight-medium);
   color: rgb(255 255 255 / 0.5);
   line-height: 1;
@@ -79,7 +79,8 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 1.25rem;
+  column-gap: 1.25rem;
+  row-gap: 0.3rem;
   flex-wrap: wrap;
 }
 
@@ -214,7 +215,7 @@
 /* Desktop — compact vertically, full width used horizontally. */
 .app-container[data-layout-tier="desktop"] .chord-practice-bar {
   padding: 0.3rem 0.85rem 0.34rem;
-  gap: 0.25rem;
+  gap: 0.3rem;
 }
 
 .app-container[data-layout-tier="desktop"] .chord-practice-bar-title {

--- a/src/components/ChordPracticeBar.tsx
+++ b/src/components/ChordPracticeBar.tsx
@@ -1,42 +1,55 @@
 import clsx from "clsx";
-import type { PracticeCue } from "../theory";
+import type { PracticeBarGroup, PracticeBarNote } from "../theory";
 import "./ChordPracticeBar.css";
 
-function cueKindDefaultRole(kind: PracticeCue["kind"]): string {
-  switch (kind) {
-    case "guide-tones": return "guide-tone";
-    case "color-note": return "color-tone";
-    case "tension": return "chord-tone-outside-scale";
-    default: return "chord-tone-in-scale";
-  }
+interface PillProps {
+  note: PracticeBarNote;
 }
 
-interface CueLineProps {
-  cue: PracticeCue;
-}
-
-function CueLine({ cue }: CueLineProps) {
+function Pill({ note }: PillProps) {
+  const aria = [note.displayNote, note.intervalName].filter(Boolean).join(", ");
   return (
-    <div className="practice-bar-cue">
-      <span className="practice-bar-cue-label">{cue.label}:</span>
-      <ul className="practice-bar-pill-list" aria-label={cue.label}>
-        {cue.notes.map((note, i) => (
-          <li
-            key={`${note.internalNote}-${i}`}
-            className="practice-bar-pill"
-            data-role={note.role ?? cueKindDefaultRole(cue.kind)}
-            aria-label={[note.displayNote, note.intervalName].filter(Boolean).join(", ")}
-          >
-            <span className="practice-bar-pill-note">{note.displayNote}</span>
-            {note.intervalName && (
-              <span className="practice-bar-pill-interval">{note.intervalName}</span>
-            )}
-            {note.resolvesTo && (
-              <span className="practice-bar-pill-resolve" aria-label={`resolves to ${note.resolvesTo.displayNote}`}>
-                →{note.resolvesTo.displayNote}
-              </span>
-            )}
-          </li>
+    <li
+      className="practice-bar-pill"
+      data-chord-root={note.isChordRoot ? "true" : undefined}
+      data-guide-tone={note.isGuideTone ? "true" : undefined}
+      data-tension={note.isTension ? "true" : undefined}
+      data-in-scale={note.isInScale ? "true" : undefined}
+      aria-label={aria}
+    >
+      <span className="practice-bar-pill-note">{note.displayNote}</span>
+      {note.intervalName && (
+        <span className="practice-bar-pill-interval">{note.intervalName}</span>
+      )}
+      {note.resolvesTo && (
+        <span
+          className="practice-bar-pill-resolve"
+          aria-label={`resolves to ${note.resolvesTo.displayNote}`}
+        >
+          →{note.resolvesTo.displayNote}
+        </span>
+      )}
+    </li>
+  );
+}
+
+interface GroupProps {
+  variant: "chord" | "land-on";
+  group: PracticeBarGroup;
+}
+
+function Group({ variant, group }: GroupProps) {
+  if (group.notes.length === 0) return null;
+  return (
+    <div
+      className="practice-bar-group"
+      data-group-variant={variant}
+      aria-label={group.label}
+    >
+      <span className="practice-bar-group-label">{group.label}:</span>
+      <ul className="practice-bar-pill-list">
+        {group.notes.map((n, i) => (
+          <Pill key={`${variant}-${n.internalNote}-${i}`} note={n} />
         ))}
       </ul>
     </div>
@@ -46,32 +59,49 @@ function CueLine({ cue }: CueLineProps) {
 export interface ChordPracticeBarProps {
   title: string;
   badge?: string | null;
-  /** Active lens label sourced from LENS_REGISTRY — shown as a small indicator in the dock header. */
+  /** Active lens label sourced from LENS_REGISTRY. */
   lensLabel?: string | null;
-  cues: PracticeCue[];
-  isShapeLocal?: boolean;
-  shapeContextLabel?: string | null;
-  /** Shape-filtered cues — shown instead of global cues when in single-shape context */
-  shapeLocalCues?: PracticeCue[];
+  /** Chord group — lens-independent; always all chord members. */
+  chordGroup: PracticeBarGroup;
+  /** Land on group — lens-driven coaching subset. */
+  landOnGroup: PracticeBarGroup;
   className?: string;
+}
+
+/**
+ * Two groups are semantically identical when they cover the same notes in
+ * the same order AND the Land on group adds no extra coaching data (e.g.
+ * resolution arrows). In that case we collapse the bar to a single group
+ * (preferring Land on) to avoid showing the same row twice.
+ */
+function landOnMatchesChord(
+  chordGroup: PracticeBarGroup,
+  landOnGroup: PracticeBarGroup,
+): boolean {
+  if (chordGroup.notes.length !== landOnGroup.notes.length) return false;
+  if (landOnGroup.notes.some((n) => n.resolvesTo !== undefined)) return false;
+  for (let i = 0; i < chordGroup.notes.length; i++) {
+    const a = chordGroup.notes[i]!;
+    const b = landOnGroup.notes[i]!;
+    if (a.internalNote !== b.internalNote) return false;
+    if (a.intervalName !== b.intervalName) return false;
+  }
+  return true;
 }
 
 export function ChordPracticeBar({
   title,
   badge,
   lensLabel,
-  cues,
-  isShapeLocal = false,
-  shapeContextLabel = null,
-  shapeLocalCues,
+  chordGroup,
+  landOnGroup,
   className,
 }: ChordPracticeBarProps) {
-  const effectiveCues =
-    isShapeLocal && shapeLocalCues && shapeLocalCues.length > 0
-      ? shapeLocalCues
-      : cues;
+  if (chordGroup.notes.length === 0 && landOnGroup.notes.length === 0) {
+    return null;
+  }
 
-  if (effectiveCues.length === 0) return null;
+  const collapse = landOnMatchesChord(chordGroup, landOnGroup);
 
   return (
     <section
@@ -86,13 +116,9 @@ export function ChordPracticeBar({
         )}
         {badge && <span className="chord-practice-bar-badge">{badge}</span>}
       </div>
-      {shapeContextLabel && (
-        <div className="chord-practice-bar-context">{shapeContextLabel}</div>
-      )}
-      <div className="chord-practice-bar-cues">
-        {effectiveCues.map((cue, i) => (
-          <CueLine key={`${cue.kind}-${i}`} cue={cue} />
-        ))}
+      <div className="chord-practice-bar-groups">
+        {!collapse && <Group variant="chord" group={chordGroup} />}
+        <Group variant="land-on" group={landOnGroup} />
       </div>
     </section>
   );

--- a/src/hooks/usePracticeBarState.ts
+++ b/src/hooks/usePracticeBarState.ts
@@ -4,11 +4,9 @@ import {
   practiceBarTitleAtom,
   practiceBarBadgeAtom,
   practiceBarLensLabelAtom,
-  isShapeLocalContextAtom,
-  shapeContextLabelAtom,
   practiceLensAtom,
-  practiceCuesAtom,
-  shapeLocalPracticeCuesAtom,
+  practiceBarChordGroupAtom,
+  practiceBarLandOnGroupAtom,
 } from "../store/atoms";
 
 export function usePracticeBarState() {
@@ -16,21 +14,17 @@ export function usePracticeBarState() {
   const practiceBarTitle = useAtomValue(practiceBarTitleAtom);
   const practiceBarBadge = useAtomValue(practiceBarBadgeAtom);
   const practiceBarLensLabel = useAtomValue(practiceBarLensLabelAtom);
-  const isShapeLocalContext = useAtomValue(isShapeLocalContextAtom);
-  const shapeContextLabel = useAtomValue(shapeContextLabelAtom);
   const practiceLens = useAtomValue(practiceLensAtom);
-  const practiceCues = useAtomValue(practiceCuesAtom);
-  const shapeLocalPracticeCues = useAtomValue(shapeLocalPracticeCuesAtom);
+  const chordGroup = useAtomValue(practiceBarChordGroupAtom);
+  const landOnGroup = useAtomValue(practiceBarLandOnGroupAtom);
 
   return {
     showChordPracticeBar,
     practiceBarTitle,
     practiceBarBadge,
     practiceBarLensLabel,
-    isShapeLocalContext,
-    shapeContextLabel,
     practiceLens,
-    practiceCues,
-    shapeLocalPracticeCues,
+    chordGroup,
+    landOnGroup,
   };
 }

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -71,6 +71,7 @@ export {
   practiceBarColorNotesFilteredAtom,
   noteSemanticMapAtom,
   practiceCuesAtom,
+  practiceBarChordGroupAtom,
   showChordPracticeBarAtom,
   practiceBarTitleAtom,
   practiceBarBadgeAtom,
@@ -140,6 +141,7 @@ import {
 import {
   practiceCuesAtom,
   practiceBarColorNotesAtom,
+  practiceBarLandOnGroupBaseAtom,
 } from "./practiceLensAtoms";
 import {
   tuningNameAtom,
@@ -389,6 +391,23 @@ export const shapeLocalColorNotesAtom = atom((get) => {
   return practiceBarColorNotes.filter((n) =>
     shapeHighlightedNoteSet.has(n.internalNote),
   );
+});
+
+/**
+ * Shape-aware Land-on group. Narrows the base lens subset to notes present in
+ * the active shape context (except for tension, which stays global). The
+ * Chord group never goes through this — it is always all chord members.
+ */
+export const practiceBarLandOnGroupAtom = atom((get) => {
+  const base = get(practiceBarLandOnGroupBaseAtom);
+  const lens = get(practiceLensAtom);
+  const shapeHighlightedNoteSet = get(shapeHighlightedNoteSetAtom);
+  if (!shapeHighlightedNoteSet || lens === "tension") return base;
+  const filtered = base.notes.filter((n) =>
+    shapeHighlightedNoteSet.has(n.internalNote),
+  );
+  if (filtered.length === 0) return base;
+  return { ...base, notes: filtered };
 });
 
 export const shapeLocalPracticeCuesAtom = atom((get) => {

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -42,6 +42,26 @@ const GUIDE_TONE_RAW = new Set(["b3", "3", "b7", "7"]);
 // After formatAccidental: "b3"→"♭3", "b7"→"♭7"
 const GUIDE_TONE_FORMATTED = new Set(["♭3", "3", "♭7", "7"]);
 
+// Nearest in-scale resolution (≤2 semitones, step-up preferred).
+// Shared between practiceCuesAtom and practiceBarLandOnGroupBaseAtom so the
+// radius + tie-breaking stay in lockstep.
+function findNearestScaleResolution(
+  note: string,
+  scaleNotes: readonly string[],
+  displayNote: (n: string) => string,
+): { internalNote: string; displayNote: string } | undefined {
+  const noteIdx = NOTES.indexOf(note);
+  if (noteIdx === -1) return undefined;
+  const scaleNoteSet = new Set(scaleNotes);
+  for (let step = 1; step <= 2; step++) {
+    const up = NOTES[(noteIdx + step) % 12];
+    const down = NOTES[(noteIdx - step + 12) % 12];
+    if (scaleNoteSet.has(up)) return { internalNote: up, displayNote: displayNote(up) };
+    if (scaleNoteSet.has(down)) return { internalNote: down, displayNote: displayNote(down) };
+  }
+  return undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Practice bar color notes — derived from scale color tones
 // ---------------------------------------------------------------------------
@@ -160,23 +180,8 @@ export const practiceCuesAtom = atom((get) => {
     role: e.role,
   });
 
-  // Find the nearest in-scale note (up to 2 semitones in each direction).
-  // Prefers 1-step up, then 1-step down, then 2-step up, then 2-step down.
-  // The 2-step radius ensures coverage for pentatonic scales with wider gaps.
-  const findResolution = (
-    note: string,
-  ): { internalNote: string; displayNote: string } | undefined => {
-    const noteIdx = NOTES.indexOf(note);
-    if (noteIdx === -1) return undefined;
-    const scaleNoteSet = new Set(scaleNotes);
-    for (let step = 1; step <= 2; step++) {
-      const up = NOTES[(noteIdx + step) % 12];
-      const down = NOTES[(noteIdx - step + 12) % 12];
-      if (scaleNoteSet.has(up)) return { internalNote: up, displayNote: displayNote(up) };
-      if (scaleNoteSet.has(down)) return { internalNote: down, displayNote: displayNote(down) };
-    }
-    return undefined;
-  };
+  const findResolution = (note: string) =>
+    findNearestScaleResolution(note, scaleNotes, displayNote);
 
   const buildLandOnCue = (): PracticeCue => ({
     kind: "land-on",
@@ -288,20 +293,8 @@ export const practiceBarLandOnGroupBaseAtom = atom((get): PracticeBarGroup => {
   const displayNote = (note: string) =>
     formatAccidental(getNoteDisplay(note, chordRoot, useFlats));
 
-  const findResolution = (
-    note: string,
-  ): { internalNote: string; displayNote: string } | undefined => {
-    const noteIdx = NOTES.indexOf(note);
-    if (noteIdx === -1) return undefined;
-    const scaleNoteSet = new Set(scaleNotes);
-    for (let step = 1; step <= 2; step++) {
-      const up = NOTES[(noteIdx + step) % 12];
-      const down = NOTES[(noteIdx - step + 12) % 12];
-      if (scaleNoteSet.has(up)) return { internalNote: up, displayNote: displayNote(up) };
-      if (scaleNoteSet.has(down)) return { internalNote: down, displayNote: displayNote(down) };
-    }
-    return undefined;
-  };
+  const findResolution = (note: string) =>
+    findNearestScaleResolution(note, scaleNotes, displayNote);
 
   let subset: ChordRowEntry[];
   switch (lens) {

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -16,6 +16,8 @@ import type {
   PracticeCueNote,
   ChordRowEntry,
   PracticeBarColorNote,
+  PracticeBarNote,
+  PracticeBarGroup,
 } from "../theory";
 import {
   rootNoteAtom,
@@ -236,6 +238,93 @@ export const practiceCuesAtom = atom((get) => {
   }
 
   return cues;
+});
+
+// ---------------------------------------------------------------------------
+// Practice bar groups — composable two-group model (Chord + Land on)
+// ---------------------------------------------------------------------------
+
+const entryToBarNote = (e: ChordRowEntry): PracticeBarNote => ({
+  internalNote: e.internalNote,
+  displayNote: e.displayNote,
+  intervalName: e.memberName,
+  isChordRoot: e.role === "chord-root",
+  isGuideTone: GUIDE_TONE_FORMATTED.has(e.memberName),
+  isTension: !e.inScale,
+  isInScale: e.inScale,
+});
+
+/**
+ * Chord group — lens-independent. Always shows all chord members.
+ * Never filtered by shape-local context.
+ */
+export const practiceBarChordGroupAtom = atom((get): PracticeBarGroup => {
+  const members = get(allChordMembersAtom);
+  return {
+    label: "Chord",
+    notes: members.map(entryToBarNote),
+  };
+});
+
+/**
+ * Land-on group (shape-agnostic base) — lens-driven coaching subset.
+ *  - targets      → all chord members
+ *  - guide-tones  → only the 3rd/7th members (falls back to all if none)
+ *  - tension      → only outside-scale chord members, with resolution arrows
+ *
+ * Shape-local narrowing is applied on top of this in `atoms.ts` so we can
+ * read `shapeHighlightedNoteSetAtom` without a circular import.
+ */
+export const practiceBarLandOnGroupBaseAtom = atom((get): PracticeBarGroup => {
+  const chordType = get(chordTypeAtom);
+  if (!chordType) return { label: "Land on", notes: [] };
+
+  const lens = get(practiceLensAtom);
+  const chordRoot = get(chordRootAtom);
+  const useFlats = get(useFlatsAtom);
+  const allMembers = get(allChordMembersAtom);
+  const scaleNotes = get(scaleNotesAtom);
+
+  const displayNote = (note: string) =>
+    formatAccidental(getNoteDisplay(note, chordRoot, useFlats));
+
+  const findResolution = (
+    note: string,
+  ): { internalNote: string; displayNote: string } | undefined => {
+    const noteIdx = NOTES.indexOf(note);
+    if (noteIdx === -1) return undefined;
+    const scaleNoteSet = new Set(scaleNotes);
+    for (let step = 1; step <= 2; step++) {
+      const up = NOTES[(noteIdx + step) % 12];
+      const down = NOTES[(noteIdx - step + 12) % 12];
+      if (scaleNoteSet.has(up)) return { internalNote: up, displayNote: displayNote(up) };
+      if (scaleNoteSet.has(down)) return { internalNote: down, displayNote: displayNote(down) };
+    }
+    return undefined;
+  };
+
+  let subset: ChordRowEntry[];
+  switch (lens) {
+    case "guide-tones": {
+      const gt = allMembers.filter((e) => GUIDE_TONE_FORMATTED.has(e.memberName));
+      subset = gt.length > 0 ? gt : allMembers;
+      break;
+    }
+    case "tension":
+      subset = allMembers.filter((e) => !e.inScale);
+      break;
+    default:
+      subset = allMembers;
+  }
+
+  const notes: PracticeBarNote[] = subset.map((e) => {
+    const base = entryToBarNote(e);
+    return lens === "tension"
+      ? { ...base, resolvesTo: findResolution(e.internalNote) }
+      : base;
+  });
+
+  return { label: "Land on", notes };
 });
 
 // ---------------------------------------------------------------------------

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -226,6 +226,29 @@ export interface PracticeCue {
   notes: PracticeCueNote[];
 }
 
+// ---------------------------------------------------------------------------
+// Practice bar note model — composable semantic flags (multiple can coexist).
+// Mirrors the fretboard's semantic model so that e.g. an outside chord root
+// simultaneously carries isChordRoot + isTension, and guide tones stay
+// distinct from ordinary chord tones.
+// ---------------------------------------------------------------------------
+
+export interface PracticeBarNote {
+  internalNote: string;
+  displayNote: string;
+  intervalName?: string;
+  isChordRoot: boolean;
+  isGuideTone: boolean;
+  isTension: boolean;
+  isInScale: boolean;
+  resolvesTo?: { internalNote: string; displayNote: string };
+}
+
+export interface PracticeBarGroup {
+  label: string;
+  notes: PracticeBarNote[];
+}
+
 export const CHORD_DEFINITIONS: Record<string, ChordDefinition> = {
   "Major Triad": {
     quality: "triad",


### PR DESCRIPTION
## Summary
- Replace the single-role cue model in `ChordPracticeBar` with two explicit groups (Chord + Land on) driven by composable note flags (`isChordRoot`, `isGuideTone`, `isTension`, `isInScale`, `resolvesTo`). An outside chord root now reads as both root (solid amber body) and tension (dashed orange border) simultaneously — something the old exclusive role enum could not express.
- **Chord group** is always all chord members, lens-independent, never filtered by shape-local context.
- **Land on group** is lens-driven — `targets` → all members, `guide-tones` → 3rd/7th, `tension` → outside members with resolution arrows. Shape-local narrowing applies to Land on for non-tension lenses.
- When Land on is semantically identical to Chord (same notes, intervals, no resolution data), the bar collapses to a single Land on row so the `targets` lens doesn't show duplicate groups.
- Groups render side-by-side on desktop and stack only on narrow tiers. Shape-context subtitle (\"In E shape\") removed.
- Duplicate `DegreeChipStrip` removed from `ChordOverlayDock` — the scale strip is now owned exclusively by `SummaryRibbon`. Practice bar width tracks the degree-chip-strip width clamps so the two surfaces align vertically.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` — 916 passed (added atom coverage for `practiceBarChordGroupAtom` / `practiceBarLandOnGroupAtom`, dock coverage asserting no duplicate chip strip, rewrote `ChordPracticeBar.test.tsx` around the two-group API, added collapsed-group rendering tests)
- [x] `npm run build`
- [ ] Smoke-test targets / guide-tones / tension lenses in the running app (desktop + mobile)
- [ ] Verify an outside chord root (e.g. C# Minor Triad on C Major) shows amber fill + dashed tension border

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated duplicate degree chip strip in the chord practice interface

* **UI/Layout Improvements**
  * Restructured chord practice bar to display practice groups in a side-by-side layout
  * Enhanced responsive styling and spacing for mobile and desktop environments
  * Refined visual presentation and organization of practice coaching information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->