### PR TITLE
fix(loading): theme skeleton loading states for light mode

### DIFF
--- a/src/components/LoadingSkeleton/LoadingSkeleton.module.css
+++ b/src/components/LoadingSkeleton/LoadingSkeleton.module.css
@@ -11,7 +11,7 @@
   background: linear-gradient(
     90deg,
     var(--token-surface-dim) 25%,
-    rgb(255 255 255 / 0.08) 50%,
+    var(--token-shimmer-highlight) 50%,
     var(--token-surface-dim) 75%
   );
   background-size: 200% 100%;
@@ -41,7 +41,7 @@
 
 /* Card-shaped skeleton matching the app's Card component */
 .card-skeleton {
-  background: var(--token-surface-card-base);
+  background: var(--surface-card-top);
   border: 1px solid var(--token-border-subtle);
   border-radius: var(--radius-card);
   box-shadow: var(--elevation-card);

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -120,6 +120,7 @@
   --token-border-subtler: var(--surface-raised);    /* was #f1f5f9 */
   --token-border-faint:   var(--surface-shell);     /* was #f8fafc */
   --token-surface-dim:    var(--surface-shell);     /* was #f8fafc */
+  --token-shimmer-highlight: rgb(0 0 0 / 0.06);
 
   /* Chip backgrounds — using solid accents for active states */
   --token-chip-active-bg: #0891b2;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -57,6 +57,7 @@
   --token-border-subtler: rgb(255 255 255 / 0.04);
   --token-border-faint: rgb(255 255 255 / 0.08);
   --token-surface-dim: rgb(255 255 255 / 0.04);
+  --token-shimmer-highlight: rgb(255 255 255 / 0.08);
 
   --token-surface-card-base: rgb(22 27 38);
 


### PR DESCRIPTION
## Summary
- Add `--token-shimmer-highlight` design token so the skeleton shimmer gradient adapts between dark mode (white overlay) and light mode (dark overlay), fixing invisible shimmer on light backgrounds
- Switch skeleton card background from `--token-surface-card-base` (never overridden for light theme) to `--surface-card-top` (properly themed)

## Test plan
- [ ] Toggle to light mode and trigger a Suspense boundary (e.g., slow network or code-split panel) — skeleton cards should have a cream background matching real cards
- [ ] Shimmer animation should be visible as a subtle dark sweep on light mode
- [ ] Dark mode skeletons remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined loading skeleton appearance with updated visual styling for improved consistency across the application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/362)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->