### PR TITLE
fix(workflows): restore deploy trigger broken by GITHUB_TOKEN push limitation

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -72,7 +72,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ steps.tag.outputs.new_tag }}
         run: |
-          gh workflow run deploy.yml --ref "refs/tags/$TAG_NAME"
+          gh workflow run deploy.yml --ref "$TAG_NAME"
 
       - name: Create version bump PR
         if: steps.tag.outputs.new_tag

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -64,6 +64,16 @@ jobs:
           git tag -a "$TAG_NAME" -F "$TAG_MESSAGE_FILE"
           git push origin "refs/tags/$TAG_NAME"
 
+      # GITHUB_TOKEN push events do not trigger other workflows (GitHub security
+      # restriction), so we must explicitly dispatch deploy after the tag push.
+      - name: Trigger deploy
+        if: steps.tag.outputs.new_tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.tag.outputs.new_tag }}
+        run: |
+          gh workflow run deploy.yml --ref "refs/tags/$TAG_NAME"
+
       - name: Create version bump PR
         if: steps.tag.outputs.new_tag
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Root cause

PR #258 dropped the explicit `gh workflow run deploy.yml` call from `auto-release.yml`, assuming the tag push would automatically trigger `deploy.yml`. This assumption is incorrect.

GitHub Actions has a documented security restriction: **events caused by `GITHUB_TOKEN` do not trigger other workflows**. When `auto-release.yml` pushes a tag via `git push origin "refs/tags/$TAG_NAME"` (authenticated with `GITHUB_TOKEN`), GitHub suppresses the resulting `push` event so it cannot fire downstream `push: tags` triggers.

PR #258 compounded the problem by also removing `workflow_dispatch` from `deploy.yml`, leaving no path to trigger deploy at all — not automatically, not manually.

## Fix

- Restore `workflow_dispatch` to `deploy.yml`
- Add an explicit `gh workflow run deploy.yml --ref "refs/tags/$TAG_NAME"` step in `auto-release.yml` immediately after the tag push — this is an API dispatch (not a git event), which GitHub does allow to trigger other workflows

## Test plan
- [ ] Run Auto Release from `main` → confirm `deploy.yml` is triggered and GitHub Pages updates

https://claude.ai/code/session_01DvxiuuKjKVK6ppSoo2QtFJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated deployment so new releases trigger the deployment workflow as soon as a release tag is created.
  * Added the ability to manually trigger the Deploy workflow for on-demand deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->