### PR TITLE
test(store): suppress expected console.warn stderr in storage error tests

### DIFF
--- a/src/store/atoms.test.ts
+++ b/src/store/atoms.test.ts
@@ -136,13 +136,16 @@ describe("atoms", () => {
     });
 
     it("returns initialValue when localStorage.getItem throws", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const spy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
         throw new Error("storage blocked");
       });
       const store = makeStore();
       const unsub = mount(store, isMutedAtom);
       expect(store.get(isMutedAtom)).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith("localStorage.getItem failed", expect.objectContaining({ key: k("isMuted") }));
       spy.mockRestore();
+      warnSpy.mockRestore();
       unsub();
     });
   });
@@ -213,13 +216,16 @@ describe("atoms", () => {
     });
 
     it("returns initialValue when localStorage.getItem throws", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const spy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
         throw new Error("storage blocked");
       });
       const store = makeStore();
       const unsub = mount(store, fretZoomAtom);
       expect(store.get(fretZoomAtom)).toBe(100);
+      expect(warnSpy).toHaveBeenCalledWith("localStorage.getItem failed", expect.objectContaining({ key: k("fretZoom") }));
       spy.mockRestore();
+      warnSpy.mockRestore();
       unsub();
     });
   });
@@ -369,12 +375,15 @@ describe("atoms", () => {
     });
 
     it("falls back to default Set on invalid JSON", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       localStorage.setItem(k("cagedShapes"), "not-valid-json{{{");
       const store = makeStore();
       const unsub = mount(store, cagedShapesAtom);
       const shapes = store.get(cagedShapesAtom);
       expect(shapes).toBeInstanceOf(Set);
       expect(shapes.size).toBe(CAGED_SHAPES.length);
+      expect(warnSpy).toHaveBeenCalledWith("localStorage.getItem failed", expect.objectContaining({ key: k("cagedShapes") }));
+      warnSpy.mockRestore();
       unsub();
     });
 


### PR DESCRIPTION
## Summary

- Three storage error tests were emitting `localStorage.getItem failed` to stderr via `console.warn`, making test output noisy
- Added `vi.spyOn(console, "warn").mockImplementation(() => {})` in each test's scope to silence the output
- Added `expect(warnSpy).toHaveBeenCalledWith(...)` to make the error-handling contract explicit rather than an implicit side effect

## Test plan

- [ ] `npm run test` passes with no unexpected stderr from `atoms.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for storage error handling to verify that storage operation failures properly emit console warnings with relevant diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->