### PR TITLE
feat(chord-overlay): preserve degree mode through chord-quality and mode changes

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -261,6 +261,12 @@ describe("App", () => {
       await waitFor(() => {
         expect(localStorage.getItem(k("rootNote"))).toBe("G");
         expect(localStorage.getItem(k("chordOverlayMode"))).toBe("degree");
+        // In degree mode, setRootNoteAtom must NOT propagate the new scale root
+        // ("G") into chordRootOverride. The override may be persisted at its
+        // default ("C") because atomWithStorage seeds defaults on mount, but it
+        // must never equal the new rootNote — that would mean the link-sync ran
+        // and a manual-mode override was silently set, which is the regression.
+        expect(localStorage.getItem(k("chordRootOverride"))).not.toBe("G");
       });
     });
 

--- a/src/components/ChordOverlayControls/ChordOverlayControls.test.tsx
+++ b/src/components/ChordOverlayControls/ChordOverlayControls.test.tsx
@@ -88,8 +88,13 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
       expect(screen.queryByRole("group", { name: "Chord degree" })).not.toBeInTheDocument();
     });
 
-    it("clicking Degree from manual mode brings degree picker back", async () => {
-      renderWithAtoms(<ChordOverlayControls />, [...MANUAL_MODE_SEEDS]);
+    it("clicking Degree from manual mode brings degree picker back (no degree set hides chord-type stepper)", async () => {
+      // Seed chordDegreeAtom=null explicitly so the degree-mode chord-type
+      // stepper is gated off (it only renders when a degree is active).
+      renderWithAtoms(<ChordOverlayControls />, [
+        ...MANUAL_MODE_SEEDS,
+        [chordDegreeAtom, null],
+      ]);
 
       // Manual mode initially: chord-type nav browser and root note grid visible
       expect(screen.getByRole("group", { name: "Browse chord types" })).toBeInTheDocument();
@@ -99,8 +104,25 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
 
       // Degree picker visible
       expect(screen.getByRole("group", { name: "Chord degree" })).toBeInTheDocument();
-      // Chord type browser gone
+      // Without an active degree, the chord-type stepper is gated off
       expect(screen.queryByRole("group", { name: "Browse chord types" })).not.toBeInTheDocument();
+    });
+
+    it("clicking Degree from manual mode preserves chord-type stepper when a degree is active", async () => {
+      // With an active degree, the chord-type stepper appears in degree mode
+      // too — letting the user pick a quality (e.g. Dom7) without leaving degree.
+      renderWithAtoms(<ChordOverlayControls />, [
+        ...MANUAL_MODE_SEEDS,
+        [chordDegreeAtom, "V"],
+      ]);
+
+      expect(screen.getByRole("group", { name: "Browse chord types" })).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole("button", { name: "Degree" }));
+
+      // Both the degree picker AND the chord-type stepper are visible in degree mode.
+      expect(screen.getByRole("group", { name: "Chord degree" })).toBeInTheDocument();
+      expect(screen.getByRole("group", { name: "Browse chord types" })).toBeInTheDocument();
     });
   });
 

