### PR TITLE
refactor(settings-overlay): integrate extracted settings sections

### DIFF
--- a/src/components/SettingsOverlay/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay/SettingsOverlay.tsx
@@ -1,16 +1,9 @@
 import { useEffect, useRef, useState } from "react";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom } from "jotai";
 import clsx from "clsx";
 import { AnimatePresence, motion } from "motion/react";
 import { X } from "lucide-react";
-import {
-  settingsOverlayOpenAtom,
-  fretZoomAtom,
-  fretStartAtom,
-  fretEndAtom,
-  tuningNameAtom,
-  chordFretSpreadAtom,
-} from "../../store/atoms";
+import { settingsOverlayOpenAtom } from "../../store/atoms";
 import {
   getResponsiveLayout,
   getResponsiveTier,
@@ -21,9 +14,6 @@ import {
   ANIMATION_DURATION_STANDARD,
   ANIMATION_EASE,
 } from "../../core/constants";
-import {
-  SETTINGS_SECTIONS,
-} from "./constants";
 import { OverlaySection } from "./shared";
 import { useHelpPopover } from "./useHelpPopover";
 import { ViewSettingsSection } from "./sections/ViewSettingsSection";
@@ -133,44 +123,25 @@ function SettingsOverlaySurface({
           </button>
         </div>
         <div className={clsx(styles["settings-overlay-content"], "custom-scrollbar")}>
-          {SETTINGS_SECTIONS.map((section) => {
-            if (section.id === "notation") {
-              return (
-                <NotationSettingsSection
-                  key={section.id}
-                  activeHelpField={activeHelpField}
-                  handleHelpToggle={handleHelpToggle}
-                  registerHelpContainer={registerHelpContainer}
-                />
-              );
-            }
-            if (section.id === "chord-layout") {
-              return (
-                <ChordLayoutSettingsSection
-                  key={section.id}
-                  activeHelpField={activeHelpField}
-                  handleHelpToggle={handleHelpToggle}
-                  registerHelpContainer={registerHelpContainer}
-                />
-              );
-            }
-            return (
-              <OverlaySection
-                key={section.id}
-                id={section.id}
-                title={section.title}
-                tone={section.tone}
-              >
-                {section.id === "reset" ? (
-                  <ResetSettingsSection onClose={close} />
-                ) : section.id === "view" ? (
-                  <ViewSettingsSection />
-                ) : section.id === "instrument" ? (
-                  <InstrumentSettingsSection />
-                ) : null}
-              </OverlaySection>
-            );
-          })}
+          <OverlaySection id="view" title="View">
+            <ViewSettingsSection />
+          </OverlaySection>
+          <OverlaySection id="instrument" title="Instrument">
+            <InstrumentSettingsSection />
+          </OverlaySection>
+          <NotationSettingsSection
+            activeHelpField={activeHelpField}
+            handleHelpToggle={handleHelpToggle}
+            registerHelpContainer={registerHelpContainer}
+          />
+          <ChordLayoutSettingsSection
+            activeHelpField={activeHelpField}
+            handleHelpToggle={handleHelpToggle}
+            registerHelpContainer={registerHelpContainer}
+          />
+          <OverlaySection id="reset" title="Reset" tone="danger">
+            <ResetSettingsSection onClose={close} />
+          </OverlaySection>
         </div>
       </motion.div>
     </>
@@ -182,12 +153,6 @@ export default function SettingsOverlay() {
   const [viewport, setViewport] = useState(getViewportSnapshot);
   const openTierRef = useRef<ResponsiveTier | null>(null);
   const layout = getResponsiveLayout(viewport.width, viewport.height);
-
-  useAtomValue(fretZoomAtom);
-  useAtomValue(fretStartAtom);
-  useAtomValue(fretEndAtom);
-  useAtomValue(tuningNameAtom);
-  useAtomValue(chordFretSpreadAtom);
 
   useEffect(() => {
     const onResize = () => setViewport(getViewportSnapshot());

--- a/src/components/SettingsOverlay/constants.ts
+++ b/src/components/SettingsOverlay/constants.ts
@@ -40,6 +40,7 @@ export const SETTING_FIELDS: Record<SettingFieldKey, SettingFieldConfig> = {
   accidentals: {
     key: "accidentals",
     label: "Accidentals",
+    className: "overlay-field--accidentals",
     help: {
       id: "accidentals",
       content:


### PR DESCRIPTION
## Summary

- Replace `SETTINGS_SECTIONS.map()` render switch with direct, readable section component rendering
- Remove dead atom subscriptions (`fretZoom`, `fretStart`, `fretEnd`, `tuningName`, `chordFretSpread`) from outer shell — each section now owns its atoms
- `SettingsOverlay.tsx` reduced from 219 to 184 lines; outer component is pure shell orchestration (viewport tracking, tier-change close, `AnimatePresence`)
- All drawer/backdrop animation, focus trap, trigger focus restore, responsive tier close, and ESC priority behavior preserved
- Help popover behavior (ESC closes help before drawer; outside mousedown closes help) fully intact

> **Stack note:** stacks on `settings-overlay-split/refactor-shared-shell` (view + instrument section extraction). Base will be updated to that branch once it's pushed.

## Test plan

- [x] `npm run test -- src/components/SettingsOverlay/SettingsOverlay.test.tsx` — 20/20 pass
- [x] `npm run test` — 938/938 pass
- [x] `npm run lint` — clean
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)