### PR TITLE
feat(chord-overlay): indicate non-default chord type on degree button

### DIFF
--- a/src/components/ChordOverlayControls/ChordOverlayControls.test.tsx
+++ b/src/components/ChordOverlayControls/ChordOverlayControls.test.tsx
@@ -50,6 +50,7 @@ const DEGREE_MODE_SEEDS = [
   [rootNoteAtom, "C"],
   [chordOverlayModeAtom, "degree"],
   [chordDegreeAtom, "I"],
+  [chordQualityOverrideAtom, null],
   [fingeringPatternAtom, "caged"],
 ] as const;
 

--- a/src/components/ChordOverlayControls/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls/ChordOverlayControls.tsx
@@ -80,11 +80,12 @@ export function ChordOverlayControls({ compact }: ChordOverlayControlsProps) {
   const isPatternDisabled =
     fingeringPattern === "one-string" || fingeringPattern === "two-strings";
 
+  const hasQualityOverride = chordQualityOverride != null;
   const degreeSelectOptions = [
     { value: CHORD_NONE_VALUE, label: "Off" },
     ...Object.values(getDegreesForScale(scaleName)).map((deg) => ({
       value: deg,
-      label: deg,
+      label: hasQualityOverride && deg === chordDegree ? `${deg}*` : deg,
     })),
   ];
 
@@ -196,7 +197,9 @@ export function ChordOverlayControls({ compact }: ChordOverlayControlsProps) {
                 overflow="scroll"
               />
               <p className={shared["field-hint"]}>
-                Switching degrees picks the diatonic default automatically.
+                {hasQualityOverride
+                  ? "Custom chord type — not the diatonic default."
+                  : "Switching degrees picks the diatonic default automatically."}
               </p>
             </div>
           ) : null}


### PR DESCRIPTION
## Summary

- Adds an asterisk (`V*`) to the active degree button when the chord type has been overridden from the diatonic default
- Swaps the hint text to "Custom chord type — not the diatonic default." when an override is active
- Fixes a test isolation issue where `chordQualityOverrideAtom` leaked via `localStorage` between tests

## Test plan

- [x] All 1128 unit tests pass
- [x] Lint clean
- [x] Build passes
- [ ] Select a degree (e.g. V) → verify no asterisk, hint says "Switching degrees picks the diatonic default automatically."
- [ ] Override chord type (e.g. pick Dominant 7th) → verify degree shows `V*`, hint says "Custom chord type — not the diatonic default."
- [ ] Switch to a different degree and back → verify asterisk clears (override is reset per degree change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)