### PR TITLE
fix(chord-overlay): reduce chord connector overlap with graph-coloring offset assignment

### DIFF
--- a/src/components/FretboardSVG/hooks/useChordConnectorPolylines.test.ts
+++ b/src/components/FretboardSVG/hooks/useChordConnectorPolylines.test.ts
@@ -7,6 +7,7 @@ import {
   CHORD_CONNECTOR_BASE_RADIUS_FACTOR,
   clampConnectorRadiusToYBounds,
   useChordConnectorPolylines,
+  INTERVAL_TO_PALETTE,
 } from "./useChordConnectorPolylines";
 import type { NoteData } from "./useNoteData";
 
@@ -1473,5 +1474,75 @@ describe("voicingKey field", () => {
     expect(key).toContain("0,5");
     expect(key).toContain("1,7");
     expect(key).toContain("2,6");
+  });
+
+  // -------------------------------------------------------------------------
+  // INTERVAL_TO_PALETTE — collision-free mapping
+  // -------------------------------------------------------------------------
+
+  describe("INTERVAL_TO_PALETTE", () => {
+    it("maps all 12 semitone intervals to valid palette indices 0-7", () => {
+      expect(INTERVAL_TO_PALETTE).toHaveLength(12);
+      for (const slot of INTERVAL_TO_PALETTE) {
+        expect(slot).toBeGreaterThanOrEqual(0);
+        expect(slot).toBeLessThanOrEqual(7);
+      }
+    });
+
+    it.each([
+      { name: "augmented triad", intervals: [0, 4, 8] },
+      { name: "diminished 7th", intervals: [0, 3, 6, 9] },
+      { name: "dominant 7th", intervals: [0, 4, 7, 10] },
+      { name: "major 7th", intervals: [0, 4, 7, 11] },
+      { name: "minor 7th", intervals: [0, 3, 7, 10] },
+      { name: "augmented 7th", intervals: [0, 4, 8, 10] },
+      { name: "minor-major 7th", intervals: [0, 3, 7, 11] },
+      { name: "half-diminished 7th", intervals: [0, 3, 6, 10] },
+    ])("produces distinct palette indices for $name ($intervals)", ({ intervals }) => {
+      const mapped = intervals.map((i) => INTERVAL_TO_PALETTE[i]);
+      const unique = new Set(mapped);
+      expect(unique.size).toBe(intervals.length);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Augmented triad inversions get distinct colors
+  // -------------------------------------------------------------------------
+
+  it("augmented triad inversions (E aug: E, G#, C) receive distinct paletteIndex values", () => {
+    // E augmented triad: E (root), G# (maj 3rd), C (aug 5th = enharmonic B#)
+    // Three voicings on strings 0-2, each with a different bass note on string 2.
+    // Frets kept within MAX_FRET_SPAN (5) per voicing.
+    const noteData = [
+      // Voicing 1: E in bass (string 2) — root position, interval 0
+      // Frets 4,5,4 → fretted span = 5-4+1 = 2 ✓
+      makeNote(0, 4, "G#", "chord-tone-in-scale"),
+      makeNote(1, 5, "C", "chord-tone-in-scale"),
+      makeNote(2, 4, "E", "chord-tone-in-scale"),
+      // Voicing 2: G# in bass (string 2) — 1st inversion, interval 4
+      makeNote(0, 8, "C", "chord-tone-in-scale"),
+      makeNote(1, 9, "E", "chord-tone-in-scale"),
+      makeNote(2, 8, "G#", "chord-tone-in-scale"),
+      // Voicing 3: C in bass (string 2) — 2nd inversion, interval 8
+      makeNote(0, 12, "E", "chord-tone-in-scale"),
+      makeNote(1, 13, "G#", "chord-tone-in-scale"),
+      makeNote(2, 12, "C", "chord-tone-in-scale"),
+    ];
+
+    const result = buildChordConnectorPolylines(
+      noteData,
+      ["E", "G#", "C"],
+      fretCenterX,
+      stringYAt,
+      STRING_ROW_PX,
+      "E",
+    );
+
+    expect(result.length).toBeGreaterThanOrEqual(3);
+
+    const paletteIndices = result.map((v) => v.paletteIndex);
+    const unique = new Set(paletteIndices);
+    // All three inversions must have distinct palette indices.
+    expect(unique.size).toBe(paletteIndices.length);
   });
 });

--- a/src/components/FretboardSVG/hooks/useChordConnectorPolylines.test.ts
+++ b/src/components/FretboardSVG/hooks/useChordConnectorPolylines.test.ts
@@ -1214,6 +1214,192 @@ describe("adjacency-aware offset assignment", () => {
 });
 
 // -------------------------------------------------------------------------
+// Overlap offset regression: G major triad on full neck
+//
+// C major scale, degree V (G major = G, B, D).
+// Standard tuning high-to-low: E4(str0) B3(str1) G3(str2) D3(str3) A2(str4) E2(str5)
+//
+// Chord-tone positions (frets 0–22):
+//   G: str0@{3,15}, str1@{8,20}, str2@{0,12}, str3@{5,17}, str4@{10,22}, str5@{3,15}
+//   B: str0@{7,19}, str1@{0,12}, str2@{4,16}, str3@{9,21}, str4@{2,14}, str5@{7,19}
+//   D: str0@{10,22}, str1@{3,15}, str2@{7,19}, str3@{0,12}, str4@{5,17}, str5@{10,22}
+//
+// The E-shape CAGED voicings cluster around frets 7–10 and repeat at 19–22.
+// Both groups should receive independent offset budgets so their
+// overlapping connectors are visually separated.
+// -------------------------------------------------------------------------
+
+describe("G major triad overlap offsets (full neck)", () => {
+  // All G-major chord tones on 6 strings, frets 0–22.
+  function gMajorChordTones(): NoteData[] {
+    const tones: Array<[number, number, string, string]> = [
+      // G positions
+      [0, 3, "G", "chord-tone-in-scale"], [0, 15, "G", "chord-tone-in-scale"],
+      [1, 8, "G", "chord-tone-in-scale"], [1, 20, "G", "chord-tone-in-scale"],
+      [2, 0, "G", "chord-root"],          [2, 12, "G", "chord-root"],
+      [3, 5, "G", "chord-tone-in-scale"], [3, 17, "G", "chord-tone-in-scale"],
+      [4, 10, "G", "chord-tone-in-scale"],[4, 22, "G", "chord-tone-in-scale"],
+      [5, 3, "G", "chord-tone-in-scale"], [5, 15, "G", "chord-tone-in-scale"],
+      // B positions
+      [0, 7, "B", "chord-tone-in-scale"], [0, 19, "B", "chord-tone-in-scale"],
+      [1, 0, "B", "chord-tone-in-scale"], [1, 12, "B", "chord-tone-in-scale"],
+      [2, 4, "B", "chord-tone-in-scale"], [2, 16, "B", "chord-tone-in-scale"],
+      [3, 9, "B", "chord-tone-in-scale"], [3, 21, "B", "chord-tone-in-scale"],
+      [4, 2, "B", "chord-tone-in-scale"], [4, 14, "B", "chord-tone-in-scale"],
+      [5, 7, "B", "chord-tone-in-scale"], [5, 19, "B", "chord-tone-in-scale"],
+      // D positions
+      [0, 10, "D", "chord-tone-in-scale"],[0, 22, "D", "chord-tone-in-scale"],
+      [1, 3, "D", "chord-tone-in-scale"], [1, 15, "D", "chord-tone-in-scale"],
+      [2, 7, "D", "chord-tone-in-scale"], [2, 19, "D", "chord-tone-in-scale"],
+      [3, 0, "D", "chord-tone-in-scale"], [3, 12, "D", "chord-tone-in-scale"],
+      [4, 5, "D", "chord-tone-in-scale"], [4, 17, "D", "chord-tone-in-scale"],
+      [5, 10, "D", "chord-tone-in-scale"],[5, 22, "D", "chord-tone-in-scale"],
+    ];
+    return tones.map(([si, fi, name, cls]) => makeNote(si, fi, name, cls));
+  }
+
+  // Helper: extract voicings whose vertices fall within a fret range.
+  function voicingsInFretRange(
+    voicings: ReturnType<typeof buildChordConnectorPolylines>,
+    minFret: number,
+    maxFret: number,
+  ) {
+    return voicings.filter((v) => {
+      const frets = v.voicingKey.split("|").map((p) => Number(p.split(",")[1]));
+      return frets.every((f) => f >= minFret && f <= maxFret);
+    });
+  }
+
+  // Helper: check if two voicingKeys share a (string,fret) position.
+  function keysSharePosition(a: string, b: string): boolean {
+    const setA = new Set(a.split("|"));
+    for (const pos of b.split("|")) {
+      if (setA.has(pos)) return true;
+    }
+    return false;
+  }
+
+  it("produces voicings in both the fret 7–10 and 19–22 regions", () => {
+    const result = buildChordConnectorPolylines(
+      gMajorChordTones(), ["G", "B", "D"], fretCenterX, stringYAt, STRING_ROW_PX, "G",
+    );
+
+    const low = voicingsInFretRange(result, 7, 10);
+    const high = voicingsInFretRange(result, 19, 22);
+
+    expect(low.length).toBeGreaterThanOrEqual(3);
+    expect(high.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("frets 7–10: overlapping voicings have distinct paths", () => {
+    const result = buildChordConnectorPolylines(
+      gMajorChordTones(), ["G", "B", "D"], fretCenterX, stringYAt, STRING_ROW_PX, "G",
+    );
+
+    const group = voicingsInFretRange(result, 7, 10);
+    // Every pair that shares a position must have different paths.
+    for (let i = 0; i < group.length; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        if (keysSharePosition(group[i]!.voicingKey, group[j]!.voicingKey)) {
+          expect(
+            group[i]!.paths.fill,
+            `frets 7-10: voicings "${group[i]!.voicingKey}" and "${group[j]!.voicingKey}" share a position but have identical paths (same radius)`,
+          ).not.toBe(group[j]!.paths.fill);
+        }
+      }
+    }
+  });
+
+  it("frets 19–22: overlapping voicings have distinct paths", () => {
+    const result = buildChordConnectorPolylines(
+      gMajorChordTones(), ["G", "B", "D"], fretCenterX, stringYAt, STRING_ROW_PX, "G",
+    );
+
+    const group = voicingsInFretRange(result, 19, 22);
+    // Every pair that shares a position must have different paths.
+    for (let i = 0; i < group.length; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        if (keysSharePosition(group[i]!.voicingKey, group[j]!.voicingKey)) {
+          expect(
+            group[i]!.paths.fill,
+            `frets 19-22: voicings "${group[i]!.voicingKey}" and "${group[j]!.voicingKey}" share a position but have identical paths (same radius)`,
+          ).not.toBe(group[j]!.paths.fill);
+        }
+      }
+    }
+  });
+
+  it("non-overlapping voicings share the same (minimal) offset", () => {
+    const result = buildChordConnectorPolylines(
+      gMajorChordTones(), ["G", "B", "D"], fretCenterX, stringYAt, STRING_ROW_PX, "G",
+    );
+
+    const group = voicingsInFretRange(result, 7, 10);
+    // Non-overlapping pairs should share the same radius.
+    for (let i = 0; i < group.length; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        if (!keysSharePosition(group[i]!.voicingKey, group[j]!.voicingKey)) {
+          const rxI = parseFloat(group[i]!.paths.fill.match(/A ([\d.]+)/)?.[1] ?? "0");
+          const rxJ = parseFloat(group[j]!.paths.fill.match(/A ([\d.]+)/)?.[1] ?? "0");
+          expect(
+            rxI,
+            `non-overlapping voicings "${group[i]!.voicingKey}" and "${group[j]!.voicingKey}" should share the same radius`,
+          ).toBeCloseTo(rxJ, 1);
+        }
+      }
+    }
+  });
+
+  it("frets 7-10 and 19-22 receive independent offset budgets", () => {
+    const result = buildChordConnectorPolylines(
+      gMajorChordTones(), ["G", "B", "D"], fretCenterX, stringYAt, STRING_ROW_PX, "G",
+    );
+
+    const baseRadius = STRING_ROW_PX * CHORD_CONNECTOR_BASE_RADIUS_FACTOR;
+
+    // Both regions should have the same offset distribution (isomorphic shapes).
+    const extractOffsets = (minF: number, maxF: number) =>
+      voicingsInFretRange(result, minF, maxF)
+        .map((v) => {
+          const rx = parseFloat(v.paths.fill.match(/A ([\d.]+)/)?.[1] ?? "0");
+          return Math.round(rx - baseRadius);
+        })
+        .sort((a, b) => a - b);
+
+    const offsets7 = extractOffsets(7, 10);
+    const offsets19 = extractOffsets(19, 22);
+
+    expect(offsets7).toEqual(offsets19);
+    // Verify they use minimal offsets (0 and CONNECTOR_OFFSET_STEP=3).
+    expect(offsets7).toEqual([0, 3, 3]);
+  });
+
+  it("yBounds clamping does not erase offset differentiation", () => {
+    // With yBounds, edge voicings (touching str0 or str5) get clamped.
+    // The post-clamp fix should ensure overlapping pairs still differ.
+    // stringYAt = si * 20 → str0=0, str5=100. neckHeight = 100.
+    const yBounds = { minY: 0, maxY: 100 };
+
+    const result = buildChordConnectorPolylines(
+      gMajorChordTones(), ["G", "B", "D"], fretCenterX, stringYAt, STRING_ROW_PX, "G", yBounds,
+    );
+
+    const group = voicingsInFretRange(result, 19, 22);
+    // Every pair sharing a position must have distinct paths even after clamping.
+    for (let i = 0; i < group.length; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        if (keysSharePosition(group[i]!.voicingKey, group[j]!.voicingKey)) {
+          expect(
+            group[i]!.paths.fill,
+            `yBounds clamped: "${group[i]!.voicingKey}" and "${group[j]!.voicingKey}" share a position but have identical paths`,
+          ).not.toBe(group[j]!.paths.fill);
+        }
+      }
+    }
+  });
+});
+
+// -------------------------------------------------------------------------
 // voicingKey: stability, uniqueness, and order-independence
 // -------------------------------------------------------------------------
 

--- a/src/components/FretboardSVG/hooks/useChordConnectorPolylines.ts
+++ b/src/components/FretboardSVG/hooks/useChordConnectorPolylines.ts
@@ -141,67 +141,52 @@ export function clampConnectorRadiusToYBounds(
 }
 
 /**
- * Per-voicing pixel offset deltas added to the base radius.
- * Assigned by adjacency-aware cluster detection so that voicings whose
- * envelopes overlap receive distinct offsets with 2 px spacing between
- * adjacent values. Non-negative: smallest envelope equals base radius
- * (no bubble-clipping risk). Six entries cap the cluster size; clusters
- * larger than 6 wrap with modulo (documented, accepted trade-off).
+ * Fixed pixel step between adjacent colour indices. Each graph-colouring
+ * level adds CONNECTOR_OFFSET_STEP px to the base radius — just enough to
+ * visually separate the 1.25 px stroke outlines without inflating
+ * connectors more than necessary. Capped at MAX_CONNECTOR_OFFSET to
+ * prevent unbounded growth in highly-connected clusters.
  */
-const OFFSET_BUCKET = [0, 2, 4, 6, 8, 10] as const;
+const CONNECTOR_OFFSET_STEP = 3;
+const MAX_CONNECTOR_OFFSET = 10;
 
 /**
- * Compute the axis-aligned bounding box of a set of vertices, inflated
- * outward by `inflateBy` pixels on every side. Used to approximate
- * envelope-vs-envelope overlap before full geometry is computed.
+ * Extract the set of "stringIndex,fretIndex" position tokens from a
+ * canonical key like "0,7|1,8|2,7".
  */
-function inflatedAABB(
-  vertices: ChordConnectorVertex[],
-  inflateBy: number,
-): { minX: number; maxX: number; minY: number; maxY: number } {
-  let minX = Infinity;
-  let maxX = -Infinity;
-  let minY = Infinity;
-  let maxY = -Infinity;
-  for (const v of vertices) {
-    if (v.x < minX) minX = v.x;
-    if (v.x > maxX) maxX = v.x;
-    if (v.y < minY) minY = v.y;
-    if (v.y > maxY) maxY = v.y;
+function positionSet(canonicalKey: string): Set<string> {
+  return new Set(canonicalKey.split("|"));
+}
+
+/**
+ * Test whether two voicings share at least one (string, fret) position.
+ * Voicings that share a vertex produce overlapping connector outlines
+ * regardless of radius, so they must receive distinct offsets.
+ */
+function sharesPosition(aPositions: Set<string>, bPositions: Set<string>): boolean {
+  for (const pos of aPositions) {
+    if (bPositions.has(pos)) return true;
   }
-  return {
-    minX: minX - inflateBy,
-    maxX: maxX + inflateBy,
-    minY: minY - inflateBy,
-    maxY: maxY + inflateBy,
-  };
+  return false;
 }
 
 /**
- * Test whether two axis-aligned bounding boxes intersect.
- */
-function aabbIntersects(
-  a: { minX: number; maxX: number; minY: number; maxY: number },
-  b: { minX: number; maxX: number; minY: number; maxY: number },
-): boolean {
-  return a.minX <= b.maxX && a.maxX >= b.minX && a.minY <= b.maxY && a.maxY >= b.minY;
-}
-
-/**
- * Cluster pending voicings by inflated-AABB pairwise overlap using union-find.
- * Returns an array of clusters; each cluster is an array of indices into
- * `pendingVoicings`. Singletons (no overlap) appear as single-element arrays.
+ * Cluster pending voicings by shared (string, fret) positions using
+ * union-find. Two voicings are connected if they share at least one
+ * vertex position. This produces tight, spatially local clusters —
+ * voicings at distant fret regions remain independent even though
+ * their inflated envelopes might overlap.
+ *
+ * Returns an array of clusters; each cluster is an array of indices
+ * into `pendingVoicings`. Singletons appear as single-element arrays.
  */
 function detectOverlapClusters(
-  pendingVoicings: { rawVertices: ChordConnectorVertex[]; canonicalKey: string }[],
-  baseRadius: number,
-  maxBucketOffset: number,
+  pendingVoicings: { canonicalKey: string }[],
 ): number[][] {
   const n = pendingVoicings.length;
-  const inflate = baseRadius + maxBucketOffset;
 
-  // Precompute inflated AABBs.
-  const boxes = pendingVoicings.map((pv) => inflatedAABB(pv.rawVertices, inflate));
+  // Precompute position sets.
+  const positions = pendingVoicings.map((pv) => positionSet(pv.canonicalKey));
 
   // Union-find arrays.
   const parent = Array.from({ length: n }, (_, i) => i);
@@ -209,7 +194,7 @@ function detectOverlapClusters(
 
   function find(x: number): number {
     while (parent[x] !== x) {
-      parent[x] = parent[parent[x]!]!; // path compression (halving)
+      parent[x] = parent[parent[x]!]!;
       x = parent[x]!;
     }
     return x;
@@ -229,10 +214,10 @@ function detectOverlapClusters(
     }
   }
 
-  // Union all overlapping pairs.
+  // Union voicings that share at least one (string, fret) position.
   for (let i = 0; i < n; i++) {
     for (let j = i + 1; j < n; j++) {
-      if (aabbIntersects(boxes[i]!, boxes[j]!)) {
+      if (sharesPosition(positions[i]!, positions[j]!)) {
         union(i, j);
       }
     }
@@ -254,10 +239,24 @@ function detectOverlapClusters(
 }
 
 /**
- * Assign offsets from OFFSET_BUCKET to each voicing based on its cluster.
- * Within each cluster, members are sorted by canonicalKey (lexicographic) for
- * determinism, then assigned OFFSET_BUCKET[i % OFFSET_BUCKET.length].
- * Singleton clusters (no overlap) receive offset 0.
+ * Assign offsets to each voicing based on its cluster, using greedy graph
+ * coloring with evenly-spaced offsets.
+ *
+ * Within each cluster the algorithm:
+ * 1. Builds a pairwise adjacency graph from shared (string, fret) positions.
+ * 2. Greedy-colours the graph (decreasing-degree order, canonicalKey
+ *    tiebreak) assigning the smallest unused colour index to each node.
+ * 3. Maps colour indices to pixel offsets via fixed step:
+ *    offset = min(colour * CONNECTOR_OFFSET_STEP, MAX_CONNECTOR_OFFSET).
+ *
+ * The fixed step keeps radius increases minimal:
+ *   2 colours → {0, 3}       3 px gap
+ *   3 colours → {0, 3, 6}    3 px gap, max +6 px
+ *   4 colours → {0, 3, 6, 9} 3 px gap, max +9 px
+ * Non-overlapping pairs within a cluster share colour 0 (offset 0),
+ * keeping radii at the base minimum.
+ *
+ * Singleton clusters receive offset 0.
  * Returns a Map<canonicalKey, offsetPx>.
  */
 function assignClusterOffsets(
@@ -265,19 +264,65 @@ function assignClusterOffsets(
   pendingVoicings: { canonicalKey: string }[],
 ): Map<string, number> {
   const result = new Map<string, number>();
+
   for (const cluster of clusters) {
     if (cluster.length === 1) {
       result.set(pendingVoicings[cluster[0]!]!.canonicalKey, 0);
-    } else {
-      // Sort by canonicalKey for determinism.
-      const sorted = [...cluster].sort((a, b) =>
-        pendingVoicings[a]!.canonicalKey.localeCompare(pendingVoicings[b]!.canonicalKey),
+      continue;
+    }
+
+    const n = cluster.length;
+
+    // Build pairwise overlap adjacency within the cluster using shared
+    // (string, fret) positions — the same criterion used for clustering.
+    const positions = cluster.map((idx) => positionSet(pendingVoicings[idx]!.canonicalKey));
+    const adjacency: Set<number>[] = Array.from({ length: n }, () => new Set<number>());
+
+    for (let i = 0; i < n; i++) {
+      for (let j = i + 1; j < n; j++) {
+        if (sharesPosition(positions[i]!, positions[j]!)) {
+          adjacency[i]!.add(j);
+          adjacency[j]!.add(i);
+        }
+      }
+    }
+
+    // Process order: highest degree first; ties broken by canonicalKey for
+    // determinism.
+    const order = Array.from({ length: n }, (_, i) => i).sort((a, b) => {
+      const degDiff = adjacency[b]!.size - adjacency[a]!.size;
+      if (degDiff !== 0) return degDiff;
+      return pendingVoicings[cluster[a]!]!.canonicalKey.localeCompare(
+        pendingVoicings[cluster[b]!]!.canonicalKey,
       );
-      sorted.forEach((idx, i) => {
-        result.set(pendingVoicings[idx]!.canonicalKey, OFFSET_BUCKET[i % OFFSET_BUCKET.length]!);
-      });
+    });
+
+    // Greedy graph colouring: assign the smallest colour index not used by
+    // any overlapping neighbour.
+    const colorAssignments = new Array<number>(n).fill(-1);
+
+    for (const localIdx of order) {
+      const usedColors = new Set<number>();
+      for (const neighbor of adjacency[localIdx]!) {
+        if (colorAssignments[neighbor]! >= 0) {
+          usedColors.add(colorAssignments[neighbor]!);
+        }
+      }
+      let color = 0;
+      while (usedColors.has(color)) color++;
+      colorAssignments[localIdx] = color;
+    }
+
+    // Map colour indices to pixel offsets using a fixed step.
+    // colour 0 → 0, colour 1 → STEP, colour 2 → 2*STEP, etc.
+    // Capped at MAX_CONNECTOR_OFFSET to prevent unbounded growth.
+    for (let i = 0; i < n; i++) {
+      const color = colorAssignments[i]!;
+      const offset = Math.min(color * CONNECTOR_OFFSET_STEP, MAX_CONNECTOR_OFFSET);
+      result.set(pendingVoicings[cluster[i]!]!.canonicalKey, offset);
     }
   }
+
   return result;
 }
 
@@ -344,7 +389,7 @@ export const CHORD_TONE_CLASSES = new Set([
  *      b. **Cluster + assign pass** — after the loop, `detectOverlapClusters`
  *         computes adjacency-aware voicing groups via inflated-AABB union-find;
  *         `assignClusterOffsets` maps each `canonicalKey` to a distinct
- *         `offsetPx` from OFFSET_BUCKET (2 px spacing). Voicings that do not
+ *         `offsetPx` from graph-coloring (evenly spaced). Voicings that do not
  *         overlap any other voicing receive offset 0. Finally the pending list
  *         is iterated once more to emit final paths via
  *         `offsetOutlinePath(polarSort(rawVertices), baseRadius + offsetPx)`.
@@ -543,36 +588,70 @@ export function buildChordConnectorPolylines(
 
   // Pass 2: cluster + assign offsets, then emit final voicings with paths.
   //
-  // `detectOverlapClusters` groups voicings whose inflated AABBs intersect
-  // via union-find (AABB inflated by baseRadius + maxBucketOffset so the test
-  // approximates envelope-vs-envelope overlap, not just vertex proximity).
-  // `assignClusterOffsets` sorts each cluster by canonicalKey and assigns
-  // OFFSET_BUCKET[i % OFFSET_BUCKET.length] to member i — singletons get 0.
+  // `detectOverlapClusters` groups voicings that share at least one
+  // (string, fret) position via union-find. This produces tight, spatially
+  // local clusters — voicings at distant fret regions stay independent.
+  //
+  // `assignClusterOffsets` greedy-colours each cluster's shared-position
+  // overlap graph and maps colour indices to evenly-spaced pixel offsets
+  // across [0, MAX_CONNECTOR_OFFSET].
   //
   // `offsetOutlinePath` Minkowski-sums the polar-sorted polygon with a disk of
   // radius `baseRadius + offsetPx` and dispatches internally:
-  //   - 3+ non-collinear vertices → rounded offset polygon (smooth blob,
-  //     fixes thin-sliver triangles for cross-fret triads).
-  //   - 3+ collinear vertices → falls back to a capsule (matches old look).
+  //   - 3+ non-collinear vertices → rounded offset polygon.
+  //   - 3+ collinear vertices → capsule fallback.
   //   - 2 vertices → capsule.
   //   - 1 vertex → circle.
   // fill === outline (byte-identical) — renderer differentiates via fill/stroke.
   const baseRadius = stringRowPx * CHORD_CONNECTOR_BASE_RADIUS_FACTOR;
-  const maxBucketOffset = OFFSET_BUCKET[OFFSET_BUCKET.length - 1]!; // 10
-  const clusters = detectOverlapClusters(pendingVoicings, baseRadius, maxBucketOffset);
+  const clusters = detectOverlapClusters(pendingVoicings);
   const clusterOffsetMap = assignClusterOffsets(clusters, pendingVoicings);
 
-  const results: ChordConnectorVoicing[] = pendingVoicings.map((pv) => {
+  // Compute initial radii (offset + clamp).
+  const radii = pendingVoicings.map((pv) => {
     const offsetPx = clusterOffsetMap.get(pv.canonicalKey) ?? 0;
-    const radius = clampConnectorRadiusToYBounds(
-      pv.rawVertices,
-      baseRadius + offsetPx,
-      yBounds,
-    );
-    const pathStr = offsetOutlinePath(
-      convexHull(pv.rawVertices),
-      radius,
-    );
+    return clampConnectorRadiusToYBounds(pv.rawVertices, baseRadius + offsetPx, yBounds);
+  });
+
+  // Post-clamp collision fix: if clamping collapsed two overlapping
+  // voicings to the same radius, nudge the unclamped one so they differ.
+  // This handles edge/boundary voicings (strings 0 or 5) where the
+  // clamped radius erases the offset differentiation.
+  if (yBounds) {
+    const positionSets = pendingVoicings.map((pv) => positionSet(pv.canonicalKey));
+    for (let i = 0; i < pendingVoicings.length; i++) {
+      for (let j = i + 1; j < pendingVoicings.length; j++) {
+        if (!sharesPosition(positionSets[i]!, positionSets[j]!)) continue;
+        if (Math.abs(radii[i]! - radii[j]!) >= 1) continue;
+
+        // Two overlapping voicings have the same clamped radius.
+        // The one whose preferred radius was NOT clamped can be adjusted.
+        const prefI = baseRadius + (clusterOffsetMap.get(pendingVoicings[i]!.canonicalKey) ?? 0);
+        const prefJ = baseRadius + (clusterOffsetMap.get(pendingVoicings[j]!.canonicalKey) ?? 0);
+        const clampedI = radii[i]! < prefI - 0.5;
+        const clampedJ = radii[j]! < prefJ - 0.5;
+
+        if (clampedI && !clampedJ) {
+          // i was clamped, j is free — shrink j below the clamped value.
+          radii[j] = Math.max(0, radii[i]! - CONNECTOR_OFFSET_STEP);
+        } else if (clampedJ && !clampedI) {
+          // j was clamped, i is free — shrink i below the clamped value.
+          radii[i] = Math.max(0, radii[j]! - CONNECTOR_OFFSET_STEP);
+        } else if (clampedI && clampedJ) {
+          // Both clamped to the same value — shrink the one with the
+          // smaller preferred radius (it was closer to clamping anyway).
+          if (prefI <= prefJ) {
+            radii[i] = Math.max(0, radii[i]! - CONNECTOR_OFFSET_STEP);
+          } else {
+            radii[j] = Math.max(0, radii[j]! - CONNECTOR_OFFSET_STEP);
+          }
+        }
+      }
+    }
+  }
+
+  const results: ChordConnectorVoicing[] = pendingVoicings.map((pv, idx) => {
+    const pathStr = offsetOutlinePath(convexHull(pv.rawVertices), radii[idx]!);
     const paths = { fill: pathStr, outline: pathStr };
     return { paths, vertices: pv.rawVertices, paletteIndex: pv.paletteIndex, voicingKey: pv.canonicalKey };
   });

--- a/src/components/FretboardSVG/hooks/useChordConnectorPolylines.ts
+++ b/src/components/FretboardSVG/hooks/useChordConnectorPolylines.ts
@@ -29,6 +29,25 @@ function voicingFrettedPositionCount(combo: NoteData[]): number {
 }
 
 /**
+ * Maps each of the 12 semitone intervals (0-11) to one of 8 palette slots
+ * (0-7). Designed so intervals that co-occur within any standard chord type
+ * (triads, 7ths, aug, dim) never collide.
+ *
+ * Verification:
+ *   Aug triad  (0,4,8)    → (0,4,3) ✓
+ *   Dim7       (0,3,6,9)  → (0,3,6,5) ✓
+ *   Dom7       (0,4,7,10) → (0,4,7,1) ✓
+ *   Maj7       (0,4,7,11) → (0,4,7,6) ✓
+ *   Min7       (0,3,7,10) → (0,3,7,1) ✓
+ *   Aug7       (0,4,8,10) → (0,4,3,1) ✓
+ *   MinMaj7    (0,3,7,11) → (0,3,7,6) ✓
+ *   Half-dim7  (0,3,6,10) → (0,3,6,1) ✓
+ */
+export const INTERVAL_TO_PALETTE: readonly number[] = [
+  0, 1, 2, 3, 4, 5, 6, 7, 3, 5, 1, 6,
+];
+
+/**
  * Compute the bass-note interval (in semitones, 0-11) from the chord root to
  * the lowest physical note in a voicing.
  *
@@ -579,7 +598,8 @@ export function buildChordConnectorPolylines(
       // chord root). Same inversion → same color across positions and chord
       // qualities. Root in bass = 0 → palette[0]; major 3rd in bass = 4 →
       // palette[4]; perfect 5th in bass = 7 → palette[7]; etc.
-      const paletteIndex = bassIntervalSemitones(bestCombo, chordRoot) % 8;
+      const interval = bassIntervalSemitones(bestCombo, chordRoot);
+      const paletteIndex = INTERVAL_TO_PALETTE[interval] ?? interval % 8;
 
       // Collect — path generation deferred to pass 2 after cluster assignment.
       pendingVoicings.push({ rawVertices, paletteIndex, canonicalKey });


### PR DESCRIPTION
## Summary

- Replaced AABB-based overlap detection with shared (string, fret) position testing — prevents transitive chaining of distant fret regions into one mega-cluster
- Replaced sequential `OFFSET_BUCKET` assignment with greedy graph-coloring using a fixed 3px step — minimises radius inflation while keeping overlapping outlines distinct
- Non-overlapping voicings within a cluster share colour 0 (offset 0), keeping radii at the base minimum
- Added post-clamp collision fix: when `yBounds` clamping erases offset differentiation on edge strings, the unclamped voicing is nudged to restore separation

## Test plan

- [x] 6 new regression tests covering G major triad on full neck (frets 7–10 and 19–22 independent budgets, yBounds clamping interaction)
- [x] All 1134 existing tests pass
- [x] Lint clean
- [x] Production build succeeds
- [ ] Visual check: chord connectors on degree V CAGED E shape (C major scale) — borders no longer overlap at frets 7–10 or 19–22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual distinction of overlapping chord voicings across the fretboard with enhanced color differentiation.
  * Enhanced chord connector rendering for voicings spanning multiple fret regions with refined offset handling.
  * Fixed rendering behavior to maintain visual clarity between overlapping voicings.

* **Tests**
  * Expanded test coverage for chord rendering, including regression tests for complex multi-region chord patterns.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/358)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->