--- a/src/components/ChordOverlayControls/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls/ChordOverlayControls.tsx
@@ -150,16 +150,40 @@ export function ChordOverlayControls({ compact }: ChordOverlayControlsProps) {
       </div>
 
       {chordOverlayMode === "degree" && (
-        <div className={shared["control-section"]}>
-          <span className={shared["section-label"]}>Degree</span>
-          <ToggleBar
-            options={degreeSelectOptions}
-            value={chordDegree ?? CHORD_NONE_VALUE}
-            onChange={handleDegreeChange}
-            label="Chord degree"
-            compact={compact}
-          />
-        </div>
+        <>
+          <div className={shared["control-section"]}>
+            <span className={shared["section-label"]}>Degree</span>
+            <ToggleBar
+              options={degreeSelectOptions}
+              value={chordDegree ?? CHORD_NONE_VALUE}
+              onChange={handleDegreeChange}
+              label="Chord degree"
+              compact={compact}
+            />
+          </div>
+          {chordDegree ? (
+            <div className={shared["control-section"]}>
+              <span className={shared["section-label"]}>Chord Type</span>
+              <StepperSelect
+                selectLabel="Chord Type"
+                groupLabel="Browse chord types"
+                previousLabel="Previous chord type"
+                nextLabel="Next chord type"
+                value={chordQualityOverride ?? CHORD_NONE_VALUE}
+                options={CHORD_SELECT_OPTIONS}
+                onChange={handleChordTypeChange}
+                onPrevious={() => handleStepChordType(-1)}
+                onNext={() => handleStepChordType(1)}
+                compact={compact}
+              />
+              <p className={shared["field-hint"]}>
+                Off uses the diatonic default for this degree. Picking a quality
+                pins it for the active degree only — switching degrees resets to
+                the new degree's diatonic default.
+              </p>
+            </div>
+          ) : null}
+        </>
       )}
 
       {chordOverlayMode === "manual" && (

--- a/src/components/ChordOverlayControls/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls/ChordOverlayControls.tsx
@@ -1,6 +1,6 @@
 import { startTransition, useEffect } from "react";
 import { useAtomValue } from "jotai";
-import { NOTES, LENS_REGISTRY } from "../../core/theory";
+import { NOTES, LENS_REGISTRY, CHORD_DEFINITIONS } from "../../core/theory";
 import { getDegreesForScale } from "../../core/degrees";
 import { lensAvailabilityAtom } from "../../store/atoms";
 import { NoteGrid } from "../NoteGrid/NoteGrid";
@@ -14,17 +14,11 @@ import { useScaleState } from "../../hooks/useScaleState";
 import styles from "../TheoryControls/TheoryControls.module.css";
 import shared from "../shared/shared.module.css";
 
-const CHORD_OPTIONS: string[] = [
-  "Major Triad",
-  "Minor Triad",
-  "Diminished Triad",
-  "Major 6th",
-  "Major 7th",
-  "Minor 7th",
-  "Dominant 7th",
-  "Sus4",
-  "Power Chord (5)",
-];
+// Derive the dropdown options from the canonical chord-definition catalogue so
+// the UI never drifts when new types are added. Object.keys preserves insertion
+// order on string keys (ES2015+), and CHORD_DEFINITIONS in src/core/theory.ts
+// is declared in family order (triads → 6 → 7ths → sus → power).
+const CHORD_OPTIONS: string[] = Object.keys(CHORD_DEFINITIONS);
 
 const CHORD_NONE_VALUE = "__none__";
 

--- a/src/core/degrees.test.ts
+++ b/src/core/degrees.test.ts
@@ -5,6 +5,7 @@ import {
   getAdjacentDegree,
   getDegreesForScale,
   getQualityForDegree,
+  remapDegreeForScale,
 } from '../core/degrees';
 
 const BASE_DEGREE_COLOR_KEYS = ["I", "II", "III", "IV", "V", "VI", "VII"] as const;
@@ -425,5 +426,49 @@ describe('getAdjacentDegree', () => {
     it('"IX" (nonexistent) + direction(+1) on Major → returns "I" (first degree)', () => {
       expect(getAdjacentDegree('IX', 'Major', 1)).toBe('I');
     });
+  });
+});
+
+describe('remapDegreeForScale', () => {
+  it('same scale → returns input unchanged', () => {
+    expect(remapDegreeForScale('I', 'Major', 'Major')).toBe('I');
+    expect(remapDegreeForScale('vii°', 'Major', 'Major')).toBe('vii°');
+  });
+
+  it('Major → Dorian: I (semitone 0, Major Triad) → i (semitone 0, Minor Triad)', () => {
+    expect(remapDegreeForScale('I', 'Major', 'Dorian')).toBe('i');
+  });
+
+  it('Major → Mixolydian: V (semitone 7, Major Triad) → v (semitone 7, Minor Triad)', () => {
+    expect(remapDegreeForScale('V', 'Major', 'Mixolydian')).toBe('v');
+  });
+
+  it('Major → Lydian: V (semitone 7) → V (semitone 7) — both Major Triad', () => {
+    expect(remapDegreeForScale('V', 'Major', 'Lydian')).toBe('V');
+  });
+
+  it('Dorian → Major: i (semitone 0) → I (semitone 0)', () => {
+    expect(remapDegreeForScale('i', 'Dorian', 'Major')).toBe('I');
+  });
+
+  it('Major → Phrygian: ii (semitone 2) → null (Phrygian has no degree at semitone 2; II at semitone 1 instead)', () => {
+    // Major's ii is at semitone 2; Phrygian's degrees are at 0,1,3,5,7,8,10. No degree at semitone 2.
+    expect(remapDegreeForScale('ii', 'Major', 'Phrygian')).toBeNull();
+  });
+
+  it('unknown degree → null', () => {
+    expect(remapDegreeForScale('IX', 'Major', 'Dorian')).toBeNull();
+  });
+
+  it('Major → Natural Minor: vi (semitone 9) → null (Natural Minor has no degree at semitone 9)', () => {
+    // Major's vi sits on the 9th semitone above the tonic. Natural Minor's
+    // sixth-degree triad is rooted on semitone 8 instead, so semitone 9 has
+    // no diatonic degree to remap into.
+    expect(remapDegreeForScale('vi', 'Major', 'Natural Minor')).toBeNull();
+  });
+
+  it('Major → Harmonic Minor: V (semitone 7) → V (semitone 7) — both Major Triad', () => {
+    // Harmonic Minor's V is intentionally raised — semitone 7 stays Major.
+    expect(remapDegreeForScale('V', 'Major', 'Harmonic Minor')).toBe('V');
   });
 });

--- a/src/core/degrees.ts
+++ b/src/core/degrees.ts
@@ -112,6 +112,38 @@ const DEGREE_DIATONIC_QUALITY: Record<string, Record<number, string>> = {
 };
 
 /**
+ * Remaps a Roman-numeral degree across scales by semitone-equivalence.
+ *
+ * Example: "I" in Major (semitone 0 = Major Triad) maps to "i" in Dorian
+ * (semitone 0 = Minor Triad). The same scale-step position can have a
+ * different case + suffix in a different mode because the diatonic triad
+ * quality differs.
+ *
+ * @param degreeId   Current Roman-numeral degree in `fromScale`.
+ * @param fromScale  The scale the degree currently belongs to.
+ * @param toScale    The new scale to remap into.
+ * @returns The equivalent degree in `toScale`, or `null` if the source
+ *          semitone has no diatonic degree in the target scale (e.g. a
+ *          chromatic-step degree that doesn't survive the mode change).
+ *          Returns the input unchanged when `fromScale === toScale`.
+ */
+export function remapDegreeForScale(
+  degreeId: string,
+  fromScale: string,
+  toScale: string,
+): string | null {
+  if (fromScale === toScale) return degreeId;
+  const fromMap = getDegreesForScale(fromScale);
+  const semitoneEntry = Object.entries(fromMap).find(
+    ([, roman]) => roman === degreeId,
+  );
+  if (!semitoneEntry) return null;
+  const semitone = Number(semitoneEntry[0]);
+  const toMap = getDegreesForScale(toScale);
+  return toMap[semitone] ?? null;
+}
+
+/**
  * Returns the diatonic triad quality (chord-name key) for a given scale degree.
  *
  * @param degreeId - Roman numeral string (e.g., "I", "ii", "vii°", "III+")

--- a/src/hooks/useChordState.ts
+++ b/src/hooks/useChordState.ts
@@ -1,4 +1,4 @@
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import {
   chordRootAtom,
   chordTypeAtom,
@@ -13,6 +13,7 @@ import {
   chordOverlayModeAtom,
   chordRootOverrideAtom,
   chordQualityOverrideAtom,
+  setChordDegreeAtom,
 } from "../store/atoms";
 
 export function useChordState() {
@@ -27,7 +28,10 @@ export function useChordState() {
   const hasOutsideChordMembers = useAtomValue(hasOutsideChordMembersAtom);
   const chordLabel = useAtomValue(chordLabelAtom);
 
-  const [chordDegree, setChordDegree] = useAtom(chordDegreeAtom);
+  const chordDegree = useAtomValue(chordDegreeAtom);
+  // Use the action wrapper so that picking a new degree clears any chord-quality
+  // override — each degree starts at its diatonic default.
+  const setChordDegree = useSetAtom(setChordDegreeAtom);
   const [chordOverlayMode, setChordOverlayMode] = useAtom(chordOverlayModeAtom);
   const [chordRootOverride, setChordRootOverride] = useAtom(chordRootOverrideAtom);
   const [chordQualityOverride, setChordQualityOverride] = useAtom(chordQualityOverrideAtom);

--- a/src/hooks/useScaleState.ts
+++ b/src/hooks/useScaleState.ts
@@ -8,6 +8,7 @@ import {
   activeBrowseOptionAtom,
   scaleLabelAtom,
   setRootNoteAtom,
+  setScaleNameAtom,
   useFlatsAtom,
   hiddenNotesAtom,
   toggleHiddenNoteAtom,
@@ -18,7 +19,11 @@ import {
 
 export function useScaleState() {
   const rootNote = useAtomValue(rootNoteAtom);
-  const [scaleName, setScaleName] = useAtom(scaleNameAtom);
+  const scaleName = useAtomValue(scaleNameAtom);
+  // Use the action wrapper so that switching modes (e.g. Ionian → Dorian)
+  // remaps the active chord degree by semitone-equivalence instead of leaving
+  // the user with an invalid Roman numeral that doesn't exist in the new mode.
+  const setScaleName = useSetAtom(setScaleNameAtom);
   const [scaleBrowseMode, setScaleBrowseMode] = useAtom(scaleBrowseModeAtom);
   const setRootNote = useSetAtom(setRootNoteAtom);
 

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,14 +1,17 @@
 import { atom } from "jotai";
 import { RESET } from "jotai/utils";
 import { STORAGE_PREFIX } from "../utils/storage";
+import { remapDegreeForScale, type DegreeId } from "../core/degrees";
 import {
   rootNoteAtom,
   baseScaleNameAtom,
+  scaleNameAtom,
   scaleBrowseModeAtom,
   scaleVisibleAtom,
   accidentalModeAtom,
 } from "./scaleAtoms";
 import {
+  chordDegreeAtom,
   chordOverlayModeAtom,
   chordRootAtom,
   chordTypeAtom,
@@ -47,6 +50,30 @@ export const setRootNoteAtom = atom(null, (get, set, note: string) => {
   // chord-follows-the-scale contract. Sync only matters in manual mode.
   if (get(chordOverlayModeAtom) === "degree") return;
   if (get(linkChordRootAtom)) set(chordRootAtom, note);
+});
+
+/**
+ * Action wrapper around `scaleNameAtom` that remaps the active chord degree
+ * across mode changes by semitone-equivalence. Example: switching from
+ * A Ionian (Major) to A Dorian with degree="I" remaps to "i" (semitone 0
+ * in Dorian, lowercase because Dorian's tonic triad is minor).
+ *
+ * Direct writes to `scaleNameAtom` bypass this remap — useful in tests that
+ * want to assert atom-layer behavior without cross-domain coupling. UI paths
+ * (TheoryControls / ScaleSelector / Circle of Fifths) flow through this
+ * action via `useScaleState`.
+ */
+export const setScaleNameAtom = atom(null, (get, set, value: string) => {
+  const prevScale = get(scaleNameAtom);
+  set(scaleNameAtom, value);
+  const newScale = get(scaleNameAtom); // normalized via scaleNameAtom write
+  if (newScale === prevScale) return;
+  const oldDegree = get(chordDegreeAtom);
+  if (!oldDegree) return;
+  const remapped = remapDegreeForScale(oldDegree, prevScale, newScale);
+  if (remapped !== oldDegree) {
+    set(chordDegreeAtom, remapped as DegreeId | null);
+  }
 });
 
 export const resetAtom = atom(null, (_get, set) => {

--- a/src/store/atoms.test.ts
+++ b/src/store/atoms.test.ts
@@ -25,7 +25,9 @@ import {
   practiceLensAtom,
   chordDegreeAtom,
   chordOverlayModeAtom,
+  chordQualityOverrideAtom,
   setRootNoteAtom,
+  setScaleNameAtom,
   resetAtom,
   useFlatsAtom,
   currentTuningAtom,
@@ -546,6 +548,94 @@ describe("atoms", () => {
       expect(store.get(chordOverlayModeAtom)).toBe("degree");
       expect(store.get(chordRootAtom)).toBe("G");
       expect(store.get(chordTypeAtom)).toBe("Major Triad");
+    });
+  });
+
+  describe("setScaleNameAtom — degree remap on mode change", () => {
+    it("Major → Dorian: degree 'I' remaps to 'i' by semitone-equivalence", () => {
+      const store = makeStore();
+      store.set(chordOverlayModeAtom, "degree");
+      store.set(chordDegreeAtom, "I");
+      store.set(rootNoteAtom, "A");
+      store.set(scaleNameAtom, "Major");
+      expect(store.get(chordRootAtom)).toBe("A"); // I in A Major
+      expect(store.get(chordTypeAtom)).toBe("Major Triad");
+
+      // User switches A Ionian (Major) → A Dorian.
+      store.set(setScaleNameAtom, "Dorian");
+
+      expect(store.get(chordOverlayModeAtom)).toBe("degree"); // mode preserved
+      expect(store.get(chordDegreeAtom)).toBe("i"); // remapped
+      expect(store.get(chordRootAtom)).toBe("A"); // tonic, semitone 0
+      expect(store.get(chordTypeAtom)).toBe("Minor Triad"); // Dorian's i
+    });
+
+    it("Major → Mixolydian: V remaps to v (Mixolydian's 5th-degree is minor)", () => {
+      const store = makeStore();
+      store.set(chordOverlayModeAtom, "degree");
+      store.set(chordDegreeAtom, "V");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(setScaleNameAtom, "Mixolydian");
+      expect(store.get(chordDegreeAtom)).toBe("v");
+      expect(store.get(chordRootAtom)).toBe("G");
+      expect(store.get(chordTypeAtom)).toBe("Minor Triad");
+    });
+
+    it("Major → Lydian: V stays V (both modes have Major Triad on semitone 7)", () => {
+      const store = makeStore();
+      store.set(chordOverlayModeAtom, "degree");
+      store.set(chordDegreeAtom, "V");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(setScaleNameAtom, "Lydian");
+      expect(store.get(chordDegreeAtom)).toBe("V");
+    });
+
+    it("same scale write is a no-op — chord degree unchanged", () => {
+      const store = makeStore();
+      store.set(chordOverlayModeAtom, "degree");
+      store.set(chordDegreeAtom, "vi");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(setScaleNameAtom, "Major");
+      expect(store.get(chordDegreeAtom)).toBe("vi");
+    });
+
+    it("no chord degree set → no-op (overlay-off path)", () => {
+      const store = makeStore();
+      store.set(chordOverlayModeAtom, "degree");
+      store.set(chordDegreeAtom, null);
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(setScaleNameAtom, "Dorian");
+      expect(store.get(chordDegreeAtom)).toBeNull();
+      expect(store.get(scaleNameAtom)).toBe("Dorian");
+    });
+
+    it("Major → Phrygian: ii has no semitone-equivalent → degree clears (chord overlay off)", () => {
+      const store = makeStore();
+      store.set(chordOverlayModeAtom, "degree");
+      store.set(chordDegreeAtom, "ii");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(setScaleNameAtom, "Phrygian");
+      // Phrygian has degrees at semitones 0,1,3,5,7,8,10 — none at semitone 2.
+      expect(store.get(chordDegreeAtom)).toBeNull();
+    });
+
+    it("preserves chord-quality override across mode changes (sticky on scale change)", () => {
+      const store = makeStore();
+      store.set(chordOverlayModeAtom, "degree");
+      store.set(chordDegreeAtom, "V");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(chordQualityOverrideAtom, "Dominant 7th");
+      store.set(setScaleNameAtom, "Lydian");
+      // Override stays sticky across scale change (it's a quality preference,
+      // not tied to a specific degree resolution).
+      expect(store.get(chordQualityOverrideAtom)).toBe("Dominant 7th");
+      expect(store.get(chordTypeAtom)).toBe("Dominant 7th");
     });
   });
 

--- a/src/store/atoms.test.ts
+++ b/src/store/atoms.test.ts
@@ -485,6 +485,70 @@ describe("atoms", () => {
     });
   });
 
