### PR TITLE
refactor(motion): consolidate animation presets and fix hot-path remounts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { ScaleStripPanel } from "./components/ScaleStripPanel/ScaleStripPanel";
 import { ChordOverlayDock } from "./components/ChordOverlayDock/ChordOverlayDock";
 import { MainLayoutWrapper } from "./components/MainLayoutWrapper/MainLayoutWrapper";
 import sharedStyles from "./components/shared/shared.module.css";
+import { ANIMATION_DURATION_XFADE } from "./core/constants";
 import "./styles/App.css";
 
 const ExpandedControlsPanel = lazy(() =>
@@ -174,8 +175,8 @@ function AppContent() {
                     initial={{ opacity: 0, scale: 0.8, rotate: -10 }}
                     animate={{ opacity: 1, scale: 1, rotate: 0 }}
                     exit={{ opacity: 0, scale: 0.8, rotate: 10 }}
-                    transition={{ duration: 0.15 }}
-                    style={{ display: "flex", alignItems: "center", justifyContent: "center" }}
+                    transition={{ duration: ANIMATION_DURATION_XFADE }}
+                    className={sharedStyles["flex-center"]}
                   >
                     {isMuted ? (
                       <VolumeX className="icon icon-muted" />

--- a/src/components/ChordPracticeBar/ChordPracticeBar.module.css
+++ b/src/components/ChordPracticeBar/ChordPracticeBar.module.css
@@ -102,7 +102,8 @@
   column-gap: 1.25rem;
   row-gap: 0.3rem;
   flex-wrap: wrap;
-  padding-top: 0.15rem; /* Small buffer for focus rings/shadows */
+  /* Small buffer to keep focus rings/shadows visible despite container's overflow:hidden. */
+  padding-top: 0.15rem;
 }
 
 .practice-bar-group {

--- a/src/components/ChordPracticeBar/ChordPracticeBar.tsx
+++ b/src/components/ChordPracticeBar/ChordPracticeBar.tsx
@@ -8,6 +8,7 @@ import {
   toggleChordHiddenNoteAtom,
   toggleChordOverlayHiddenAtom,
 } from "../../store/atoms";
+import shared from "../shared/shared.module.css";
 import styles from "./ChordPracticeBar.module.css";
 
 function EyeOpenIcon() {
@@ -37,7 +38,6 @@ interface PillProps {
 
 function Pill({ note, noteHidden, onToggleNote }: PillProps) {
   const aria = [note.displayNote, note.intervalName].filter(Boolean).join(", ");
-
   return (
     <li className={styles["practice-bar-pill-item"]}>
       <button
@@ -80,7 +80,6 @@ interface GroupProps {
 
 function Group({ variant, group, hiddenNotes, onToggleNote }: GroupProps) {
   if (group.notes.length === 0) return null;
-
   return (
     <div
       className={styles["practice-bar-group"]}
@@ -166,17 +165,13 @@ export function ChordPracticeBar({
           aria-pressed={!collapsed}
           onClick={() => toggleCollapsed()}
         >
-          <span style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <span className={shared["flex-center"]}>
             {collapsed ? <EyeClosedIcon /> : <EyeOpenIcon />}
           </span>
         </button>
-        <span className={styles["chord-practice-bar-title"]}>
-          {title}
-        </span>
+        <span className={styles["chord-practice-bar-title"]}>{title}</span>
         {lensLabel && (
-          <span className={styles["chord-practice-bar-lens-label"]}>
-            {lensLabel}
-          </span>
+          <span className={styles["chord-practice-bar-lens-label"]}>{lensLabel}</span>
         )}
         {badge && <span className={styles["chord-practice-bar-badge"]}>{badge}</span>}
       </div>

--- a/src/components/CircleOfFifths/CircleOfFifths.tsx
+++ b/src/components/CircleOfFifths/CircleOfFifths.tsx
@@ -168,7 +168,7 @@ export const CircleOfFifths = memo(function CircleOfFifths({
               <motion.path
                 key={note}
                 id={`slice-${svgId}-${index}`}
-                ref={(el) => { segmentRefs.current[index] = el as unknown as SVGPathElement; }}
+                ref={(el: SVGPathElement | null) => { segmentRefs.current[index] = el; }}
                 d={slicePath(index)}
                 className={clsx(styles["circle-slice"], {
                   [styles.active]: isActive,
@@ -205,7 +205,6 @@ export const CircleOfFifths = memo(function CircleOfFifths({
                 aria-pressed={isActive}
                 tabIndex={index === focusedIndex ? 0 : -1}
                 onKeyDown={(e) => handleKeyDown(e, index)}
-                transition={{ duration: 0.3 }}
               />
             );
           })}

--- a/src/components/DegreeChipStrip/DegreeChipStrip.tsx
+++ b/src/components/DegreeChipStrip/DegreeChipStrip.tsx
@@ -62,11 +62,7 @@ export function DegreeChipStrip({
           data-has-action={headerAction ? 'true' : undefined}
         >
           {headerAction}
-          {!hideHeader && (
-            <span>
-              {scaleName}
-            </span>
-          )}
+          {!hideHeader && scaleName}
         </header>
       )}
       {visible && (
@@ -74,7 +70,6 @@ export function DegreeChipStrip({
           {chips.map((chip, i) => {
             const isHidden = hiddenNotes?.has(chip.internalNote) ?? false;
             const isColorNote = colorNotes?.has(chip.internalNote) ?? false;
-
             return (
               <li
                 key={`${chip.note}-${i}`}

--- a/src/components/FretRangeControl/FretRangeControl.module.css
+++ b/src/components/FretRangeControl/FretRangeControl.module.css
@@ -34,7 +34,7 @@
   color: var(--surface-control-fg);
   display: block;
   width: 100%;
-  padding: 0; /* Let slot handle spacing */
+  padding: 0;
 }
 
 .fret-icon {

--- a/src/components/FretRangeControl/FretRangeControl.tsx
+++ b/src/components/FretRangeControl/FretRangeControl.tsx
@@ -2,6 +2,11 @@ import { Minus, Plus } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
 import clsx from "clsx";
 import { StepperShell } from "../StepperShell/StepperShell";
+import {
+  SPRING_TAP,
+  STEPPER_VALUE_POP_TRANSITION,
+  WHILE_TAP_BTN,
+} from "../../core/constants";
 import styles from "./FretRangeControl.module.css";
 
 export interface FretRangeControlProps {
@@ -46,8 +51,8 @@ export function FretRangeControl({
             aria-label={`Decrease start fret${labels ? ` (${startFret})` : ""}`}
             onClick={() => onStartChange(Math.max(0, startFret - 1))}
             disabled={startFret <= 0}
-            whileTap={{ scale: 0.94 }}
-            transition={{ type: "spring", stiffness: 500, damping: 25 }}
+            whileTap={WHILE_TAP_BTN}
+            transition={SPRING_TAP}
           >
             <Minus className={styles["fret-icon"]} aria-hidden="true" />
           </motion.button>
@@ -58,10 +63,7 @@ export function FretRangeControl({
                 initial={{ y: 10, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
                 exit={{ y: -10, opacity: 0 }}
-                transition={{
-                  y: { type: "spring", stiffness: 400, damping: 28 },
-                  opacity: { duration: 0.15 }
-                }}
+                transition={STEPPER_VALUE_POP_TRANSITION}
                 className={styles["fret-value"]}
               >
                 {startFret}
@@ -74,8 +76,8 @@ export function FretRangeControl({
             aria-label={`Increase start fret${labels ? ` (${startFret})` : ""}`}
             onClick={() => onStartChange(Math.min(endFret - 1, startFret + 1))}
             disabled={startFret >= endFret - 1}
-            whileTap={{ scale: 0.94 }}
-            transition={{ type: "spring", stiffness: 500, damping: 25 }}
+            whileTap={WHILE_TAP_BTN}
+            transition={SPRING_TAP}
           >
             <Plus className={styles["fret-icon"]} aria-hidden="true" />
           </motion.button>
@@ -95,8 +97,8 @@ export function FretRangeControl({
             aria-label={`Decrease end fret${labels ? ` (${endFret})` : ""}`}
             onClick={() => onEndChange(Math.max(startFret + 1, endFret - 1))}
             disabled={endFret <= startFret + 1}
-            whileTap={{ scale: 0.94 }}
-            transition={{ type: "spring", stiffness: 500, damping: 25 }}
+            whileTap={WHILE_TAP_BTN}
+            transition={SPRING_TAP}
           >
             <Minus className={styles["fret-icon"]} aria-hidden="true" />
           </motion.button>
@@ -107,10 +109,7 @@ export function FretRangeControl({
                 initial={{ y: 10, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
                 exit={{ y: -10, opacity: 0 }}
-                transition={{
-                  y: { type: "spring", stiffness: 400, damping: 28 },
-                  opacity: { duration: 0.15 }
-                }}
+                transition={STEPPER_VALUE_POP_TRANSITION}
                 className={styles["fret-value"]}
               >
                 {endFret}
@@ -123,8 +122,8 @@ export function FretRangeControl({
             aria-label={`Increase end fret${labels ? ` (${endFret})` : ""}`}
             onClick={() => onEndChange(Math.min(maxFret, endFret + 1))}
             disabled={endFret >= maxFret}
-            whileTap={{ scale: 0.94 }}
-            transition={{ type: "spring", stiffness: 500, damping: 25 }}
+            whileTap={WHILE_TAP_BTN}
+            transition={SPRING_TAP}
           >
             <Plus className={styles["fret-icon"]} aria-hidden="true" />
           </motion.button>

--- a/src/components/FretboardSVG/FretboardNoteLayer.tsx
+++ b/src/components/FretboardSVG/FretboardNoteLayer.tsx
@@ -97,7 +97,7 @@ export const FretboardNoteLayer = memo(({
         const finalOpacity = baseOpacity * applyLensEmphasis.opacityBoost;
         return (
           <motion.g
-            key={`note-${stringIndex}-${fretIndex}-${noteClass}`}
+            key={`note-${stringIndex}-${fretIndex}`}
             initial={{ scale: 0, opacity: 0 }}
             animate={{
               scale: isHidden ? 0 : 1,

--- a/src/components/FretboardSVG/FretboardSVG.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.tsx
@@ -400,9 +400,9 @@ export const FretboardSVG = memo(function FretboardSVG({
                   data-has-active-voicing={activeVoicingKey ? "true" : undefined}
                 >
                   {/* Fill pass: all voicings rendered first (below outlines) */}
-                  {connectorPolylines.map((voicing, i) => (
+                  {connectorPolylines.map((voicing) => (
                     <motion.path
-                      key={`fill-${voicing.voicingKey}-${i}`}
+                      key={`fill-${voicing.voicingKey}`}
                       initial={{ opacity: 0, scale: 0.98 }}
                       animate={{ opacity: 1, scale: 1 }}
                       exit={{ opacity: 0, scale: 0.98 }}
@@ -415,9 +415,9 @@ export const FretboardSVG = memo(function FretboardSVG({
                     />
                   ))}
                   {/* Outline pass: all voicings rendered on top */}
-                  {connectorPolylines.map((voicing, i) => (
+                  {connectorPolylines.map((voicing) => (
                     <motion.path
-                      key={`outline-${voicing.voicingKey}-${i}`}
+                      key={`outline-${voicing.voicingKey}`}
                       initial={{ opacity: 0, scale: 0.98 }}
                       animate={{ opacity: 1, scale: 1 }}
                       exit={{ opacity: 0, scale: 0.98 }}

--- a/src/components/NoteGrid/NoteGrid.tsx
+++ b/src/components/NoteGrid/NoteGrid.tsx
@@ -94,8 +94,8 @@ export function NoteGrid({
         return (
           <motion.button
             key={n}
-            ref={(el) => {
-              buttonRefs.current[index] = el as unknown as HTMLButtonElement;
+            ref={(el: HTMLButtonElement | null) => {
+              buttonRefs.current[index] = el;
             }}
             type="button"
             className={clsx(shared["note-btn"], isActive && shared.active)}

--- a/src/components/ScaleStripPanel/ScaleStripPanel.tsx
+++ b/src/components/ScaleStripPanel/ScaleStripPanel.tsx
@@ -1,5 +1,6 @@
 import { useScaleState } from "../../hooks/useScaleState";
 import { DegreeChipStrip } from "../DegreeChipStrip/DegreeChipStrip";
+import shared from "../shared/shared.module.css";
 import styles from "../DegreeChipStrip/DegreeChipStrip.module.css";
 
 function EyeOpenIcon() {
@@ -52,7 +53,7 @@ export function ScaleStripPanel() {
           aria-pressed={!scaleVisible}
           onClick={toggleScaleVisible}
         >
-          <span style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <span className={shared["flex-center"]}>
             {scaleVisible ? <EyeOpenIcon /> : <EyeClosedIcon />}
           </span>
         </button>

--- a/src/components/StepperControl/StepperControl.module.css
+++ b/src/components/StepperControl/StepperControl.module.css
@@ -44,7 +44,7 @@
   color: var(--surface-control-fg);
   display: block;
   width: 100%;
-  padding: 0; /* Centering handled by stepper-value-slot */
+  padding: 0;
 }
 
 .stepper-icon {

--- a/src/components/StepperControl/StepperControl.tsx
+++ b/src/components/StepperControl/StepperControl.tsx
@@ -2,6 +2,11 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { Minus, Plus } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
 import { StepperShell } from "../StepperShell/StepperShell";
+import {
+  SPRING_TAP,
+  STEPPER_VALUE_POP_TRANSITION,
+  WHILE_TAP_BTN,
+} from "../../core/constants";
 import styles from "./StepperControl.module.css";
 import shared from "../shared/shared.module.css";
 
@@ -56,8 +61,8 @@ export function StepperControl({
           aria-label={`Decrease ${label ?? "value"} (current: ${value})`}
           onClick={() => onChange(Math.max(min, value - step))}
           disabled={value <= min}
-          whileTap={{ scale: 0.94 }}
-          transition={{ type: "spring", stiffness: 500, damping: 25 }}
+          whileTap={WHILE_TAP_BTN}
+          transition={SPRING_TAP}
         >
           <Minus className={styles["stepper-icon"]} aria-hidden="true" />
         </motion.button>
@@ -68,10 +73,7 @@ export function StepperControl({
               initial={{ y: 12, opacity: 0 }}
               animate={{ y: 0, opacity: 1 }}
               exit={{ y: -12, opacity: 0 }}
-              transition={{
-                y: { type: "spring", stiffness: 400, damping: 28 },
-                opacity: { duration: 0.15 }
-              }}
+              transition={STEPPER_VALUE_POP_TRANSITION}
               className={styles["stepper-value"]}
             >
               {formatValue(value)}
@@ -84,8 +86,8 @@ export function StepperControl({
           aria-label={`Increase ${label ?? "value"} (current: ${value})`}
           onClick={() => onChange(Math.min(max, value + step))}
           disabled={value >= max}
-          whileTap={{ scale: 0.94 }}
-          transition={{ type: "spring", stiffness: 500, damping: 25 }}
+          whileTap={WHILE_TAP_BTN}
+          transition={SPRING_TAP}
         >
           <Plus className={styles["stepper-icon"]} aria-hidden="true" />
         </motion.button>

--- a/src/components/StepperSelect/StepperSelect.tsx
+++ b/src/components/StepperSelect/StepperSelect.tsx
@@ -5,6 +5,7 @@ import {
 } from "../LabeledSelect/LabeledSelect";
 import { StepperShell } from "../StepperShell/StepperShell";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { SPRING_TAP, WHILE_TAP_BTN } from "../../core/constants";
 import styles from "./StepperSelect.module.css";
 
 export type StepperSelectOption = LabeledSelectOption;
@@ -54,8 +55,8 @@ export function StepperSelect({
         onClick={onPrevious}
         aria-label={previousLabel}
         disabled={disabled || previousDisabled}
-        whileTap={{ scale: 0.94 }}
-        transition={{ type: "spring", stiffness: 500, damping: 25 }}
+        whileTap={WHILE_TAP_BTN}
+        transition={SPRING_TAP}
       >
         <ChevronLeft className="icon" size={16} />
       </motion.button>
@@ -75,8 +76,8 @@ export function StepperSelect({
         onClick={onNext}
         aria-label={nextLabel}
         disabled={disabled || nextDisabled}
-        whileTap={{ scale: 0.94 }}
-        transition={{ type: "spring", stiffness: 500, damping: 25 }}
+        whileTap={WHILE_TAP_BTN}
+        transition={SPRING_TAP}
       >
         <ChevronRight className="icon" size={16} />
       </motion.button>

--- a/src/components/TheoryControls/TheoryControls.tsx
+++ b/src/components/TheoryControls/TheoryControls.tsx
@@ -100,7 +100,7 @@ export function TheorySection({
               duration: ANIMATION_DURATION_STANDARD,
               ease: ANIMATION_EASE,
             }}
-            style={{ clipPath: "inset(0 -1rem)", height: "auto", opacity: 1 }}
+            style={{ clipPath: "inset(0 -1rem)" }}
           >
             {children}
           </motion.div>

--- a/src/components/shared/shared.module.css
+++ b/src/components/shared/shared.module.css
@@ -353,6 +353,13 @@
   margin: 0;
 }
 
+/* Flex-center utility — used as inner span for AnimatePresence icon swaps. */
+.flex-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* Icon Button - shared circular button chrome for header, modal close, etc. */
 .icon-button {
   display: inline-flex;

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -55,7 +55,18 @@ export const DRAWER_DROPUP_THRESHOLD = 260;
 // Animation transitions (motion/react)
 export const ANIMATION_DURATION_FAST = 0.2;
 export const ANIMATION_DURATION_STANDARD = 0.24;
+export const ANIMATION_DURATION_XFADE = 0.15;
 export const ANIMATION_EASE = "easeOut";
+
+// Reusable motion presets
+export const SPRING_TAP = { type: "spring", stiffness: 500, damping: 25 } as const;
+export const WHILE_TAP_BTN = { scale: 0.94 } as const;
+export const WHILE_TAP_PILL = { scale: 0.96 } as const;
+export const ACTIVE_POP_TRANSITION = { duration: 0.2 } as const;
+export const STEPPER_VALUE_POP_TRANSITION = {
+  y: { type: "spring", stiffness: 400, damping: 28 },
+  opacity: { duration: 0.15 },
+} as const;
 
 // Settings / Atoms
 export const FRET_ZOOM_MIN = 100;


### PR DESCRIPTION
## Summary

Cleanup pass on the motion/react animation work added in `feat(layout): move chord practice bar to dock and improve app-wide animations`. Two functional bugs and broad reuse / quality cleanup.

### Bug fixes

- **FretboardNoteLayer hot-path remount** — `key` included `noteClass`, so every role transition (lens/scale/chord toggle) unmounted and remounted ~130 `motion.g` nodes, each running the spring `initial → animate`. Reverted key to position-only; the spring on visible/hidden now plays smoothly without remount.
- **FretboardSVG connector keys** — `${voicingKey}-${i}` made stable voicings remount on reorder. Switched to `${voicingKey}` only (fill + outline passes).
- **TheoryControls collapse animation** — inline `style={{ height: "auto", opacity: 1 }}` on the `motion.div` overrode the `animate`-controlled height/opacity. Removed.

### Reuse / quality

- Added `SPRING_TAP`, `WHILE_TAP_BTN`, `STEPPER_VALUE_POP_TRANSITION`, `ANIMATION_DURATION_XFADE` to `core/constants.ts`. Adopted in `StepperControl`, `StepperSelect`, `FretRangeControl`, `App` (replaces ~10 inline duplicates).
- Added `.flex-center` to `shared.module.css`; replaced three inline `style={{ display: "flex", alignItems, justifyContent }}` props (App, ChordPracticeBar, ScaleStripPanel).
- Replaced `el as unknown as SVGPathElement / HTMLButtonElement` ref casts with properly-typed callback refs in CircleOfFifths and NoteGrid.
- Removed dead `transition` prop on CircleOfFifths slice (no `animate`/`initial`).
- Removed redundant JSX wrappers in DegreeChipStrip and ChordPracticeBar; cleaned WHAT-comments and stray blank lines.

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run test` (1242 passed)
- [ ] Visual smoke check that role transitions, collapse animations, and steppers still feel right
- [ ] Visual regression suite on CI

https://claude.ai/code/session_01HhMhGbjKGAv824691d3Sns

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhMhGbjKGAv824691d3Sns)_