### PR TITLE
feat(a11y): keyboard nav for circle of fifths and SVG note ARIA

### DIFF
--- a/src/components/CircleOfFifths/CircleOfFifths.a11y.test.tsx
+++ b/src/components/CircleOfFifths/CircleOfFifths.a11y.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { CircleOfFifths } from "./CircleOfFifths";
+import { CIRCLE_OF_FIFTHS } from "../../core/theory";
+import { axe } from "../../test-utils/a11y";
+
+const getSlices = () =>
+  Array.from(
+    document.querySelectorAll<SVGPathElement>(
+      'path[class*="circle-slice"][role="button"]',
+    ),
+  );
+
+describe("CircleOfFifths keyboard navigation", () => {
+  it("has no a11y violations", async () => {
+    const { container } = render(
+      <CircleOfFifths rootNote="C" setRootNote={() => {}} />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("exposes 12 slices as buttons with a single tab stop", () => {
+    render(<CircleOfFifths rootNote="C" setRootNote={() => {}} />);
+    const slices = getSlices();
+    expect(slices).toHaveLength(12);
+    const focusable = slices.filter((s) => s.getAttribute("tabindex") === "0");
+    expect(focusable).toHaveLength(1);
+  });
+
+  it("ArrowRight moves focus clockwise", () => {
+    render(<CircleOfFifths rootNote="C" setRootNote={() => {}} />);
+    const slices = getSlices();
+    fireEvent.keyDown(slices[0], { key: "ArrowRight" });
+    expect(slices[1].getAttribute("tabindex")).toBe("0");
+  });
+
+  it("ArrowDown moves focus clockwise (alias)", () => {
+    render(<CircleOfFifths rootNote="C" setRootNote={() => {}} />);
+    const slices = getSlices();
+    fireEvent.keyDown(slices[0], { key: "ArrowDown" });
+    expect(slices[1].getAttribute("tabindex")).toBe("0");
+  });
+
+  it("ArrowLeft from index 0 wraps to index 11", () => {
+    render(<CircleOfFifths rootNote="C" setRootNote={() => {}} />);
+    const slices = getSlices();
+    fireEvent.keyDown(slices[0], { key: "ArrowLeft" });
+    expect(slices[11].getAttribute("tabindex")).toBe("0");
+  });
+
+  it("ArrowUp from index 0 wraps to index 11 (alias)", () => {
+    render(<CircleOfFifths rootNote="C" setRootNote={() => {}} />);
+    const slices = getSlices();
+    fireEvent.keyDown(slices[0], { key: "ArrowUp" });
+    expect(slices[11].getAttribute("tabindex")).toBe("0");
+  });
+
+  it("ArrowRight from index 11 wraps to index 0", () => {
+    render(<CircleOfFifths rootNote="C" setRootNote={() => {}} />);
+    const slices = getSlices();
+    // step focus to index 11 first
+    fireEvent.keyDown(slices[0], { key: "ArrowLeft" });
+    fireEvent.keyDown(slices[11], { key: "ArrowRight" });
+    expect(slices[0].getAttribute("tabindex")).toBe("0");
+  });
+
+  it("Home jumps focus to C (index 0)", () => {
+    render(<CircleOfFifths rootNote="C" setRootNote={() => {}} />);
+    const slices = getSlices();
+    fireEvent.keyDown(slices[0], { key: "ArrowRight" });
+    fireEvent.keyDown(slices[1], { key: "Home" });
+    expect(slices[0].getAttribute("tabindex")).toBe("0");
+    expect(CIRCLE_OF_FIFTHS[0]).toBe("C");
+  });
+
+  it("End jumps focus to B", () => {
+    render(<CircleOfFifths rootNote="C" setRootNote={() => {}} />);
+    const slices = getSlices();
+    fireEvent.keyDown(slices[0], { key: "End" });
+    const bIndex = CIRCLE_OF_FIFTHS.indexOf("B");
+    expect(slices[bIndex].getAttribute("tabindex")).toBe("0");
+  });
+
+  it("Enter activates the focused note", () => {
+    const setRootNote = vi.fn();
+    render(<CircleOfFifths rootNote="C" setRootNote={setRootNote} />);
+    const slices = getSlices();
+    fireEvent.keyDown(slices[2], { key: "Enter" });
+    expect(setRootNote).toHaveBeenCalledWith(CIRCLE_OF_FIFTHS[2]);
+  });
+
+  it("Space activates the focused note", () => {
+    const setRootNote = vi.fn();
+    render(<CircleOfFifths rootNote="C" setRootNote={setRootNote} />);
+    const slices = getSlices();
+    fireEvent.keyDown(slices[3], { key: " " });
+    expect(setRootNote).toHaveBeenCalledWith(CIRCLE_OF_FIFTHS[3]);
+  });
+});

--- a/src/components/CircleOfFifths/CircleOfFifths.tsx
+++ b/src/components/CircleOfFifths/CircleOfFifths.tsx
@@ -120,11 +120,11 @@ export const CircleOfFifths = memo(function CircleOfFifths({
     } else if (e.key === "Home") {
       e.preventDefault();
       setKeyboardFocused(true);
-      setFocusedIndex(0);
+      setFocusedIndex(CIRCLE_OF_FIFTHS.indexOf("C"));
     } else if (e.key === "End") {
       e.preventDefault();
       setKeyboardFocused(true);
-      setFocusedIndex(11);
+      setFocusedIndex(CIRCLE_OF_FIFTHS.indexOf("B"));
     } else if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
       setRootNote(CIRCLE_OF_FIFTHS[index]);

--- a/src/components/FretboardSVG/FretboardNoteLayer.a11y.test.tsx
+++ b/src/components/FretboardSVG/FretboardNoteLayer.a11y.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { FretboardSVG } from "./FretboardSVG";
+import { getFretboardNotes, STANDARD_TUNING } from "../../core/guitar";
+import { axe } from "../../test-utils/a11y";
+
+const BASE_PROPS = {
+  effectiveZoom: 49,
+  neckWidthPx: 49 * 13,
+  startFret: 0,
+  endFret: 12,
+  stringRowPx: 40,
+  fretboardLayout: getFretboardNotes(STANDARD_TUNING, 24),
+  tuning: STANDARD_TUNING,
+  highlightNotes: ["C", "E", "G"],
+  rootNote: "C",
+};
+
+const getSvgNotes = () =>
+  Array.from(
+    document.querySelectorAll<SVGGElement>('g[class*="fretboard-note"]'),
+  );
+
+describe("FretboardNoteLayer a11y", () => {
+  it("has no a11y violations", async () => {
+    const { container } = render(<FretboardSVG {...BASE_PROPS} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("exposes each note as a button with role and aria-label", () => {
+    render(<FretboardSVG {...BASE_PROPS} onNoteClick={() => {}} />);
+    const notes = getSvgNotes();
+    expect(notes.length).toBeGreaterThan(0);
+    notes.forEach((g) => {
+      expect(g.getAttribute("role")).toBe("button");
+      const label = g.getAttribute("aria-label") || "";
+      // Format: "<note name><octave> — <role>"
+      expect(label).toMatch(/^[A-G][#♯♭b]?\d\s—\s.+$/);
+    });
+  });
+
+  it("aria-label includes the correct octave for the open low E string (E2)", () => {
+    render(<FretboardSVG {...BASE_PROPS} highlightNotes={["E"]} onNoteClick={() => {}} />);
+    const labels = getSvgNotes()
+      .map((g) => g.getAttribute("aria-label") || "")
+      .filter(Boolean);
+    expect(labels.some((l) => l.startsWith("E2 — "))).toBe(true);
+    // High E string open is E4
+    expect(labels.some((l) => l.startsWith("E4 — "))).toBe(true);
+  });
+
+  it("sets tabIndex=0 when onNoteClick is provided", () => {
+    render(<FretboardSVG {...BASE_PROPS} onNoteClick={() => {}} />);
+    const notes = getSvgNotes();
+    const focusable = notes.filter((g) => g.getAttribute("tabindex") === "0");
+    expect(focusable.length).toBeGreaterThan(0);
+  });
+
+  it("sets tabIndex=-1 when onNoteClick is omitted", () => {
+    render(<FretboardSVG {...BASE_PROPS} />);
+    const notes = getSvgNotes();
+    expect(notes.length).toBeGreaterThan(0);
+    notes.forEach((g) => {
+      expect(g.getAttribute("tabindex")).toBe("-1");
+    });
+  });
+
+  it("invokes onNoteClick on Enter and Space", () => {
+    const onNoteClick = vi.fn();
+    render(<FretboardSVG {...BASE_PROPS} onNoteClick={onNoteClick} />);
+    const notes = getSvgNotes();
+    fireEvent.keyDown(notes[0], { key: "Enter" });
+    fireEvent.keyDown(notes[0], { key: " " });
+    expect(onNoteClick).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not invoke onNoteClick on unrelated keys", () => {
+    const onNoteClick = vi.fn();
+    render(<FretboardSVG {...BASE_PROPS} onNoteClick={onNoteClick} />);
+    const notes = getSvgNotes();
+    fireEvent.keyDown(notes[0], { key: "a" });
+    fireEvent.keyDown(notes[0], { key: "Tab" });
+    expect(onNoteClick).not.toHaveBeenCalled();
+  });
+
+  it("invokes onNoteClick on click", () => {
+    const onNoteClick = vi.fn();
+    render(<FretboardSVG {...BASE_PROPS} onNoteClick={onNoteClick} />);
+    const notes = getSvgNotes();
+    fireEvent.click(notes[0]);
+    expect(onNoteClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/FretboardSVG/FretboardNoteLayer.tsx
+++ b/src/components/FretboardSVG/FretboardNoteLayer.tsx
@@ -13,7 +13,27 @@ interface FretboardNoteLayerProps {
   noteBubblePx: number;
   displayFormat: "notes" | "degrees" | "none";
   degreeColorsEnabled?: boolean;
+  onNoteClick?: (stringIndex: number, fretIndex: number, noteName: string) => void;
 }
+
+const ROLE_DESCRIPTIONS: Record<string, string> = {
+  "root-active": "scale root",
+  "chord-root": "chord root",
+  "chord-tone": "chord tone",
+  "chord-tone-in-scale": "chord tone in scale",
+  "chord-tone-outside-scale": "chord tone outside scale",
+  "note-diatonic-chord": "diatonic chord tone",
+  "note-blue": "blue note",
+  "note-active": "scale note",
+  "note-scale-only": "scale note",
+  "chord-outside": "chord tone outside scale",
+  "color-tone": "color tone",
+  "key-tonic": "key tonic",
+  "note-inactive": "inactive",
+};
+
+const formatRole = (noteClass: string): string =>
+  ROLE_DESCRIPTIONS[noteClass] ?? noteClass.replace(/-/g, " ");
 
 export const FretboardNoteLayer = memo(({
   noteData,
@@ -22,12 +42,15 @@ export const FretboardNoteLayer = memo(({
   noteBubblePx,
   displayFormat,
   degreeColorsEnabled,
+  onNoteClick,
 }: FretboardNoteLayerProps) => {
   return (
     <>
       {noteData.map(({
         stringIndex,
         fretIndex,
+        noteName,
+        octave,
         noteClass,
         displayValue,
         applyDimOpacity,
@@ -95,6 +118,9 @@ export const FretboardNoteLayer = memo(({
 
         const baseOpacity = applyDimOpacity ? 0.8 : 1;
         const finalOpacity = baseOpacity * applyLensEmphasis.opacityBoost;
+        const roleLabel = formatRole(noteClass);
+        const ariaLabel = `${noteName}${octave} — ${roleLabel}`;
+        const interactive = !!onNoteClick && !isHidden;
         return (
           <motion.g
             key={`note-${stringIndex}-${fretIndex}`}
@@ -108,6 +134,25 @@ export const FretboardNoteLayer = memo(({
               styles["fretboard-note"],
               styles[noteClass],
             )}
+            role="button"
+            aria-label={ariaLabel}
+            aria-hidden={isHidden || undefined}
+            tabIndex={interactive ? 0 : -1}
+            onClick={
+              interactive
+                ? () => onNoteClick!(stringIndex, fretIndex, noteName)
+                : undefined
+            }
+            onKeyDown={
+              interactive
+                ? (e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onNoteClick!(stringIndex, fretIndex, noteName);
+                    }
+                  }
+                : undefined
+            }
             data-note-role={noteClass !== "note-inactive" ? noteClass : undefined}
             data-note-shape={noteShape}
             data-note-tension={isTension || undefined}

--- a/src/components/FretboardSVG/FretboardSVG.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.tsx
@@ -439,6 +439,7 @@ export const FretboardSVG = memo(function FretboardSVG({
               noteBubblePx={noteBubblePx}
               displayFormat={displayFormat}
               degreeColorsEnabled={degreeColorsEnabled}
+              onNoteClick={onNoteClick}
             />
           </g>
         </svg>

--- a/src/components/FretboardSVG/hooks/useChordConnectorPolylines.test.ts
+++ b/src/components/FretboardSVG/hooks/useChordConnectorPolylines.test.ts
@@ -33,6 +33,7 @@ function makeNote(
     stringIndex: si,
     fretIndex: fi,
     noteName,
+    octave: 4,
     noteClass,
     displayValue: noteName,
     applyDimOpacity: false,

--- a/src/components/FretboardSVG/hooks/useNoteData.ts
+++ b/src/components/FretboardSVG/hooks/useNoteData.ts
@@ -9,6 +9,7 @@ import {
   type NoteSemantics,
 } from "../../../core/theory";
 import { DEGREE_COLORS, getDegreesForScale } from "../../../core/degrees";
+import { getFretNoteWithOctave, parseNote } from "../../../core/guitar";
 import type { ShapePolygon, CagedShape } from "../../../shapes";
 import type { ActiveShapeType } from "../../../hooks/useFretboardState";
 import {
@@ -23,6 +24,7 @@ export interface NoteData {
   stringIndex: number;
   fretIndex: number;
   noteName: string;
+  octave: number;
   noteClass: string;
   displayValue: string;
   applyDimOpacity: boolean;
@@ -88,6 +90,7 @@ export function useNoteData({
   degreeColorsEnabled,
   wrappedNotes,
   practiceLens,
+  tuning,
   noteSemantics,
 }: UseNoteDataProps): NoteData[] {
   return useMemo(() => {
@@ -313,10 +316,17 @@ export function useNoteData({
           }
         }
 
+        const openString = tuning[stringIndex];
+        const noteWithOctave = openString
+          ? getFretNoteWithOctave(openString, fretIndex)
+          : `${noteName}4`;
+        const octave = parseNote(noteWithOctave)?.octave ?? 4;
+
         const objectToBePushed = {
           stringIndex,
           fretIndex,
           noteName,
+          octave,
           noteClass,
           displayValue,
           applyDimOpacity,
@@ -331,5 +341,5 @@ export function useNoteData({
       }
     }
     return notes;
-  }, [numStrings, fretboardLayout, totalColumns, startFret, maxFret, hiddenNotes, highlightNotes, hasChordOverlay, chordTones, rootNote, chordRoot, colorNotes, shapePolygons, boxBounds, chordFretSpread, scaleName, useFlats, displayFormat, degreeColorsEnabled, wrappedNotes, practiceLens, noteSemantics, activePattern, activeShape, shapeScope]);
+  }, [numStrings, fretboardLayout, totalColumns, startFret, maxFret, hiddenNotes, highlightNotes, hasChordOverlay, chordTones, rootNote, chordRoot, colorNotes, shapePolygons, boxBounds, chordFretSpread, scaleName, useFlats, displayFormat, degreeColorsEnabled, wrappedNotes, practiceLens, tuning, noteSemantics, activePattern, activeShape, shapeScope]);
 }


### PR DESCRIPTION
## Summary

- **Circle of Fifths** — Home now lands on `C`, End on `B` (per spec). Existing arrow-key wrap, roving tabindex, and Enter/Space activation remain intact.
- **FretboardSVG note layer** (`FretboardNoteLayer.tsx`) — each note `<g>` now exposes `role="button"`, an `aria-label` of the form `"<note><octave> — <role>"` (e.g. `"E2 — chord tone"`), `tabIndex` gated on `onNoteClick`, and Enter/Space invoke `onNoteClick`. Octave is derived from tuning + fret and threaded through `NoteData`.
- Adds `vitest-axe` coverage for both surfaces (`CircleOfFifths.a11y.test.tsx`, `FretboardNoteLayer.a11y.test.tsx`).

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (1263 passing)
- [x] `npm run build`
- [ ] Manual keyboard sweep of Circle of Fifths (arrow wrap, Home/End, Enter/Space)
- [ ] Screen reader check on a few fretboard notes

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ujt7iuzg7xHcJYF4TXFX7i)_