### PR TITLE
refactor(settings-overlay): extract notation and chord layout sections

### DIFF
--- a/src/components/SettingsOverlay/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay/SettingsOverlay.tsx
@@ -15,7 +15,6 @@ import { TUNINGS } from "../../core/guitar";
 import { StepperControl } from "../StepperControl/StepperControl";
 import { FretRangeControl } from "../FretRangeControl/FretRangeControl";
 import { LabeledSelect } from "../LabeledSelect/LabeledSelect";
-import { ToggleBar } from "../ToggleBar/ToggleBar";
 import {
   getResponsiveLayout,
   getResponsiveTier,
@@ -32,8 +31,6 @@ import {
 import { type SettingFieldKey } from "./types";
 import {
   ZOOM_STEP,
-  ACCIDENTAL_OPTIONS,
-  ENHARMONIC_DISPLAY_OPTIONS,
   SETTING_FIELDS,
   SETTINGS_SECTIONS,
 } from "./constants";
@@ -41,6 +38,8 @@ import { OverlaySection, OverlayFieldHeader } from "./shared";
 import { ResetSettingsSection } from "./sections/ResetSettingsSection";
 import { useSettingsForm } from "./useSettingsForm";
 import { useHelpPopover } from "./useHelpPopover";
+import { NotationSettingsSection } from "./sections/NotationSettingsSection";
+import { ChordLayoutSettingsSection } from "./sections/ChordLayoutSettingsSection";
 import styles from "./SettingsOverlay.module.css";
 import sharedStyles from "../shared/shared.module.css";
 
@@ -76,18 +75,13 @@ function SettingsOverlaySurface({
     setFretEnd,
     tuningName,
     setTuningName,
-    accidentalMode,
-    setAccidentalMode,
-    enharmonicDisplay,
-    setEnharmonicDisplay,
-    chordFretSpread,
-    setChordFretSpread,
   } = useSettingsForm();
 
   const {
     activeHelpField,
     activeHelpFieldRef,
     helpContainerRefs,
+    registerHelpContainer,
     setActiveHelpField,
     handleHelpToggle,
   } = useHelpPopover();
@@ -174,40 +168,6 @@ function SettingsOverlaySurface({
           />
         );
         break;
-      case "accidentals":
-        control = (
-          <ToggleBar
-            options={ACCIDENTAL_OPTIONS}
-            value={accidentalMode}
-            onChange={(value) =>
-              setAccidentalMode(value as typeof accidentalMode)
-            }
-          />
-        );
-        break;
-      case "enharmonicDisplay":
-        control = (
-          <ToggleBar
-            options={ENHARMONIC_DISPLAY_OPTIONS}
-            value={enharmonicDisplay}
-            onChange={(value) =>
-              setEnharmonicDisplay(value as typeof enharmonicDisplay)
-            }
-          />
-        );
-        break;
-      case "chordSpread":
-        control = (
-          <StepperControl
-            value={chordFretSpread}
-            onChange={setChordFretSpread}
-            min={0}
-            max={4}
-            step={1}
-            buttonVariant="mobile"
-          />
-        );
-        break;
     }
 
     return (
@@ -271,22 +231,44 @@ function SettingsOverlaySurface({
           </button>
         </div>
         <div className={clsx(styles["settings-overlay-content"], "custom-scrollbar")}>
-          {SETTINGS_SECTIONS.map((section) => (
-            <OverlaySection
-              key={section.id}
-              id={section.id}
-              title={section.title}
-              tone={section.tone}
-            >
-              {section.id === "reset" ? (
-                <ResetSettingsSection onClose={close} />
-              ) : (
-                section.fields.map((fieldKey, index) =>
-                  renderField(fieldKey, index, section.fields.length),
-                )
-              )}
-            </OverlaySection>
-          ))}
+          {SETTINGS_SECTIONS.map((section) => {
+            if (section.id === "notation") {
+              return (
+                <NotationSettingsSection
+                  key={section.id}
+                  activeHelpField={activeHelpField}
+                  handleHelpToggle={handleHelpToggle}
+                  registerHelpContainer={registerHelpContainer}
+                />
+              );
+            }
+            if (section.id === "chord-layout") {
+              return (
+                <ChordLayoutSettingsSection
+                  key={section.id}
+                  activeHelpField={activeHelpField}
+                  handleHelpToggle={handleHelpToggle}
+                  registerHelpContainer={registerHelpContainer}
+                />
+              );
+            }
+            return (
+              <OverlaySection
+                key={section.id}
+                id={section.id}
+                title={section.title}
+                tone={section.tone}
+              >
+                {section.id === "reset" ? (
+                  <ResetSettingsSection onClose={close} />
+                ) : (
+                  section.fields.map((fieldKey, index) =>
+                    renderField(fieldKey, index, section.fields.length),
+                  )
+                )}
+              </OverlaySection>
+            );
+          })}
         </div>
       </motion.div>
     </>

--- a/src/components/SettingsOverlay/sections/ChordLayoutSettingsSection.tsx
+++ b/src/components/SettingsOverlay/sections/ChordLayoutSettingsSection.tsx
@@ -1,0 +1,57 @@
+import { useAtom } from "jotai";
+import clsx from "clsx";
+import { chordFretSpreadAtom } from "../../../store/atoms";
+import { StepperControl } from "../../StepperControl/StepperControl";
+import { OverlaySection, OverlayFieldHeader } from "../shared";
+import { SETTING_FIELDS } from "../constants";
+import { type HelpFieldId } from "../types";
+import styles from "../SettingsOverlay.module.css";
+
+interface ChordLayoutSettingsSectionProps {
+  activeHelpField: HelpFieldId | null;
+  handleHelpToggle: (id: HelpFieldId) => void;
+  registerHelpContainer: (id: HelpFieldId, node: HTMLDivElement | null) => void;
+}
+
+export function ChordLayoutSettingsSection({
+  activeHelpField,
+  handleHelpToggle,
+  registerHelpContainer,
+}: ChordLayoutSettingsSectionProps) {
+  const [chordFretSpread, setChordFretSpread] = useAtom(chordFretSpreadAtom);
+  const config = SETTING_FIELDS.chordSpread;
+  const isHelpOpen = config.help?.id === activeHelpField;
+  const helpId = config.help?.id;
+  const helpContainerRef = helpId
+    ? (node: HTMLDivElement | null) => registerHelpContainer(helpId, node)
+    : undefined;
+
+  return (
+    <OverlaySection id="chord-layout" title="Chord Layout">
+      <div
+        className={clsx(
+          styles["overlay-field"],
+          isHelpOpen && styles["overlay-field--help-open"],
+        )}
+      >
+        <OverlayFieldHeader
+          label={config.label}
+          help={config.help}
+          isHelpOpen={Boolean(isHelpOpen)}
+          onToggleHelp={() => config.help && handleHelpToggle(config.help.id)}
+          helpContainerRef={helpContainerRef}
+        />
+        <div className={styles["overlay-field-control"]}>
+          <StepperControl
+            value={chordFretSpread}
+            onChange={setChordFretSpread}
+            min={0}
+            max={4}
+            step={1}
+            buttonVariant="mobile"
+          />
+        </div>
+      </div>
+    </OverlaySection>
+  );
+}

--- a/src/components/SettingsOverlay/sections/NotationSettingsSection.tsx
+++ b/src/components/SettingsOverlay/sections/NotationSettingsSection.tsx
@@ -1,0 +1,79 @@
+import { useAtom } from "jotai";
+import clsx from "clsx";
+import { accidentalModeAtom, enharmonicDisplayAtom } from "../../../store/atoms";
+import { ToggleBar } from "../../ToggleBar/ToggleBar";
+import { OverlaySection, OverlayFieldHeader } from "../shared";
+import { ACCIDENTAL_OPTIONS, ENHARMONIC_DISPLAY_OPTIONS, SETTING_FIELDS } from "../constants";
+import { type HelpFieldId } from "../types";
+import styles from "../SettingsOverlay.module.css";
+
+interface NotationSettingsSectionProps {
+  activeHelpField: HelpFieldId | null;
+  handleHelpToggle: (id: HelpFieldId) => void;
+  registerHelpContainer: (id: HelpFieldId, node: HTMLDivElement | null) => void;
+}
+
+export function NotationSettingsSection({
+  activeHelpField,
+  handleHelpToggle,
+  registerHelpContainer,
+}: NotationSettingsSectionProps) {
+  const [accidentalMode, setAccidentalMode] = useAtom(accidentalModeAtom);
+  const [enharmonicDisplay, setEnharmonicDisplay] = useAtom(enharmonicDisplayAtom);
+
+  const fields = [
+    {
+      config: SETTING_FIELDS.accidentals,
+      control: (
+        <ToggleBar
+          options={ACCIDENTAL_OPTIONS}
+          value={accidentalMode}
+          onChange={(v) => setAccidentalMode(v as typeof accidentalMode)}
+        />
+      ),
+    },
+    {
+      config: SETTING_FIELDS.enharmonicDisplay,
+      control: (
+        <ToggleBar
+          options={ENHARMONIC_DISPLAY_OPTIONS}
+          value={enharmonicDisplay}
+          onChange={(v) => setEnharmonicDisplay(v as typeof enharmonicDisplay)}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <OverlaySection id="notation" title="Notation">
+      {fields.map(({ config, control }, index) => {
+        const isHelpOpen = config.help?.id === activeHelpField;
+        const helpId = config.help?.id;
+        const helpContainerRef = helpId
+          ? (node: HTMLDivElement | null) => registerHelpContainer(helpId, node)
+          : undefined;
+
+        return (
+          <div
+            key={config.key}
+            className={clsx(
+              styles["overlay-field"],
+              config.className,
+              isHelpOpen && styles["overlay-field--help-open"],
+              index < fields.length - 1 && styles["overlay-field--divided"],
+            )}
+          >
+            <OverlayFieldHeader
+              label={config.label}
+              help={config.help}
+              isHelpOpen={Boolean(isHelpOpen)}
+              onToggleHelp={() => config.help && handleHelpToggle(config.help.id)}
+              helpContainerRef={helpContainerRef}
+            />
+            <div className={styles["overlay-field-control"]}>{control}</div>
+          </div>
+        );
+      })}
+    </OverlaySection>
+  );
+}

--- a/src/components/SettingsOverlay/useHelpPopover.ts
+++ b/src/components/SettingsOverlay/useHelpPopover.ts
@@ -31,10 +31,15 @@ export function useHelpPopover() {
     return () => document.removeEventListener("mousedown", handlePointerDown);
   }, [activeHelpField]);
 
+  const registerHelpContainer = (id: HelpFieldId, node: HTMLDivElement | null) => {
+    helpContainerRefs.current[id] = node;
+  };
+
   return {
     activeHelpField,
     activeHelpFieldRef,
     helpContainerRefs,
+    registerHelpContainer,
     setActiveHelpField,
     handleHelpToggle,
   };


### PR DESCRIPTION
## Summary

- Extracts `NotationSettingsSection` (Accidentals + Enharmonic Display) and `ChordLayoutSettingsSection` (Chord Spread) into `src/components/SettingsOverlay/sections/`
- Moves `registerHelpContainer` into `useHelpPopover` to satisfy the hooks immutability lint rule and keep ref mutations inside the hook that owns the ref
- Section components accept `activeHelpField`, `handleHelpToggle`, and `registerHelpContainer` as props — preserving one-open-at-a-time help behavior across sections

## Test plan

- [ ] `npm run test -- src/components/SettingsOverlay` — all 20 tests pass
- [ ] `npm run lint` — clean
- [ ] Help popovers open/close independently and only one is open at a time
- [ ] Accidentals and Enharmonic Display use `ToggleBar`; Chord Spread uses `StepperControl` with min 0 / max 4 / step 1 / `buttonVariant="mobile"`

Stacks on: `settings-overlay-split/refactor-shared-shell`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized settings overlay with dedicated sections for notation and chord layout settings.
  * Enhanced help popover functionality across settings controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->