### PR TITLE
feat: expand chord overlay support and practice bar labeling

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -229,8 +229,14 @@ describe("App", () => {
       });
     });
 
-    it("links chord root to scale root by default", async () => {
+    it("links chord root to scale root in manual mode by default", async () => {
+      // Seed manual mode explicitly. In degree mode the link sync is intentionally
+      // skipped — the derived chord root re-resolves via getDiatonicChord against
+      // the new scale root, so writing through chordRootAtom is unnecessary and
+      // would force mode→manual (the bug Phase 01 fixes).
+      localStorage.setItem(k("chordOverlayMode"), "manual");
       localStorage.setItem(k("chordType"), "Major Triad");
+      localStorage.setItem(k("chordRootOverride"), "C");
       render(<App />);
 
       const cofButton = await screen.findByTestId("circle-of-fifths");
@@ -239,6 +245,22 @@ describe("App", () => {
       await waitFor(() => {
         // Phase 02: chordRootAtom writes go to chordRootOverride (manual mode override key).
         expect(localStorage.getItem(k("chordRootOverride"))).toBe("G");
+      });
+    });
+
+    it("preserves degree mode when scale root changes (chord root re-resolves via degree)", async () => {
+      // Default after migration with a diatonic triad: degree mode, chordDegree="I".
+      // Changing the scale root must keep the user in degree mode (the chord root
+      // auto-resolves via getDiatonicChord) and must NOT write to chordRootOverride.
+      localStorage.setItem(k("chordType"), "Major Triad");
+      render(<App />);
+
+      const cofButton = await screen.findByTestId("circle-of-fifths");
+      fireEvent.click(cofButton);
+
+      await waitFor(() => {
+        expect(localStorage.getItem(k("rootNote"))).toBe("G");
+        expect(localStorage.getItem(k("chordOverlayMode"))).toBe("degree");
       });
     });
 

--- a/src/components/ChordOverlayControls/ChordOverlayControls.test.tsx
+++ b/src/components/ChordOverlayControls/ChordOverlayControls.test.tsx
@@ -21,9 +21,11 @@ const CHORD_OPTION_VALUES = [
   "Major Triad",
   "Minor Triad",
   "Diminished Triad",
+  "Major 6th",
   "Major 7th",
   "Minor 7th",
   "Dominant 7th",
+  "Sus4",
   "Power Chord (5)",
 ];
 

--- a/src/components/ChordOverlayControls/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls/ChordOverlayControls.tsx
@@ -18,9 +18,11 @@ const CHORD_OPTIONS: string[] = [
   "Major Triad",
   "Minor Triad",
   "Diminished Triad",
+  "Major 6th",
   "Major 7th",
   "Minor 7th",
   "Dominant 7th",
+  "Sus4",
   "Power Chord (5)",
 ];
 

--- a/src/components/ChordPracticeBar/ChordPracticeBar.test.tsx
+++ b/src/components/ChordPracticeBar/ChordPracticeBar.test.tsx
@@ -347,7 +347,7 @@ describe("ChordPracticeBar/ChordPracticeBar", () => {
           mkNote({
             internalNote: "C",
             displayNote: "C",
-            intervalName: "1",
+            intervalName: "I",
             isChordRoot: true,
             scaleDegree: "I",
             degreeColor: "#ff7f00",
@@ -355,9 +355,9 @@ describe("ChordPracticeBar/ChordPracticeBar", () => {
           mkNote({
             internalNote: "E",
             displayNote: "E",
-            intervalName: "3",
+            intervalName: "iii",
             isGuideTone: true,
-            scaleDegree: "III",
+            scaleDegree: "iii",
             degreeColor: "#4daf4a",
           }),
         ],
@@ -380,11 +380,13 @@ describe("ChordPracticeBar/ChordPracticeBar", () => {
         '[data-chord-root="true"][data-scale-degree="I"]',
       ) as HTMLElement | null;
       const guideTonePill = container.querySelector(
-        '[data-guide-tone="true"][data-scale-degree="III"]',
+        '[data-guide-tone="true"][data-scale-degree="iii"]',
       ) as HTMLElement | null;
 
       expect(rootPill?.style.getPropertyValue("--degree-color")).toBe("#ff7f00");
       expect(guideTonePill?.style.getPropertyValue("--degree-color")).toBe("#4daf4a");
+      expect(screen.getByText("I")).toBeTruthy();
+      expect(screen.getByText("iii")).toBeTruthy();
       expect(container.querySelector(".chord-practice-bar")?.getAttribute("data-degree-colors")).toBe("true");
     });
 

--- a/src/components/FretboardSVG/hooks/useNoteData.test.ts
+++ b/src/components/FretboardSVG/hooks/useNoteData.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useNoteData } from "./useNoteData";
+import type { ShapePolygon, CagedShape } from "../../../shapes";
 
 describe("useNoteData", () => {
   it("generates correct note data for a simple tuning", () => {
@@ -39,6 +40,147 @@ describe("useNoteData", () => {
     const e2Note = data.find(n => n.noteName === "E" && n.fretIndex === 0 && n.stringIndex === 0);
     expect(e2Note).toBeDefined();
     expect(e2Note?.noteClass).toBe("key-tonic");
+  });
+
+  describe("symmetric chord-spread contract", () => {
+    // Single-string chromatic layout starting on E2 across frets 0-12.
+    // E, F, F#, G, G#, A, A#, B, C, C#, D, D#, E
+    const SINGLE_STRING_LAYOUT = [[
+      "E", "F", "F#", "G", "G#", "A", "A#", "B", "C", "C#", "D", "D#", "E",
+    ]];
+
+    // CAGED-style polygon spanning frets 5-7 on a single string. Anchored well
+    // clear of fret 0 so left-spread is observable (clampedLeft = 5; spread
+    // values up to 4 still produce a positive lower bound). Vertex layout
+    // matches buildPolygonFromNotes: leftEdge first, rightEdge reversed.
+    const polyAt5To7: ShapePolygon = {
+      shape: "E" as CagedShape,
+      color: "rgba(0,0,0,0.1)",
+      cagedLabel: "E",
+      modalLabel: null,
+      truncated: false,
+      intendedMin: 5,
+      intendedMax: 7,
+      vertices: [
+        { fret: 5, string: 0 },
+        { fret: 7, string: 0 },
+      ],
+    };
+
+    function buildSpreadHook(chordFretSpread: number) {
+      return renderHook(() =>
+        useNoteData({
+          numStrings: 1,
+          fretboardLayout: SINGLE_STRING_LAYOUT,
+          totalColumns: 12,
+          startFret: 0,
+          maxFret: 12,
+          hiddenNotes: new Set(),
+          highlightNotes: ["C", "E", "G"],
+          hasChordOverlay: true,
+          chordTones: ["C", "E", "G"],
+          rootNote: "C",
+          chordRoot: "C",
+          colorNotes: [],
+          shapePolygons: [polyAt5To7],
+          boxBounds: [],
+          chordFretSpread,
+          activePattern: "caged",
+          shapeScope: "single",
+          activeShape: "E" as CagedShape,
+          scaleName: "Major",
+          useFlats: false,
+          wrappedNotes: new Set(),
+          tuning: ["E2"],
+        }),
+      );
+    }
+
+    // Chord-emphasis classes — the visible "active region" classes that indicate
+    // a chord tone is reached by the polygon + chordFretSpread window. The chord
+    // root takes precedence over chord-tone-in-scale (see semantics.classifyNote
+    // line 83), so fret 8 (C, the chord root) gets `chord-root` not
+    // `chord-tone-in-scale` even though the spread is reaching it.
+    const CHORD_EMPHASIS_CLASSES = new Set([
+      "chord-root",
+      "chord-tone-in-scale",
+      "chord-tone-outside-scale",
+      "note-diatonic-chord",
+    ]);
+
+    function isEmphasized(noteClass: string): boolean {
+      return CHORD_EMPHASIS_CLASSES.has(noteClass);
+    }
+
+    function emphasizedFrets(notes: ReturnType<typeof useNoteData>): number[] {
+      return notes
+        .filter((n) => isEmphasized(n.noteClass))
+        .map((n) => n.fretIndex)
+        .sort((a, b) => a - b);
+    }
+
+    it("chordFretSpread=0 emphasizes no chord tones outside the polygon (5-7)", () => {
+      const { result } = buildSpreadHook(0);
+      const emphasized = emphasizedFrets(result.current);
+      // The single-string layout has chord tones at frets 0(E), 3(G), 8(C), 12(E).
+      // Polygon spans frets 5-7; with spread=0, none of those chord-tone frets
+      // fall within [5,7] (5=A, 6=A#, 7=B). All chord tones must be note-inactive.
+      expect(emphasized).toEqual([]);
+    });
+
+    it("chordFretSpread=1 reaches one fret outward both sides — neither chord tone yet", () => {
+      const { result } = buildSpreadHook(1);
+      const emphasized = emphasizedFrets(result.current);
+      // Spread=1 → active window [4, 8]. Layout chord tones in that window:
+      // fret 4 (G#) — not a chord tone; fret 8 (C) — chord root in window.
+      // fret 3 (G) is just outside the left edge of the spread window.
+      expect(emphasized).toContain(8); // C, chord root, in active window
+      expect(emphasized).not.toContain(3); // G, just outside left edge
+      expect(emphasized).not.toContain(0); // E at open string, far outside
+      expect(emphasized).not.toContain(12); // E far outside right edge
+    });
+
+    it("chordFretSpread=2 reaches both directions — fret 3 (left) and fret 8 (right) emphasized", () => {
+      const { result } = buildSpreadHook(2);
+      const emphasized = emphasizedFrets(result.current);
+      // Spread=2 → active window [3, 9]. Both fret 3 (G, chord tone in scale)
+      // and fret 8 (C, chord root) sit inside the window.
+      expect(emphasized).toContain(3); // left-spread reach: G
+      expect(emphasized).toContain(8); // within polygon + spread: C chord root
+      expect(emphasized).not.toContain(0); // E at open string, beyond left edge
+      expect(emphasized).not.toContain(12); // E beyond right edge
+    });
+
+    it("chordFretSpread spread is symmetric — left reach equals right reach for an interior polygon", () => {
+      // For polygon at frets 5-7 with spread=4, the active window is [1, 11].
+      // The chromatic single-string layout provides exactly one chord tone in
+      // each direction within reach: fret 3 (G) on the left, fret 8 (C) on the
+      // right. Symmetric spread → equal counts on both sides.
+      const { result } = buildSpreadHook(4);
+      const emphasized = emphasizedFrets(result.current);
+      const leftEmphasized = emphasized.filter((f) => f < 5);
+      const rightEmphasized = emphasized.filter((f) => f > 7);
+      expect(leftEmphasized).toEqual([3]);
+      expect(rightEmphasized).toEqual([8]);
+      expect(leftEmphasized.length).toBe(rightEmphasized.length);
+    });
+
+    it("chordFretSpread is exact — left edge and right edge are inclusive", () => {
+      // Spread=N means the active window is exactly [polygonMin - N, polygonMax + N].
+      // For polygon 5-7, spread=2 gives [3, 9] inclusive. Verify the BOUNDARIES:
+      // fret 3 (G, chord tone) IS emphasized; fret 8 (C, chord root) IS emphasized.
+      // Spread=1 should EXCLUDE fret 3 (5-1=4 > 3) but INCLUDE fret 8 (7+1=8).
+      const { result: r1 } = buildSpreadHook(1);
+      const { result: r2 } = buildSpreadHook(2);
+      const e1 = emphasizedFrets(r1.current);
+      const e2 = emphasizedFrets(r2.current);
+      // At spread=1: fret 3 NOT included (one fret beyond left bound), fret 8 included.
+      expect(e1).not.toContain(3);
+      expect(e1).toContain(8);
+      // At spread=2: fret 3 included (exactly at left bound), fret 8 still included.
+      expect(e2).toContain(3);
+      expect(e2).toContain(8);
+    });
   });
 
   it("assigns the blue-note color to blues-scale color notes", () => {

--- a/src/components/HelpModal/HelpModal.tsx
+++ b/src/components/HelpModal/HelpModal.tsx
@@ -141,8 +141,9 @@ export function HelpModal({ isOpen, onClose, triggerRef }: HelpModalProps) {
                 <li>
                   <strong>Chord Tones</strong> — the default lens. Highlights
                   every chord member (root, 3rd, 5th, 7th, etc.) and shows a{" "}
-                  <em>Land on</em> cue in the practice bar listing all of them.
-                  Use this to learn the shape of a chord across the neck and
+                  <em>Land on</em> cue in the practice bar using scale degrees
+                  for in-scale notes and chord intervals for outside tones. Use
+                  this to learn the shape of a chord across the neck and
                   practice landing phrases on strong harmonic tones.
                 </li>
                 <li>

--- a/src/core/theory.test.ts
+++ b/src/core/theory.test.ts
@@ -98,6 +98,14 @@ describe("getChordNotes", () => {
   it("returns A Minor 7th", () => {
     expect(getChordNotes("A", "Minor 7th")).toEqual(["A", "C", "E", "G"]);
   });
+
+  it("returns C Major 6th", () => {
+    expect(getChordNotes("C", "Major 6th")).toEqual(["C", "E", "G", "A"]);
+  });
+
+  it("returns D Sus4", () => {
+    expect(getChordNotes("D", "Sus4")).toEqual(["D", "G", "A"]);
+  });
 });
 
 describe("getDivergentNotes", () => {
@@ -293,7 +301,7 @@ describe("resolver + key signature integration", () => {
 describe("CHORD_DEFINITIONS", () => {
   it("every chord in CHORD_DEFINITIONS has a quality and members", () => {
     for (const [name, def] of Object.entries(CHORD_DEFINITIONS)) {
-      expect(def.quality).toMatch(/^(triad|seventh|power)$/);
+      expect(def.quality).toMatch(/^(triad|seventh|power|sixth|suspended)$/);
       expect(def.members.length).toBeGreaterThan(0);
       expect(def.members[0].name).toBe("root");
       void name;
@@ -304,6 +312,8 @@ describe("CHORD_DEFINITIONS", () => {
     expect(CHORDS["Major Triad"]).toEqual([0, 4, 7]);
     expect(CHORDS["Minor 7th"]).toEqual([0, 3, 7, 10]);
     expect(CHORDS["Power Chord (5)"]).toEqual([0, 7]);
+    expect(CHORDS["Major 6th"]).toEqual([0, 4, 7, 9]);
+    expect(CHORDS["Sus4"]).toEqual([0, 5, 7]);
   });
 
   it("Major Triad has triad quality with root, 3, 5 members", () => {
@@ -322,6 +332,20 @@ describe("CHORD_DEFINITIONS", () => {
     const def = CHORD_DEFINITIONS["Power Chord (5)"];
     expect(def.quality).toBe("power");
     expect(def.members.map((m) => m.name)).toEqual(["root", "5"]);
+  });
+
+  it("Major 6th has sixth quality with root, 3, 5, 6 members", () => {
+    const def = CHORD_DEFINITIONS["Major 6th"];
+    expect(def.quality).toBe("sixth");
+    expect(def.members.map((m) => m.name)).toEqual(["root", "3", "5", "6"]);
+    expect(def.members.map((m) => m.semitone)).toEqual([0, 4, 7, 9]);
+  });
+
+  it("Sus4 has suspended quality with root, 4, 5 members", () => {
+    const def = CHORD_DEFINITIONS["Sus4"];
+    expect(def.quality).toBe("suspended");
+    expect(def.members.map((m) => m.name)).toEqual(["root", "4", "5"]);
+    expect(def.members.map((m) => m.semitone)).toEqual([0, 5, 7]);
   });
 });
 

--- a/src/core/theory.ts
+++ b/src/core/theory.ts
@@ -64,8 +64,8 @@ export const FLAT_KEYS = [
 
 export { normalizeScaleName, SCALES, SCALE_TO_PARENT_MAJOR_OFFSET };
 
-export type ChordMemberName = "root" | "b3" | "3" | "b5" | "5" | "b7" | "7";
-export type ChordQuality = "triad" | "seventh" | "power";
+export type ChordMemberName = "root" | "b3" | "3" | "4" | "b5" | "5" | "6" | "b7" | "7";
+export type ChordQuality = "triad" | "seventh" | "power" | "sixth" | "suspended";
 
 export interface ChordMember {
   name: ChordMemberName;
@@ -263,6 +263,15 @@ export const CHORD_DEFINITIONS: Record<string, ChordDefinition> = {
       { name: "b5", semitone: 6 },
     ],
   },
+  "Major 6th": {
+    quality: "sixth",
+    members: [
+      { name: "root", semitone: 0 },
+      { name: "3", semitone: 4 },
+      { name: "5", semitone: 7 },
+      { name: "6", semitone: 9 },
+    ],
+  },
   "Major 7th": {
     quality: "seventh",
     members: [
@@ -288,6 +297,14 @@ export const CHORD_DEFINITIONS: Record<string, ChordDefinition> = {
       { name: "3", semitone: 4 },
       { name: "5", semitone: 7 },
       { name: "b7", semitone: 10 },
+    ],
+  },
+  "Sus4": {
+    quality: "suspended",
+    members: [
+      { name: "root", semitone: 0 },
+      { name: "4", semitone: 5 },
+      { name: "5", semitone: 7 },
     ],
   },
   "Power Chord (5)": {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -9,6 +9,7 @@ import {
   accidentalModeAtom,
 } from "./scaleAtoms";
 import {
+  chordOverlayModeAtom,
   chordRootAtom,
   chordTypeAtom,
   linkChordRootAtom,
@@ -40,6 +41,11 @@ import {
 
 export const setRootNoteAtom = atom(null, (get, set, note: string) => {
   set(rootNoteAtom, note);
+  // In degree mode the derived chordRootAtom/chordTypeAtom auto-resolve via
+  // getDiatonicChord against the new rootNote — no explicit sync needed.
+  // Writing through chordRootAtom would force mode→manual, collapsing the
+  // chord-follows-the-scale contract. Sync only matters in manual mode.
+  if (get(chordOverlayModeAtom) === "degree") return;
   if (get(linkChordRootAtom)) set(chordRootAtom, note);
 });
 

--- a/src/store/atoms.test.ts
+++ b/src/store/atoms.test.ts
@@ -23,6 +23,8 @@ import {
   npsPositionAtom,
   chordFretSpreadAtom,
   practiceLensAtom,
+  chordDegreeAtom,
+  chordOverlayModeAtom,
   setRootNoteAtom,
   resetAtom,
   useFlatsAtom,
@@ -427,11 +429,15 @@ describe("atoms", () => {
       expect(store.get(rootNoteAtom)).toBe("G");
     });
 
-    it("syncs chordRoot when linkChordRoot is true", () => {
+    it("syncs chordRoot when linkChordRoot is true (manual mode)", () => {
+      // Seed manual mode explicitly. In degree mode the link sync is intentionally
+      // skipped because the derived chord root auto-resolves via getDiatonicChord.
       const store = makeStore();
+      store.set(chordOverlayModeAtom, "manual");
       store.set(linkChordRootAtom, true);
       store.set(setRootNoteAtom, "G");
       expect(store.get(chordRootAtom)).toBe("G");
+      expect(store.get(chordOverlayModeAtom)).toBe("manual");
     });
 
     it("does not sync chordRoot when linkChordRoot is false", () => {
@@ -441,6 +447,41 @@ describe("atoms", () => {
       store.set(setRootNoteAtom, "G");
       expect(store.get(rootNoteAtom)).toBe("G");
       expect(store.get(chordRootAtom)).toBe("D");
+    });
+
+    it("preserves degree mode when scale root changes (I degree)", () => {
+      const store = makeStore();
+      store.set(chordOverlayModeAtom, "degree");
+      store.set(chordDegreeAtom, "I");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      // Baseline: I in C Major resolves to C Major Triad.
+      expect(store.get(chordRootAtom)).toBe("C");
+      expect(store.get(chordTypeAtom)).toBe("Major Triad");
+      // Change the scale root.
+      store.set(setRootNoteAtom, "G");
+      // Mode stays degree; chord re-resolves to I in G Major.
+      expect(store.get(chordOverlayModeAtom)).toBe("degree");
+      expect(store.get(rootNoteAtom)).toBe("G");
+      expect(store.get(chordRootAtom)).toBe("G");
+      expect(store.get(chordTypeAtom)).toBe("Major Triad");
+    });
+
+    it("preserves degree mode when scale root changes (vi degree)", () => {
+      const store = makeStore();
+      store.set(chordOverlayModeAtom, "degree");
+      store.set(chordDegreeAtom, "vi");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      // Baseline: vi in C Major resolves to A Minor Triad.
+      expect(store.get(chordRootAtom)).toBe("A");
+      expect(store.get(chordTypeAtom)).toBe("Minor Triad");
+      // Change the scale root.
+      store.set(setRootNoteAtom, "G");
+      // Mode stays degree; vi in G Major resolves to E Minor Triad.
+      expect(store.get(chordOverlayModeAtom)).toBe("degree");
+      expect(store.get(chordRootAtom)).toBe("E");
+      expect(store.get(chordTypeAtom)).toBe("Minor Triad");
     });
   });
 

--- a/src/store/practiceLens.test.ts
+++ b/src/store/practiceLens.test.ts
@@ -126,6 +126,12 @@ describe("practiceCuesAtom", () => {
       expect(noteNames).toContain("G");
     });
 
+    it("uses scale degrees for in-scale note labels", () => {
+      const store = makeChordStore("Major", "C", "Major Triad", "targets");
+      const cues = store.get(practiceCuesAtom);
+      expect(cues[0]!.notes.map((n) => n.intervalName)).toEqual(["I", "iii", "V"]);
+    });
+
     it("returns empty cues when no chord is set", () => {
       const store = makeStore();
       store.set(chordTypeAtom, null);
@@ -274,6 +280,27 @@ describe("practiceCuesAtom", () => {
       expect(ids).toContain("tension");
       expect(ids).toHaveLength(3);
     });
+  });
+});
+
+describe("practiceBarChordGroupAtom", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("falls back to chord-member labels only for outside-scale tones", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C#");
+    store.set(chordTypeAtom, "Minor Triad");
+
+    const chordGroup = store.get(practiceBarChordGroupAtom);
+    expect(chordGroup.notes.map((n) => [n.internalNote, n.intervalName])).toEqual([
+      ["C#", "1"],
+      ["E", "iii"],
+      ["G#", "5"],
+    ]);
   });
 });
 

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -82,6 +82,9 @@ export const practiceBarColorNotesFilteredAtom = atom((get) => {
   return practiceBarColorNotes.filter((n) => !chordToneSet.has(n.internalNote));
 });
 
+const getDisplayLabel = (e: ChordRowEntry): string =>
+  e.scaleDegree ?? e.memberName;
+
 /**
  * Maps note → NoteSemantics allowing multiple properties to coexist.
  * Accommodates notes with multiple roles (e.g., chord root outside scale).
@@ -190,7 +193,7 @@ export const practiceCuesAtom = atom((get) => {
   const toCueNote = (e: ChordRowEntry): PracticeCueNote => ({
     internalNote: e.internalNote,
     displayNote: e.displayNote,
-    intervalName: e.memberName,
+    intervalName: getDisplayLabel(e),
     role: e.role,
   });
 
@@ -260,7 +263,7 @@ export const practiceCuesAtom = atom((get) => {
 const entryToBarNote = (e: ChordRowEntry): PracticeBarNote => ({
   internalNote: e.internalNote,
   displayNote: e.displayNote,
-  intervalName: e.memberName,
+  intervalName: getDisplayLabel(e),
   isChordRoot: e.role === "chord-root",
   isGuideTone: GUIDE_TONE_FORMATTED.has(e.memberName),
   isTension: !e.inScale,


### PR DESCRIPTION
## Summary
- preserve chord-overlay degree mode when the active scale changes
- add Major 6th and Sus4 chord overlay support
- use scale-degree labels for in-scale chord practice bar notes, while keeping chord-member labels for outside tones
- expand regression coverage around chord spread, note data, practice cues, and degree-mode behavior

## Why
This branch improves how the chord overlay behaves as theory state changes and expands the chord vocabulary it can represent. It also fixes the practice bar so its note labels reflect the active scale context instead of always showing chord-member intervals.

## Impact
- degree-driven chord overlays stay resolved correctly when the scale context changes
- players can use Major 6th and Sus4 chord overlays
- the practice bar now teaches in-scale chord tones using scale-relative degrees
- regression coverage is stronger for the affected overlay and practice-bar paths

## Included changes
- `fix(chord-overlay): preserve degree mode when scale root changes`
- `feat(chord-overlay): add Major 6th and Sus4 chord types`
- `test(chord-overlay): assert symmetric chord-spread contract`
- `fix: use scale degrees in chord practice bar`

## Validation
- `npm run test -- src/store/practiceLens.test.ts src/components/ChordPracticeBar/ChordPracticeBar.test.tsx`
- pre-push hook passed:
  - `npm run build:types`
  - `npm run test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Major 6th and Sus4 chord options to expand available chord types
  * Introduced scale degree coloring and labeling for chord tones in chord practice mode

* **Bug Fixes**
  * Improved chord overlay behavior to preserve degree mode when changing scale root

* **Documentation**
  * Clarified "Land on" cue descriptions for scale-degree-aware notes in the Chord Tones lens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->