### PR TITLE
test: normalize React useId tokens in DOM snapshots

### DIFF
--- a/src/test-utils/setup.ts
+++ b/src/test-utils/setup.ts
@@ -47,3 +47,59 @@ window.matchMedia = vi.fn().mockImplementation((query: string) => ({
   removeEventListener: vi.fn(),
   dispatchEvent: vi.fn(),
 }));
+
+/**
+ * Snapshot serializer that normalizes React useId() generated IDs.
+ * React generated IDs (e.g., _r_c_) shift between runs, causing snapshot instability.
+ * This serializer replaces them with stable tokens like react-id-1, react-id-2, etc.
+ */
+const normalizedNodes = new WeakSet<Node>();
+
+expect.addSnapshotSerializer({
+  test(val) {
+    return (
+      val &&
+      typeof val === 'object' &&
+      (val.nodeType === 1 || val.nodeType === 11) &&
+      !normalizedNodes.has(val)
+    );
+  },
+  serialize(val, config, indentation, depth, refs, printer) {
+    const clone = val.cloneNode(true) as Element | DocumentFragment;
+    normalizedNodes.add(clone);
+
+    const idMap = new Map<string, string>();
+    let idCounter = 1;
+    const reactIdRegExp = /_r_[a-z0-9]+_/g;
+
+    const normalize = (text: string) => {
+      return text.replace(reactIdRegExp, (match) => {
+        if (!idMap.has(match)) {
+          idMap.set(match, `react-id-${idCounter++}`);
+        }
+        return idMap.get(match)!;
+      });
+    };
+
+    const walk = (node: Node) => {
+      if (node.nodeType === 1) {
+        // Element
+        const el = node as Element;
+        const attrs = el.attributes;
+        for (let i = 0; i < attrs.length; i++) {
+          const attr = attrs[i];
+          if (attr.value.match(reactIdRegExp)) {
+            attr.value = normalize(attr.value);
+          }
+        }
+      }
+      for (let i = 0; i < node.childNodes.length; i++) {
+        walk(node.childNodes[i]);
+      }
+    };
+
+    walk(clone);
+
+    return printer(clone, config, indentation, depth, refs);
+  },
+});

--- a/src/test-utils/setup.ts
+++ b/src/test-utils/setup.ts
@@ -66,6 +66,7 @@ expect.addSnapshotSerializer({
   },
   serialize(val, config, indentation, depth, refs, printer) {
     const clone = val.cloneNode(true) as Element | DocumentFragment;
+    normalizedNodes.add(val);
     normalizedNodes.add(clone);
 
     const idMap = new Map<string, string>();


### PR DESCRIPTION
## Summary

Adds a custom Vitest snapshot serializer in `src/test-utils/setup.ts` to stabilize DOM snapshots against React `useId()` drift.

- Normalizes generated IDs (matching `/_r_[a-z0-9]+_/`) to stable tokens (`react-id-1`, `react-id-2`, etc.)
- Preserves relationships between IDs and referencing attributes (e.g. `aria-labelledby`) within a snapshot
- Prevents CI failures and local "dirty" snapshots caused by minor shifts in React's internal ID counter between test runs
- Delegates final markup formatting back to Vitest's default DOM printer

## Test Plan

- `npm run test -- src/snapshots.test.tsx --reporter=verbose` — All 31 tests pass with normalized IDs
- Verified snapshots no longer contain raw `_r_*` IDs
- Full test suite (`npm run test`) passes

🤖 Generated with Gemini CLI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved snapshot serialization stability for DOM testing, ensuring deterministic handling of auto-generated identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->