+  describe("scaleNameAtom — degree mode preservation", () => {
+    it("preserves degree mode when scale mode changes (ii: Major → Dorian)", () => {
+      // "ii" exists in both C Major and C Dorian at semitone 2 (same label → same DegreeId).
+      // C Major ii = D Minor Triad. C Dorian ii = D Minor Triad.
+      // Changing scaleNameAtom must NOT write through chordRootAtom or chordTypeAtom,
+      // so chordOverlayModeAtom must stay "degree" and the chord re-resolves via
+      // getDiatonicChord against the new scaleName automatically.
+      const store = makeStore();
+      store.set(chordOverlayModeAtom, "degree");
+      store.set(chordDegreeAtom, "ii");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      expect(store.get(chordOverlayModeAtom)).toBe("degree");
+      expect(store.get(chordRootAtom)).toBe("D");
+      expect(store.get(chordTypeAtom)).toBe("Minor Triad");
+      // Switch scale mode — degree atom is unchanged, chord re-resolves via reactive graph.
+      store.set(scaleNameAtom, "Dorian");
+      expect(store.get(chordOverlayModeAtom)).toBe("degree");
+      expect(store.get(chordRootAtom)).toBe("D");
+      expect(store.get(chordTypeAtom)).toBe("Minor Triad");
+    });
+
+    it("preserves degree mode when scale mode changes (ii: Major → Mixolydian re-resolves to Diminished)", () => {
+      // "ii" in Major at semitone 2 = Minor Triad.
+      // In Mixolydian "ii" is also at semitone 2 → but DEGREE_DIATONIC_QUALITY for Mixolydian
+      // at semitone 2 is still "Minor Triad". Use "iii°" path instead:
+      // Mixolydian has "iii°" at semitone 4. Major has "iii" at semitone 4.
+      // To find a quality difference: use "V" (Major) vs "v" (Mixolydian) — different DegreeIds.
+      // Safest cross-family test: remain within Diatonic family, check mode does NOT flip.
+      // C Major "ii" (D Minor Triad) → C Mixolydian "ii" (D Minor Triad): mode preserved.
+      // The important invariant is chordOverlayModeAtom stays "degree" — the re-resolution
+      // is a pure Jotai reactive side-effect, no chord atom writes occur.
+      const store = makeStore();
+      store.set(chordOverlayModeAtom, "degree");
+      store.set(chordDegreeAtom, "ii");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      store.set(scaleNameAtom, "Mixolydian");
+      // chordOverlayModeAtom must not have been mutated by the scale-mode write.
+      expect(store.get(chordOverlayModeAtom)).toBe("degree");
+      expect(store.get(chordRootAtom)).toBe("D");
+      expect(store.get(chordTypeAtom)).toBe("Minor Triad");
+    });
+
+    it("re-resolves chord root and type when both root and scale mode change (relative browse)", () => {
+      // Simulates applyTheorySelection: setRootNote + setScaleName written together.
+      // "I" exists in Major and Mixolydian (both uppercase tonic). C Major I → C Major Triad.
+      // After browse to G Mixolydian: "I" → G Major Triad.
+      const store = makeStore();
+      store.set(chordOverlayModeAtom, "degree");
+      store.set(chordDegreeAtom, "I");
+      store.set(rootNoteAtom, "C");
+      store.set(scaleNameAtom, "Major");
+      expect(store.get(chordRootAtom)).toBe("C");
+      expect(store.get(chordTypeAtom)).toBe("Major Triad");
+      // Simulate relative/parallel browse: both root and mode written (no chord atom written).
+      store.set(rootNoteAtom, "G");
+      store.set(scaleNameAtom, "Mixolydian");
+      expect(store.get(chordOverlayModeAtom)).toBe("degree");
+      expect(store.get(chordRootAtom)).toBe("G");
+      expect(store.get(chordTypeAtom)).toBe("Major Triad");
+    });
+  });
+
   describe("resetAtom", () => {
     it("clears only fretflow-prefixed keys from localStorage", () => {
       localStorage.setItem(k("rootNote"), "G");

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -56,6 +56,7 @@ export {
   toggleChordHiddenNoteAtom,
   toggleChordOverlayHiddenAtom,
   activeVoicingKeyAtom,
+  setChordDegreeAtom,
 } from "./chordOverlayAtoms";
 
 export {

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -106,5 +106,6 @@ export {
 
 export {
   setRootNoteAtom,
+  setScaleNameAtom,
   resetAtom,
 } from "./actions";

--- a/src/store/chordOverlayAtoms.test.ts
+++ b/src/store/chordOverlayAtoms.test.ts
@@ -11,6 +11,7 @@ import {
   chordTypeAtom,
   chordQualityOverrideAtom,
   allChordMembersAtom,
+  setChordDegreeAtom,
 } from "./chordOverlayAtoms";
 import { rootNoteAtom, scaleNameAtom } from "./scaleAtoms";
 import { makeAtomStore } from "../test-utils/renderWithAtoms";
@@ -108,6 +109,137 @@ describe("chordOverlayAtoms — manual mode (write path)", () => {
     // Direct atom injection via renderWithAtoms sets manual mode. This is correct: tests that
     // seed a specific chord type care about chord rendering, not degree alignment.
     expect(store.get(chordOverlayModeAtom)).toBe("manual");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group B.5 — degree mode quality override (preserves degree on quality change)
+// ---------------------------------------------------------------------------
+
+describe("chordOverlayAtoms — degree mode quality override", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("read path: degree mode + override returns the override quality (V Dom7 in C Major)", () => {
+    const store = makeAtomStore([
+      [chordDegreeAtom, "V"],
+      [chordOverlayModeAtom, "degree"],
+      [rootNoteAtom, "C"],
+      [scaleNameAtom, "Major"],
+      [chordQualityOverrideAtom, "Dominant 7th"],
+    ]);
+    expect(store.get(chordRootAtom)).toBe("G"); // V root from degree
+    expect(store.get(chordTypeAtom)).toBe("Dominant 7th"); // user override
+    expect(store.get(chordOverlayModeAtom)).toBe("degree"); // mode preserved
+  });
+
+  it("read path: degree mode without override returns diatonic default (V Major Triad in C Major)", () => {
+    const store = makeAtomStore([
+      [chordDegreeAtom, "V"],
+      [chordOverlayModeAtom, "degree"],
+      [rootNoteAtom, "C"],
+      [scaleNameAtom, "Major"],
+      // chordQualityOverrideAtom intentionally not seeded → null
+    ]);
+    expect(store.get(chordRootAtom)).toBe("G");
+    expect(store.get(chordTypeAtom)).toBe("Major Triad"); // diatonic default
+  });
+
+  it("write path: writing chordTypeAtom in degree mode with active degree keeps mode = degree", () => {
+    const store = makeAtomStore([
+      [chordDegreeAtom, "V"],
+      [chordOverlayModeAtom, "degree"],
+      [rootNoteAtom, "C"],
+      [scaleNameAtom, "Major"],
+    ]);
+    store.set(chordTypeAtom, "Dominant 7th");
+    expect(store.get(chordOverlayModeAtom)).toBe("degree"); // NOT flipped to manual
+    expect(store.get(chordQualityOverrideAtom)).toBe("Dominant 7th");
+    expect(store.get(chordTypeAtom)).toBe("Dominant 7th");
+    expect(store.get(chordRootAtom)).toBe("G"); // V root still derived from degree
+  });
+
+  it("write path: writing chordTypeAtom in degree mode WITHOUT active degree falls through to manual", () => {
+    // Without a degree set, there's nothing to "preserve" — degree mode with a
+    // null degree means overlay-off, so writing a chord type explicitly should
+    // engage manual mode (current contract).
+    const store = makeAtomStore([
+      [chordDegreeAtom, null],
+      [chordOverlayModeAtom, "degree"],
+    ]);
+    store.set(chordTypeAtom, "Dominant 7th");
+    expect(store.get(chordOverlayModeAtom)).toBe("manual");
+  });
+
+  it("write path: manual mode unchanged — writing chordTypeAtom keeps mode = manual", () => {
+    const store = makeAtomStore([
+      [chordOverlayModeAtom, "manual"],
+      [chordRootOverrideAtom, "C"],
+    ]);
+    store.set(chordTypeAtom, "Dominant 7th");
+    expect(store.get(chordOverlayModeAtom)).toBe("manual");
+    expect(store.get(chordTypeAtom)).toBe("Dominant 7th");
+  });
+
+  it("setChordDegreeAtom: changing degree clears the quality override", () => {
+    const store = makeAtomStore([
+      [chordDegreeAtom, "V"],
+      [chordOverlayModeAtom, "degree"],
+      [rootNoteAtom, "C"],
+      [scaleNameAtom, "Major"],
+      [chordQualityOverrideAtom, "Dominant 7th"],
+    ]);
+    expect(store.get(chordTypeAtom)).toBe("Dominant 7th");
+    store.set(setChordDegreeAtom, "ii");
+    expect(store.get(chordDegreeAtom)).toBe("ii");
+    expect(store.get(chordQualityOverrideAtom)).toBeNull();
+    expect(store.get(chordTypeAtom)).toBe("Minor Triad"); // ii diatonic default
+    expect(store.get(chordRootAtom)).toBe("D");
+  });
+
+  it("setChordDegreeAtom: re-selecting the same degree does NOT clear the override", () => {
+    const store = makeAtomStore([
+      [chordDegreeAtom, "V"],
+      [chordOverlayModeAtom, "degree"],
+      [rootNoteAtom, "C"],
+      [scaleNameAtom, "Major"],
+      [chordQualityOverrideAtom, "Dominant 7th"],
+    ]);
+    store.set(setChordDegreeAtom, "V"); // no-op
+    expect(store.get(chordQualityOverrideAtom)).toBe("Dominant 7th");
+    expect(store.get(chordTypeAtom)).toBe("Dominant 7th");
+  });
+
+  it("setChordDegreeAtom: turning overlay off (degree=null) clears override", () => {
+    const store = makeAtomStore([
+      [chordDegreeAtom, "V"],
+      [chordOverlayModeAtom, "degree"],
+      [chordQualityOverrideAtom, "Dominant 7th"],
+    ]);
+    store.set(setChordDegreeAtom, null);
+    expect(store.get(chordDegreeAtom)).toBeNull();
+    expect(store.get(chordQualityOverrideAtom)).toBeNull();
+  });
+
+  it("scale change in degree mode preserves both degree and override (sticky on scale change)", () => {
+    // Use Major → Lydian — both define "V" at semitone 7 (Major Triad), so the
+    // degree resolves consistently across the scale change. Dorian etc. would
+    // remap V → v (minor) which is a different code path (cross-scale degree
+    // remapping is outside this fix's scope).
+    const store = makeAtomStore([
+      [chordDegreeAtom, "V"],
+      [chordOverlayModeAtom, "degree"],
+      [rootNoteAtom, "C"],
+      [scaleNameAtom, "Major"],
+      [chordQualityOverrideAtom, "Dominant 7th"],
+    ]);
+    store.set(scaleNameAtom, "Lydian");
+    expect(store.get(chordOverlayModeAtom)).toBe("degree");
+    expect(store.get(chordQualityOverrideAtom)).toBe("Dominant 7th");
+    expect(store.get(chordTypeAtom)).toBe("Dominant 7th");
+    // V in C Lydian → G (degree-derived root re-resolves).
+    expect(store.get(chordRootAtom)).toBe("G");
   });
 });
 

--- a/src/store/chordOverlayAtoms.ts
+++ b/src/store/chordOverlayAtoms.ts
@@ -232,12 +232,18 @@ export const chordTypeAtom = atom(
     if (mode === "manual") return get(chordQualityOverrideAtom);
     const degree = get(chordDegreeAtom);
     if (!degree) return null; // overlay off
+    // Degree mode: prefer the user's quality override when set so the user can
+    // pin a specific quality (e.g. Dominant 7th on V) while keeping the chord
+    // root bound to the active scale degree. Without an override, fall back to
+    // the diatonic default for this degree + scale.
+    const override = get(chordQualityOverrideAtom);
+    if (override) return override;
     const rootNote = get(rootNoteAtom);
     const scaleName = get(scaleNameAtom);
     const result = getDiatonicChord(degree, scaleName, rootNote);
     return result?.quality ?? null;
   },
-  (_get, set, value: string | null | typeof RESET) => {
+  (get, set, value: string | null | typeof RESET) => {
     if (value === RESET) {
       set(chordDegreeAtom, RESET);
       set(chordOverlayModeAtom, RESET);
@@ -246,7 +252,29 @@ export const chordTypeAtom = atom(
       return;
     }
     set(chordQualityOverrideAtom, value);
+    // In degree mode with a degree active, preserve the degree binding —
+    // the override applies on top of the derived chord root. Manual mode
+    // behavior is unchanged: a chord-type write flips the overlay to manual.
+    if (get(chordOverlayModeAtom) === "degree" && get(chordDegreeAtom)) {
+      return;
+    }
     set(chordOverlayModeAtom, "manual");
+  },
+);
+
+/**
+ * Action atom for changing the active scale degree in degree mode. Clears any
+ * `chordQualityOverride` so each new degree starts at its diatonic default
+ * (e.g. picking V resolves to Major Triad even if the previous degree had a
+ * Dominant 7th override). No-op writes (same degree) do NOT clear the override.
+ */
+export const setChordDegreeAtom = atom(
+  null,
+  (get, set, value: DegreeId | null) => {
+    const current = get(chordDegreeAtom);
+    if (current === value) return;
+    set(chordDegreeAtom, value);
+    set(chordQualityOverrideAtom, null);
   },
 );
 

--- a/src/store/practiceLens.test.ts
+++ b/src/store/practiceLens.test.ts
@@ -831,7 +831,13 @@ describe("noteSemanticMapAtom — Phase 04 scaleDegree and isDiatonicChord", () 
     }
   });
 
-  it("isDiatonicChord is false when a manual chord override pulls the overlay out of degree mode", () => {
+  it("isDiatonicChord is false when a non-diatonic quality override is set in degree mode", () => {
+    // After the "preserve degree-mode on chord-quality change" fix, writing a
+    // chord type while in degree mode no longer flips to manual — instead the
+    // override is applied on top of the degree binding. The diatonic-chord
+    // check correctly identifies the override chord (C Minor Triad on degree I
+    // in C Major) as non-diatonic since it doesn't match the degree's diatonic
+    // default (C Major Triad).
     const store = makeStore();
     store.set(rootNoteAtom, "C");
     store.set(scaleNameAtom, "Major");
@@ -839,13 +845,17 @@ describe("noteSemanticMapAtom — Phase 04 scaleDegree and isDiatonicChord", () 
     store.set(chordOverlayModeAtom, "degree");
     store.set(chordTypeAtom, "Minor Triad");
 
-    expect(store.get(chordOverlayModeAtom)).toBe("manual");
+    // Mode stays "degree" — the quality override does NOT flip the overlay.
+    expect(store.get(chordOverlayModeAtom)).toBe("degree");
+    expect(store.get(chordTypeAtom)).toBe("Minor Triad");
 
     const semanticMap = store.get(noteSemanticMapAtom);
     expect(semanticMap.size).toBeGreaterThan(0);
 
     const gSem = semanticMap.get("G");
     expect(gSem?.isChordTone).toBe(true);
+    // The chord (C Minor Triad: C, Eb, G) is not the diatonic chord for I in
+    // C Major (which is C Major Triad: C, E, G). isDiatonicChord stays false.
     expect(gSem?.isDiatonicChord).toBeFalsy();
   });
 });

--- a/src/store/practiceLens.test.ts
+++ b/src/store/practiceLens.test.ts
@@ -283,27 +283,6 @@ describe("practiceCuesAtom", () => {
   });
 });
 
-describe("practiceBarChordGroupAtom", () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
-  it("falls back to chord-member labels only for outside-scale tones", () => {
-    const store = makeStore();
-    store.set(rootNoteAtom, "C");
-    store.set(scaleNameAtom, "Major");
-    store.set(chordRootAtom, "C#");
-    store.set(chordTypeAtom, "Minor Triad");
-
-    const chordGroup = store.get(practiceBarChordGroupAtom);
-    expect(chordGroup.notes.map((n) => [n.internalNote, n.intervalName])).toEqual([
-      ["C#", "1"],
-      ["E", "iii"],
-      ["G#", "5"],
-    ]);
-  });
-});
-
 describe("noteSemanticMapAtom", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -421,6 +400,21 @@ describe("showChordPracticeBarAtom", () => {
 describe("practiceBarChordGroupAtom", () => {
   beforeEach(() => {
     localStorage.clear();
+  });
+
+  it("falls back to chord-member labels only for outside-scale tones", () => {
+    const store = makeStore();
+    store.set(rootNoteAtom, "C");
+    store.set(scaleNameAtom, "Major");
+    store.set(chordRootAtom, "C#");
+    store.set(chordTypeAtom, "Minor Triad");
+
+    const chordGroup = store.get(practiceBarChordGroupAtom);
+    expect(chordGroup.notes.map((n) => [n.internalNote, n.intervalName])).toEqual([
+      ["C#", "1"],
+      ["E", "iii"],
+      ["G#", "5"],
+    ]);
   });
 
   it("is lens-independent — same chord regardless of active lens", () => {


### PR DESCRIPTION
## Summary

- Picking a chord quality in degree mode (e.g. V → Dominant 7th) no longer collapses the overlay to manual. The user-chosen quality is treated as a per-degree override; the chord root stays bound to the active scale degree.
- Switching scale modes (e.g. A Ionian → A Dorian) with an active chord degree now remaps the Roman numeral by semitone-equivalence: `I → i`, `V → v`, etc. When the source semitone has no diatonic degree in the target scale (e.g. Major `ii` → Phrygian, where Phrygian's degrees sit on different semitones), the chord degree clears.
- Regression tests document the scale-mode-change → degree-mode preservation contract for the paths that were already symmetric in the gating layer.
- Addresses CodeRabbit review feedback (see CodeRabbit fixes section below).

## Why

These two behaviors (chord-quality changes, mode changes) were the last two scale-state transitions that could yank the user out of degree mode unexpectedly:

- Today (without this PR), the moment a degree-mode user picks a Dom7 they get bumped into manual and lose the chord-follows-the-key contract.
- Today, the moment they switch from Ionian to Dorian, their `I` Roman numeral becomes invalid because Dorian doesn't have an `I` — it has `i` at the same semitone.

Both are handled minimally: the overlay-mode flip is gated by an existing-degree check, and the scale-mode change is wrapped by a small action atom (`setScaleNameAtom`) that does the semitone remap.

## Commits (post-rebase)

This branch was rebased onto `main`. **Four of the original seven commits dropped** as already-upstream — they landed via #333:

- `fix(chord-overlay): preserve degree mode when scale root changes` → in main
- `feat(chord-overlay): add Major 6th and Sus4 chord types` → in main
- `test(chord-overlay): assert symmetric chord-spread contract` → in main
- `fix: use scale degrees in chord practice bar` → in main

What remains on this branch:

- `482e007` — `test(store): add regression tests for degree-mode preservation on scale-mode change`
- `1bdca94` — `feat(chord-overlay): preserve degree mode on chord-quality change`
- `5f4efa3` — `feat(chord-overlay): remap chord degree by semitone-equivalence on mode change`
- `623d807` — `chore(review): address CodeRabbit review feedback`

## CodeRabbit fixes

Folded into `623d807`:

1. `src/store/practiceLens.test.ts` — deduplicated the `describe(\"practiceBarChordGroupAtom\")` wrapper. The orphan single-test block was merged into the larger lens-related block.
2. `src/App.test.tsx` (\"preserves degree mode...\" test) — added an assertion that `chordRootOverride` does not equal the new scale root after a Circle-of-Fifths click. Used `not.toBe(\"G\")` rather than `toBeNull()` because `chordRootOverrideAtom` seeds its default (\"C\") into localStorage on mount via `atomWithStorage`; the semantic check (\"must not equal the new rootNote\") still catches the regression we are guarding against.
3. `src/components/ChordOverlayControls/ChordOverlayControls.tsx` — replaced the hardcoded `CHORD_OPTIONS` array with `Object.keys(CHORD_DEFINITIONS)`. `CHORD_DEFINITIONS` in `src/core/theory.ts` is declared in family order (triads → 6 → 7ths → sus → power) and `Object.keys` preserves string-key insertion order, so the dropdown order is unchanged.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test` — 1241 / 1241 passing on the pre-push hook
- [x] `npm run build` — clean
- [ ] Manual: in degree mode, switch root via Circle of Fifths → overlay stays `degree`, chord root re-resolves to the new key's degree (already covered by #333 but still part of the integration story).
- [ ] Manual: in degree mode, switch Mode dropdown from Major → Dorian → Mixolydian → Lydian; chord degree symbol updates by semitone-equivalence (`I` ↔ `i`, `V` ↔ `v`, etc.).
- [ ] Manual: in degree mode, the chord-type stepper now appears below the degree picker; pick a quality (e.g. Dom7 on V) and confirm the overlay stays in `degree` mode. Switch to a different degree and confirm the override resets to that degree's diatonic default.
- [ ] Manual: manual mode behavior unchanged — writing a chord type still flips the overlay to `manual`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)