### PR TITLE
fix(fretboard): use scale-only fill for note-inactive notes

### DIFF
--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -123,7 +123,8 @@
   fill: var(--fretboard-note-text-fill);
 }
 
-.fretboard-note.scale-only :is(circle, path, polygon) {
+.fretboard-note.scale-only :is(circle, path, polygon),
+.fretboard-note.note-inactive :is(circle, path, polygon) {
   stroke: var(--note-ring);
   fill: var(--fretboard-note-fill-scale-only);
   stroke-width: 1.7;


### PR DESCRIPTION
## Summary
- Fix: note-inactive notes now use `var(--fretboard-note-fill-scale-only)` instead of defaulting to black in light mode
- Inactive notes (outside active CAGED shape) now have consistent fill color across light and dark themes

## Test Plan
- [x] Tests pass (1237 passed)
- [x] Build succeeds
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual appearance of inactive notes on the fretboard to match the styling of scale-only notes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/367)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->