### PR TITLE
feat(loading): replace bare spinners with skeleton loading states

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ import { ChordOverlayDock } from "./components/ChordOverlayDock/ChordOverlayDock
 import { MainLayoutWrapper } from "./components/MainLayoutWrapper/MainLayoutWrapper";
 import { SettingsTooltip } from "./components/SettingsTooltip/SettingsTooltip";
 import sharedStyles from "./components/shared/shared.module.css";
-import { ControlsPanelSkeleton, MobileTabSkeleton, OverlaySpinner } from "./components/LoadingSkeleton/LoadingSkeleton";
+import { ControlsPanelSkeleton, MobileTabSkeleton } from "./components/LoadingSkeleton/LoadingSkeleton";
 import { ANIMATION_DURATION_XFADE } from "@fretflow/core";
 import "./styles/App.css";
 
@@ -210,7 +210,7 @@ function AppContent() {
       summary={<ScaleStripPanel />}
       chordDock={<ChordOverlayDock />}
       helpModal={
-        <Suspense fallback={<OverlaySpinner />}>
+        <Suspense fallback={null}>
           <HelpModal
             isOpen={showHelp}
             onClose={() => setShowHelp(false)}
@@ -229,7 +229,7 @@ function AppContent() {
         </Suspense>
       }
       settingsOverlay={
-        <Suspense fallback={<OverlaySpinner />}>
+        <Suspense fallback={null}>
           <SettingsOverlay />
         </Suspense>
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import { ChordOverlayDock } from "./components/ChordOverlayDock/ChordOverlayDock
 import { MainLayoutWrapper } from "./components/MainLayoutWrapper/MainLayoutWrapper";
 import { SettingsTooltip } from "./components/SettingsTooltip/SettingsTooltip";
 import sharedStyles from "./components/shared/shared.module.css";
+import { ControlsPanelSkeleton, MobileTabSkeleton, OverlaySpinner } from "./components/LoadingSkeleton/LoadingSkeleton";
 import { ANIMATION_DURATION_XFADE } from "@fretflow/core";
 import "./styles/App.css";
 
@@ -209,7 +210,7 @@ function AppContent() {
       summary={<ScaleStripPanel />}
       chordDock={<ChordOverlayDock />}
       helpModal={
-        <Suspense fallback={<div className="loading-spinner" />}>
+        <Suspense fallback={<OverlaySpinner />}>
           <HelpModal
             isOpen={showHelp}
             onClose={() => setShowHelp(false)}
@@ -218,17 +219,17 @@ function AppContent() {
         </Suspense>
       }
       controlsPanel={
-        <Suspense fallback={<div className="loading-spinner" />}>
+        <Suspense fallback={<ControlsPanelSkeleton mode={layout.panelMode} />}>
           <ExpandedControlsPanel mode={layout.panelMode} />
         </Suspense>
       }
       mobileTabs={
-        <Suspense fallback={<div className="loading-spinner" />}>
+        <Suspense fallback={<MobileTabSkeleton />}>
           <MobileTabPanel />
         </Suspense>
       }
       settingsOverlay={
-        <Suspense fallback={<div className="loading-spinner" />}>
+        <Suspense fallback={<OverlaySpinner />}>
           <SettingsOverlay />
         </Suspense>
       }

--- a/src/components/ExpandedControlsPanel/ExpandedControlsPanel.tsx
+++ b/src/components/ExpandedControlsPanel/ExpandedControlsPanel.tsx
@@ -21,6 +21,7 @@ import { Card } from "../Card/Card";
 import { TAB_LABELS } from "../../constants/tabLabels";
 import { MAX_FRET } from "@fretflow/core";
 import { useCompactDensity } from "../../hooks/useCompactDensity";
+import { CircleOfFifthsSkeleton } from "../LoadingSkeleton/LoadingSkeleton";
 
 // Lazy-loaded component
 const CircleOfFifths = lazy(() =>
@@ -89,7 +90,7 @@ export function KeyColumn() {
 
   return (
     <Card title={TAB_LABELS.cof} data-layout-column="key" data-testid="key-column">
-      <Suspense fallback={null}>
+      <Suspense fallback={<CircleOfFifthsSkeleton />}>
         <CircleOfFifths
           rootNote={rootNote}
           setRootNote={handleSetRootNote}

--- a/src/components/LoadingSkeleton/LoadingSkeleton.module.css
+++ b/src/components/LoadingSkeleton/LoadingSkeleton.module.css
@@ -1,0 +1,179 @@
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.bone {
+  background: linear-gradient(
+    90deg,
+    var(--token-surface-dim) 25%,
+    rgb(255 255 255 / 0.08) 50%,
+    var(--token-surface-dim) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.8s ease-in-out infinite;
+  border-radius: var(--radius-sm);
+}
+
+.bar {
+  composes: bone;
+  height: 0.75rem;
+  width: 100%;
+}
+
+.bar--sm {
+  height: 0.5rem;
+}
+
+.bar--lg {
+  height: 1rem;
+}
+
+.circle {
+  composes: bone;
+  border-radius: 50%;
+  aspect-ratio: 1;
+}
+
+/* Card-shaped skeleton matching the app's Card component */
+.card-skeleton {
+  background: var(--token-surface-card-base);
+  border: 1px solid var(--token-border-subtle);
+  border-radius: var(--radius-card);
+  box-shadow: var(--elevation-card);
+  overflow: hidden;
+}
+
+.card-skeleton__header {
+  display: flex;
+  align-items: center;
+  padding: 1.15rem 1.3rem 0.9rem;
+  border-bottom: 1px solid var(--token-border-subtler);
+}
+
+.card-skeleton__header .bone {
+  height: 1.1rem;
+  width: 5rem;
+  border-radius: var(--radius-sm);
+}
+
+.card-skeleton__body {
+  padding: 0.95rem 1.3rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* Controls panel skeleton: matches the 3-card grid */
+.controls-skeleton {
+  display: grid;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.controls-skeleton[data-mode="3col"] {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 1fr);
+}
+
+.controls-skeleton[data-mode="split"] {
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 1fr);
+}
+
+.controls-skeleton[data-mode="stacked"] {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+/* Circle of Fifths skeleton */
+.cof-skeleton {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.7rem 0;
+}
+
+.cof-skeleton .circle {
+  width: min(14rem, 100%);
+}
+
+/* Centered spinner for overlays */
+.overlay-spinner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 8rem;
+}
+
+.spinner {
+  width: 2rem;
+  height: 2rem;
+  border: 2.5px solid var(--token-border-subtle);
+  border-top-color: var(--neon-cyan);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Mobile tab skeleton */
+.mobile-tab-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bone {
+    animation: none;
+    background: var(--token-surface-dim);
+  }
+
+  .spinner {
+    animation: none;
+    border-top-color: var(--token-border-subtle);
+  }
+}
+
+/* Desktop density overrides */
+/* stylelint-disable selector-pseudo-class-no-unknown */
+:global(.app-container[data-layout-tier="desktop"]) .card-skeleton__header {
+  padding: 0.62rem 1rem 0.5rem;
+}
+
+:global(.app-container[data-layout-tier="desktop"]) .card-skeleton__body {
+  padding: 0.6rem 1rem 0.75rem;
+}
+
+:global(.app-container[data-layout-tier="desktop"]) .controls-skeleton {
+  gap: 0.82rem;
+}
+
+:global(.app-container[data-layout-tier="tablet"]) .card-skeleton__header {
+  padding: 0.65rem 1.1rem 0.52rem;
+}
+
+:global(.app-container[data-layout-tier="tablet"]) .card-skeleton__body {
+  padding: 0.65rem 1.1rem 0.78rem;
+}
+
+:global(.app-container[data-layout-tier="tablet"]) .controls-skeleton {
+  gap: 1rem;
+}
+
+:global([data-layout-scope="mobile-tabs"]) .card-skeleton__header {
+  padding: 0.6rem 0.95rem 0.5rem;
+}
+
+:global([data-layout-scope="mobile-tabs"]) .card-skeleton__body {
+  padding: 0.55rem 0.95rem 0.7rem;
+}
+/* stylelint-enable selector-pseudo-class-no-unknown */

--- a/src/components/LoadingSkeleton/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton/LoadingSkeleton.tsx
@@ -1,0 +1,60 @@
+import clsx from "clsx";
+import styles from "./LoadingSkeleton.module.css";
+
+function SkeletonBar({ size = "md", width }: { size?: "sm" | "md" | "lg"; width?: string }) {
+  const sizeClass = size !== "md" ? styles[`bar--${size}`] : undefined;
+  return <div className={clsx(styles.bar, sizeClass)} style={width ? { width } : undefined} />;
+}
+
+function CardSkeleton({ rows = 3, children }: { rows?: number; children?: React.ReactNode }) {
+  return (
+    <div className={styles["card-skeleton"]} aria-hidden="true">
+      <div className={styles["card-skeleton__header"]}>
+        <div className={styles.bone} />
+      </div>
+      <div className={styles["card-skeleton__body"]}>
+        {children ?? Array.from({ length: rows }, (_, i) => (
+          <SkeletonBar key={i} width={i === rows - 1 ? "60%" : undefined} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ControlsPanelSkeleton({ mode }: { mode: "3col" | "split" | "stacked" }) {
+  return (
+    <div className={styles["controls-skeleton"]} data-mode={mode} aria-label="Loading controls" role="status">
+      <CardSkeleton rows={4} />
+      <CardSkeleton rows={5} />
+      <CardSkeleton>
+        <div className={styles["cof-skeleton"]}>
+          <div className={clsx(styles.circle)} style={{ width: "min(14rem, 100%)" }} />
+        </div>
+      </CardSkeleton>
+    </div>
+  );
+}
+
+export function MobileTabSkeleton() {
+  return (
+    <div className={styles["mobile-tab-skeleton"]} aria-label="Loading tab" role="status">
+      <CardSkeleton rows={4} />
+    </div>
+  );
+}
+
+export function CircleOfFifthsSkeleton() {
+  return (
+    <div className={styles["cof-skeleton"]} aria-label="Loading circle of fifths" role="status">
+      <div className={styles.circle} style={{ width: "min(14rem, 100%)" }} />
+    </div>
+  );
+}
+
+export function OverlaySpinner() {
+  return (
+    <div className={styles["overlay-spinner"]} aria-label="Loading" role="status">
+      <div className={styles.spinner} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Created `LoadingSkeleton` component with shimmer-animated skeleton primitives (bars, circles, card shapes) that match the app's Card component structure and design tokens
- Replaced all 4 bare `<div class="loading-spinner">` Suspense fallbacks in `App.tsx` with context-aware skeletons: `ControlsPanelSkeleton` (3-card grid), `MobileTabSkeleton`, and `OverlaySpinner` (centered spinner for Settings/Help)
- Added `CircleOfFifthsSkeleton` to `ExpandedControlsPanel` (previously `null` fallback)
- All skeletons respect `prefers-reduced-motion`, use existing design tokens, match tier-specific padding, and include `role="status"` + `aria-label`

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (eslint + stylelint)
- [x] `npm run test` — all 1169 tests pass
- [ ] Throttle network in DevTools to see skeleton flash during lazy chunk loads
- [ ] Verify `prefers-reduced-motion` disables shimmer animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added animated skeleton loading placeholders for controls panel, mobile tabs, Circle of Fifths visualization, and overlay spinner to improve loading feedback.
  * Swapped generic spinner fallbacks for context-aware skeletons (and `null` in select modal fallbacks) to reduce visual flicker during lazy loading.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/361)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->