### PR TITLE
fix(fretboard): render chord connectors above non-chord notes

### DIFF
--- a/src/components/FretboardSVG/FretboardNoteLayer.tsx
+++ b/src/components/FretboardSVG/FretboardNoteLayer.tsx
@@ -6,6 +6,15 @@ import { getNoteVisuals } from "./utils/semantics";
 import styles from "./FretboardSVG.module.css";
 import type { NoteData } from "./hooks/useNoteData";
 
+const CHORD_NOTE_CLASSES = new Set([
+  "chord-root",
+  "chord-tone",
+  "chord-tone-in-scale",
+  "chord-tone-outside-scale",
+  "chord-outside",
+  "note-diatonic-chord",
+]);
+
 interface FretboardNoteLayerProps {
   noteData: NoteData[];
   fretCenterX: (fretIndex: number) => number;
@@ -14,6 +23,7 @@ interface FretboardNoteLayerProps {
   displayFormat: "notes" | "degrees" | "none";
   degreeColorsEnabled?: boolean;
   onNoteClick?: (stringIndex: number, fretIndex: number, noteName: string) => void;
+  filter?: "chord" | "non-chord";
 }
 
 const ROLE_DESCRIPTIONS: Record<string, string> = {
@@ -43,10 +53,18 @@ export const FretboardNoteLayer = memo(({
   displayFormat,
   degreeColorsEnabled,
   onNoteClick,
+  filter,
 }: FretboardNoteLayerProps) => {
+  const filteredNotes = filter
+    ? noteData.filter(({ noteClass }) => {
+        const isChord = CHORD_NOTE_CLASSES.has(noteClass);
+        return filter === "chord" ? isChord : !isChord;
+      })
+    : noteData;
+
   return (
     <>
-      {noteData.map(({
+      {filteredNotes.map(({
         stringIndex,
         fretIndex,
         noteName,

--- a/src/components/FretboardSVG/FretboardSVG.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.tsx
@@ -419,14 +419,29 @@ export const FretboardSVG = memo(function FretboardSVG({
             <FretboardShapeLayer svgPolygons={svgPolygons} />
           </g>
 
+          {/* Non-chord notes render BEFORE connectors so connectors paint on top. */}
+          {hasChordOverlay && (
+            <g clipPath={svgDefUrl("fretboard-taper")}>
+              <FretboardNoteLayer
+                noteData={noteData}
+                fretCenterX={fretCenterX}
+                stringYAt={stringYAt}
+                noteBubblePx={noteBubblePx}
+                displayFormat={displayFormat}
+                degreeColorsEnabled={degreeColorsEnabled}
+                onNoteClick={onNoteClick}
+                filter="non-chord"
+              />
+            </g>
+          )}
+
           {/* Chord + interval connectors render OUTSIDE the wood `fretboard-taper`
               clip so geometry that crosses the wood's tapered top/bottom + nut/body
               edges near the outer strings stays visible. They are clipped to the
               SVG's bounding box (`fretboard-svg-box`). Connector pixels that land
               in the taper-carved corner gaps paint on the app-container backdrop —
               that's an accepted trade-off; the wood gradient stays clipped to the
-              taper and does not overflow. Rendered BEFORE the note layer so note
-              bubbles paint on top (later SVG siblings paint above earlier ones). */}
+              taper and does not overflow. */}
           <g
             className={styles["fretboard-overlays"]}
             clipPath={svgDefUrl("fretboard-svg-box")}
@@ -507,7 +522,7 @@ export const FretboardSVG = memo(function FretboardSVG({
             )}
           </g>
 
-          {/* Note bubbles render LAST so they paint on top of the connectors. */}
+          {/* Chord notes (or all notes when no overlay) render LAST — on top of connectors. */}
           <g clipPath={svgDefUrl("fretboard-taper")}>
             <FretboardNoteLayer
               noteData={noteData}
@@ -517,6 +532,7 @@ export const FretboardSVG = memo(function FretboardSVG({
               displayFormat={displayFormat}
               degreeColorsEnabled={degreeColorsEnabled}
               onNoteClick={onNoteClick}
+              filter={hasChordOverlay ? "chord" : undefined}
             />
           </g>
         </svg>


### PR DESCRIPTION
## Summary

- Splits the note layer into two render passes when a chord overlay is active: non-chord notes render before connectors (connectors paint on top), chord notes render after connectors (chord notes paint on top).
- Without a chord overlay, all notes render in a single pass — no behavioral change.
- Adds a `filter` prop to `FretboardNoteLayer` (`"chord"` | `"non-chord"`) for selective rendering.

## Why

Commit b63d77e fixed connectors rendering *above* note bubbles by moving connectors before the note layer. But the correct z-order is: connectors should paint on top of non-chord notes while chord-tone notes should paint on top of connectors — giving chord tones visual prominence over the connector fill.

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (1128/1128)
- [x] `npm run build`
- [ ] Visual confirm in dev: chord overlay connectors render above non-chord scale notes but below chord-tone bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional filtering to the fretboard note display, allowing users to selectively display only chord-related or non-chord-related notes for more focused learning and practice sessions

* **Style**
  * Improved the visual rendering order and z-index layering of chord overlays and note indicators on the fretboard to ensure clearer and more professional visual presentation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/355)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->