### PR TITLE
chore(components): use animation constants and remove unused CSS

### DIFF
--- a/src/components/ChordPracticeBar/ChordPracticeBar.tsx
+++ b/src/components/ChordPracticeBar/ChordPracticeBar.tsx
@@ -2,6 +2,7 @@ import clsx from "clsx";
 import { useAtomValue, useSetAtom } from "jotai";
 import { Eye, EyeOff } from "lucide-react";
 import { AnimatePresence, motion } from 'motion/react';
+import { ANIMATION_DURATION_FAST, ANIMATION_EASE } from "@fretflow/core";
 import type { PracticeBarGroup, PracticeBarNote } from "@fretflow/core";
 import {
   chordOverlayHiddenAtom,
@@ -168,7 +169,7 @@ export function ChordPracticeBar({
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.18, ease: "easeOut" }}
+            transition={{ duration: ANIMATION_DURATION_FAST, ease: ANIMATION_EASE }}
             style={{ overflow: "hidden" }}
           >
             <div className={styles["chord-practice-bar-groups"]}>

--- a/src/components/CircleOfFifths/CircleOfFifths.module.css
+++ b/src/components/CircleOfFifths/CircleOfFifths.module.css
@@ -108,10 +108,10 @@
   fill: var(--surface-base);
   cursor: pointer;
   transition:
-    fill var(--transition-fast),
-    filter var(--transition-fast),
-    opacity var(--transition-fast),
-    stroke var(--transition-fast);
+    fill 0.2s ease,
+    filter 0.2s ease,
+    opacity 0.2s ease,
+    stroke 0.2s ease;
   stroke: var(--surface-highlight) !important;
   stroke-width: 1 !important;
 }

--- a/src/components/CircleOfFifths/CircleOfFifths.tsx
+++ b/src/components/CircleOfFifths/CircleOfFifths.tsx
@@ -7,6 +7,8 @@ import {
   getKeySignatureForDisplay,
   formatAccidental,
   SCALES,
+  ANIMATION_DURATION_FAST,
+  ANIMATION_EASE,
 } from "@fretflow/core";
 import { getDegreesForScale } from "@fretflow/core";
 import { getScaleCatalogEntry } from "@fretflow/core";
