### PR TITLE
docs(types): tighten test-setup typing and document lens composites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,10 @@ src/
 
 Notes carry a semantic role (`root-active`, `chord-tone`, `note-blue`, `note-active`, `note-scale-only`, `chord-outside`, `note-inactive`). **Lenses** (registered in `src/store/practiceLensAtoms.ts` + `chordOverlayAtoms.ts`) compose emphasis rules (colors, squircles, tension cues) on top of that base model. **Scale and chord are independent domains** — do not cross-wire their visibility, lens, or color state.
 
+## Debug modes
+
+- `?audit=note-colors` — swaps the app for `src/components/NoteColorAudit/` (a contrast/swatch harness). `data-theme` is removed while active so both light- and dark-theme swatches render side-by-side; the previous theme is restored on exit. Wired in `src/App.tsx`.
+
 ## Testing
 
 - **Vitest** + Testing Library for unit/component (jsdom). Coverage via `@vitest/coverage-v8`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,9 @@ function AppContent() {
   const helpTriggerRef = useRef<HTMLButtonElement>(null);
   const layout = useLayoutMode();
   const theme = useResolvedTheme();
+  // Debug mode: visiting `?audit=note-colors` swaps the entire app for the
+  // NoteColorAudit harness (and clears `data-theme` so both light/dark swatches
+  // can be inspected side-by-side). See "Debug modes" in CLAUDE.md.
   const showNoteColorAudit =
     typeof window !== "undefined" &&
     new URLSearchParams(window.location.search).get("audit") === "note-colors";

--- a/src/store/chordOverlayAtoms.ts
+++ b/src/store/chordOverlayAtoms.ts
@@ -438,8 +438,17 @@ export const chordMemberFactsAtom = atom((get): ChordMemberFact[] => {
 });
 
 /**
- * ChordRowEntry list with scale-membership and roles.
- * Used by practiceLensAtoms and atoms.ts summary atoms.
+ * Catalog of chord members annotated with scale-membership flags and role
+ * tags — the canonical input shared by every practice-lens composite (see
+ * `practiceLensAtoms.ts`) and the chord summary atoms in `atoms.ts`.
+ *
+ * Inputs (read via `get`): `chordTypeAtom`, `chordRootAtom`, `rootNoteAtom`,
+ * `scaleNameAtom`. Empty array when no chord is selected.
+ *
+ * Output: `ChordRowEntry[]` covering every chord member, including those that
+ * fall outside the active scale (consumers decide how to render outsiders).
+ *
+ * See the "Lens & Note Roles" section in `CLAUDE.md` for the role taxonomy.
  */
 export const allChordMembersAtom = atom((get) => {
   const chordType = get(chordTypeAtom);

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -86,8 +86,17 @@ const getDisplayLabel = (e: ChordRowEntry): string =>
   e.scaleInterval ?? e.memberName;
 
 /**
- * Maps note → NoteSemantics allowing multiple properties to coexist.
- * Accommodates notes with multiple roles (e.g., chord root outside scale).
+ * Maps note → {@link NoteSemantics}, allowing multiple properties to coexist
+ * for notes that fill more than one role (e.g. a chord root that lies outside
+ * the active scale).
+ *
+ * Inputs (read via `get`): `chordTypeAtom`, `chordOverlayHiddenAtom`,
+ * `rootNoteAtom`, `scaleNameAtom`, plus the chord-row catalog.
+ *
+ * Output: `Map<note, NoteSemantics>`. Empty map when there is no chord or the
+ * overlay is hidden — consumers fall back to the scale-only base model.
+ *
+ * See the "Lens & Note Roles" section in `CLAUDE.md` for the role taxonomy.
  */
 export const noteSemanticMapAtom = atom((get) => {
   const chordType = get(chordTypeAtom);
@@ -175,7 +184,16 @@ export const noteSemanticMapAtom = atom((get) => {
 });
 
 /**
- * Derives ordered coaching cues for the practice bar based on active lens.
+ * Derives the ordered coaching cues rendered in the practice bar.
+ *
+ * Inputs (read via `get`): the active practice lens (`practiceLensAtom`),
+ * chord root/type, scale name, and the chord-row catalog.
+ *
+ * Output: `PracticeCue[]` ordered for left-to-right display. Returns `[]`
+ * when no chord is active.
+ *
+ * See the "Lens & Note Roles" section in `CLAUDE.md` for how cues compose
+ * with the base note-role model.
  */
 export const practiceCuesAtom = atom((get) => {
   const chordType = get(chordTypeAtom);

--- a/src/test-utils/setup.ts
+++ b/src/test-utils/setup.ts
@@ -3,8 +3,7 @@ import { vi, expect } from 'vitest';
 import { configure } from '@testing-library/react';
 import { configureAxe } from 'vitest-axe';
 import { toHaveNoViolations } from 'vitest-axe/dist/matchers.js';
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-expect.extend({ toHaveNoViolations } as any);
+expect.extend({ toHaveNoViolations });
 
 // vitest-axe: registers toHaveNoViolations matcher globally.
 // color-contrast rule disabled — jsdom cannot compute CSS custom property values.

--- a/src/test-utils/vitest-axe.d.ts
+++ b/src/test-utils/vitest-axe.d.ts
@@ -1,10 +1,9 @@
 import 'vitest';
+import type { AxeMatchers } from 'vitest-axe';
 
 declare module 'vitest' {
-  interface Assertion {
-    toHaveNoViolations(): void;
-  }
-  interface AsymmetricMatchersContaining {
-    toHaveNoViolations(): void;
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-unused-vars
+  interface Assertion<T = unknown> extends AxeMatchers {}
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface AsymmetricMatchersContaining extends AxeMatchers {}
 }


### PR DESCRIPTION
## Summary

Group D from the prioritized improvements list — low-risk type and documentation cleanups.

- **Eliminate `as any` in test setup.** Replaced the cast in `src/test-utils/setup.ts` with a proper module augmentation in `src/test-utils/vitest-axe.d.ts` that extends vitest's `Assertion`/`AsymmetricMatchersContaining` interfaces using `AxeMatchers` from `vitest-axe`.
- **JSDoc on lens composites.** Documented inputs, outputs, and behavior of `noteSemanticMapAtom` and `practiceCuesAtom` in `src/store/practiceLensAtoms.ts`, and `allChordMembersAtom` in `src/store/chordOverlayAtoms.ts`. Each comment points back to the "Lens & Note Roles" section of `CLAUDE.md`.
- **Document the `?audit=note-colors` debug mode.** Added an inline comment in `src/App.tsx` and a new "Debug modes" subsection to `CLAUDE.md` so the query-param toggle is discoverable.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test` — 1244 passed (54 files)
- [x] `npm run build` — clean
- [ ] No runtime behavior changes; visual/e2e suites not required for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzyV2Z28N6EKVcSt8PmSMB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added debug mode documentation for auditing note color displays.
  * Enhanced internal documentation for atom behaviors and data flow.

* **Chores**
  * Updated test utility type declarations for improved type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->