### PR TITLE
test(hooks): fix flaky focus trap wrap-back test

### DIFF
--- a/src/hooks/useFocusTrap.test.ts
+++ b/src/hooks/useFocusTrap.test.ts
@@ -80,6 +80,11 @@ describe("useFocusTrap", () => {
       useFocusTrap({ containerRef, active: true, onEscape })
     );
 
+    // Wait for initial RAF focus to complete before manually focusing
+    await act(async () => {
+      await new Promise(requestAnimationFrame);
+    });
+
     button2.focus();
     expect(document.activeElement).toBe(button2);
 


### PR DESCRIPTION
## Summary
- Fix flaky `useFocusTrap` unit test `Tab wraps from last button back to first button`.
- The test focused `button2` immediately after `renderHook` without flushing the hook's initial `requestAnimationFrame` focus callback. Under CI load that pending rAF could resolve during `await user.tab()`, re-focusing `button1` and causing tab to advance to `button2` instead of wrapping back to `button1`.
- Added the same rAF-flush pattern already used by the sibling tab tests so the initial focus settles before the test takes control.

## Test plan
- [x] `npx vitest run src/hooks/useFocusTrap.test.ts` (8/8 passing locally, repeated runs stable)
- [x] Full `npm run test` suite via pre-push hook (916/916)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test timing stability for focus management functionality to ensure consistent test execution.

---

**Note:** This release contains no user-facing changes. Updates are internal testing improvements only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->