@@ -227,7 +229,7 @@ export const CircleOfFifths = memo(function CircleOfFifths({
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              transition={{ duration: 0.2 }}
+              transition={{ duration: ANIMATION_DURATION_FAST, ease: ANIMATION_EASE }}
               d={slicePath(CIRCLE_OF_FIFTHS.indexOf(rootNote))}
               className={clsx(styles["circle-slice"], styles["active"])}
               pointerEvents="none"
@@ -384,10 +386,10 @@ export const CircleOfFifths = memo(function CircleOfFifths({
           <AnimatePresence mode="wait">
             <motion.text
               key={rootNote}
-              initial={{ opacity: 0, scale: 0.8 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.8 }}
-              transition={{ duration: 0.15 }}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: ANIMATION_DURATION_FAST, ease: ANIMATION_EASE }}
               x={CX}
               y={CY}
               dominantBaseline="middle"
@@ -409,10 +411,10 @@ export const CircleOfFifths = memo(function CircleOfFifths({
           <AnimatePresence mode="wait">
             <motion.span
               key={keySigText}
-              initial={{ opacity: 0, y: 5 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -5 }}
-              transition={{ duration: 0.1 }}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: ANIMATION_DURATION_FAST, ease: ANIMATION_EASE }}
               className={styles["circle-footer-value"]}
             >
               {keySigText}
@@ -424,10 +426,10 @@ export const CircleOfFifths = memo(function CircleOfFifths({
           <AnimatePresence mode="wait">
             <motion.span
               key={`${relDisplay}-${relSuffix}`}
-              initial={{ opacity: 0, y: 5 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -5 }}
-              transition={{ duration: 0.1 }}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: ANIMATION_DURATION_FAST, ease: ANIMATION_EASE }}
               className={styles["circle-footer-value"]}
             >
               {formatAccidental(relDisplay)}{relSuffix}

--- a/src/components/DegreeChipStrip/DegreeChipStrip.tsx
+++ b/src/components/DegreeChipStrip/DegreeChipStrip.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from 'react';
 import clsx from 'clsx';
 import { AnimatePresence, motion } from 'motion/react';
 import { useAtomValue } from 'jotai';
+import { ANIMATION_DURATION_FAST } from '@fretflow/core';
+
 import { scaleDegreeColorsEnabledAtom } from '../../store/atoms';
 import styles from './DegreeChipStrip.module.css';
 
@@ -71,7 +73,7 @@ export function DegreeChipStrip({
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.18, ease: 'easeOut' }}
+            transition={{ duration: ANIMATION_DURATION_FAST }}
             style={{ overflow: 'hidden' }}
           >
             {chips.map((chip, i) => {

--- a/src/components/FingeringPatternControls/FingeringPatternControls.tsx
+++ b/src/components/FingeringPatternControls/FingeringPatternControls.tsx
@@ -2,7 +2,7 @@ import { useCallback, useId, useRef, useState } from "react";
 import { useAtom } from "jotai";
 import { motion } from "motion/react";
 import clsx from "clsx";
-import { CAGED_SHAPES, type CagedShape } from "@fretflow/core";
+import { CAGED_SHAPES, type CagedShape, ANIMATION_DURATION_FAST } from "@fretflow/core";
 import { useShapeState } from "../../hooks/useShapeState";
 import { displayFormatAtom, type FingeringPattern } from "../../store/atoms";
 import { ToggleBar } from "../ToggleBar/ToggleBar";
@@ -104,7 +104,7 @@ export function FingeringPatternControls({ compact = false }: { compact?: boolea
                 onClick={() => setCagedShapes(new Set(CAGED_SHAPES))}
                 whileTap={{ scale: 0.96 }}
                 animate={cagedShapes.size === CAGED_SHAPES.length ? { scale: [1, 1.04, 1] } : { scale: 1 }}
-                transition={{ duration: 0.2 }}
+                transition={{ duration: ANIMATION_DURATION_FAST }}
               >
                 All
               </motion.button>
@@ -170,7 +170,7 @@ export function FingeringPatternControls({ compact = false }: { compact?: boolea
                     }}
                     whileTap={{ scale: 0.96 }}
                     animate={isActive ? { scale: [1, 1.04, 1] } : { scale: 1 }}
-                    transition={{ duration: 0.2 }}
+                    transition={{ duration: ANIMATION_DURATION_FAST }}
                   >
                     {s}
                   </motion.button>

--- a/src/components/FretboardSVG/FretboardNoteLayer.tsx
+++ b/src/components/FretboardSVG/FretboardNoteLayer.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from "react";
 import { motion } from "motion/react";
 import { clsx } from "clsx";
-import { formatAccidental } from "@fretflow/core";
+import { formatAccidental, ANIMATION_DURATION_FAST, ANIMATION_EASE } from "@fretflow/core";
 import { getNoteVisuals } from "./utils/semantics";
 import { CHORD_ROOT_HALO_RADIUS_PX, reduceCircleRadius, reduceSquircleRadius, squirclePath } from "./utils/noteSizing";
 import styles from "./FretboardSVG.module.css";
@@ -136,7 +136,10 @@ export const FretboardNoteLayer = memo(({
               scale: isHidden ? 0 : 1,
               opacity: isHidden ? 0 : finalOpacity,
             }}
-            transition={{ type: "spring", damping: 20, stiffness: 300, duration: 0.2 }}
+            transition={{
+              duration: ANIMATION_DURATION_FAST,
+              ease: ANIMATION_EASE,
+            }}
             className={clsx(
               styles["fretboard-note"],
               styles[noteClass],

--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -27,10 +27,6 @@
   --placeholder: 0;
 }
 
-.fretboard-note {
-  transition: opacity 0.15s ease-out;
-}
-
 .fretboard-note:global(.hidden) {
   display: none;
 }

--- a/src/components/FretboardSVG/FretboardSVG.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.tsx
@@ -6,6 +6,8 @@ import {
   getScaleSemitones,
   type PracticeLens,
   type NoteSemantics,
+  ANIMATION_DURATION_FAST,
+  ANIMATION_EASE,
 } from "@fretflow/core";
 import {
   scaleDegreeColorsEnabledAtom,
@@ -495,14 +497,14 @@ export const FretboardSVG = memo(function FretboardSVG({
             aria-hidden="true"
             pointerEvents="none"
           >
-            <AnimatePresence>
+            <AnimatePresence mode="wait">
               {connectorPolylines.length > 0 && (
                 <motion.g
-                  key="chord-connectors"
+                  key={`chord-connectors-${chordRoot}-${chordTones?.join("-") ?? "none"}`}
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
                   exit={{ opacity: 0 }}
-                  transition={{ duration: 0.25 }}
+                  transition={{ duration: ANIMATION_DURATION_FAST, ease: ANIMATION_EASE }}
                   className={styles["chord-connectors"]}
                   aria-hidden="true"
                   pointerEvents="none"

--- a/src/components/FretboardSVG/FretboardShapeLayer.tsx
+++ b/src/components/FretboardSVG/FretboardShapeLayer.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import { motion, AnimatePresence } from "motion/react";
+import { ANIMATION_DURATION_FAST, ANIMATION_EASE } from "@fretflow/core";
 
 interface SvgPolygon {
   points: string;
@@ -20,7 +21,7 @@ export const FretboardShapeLayer = memo(({ svgPolygons }: FretboardShapeLayerPro
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          transition={{ duration: 0.25 }}
+          transition={{ duration: ANIMATION_DURATION_FAST, ease: ANIMATION_EASE }}
           points={points}
           fill={color}
           stroke="none"

--- a/src/components/MobileTabPanel/MobileTabPanel.tsx
+++ b/src/components/MobileTabPanel/MobileTabPanel.tsx
@@ -8,6 +8,7 @@ import {
   useFlatsAtom,
   enharmonicDisplayAtom,
 } from "../../store/atoms";
+import { ANIMATION_DURATION_XFADE } from "@fretflow/core";
 import { CircleOfFifths } from "../CircleOfFifths/CircleOfFifths";
 import { ScaleSelector } from "../ScaleSelector/ScaleSelector";
 import { ChordOverlayControls } from "../ChordOverlayControls/ChordOverlayControls";
@@ -50,7 +51,7 @@ export function MobileTabPanel() {
             initial={{ opacity: 0, x: 10 }}
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: -10 }}
-            transition={{ duration: 0.15 }}
+            transition={{ duration: ANIMATION_DURATION_XFADE }}
           >
             <Card title={TAB_LABELS.scales} className={styles["mobile-tab-card"]} data-mobile-tab="scales">
               <ScaleSelector compact={compact} />
@@ -63,7 +64,7 @@ export function MobileTabPanel() {
             initial={{ opacity: 0, x: 10 }}
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: -10 }}
-            transition={{ duration: 0.15 }}
+            transition={{ duration: ANIMATION_DURATION_XFADE }}
           >
             <Card title={TAB_LABELS.chords} className={styles["mobile-tab-card"]} data-mobile-tab="chords">
               <ChordOverlayControls compact={compact} />
@@ -76,7 +77,7 @@ export function MobileTabPanel() {
             initial={{ opacity: 0, x: 10 }}
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: -10 }}
-            transition={{ duration: 0.15 }}
+            transition={{ duration: ANIMATION_DURATION_XFADE }}
           >
             <Card title={TAB_LABELS.cof} className={styles["mobile-tab-card"]} data-mobile-tab="cof">
               <MobileKeyExplorer />
@@ -89,7 +90,7 @@ export function MobileTabPanel() {
             initial={{ opacity: 0, x: 10 }}
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: -10 }}
-            transition={{ duration: 0.15 }}
+            transition={{ duration: ANIMATION_DURATION_XFADE }}
           >
             <Card title={TAB_LABELS.view} className={styles["mobile-tab-card"]} data-mobile-tab="view">
               <FingeringPatternControls compact={compact} />

--- a/src/components/NoteGrid/NoteGrid.tsx
+++ b/src/components/NoteGrid/NoteGrid.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect } from "react";
 import { motion } from "motion/react";
 import clsx from "clsx";
-import { formatAccidental, getNoteDisplay } from "@fretflow/core";
+import { formatAccidental, getNoteDisplay, ANIMATION_DURATION_FAST } from "@fretflow/core";
 import shared from "../shared/shared.module.css";
 
 interface NoteGridProps {
@@ -104,7 +104,7 @@ export function NoteGrid({
             onKeyDown={(e) => handleKeyDown(e, index)}
             whileTap={{ scale: 0.95 }}
             animate={isActive ? { scale: [1, 1.05, 1] } : { scale: 1 }}
-            transition={{ duration: 0.2 }}
+            transition={{ duration: ANIMATION_DURATION_FAST }}
           >
             <span className={shared["note-btn-label"]}>
               {formatAccidental(getNoteDisplay(n, n, useFlats))}

--- a/src/components/TheoryControls/TheoryControls.tsx
+++ b/src/components/TheoryControls/TheoryControls.tsx
@@ -8,7 +8,7 @@ import { ChordOverlayControls } from "../ChordOverlayControls/ChordOverlayContro
 import { KeyExplorer } from "../KeyExplorer/KeyExplorer";
 import { NOTES } from "@fretflow/core";
 import {
-  ANIMATION_DURATION_STANDARD,
+  ANIMATION_DURATION_XFADE,
   ANIMATION_EASE,
 } from "@fretflow/core";
 import { getDegreesForScale } from "@fretflow/core";
@@ -82,7 +82,7 @@ export function TheorySection({
             initial={{ opacity: 0, x: -12 }}
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: 12 }}
-            transition={{ duration: 0.16 }}
+            transition={{ duration: ANIMATION_DURATION_XFADE, ease: ANIMATION_EASE }}
             className={styles["theory-disclosure-title"]}
           >
             {title}
@@ -94,7 +94,7 @@ export function TheorySection({
             initial={{ opacity: 0, x: 8 }}
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: -8 }}
-            transition={{ duration: 0.16 }}
+            transition={{ duration: ANIMATION_DURATION_XFADE, ease: ANIMATION_EASE }}
             className={styles["theory-disclosure-summary"]}
           >
             {summary}
@@ -116,7 +116,7 @@ export function TheorySection({
             animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={{
-              duration: ANIMATION_DURATION_STANDARD,
+              duration: ANIMATION_DURATION_XFADE,
               ease: ANIMATION_EASE,
             }}
             style={{ clipPath: "inset(0 -1rem)" }}

--- a/src/components/ToggleBar/ToggleBar.tsx
+++ b/src/components/ToggleBar/ToggleBar.tsx
@@ -1,6 +1,7 @@
 import { useId } from "react";
 import { motion } from "motion/react";
 import { cva, type VariantProps } from "class-variance-authority";
+import { ANIMATION_DURATION_FAST } from "@fretflow/core";
 import styles from "./ToggleBar.module.css";
 import shared from "../shared/shared.module.css";
 
@@ -92,7 +93,7 @@ export function ToggleBar<Value extends string | number>({
             aria-describedby={descId}
             whileTap={{ scale: 0.96 }}
             animate={isActive ? { scale: [1, 1.04, 1] } : { scale: 1 }}
-            transition={{ duration: 0.2 }}
+            transition={{ duration: ANIMATION_DURATION_FAST }}
           >
             {option.label}
           </motion.button>

--- a/src/components/TopBandSummary/TopBandSummary.tsx
+++ b/src/components/TopBandSummary/TopBandSummary.tsx
@@ -1,6 +1,7 @@
 import { useAtomValue } from "jotai";
 import { AnimatePresence, MotionConfig, motion } from "motion/react";
 import { Eye, EyeOff } from "lucide-react";
+import { ANIMATION_DURATION_FAST, ANIMATION_EASE } from "@fretflow/core";
 import { showChordPracticeBarAtom } from "../../store/atoms";
 import { useScaleState } from "../../hooks/useScaleState";
 import { usePracticeBarState } from "../../hooks/usePracticeBarState";
@@ -66,7 +67,7 @@ export function TopBandSummary() {
             initial={{ height: 0, overflow: "hidden", opacity: 0 }}
             animate={{ height: "auto", overflow: "visible", opacity: 1 }}
             exit={{ height: 0, overflow: "hidden", opacity: 0 }}
-            transition={{ duration: 0.2, ease: "easeOut" }}
+            transition={{ duration: ANIMATION_DURATION_FAST, ease: ANIMATION_EASE }}
           >
             <ChordPracticeBar
               title={practiceBarTitle}


### PR DESCRIPTION
## Summary
- Replace hardcoded animation duration values with `ANIMATION_DURATION_FAST` constant
- Remove unused `.fretboard-note` transition CSS from FretboardSVG module
- Apply consistent animation timing across ToggleBar and other components

## Test Plan
- [x] Tests pass (1237 tests)
- [x] Type-check passes