### PR TITLE
fix: recompute chord connectors on resize

### DIFF
--- a/src/components/FretboardSVG/hooks/useChordConnectorPolylines.test.ts
+++ b/src/components/FretboardSVG/hooks/useChordConnectorPolylines.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
 import {
   buildChordConnectorPolylines,
   MAX_PLAYABLE_FRET_POSITIONS,
   CHORD_TONE_CLASSES,
   CHORD_CONNECTOR_BASE_RADIUS_FACTOR,
+  useChordConnectorPolylines,
 } from "./useChordConnectorPolylines";
 import type { NoteData } from "./useNoteData";
 
@@ -939,6 +941,58 @@ describe("per-voicing offset: determinism and paletteIndex independence", () => 
     const minEnvelope = STRING_ROW_PX * CHORD_CONNECTOR_BASE_RADIUS_FACTOR;
     const bubbleRadius = STRING_ROW_PX * 0.45;
     expect(minEnvelope).toBeGreaterThan(bubbleRadius);
+  });
+});
+
+describe("useChordConnectorPolylines", () => {
+  it("recomputes paths when resize changes fret/string geometry", () => {
+    const noteData = [
+      makeNote(0, 1, "C", "chord-root"),
+      makeNote(1, 2, "E", "chord-tone-in-scale"),
+      makeNote(2, 3, "G", "chord-tone-in-scale"),
+    ];
+    const chordToneNames = ["C", "E", "G"];
+    const wideFretCenterX = (fi: number) => fi * 20;
+    const compactFretCenterX = (fi: number) => fi * 10;
+    const tallStringYAt = (si: number) => si * 24;
+    const compactStringYAt = (si: number) => si * 18;
+
+    const { result, rerender } = renderHook(
+      ({
+        fretCenterX,
+        stringYAt,
+      }: {
+        fretCenterX: (fretIndex: number) => number;
+        stringYAt: (stringIndex: number, x: number) => number;
+      }) =>
+        useChordConnectorPolylines({
+          noteData,
+          chordToneNames,
+          fretCenterX,
+          stringYAt,
+          stringRowPx: STRING_ROW_PX,
+          chordRoot: "C",
+        }),
+      {
+        initialProps: {
+          fretCenterX: wideFretCenterX,
+          stringYAt: tallStringYAt,
+        },
+      },
+    );
+
+    const initialPath = result.current[0]!.paths.fill;
+    expect(result.current[0]!.vertices.map((v) => v.x)).toEqual([20, 40, 60]);
+    expect(result.current[0]!.vertices.map((v) => v.y)).toEqual([0, 24, 48]);
+
+    rerender({
+      fretCenterX: compactFretCenterX,
+      stringYAt: compactStringYAt,
+    });
+
+    expect(result.current[0]!.paths.fill).not.toBe(initialPath);
+    expect(result.current[0]!.vertices.map((v) => v.x)).toEqual([10, 20, 30]);
+    expect(result.current[0]!.vertices.map((v) => v.y)).toEqual([0, 18, 36]);
   });
 });
 

--- a/src/components/FretboardSVG/hooks/useChordConnectorPolylines.ts
+++ b/src/components/FretboardSVG/hooks/useChordConnectorPolylines.ts
@@ -570,7 +570,9 @@ export interface UseChordConnectorPolylinesParams {
  * - `paletteIndex` — 0–7, deterministic per shape identity; indexes into
  *   --chord-connector-color-N CSS tokens for per-voicing color differentiation.
  *
- * Re-runs only when noteData, chordToneNames, or geometry helpers change.
+ * Re-runs when noteData, chordToneNames, or geometry helpers change.
+ * The geometry helpers are included because resize/layout shifts can change
+ * fret and string coordinates without changing the musical note data.
  */
 export function useChordConnectorPolylines({
   noteData,
@@ -590,7 +592,6 @@ export function useChordConnectorPolylines({
         stringRowPx,
         chordRoot,
       ),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [noteData, chordToneNames, stringRowPx, chordRoot],
+    [noteData, chordToneNames, fretCenterX, stringYAt, stringRowPx, chordRoot],
   );
 }


### PR DESCRIPTION
## Summary
- Recompute chord connector paths when fret/string geometry callbacks change during resize or layout shifts.
- Add a regression test that rerenders the hook with new geometry and verifies the connector path updates.

## Testing
- `vitest` hook test added for geometry-driven rerenders.
- `npm run test -- src/components/FretboardSVG/hooks/useChordConnectorPolylines.test.ts`
- `npm run build:types`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for chord connector polyline recalculation behavior across different geometry configurations.

* **Bug Fixes**
  * Improved chord connector polyline memoization to ensure proper recomputation when underlying geometry functions change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->