### PR TITLE
fix: raise fret zoom minimum to auto-fit threshold

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -58,6 +58,6 @@ export const ANIMATION_DURATION_STANDARD = 0.24;
 export const ANIMATION_EASE = "easeOut";
 
 // Settings / Atoms
-export const FRET_ZOOM_MIN = 50;
+export const FRET_ZOOM_MIN = 100;
 export const FRET_ZOOM_MAX = 200;
 export const FRET_ZOOM_DEFAULT = 100;

--- a/src/store/atoms.test.ts
+++ b/src/store/atoms.test.ts
@@ -210,7 +210,16 @@ describe("atoms", () => {
     });
 
     it("self-heals below-min values to default", () => {
-      localStorage.setItem(k("fretZoom"), "10"); // fretZoom min is 50
+      localStorage.setItem(k("fretZoom"), "10"); // fretZoom min is 100
+      const store = makeStore();
+      const unsub = mount(store, fretZoomAtom);
+      expect(store.get(fretZoomAtom)).toBe(100);
+      expect(localStorage.getItem(k("fretZoom"))).toBe("100");
+      unsub();
+    });
+
+    it("self-heals legacy sub-auto zoom values to default", () => {
+      localStorage.setItem(k("fretZoom"), "50");
       const store = makeStore();
       const unsub = mount(store, fretZoomAtom);
       expect(store.get(fretZoomAtom)).toBe(100);


### PR DESCRIPTION
## Summary
- Raise the fret zoom minimum from `50` to `100` so the stepper no longer exposes values that render identically to Auto.
- Self-heal legacy sub-auto zoom values back to the default on load.
- Add coverage for the new zoom floor and the legacy value migration.

## Testing
- `npm test -- src/store/atoms.test.ts src/components/StepperControl/StepperControl.test.tsx --run`
- `npm test -- src/components/SettingsOverlay/SettingsOverlay.test.tsx src/components/Fretboard/Fretboard.test.tsx --run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased minimum fretboard zoom level from 50 to 100 with validation to automatically correct invalid zoom values to the default setting.

* **Tests**
  * Added and updated test coverage to verify invalid fretboard zoom values are properly detected and corrected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->