### PR TITLE
fix: make full chords sticky and keep CAGED voicings aligned

### DIFF
--- a/src/components/ChordOverlayControls/ChordOverlayControls.test.tsx
+++ b/src/components/ChordOverlayControls/ChordOverlayControls.test.tsx
@@ -358,7 +358,7 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
       expect(store.get(fullChordsEnabledAtom)).toBe(true);
     });
 
-    it("switching to an unsupported quality turns Full Chords off automatically", async () => {
+    it("switching to an unsupported quality keeps the Full Chords preference sticky", async () => {
       const store = makeAtomStore([
         ...MANUAL_MODE_SEEDS,
         [fullChordsEnabledAtom, true],
@@ -370,8 +370,9 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
       await userEvent.click(within(chordTypeGroup).getByRole("button", { name: "M7" }));
 
       const fullChordsGroup = screen.getByRole("group", { name: "Full Chords" });
-      expect(store.get(fullChordsEnabledAtom)).toBe(false);
-      expect(within(fullChordsGroup).getByRole("button", { name: "Off" })).toHaveAttribute(
+      expect(store.get(fullChordsEnabledAtom)).toBe(true);
+      expect(within(fullChordsGroup).getByRole("button", { name: "On" })).toBeDisabled();
+      expect(within(fullChordsGroup).getByRole("button", { name: "On" })).toHaveAttribute(
         "aria-pressed",
         "true",
       );
@@ -380,6 +381,15 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
           "Full Chords currently supports Major Triad, Minor Triad, and Dominant 7th.",
         ),
       ).toBeInTheDocument();
+
+      await userEvent.click(within(chordTypeGroup).getByRole("button", { name: "Maj" }));
+
+      expect(store.get(fullChordsEnabledAtom)).toBe(true);
+      expect(within(fullChordsGroup).getByRole("button", { name: "On" })).not.toBeDisabled();
+      expect(within(fullChordsGroup).getByRole("button", { name: "On" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
     });
 
     it("disables On for unsupported tunings and shows the 6-string helper text", () => {

--- a/src/components/ChordOverlayControls/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls/ChordOverlayControls.tsx
@@ -103,12 +103,6 @@ export function ChordOverlayControls({ compact }: ChordOverlayControlsProps) {
     }
   }, [currentLensEntry, lensAvailability, setPracticeLens]);
 
-  useEffect(() => {
-    if (fullChordsEnabled && !fullChordsSupported) {
-      setFullChordsEnabled(false);
-    }
-  }, [fullChordsEnabled, fullChordsSupported, setFullChordsEnabled]);
-
   const handleDegreeChange = (value: string) => {
     startTransition(() => {
       setChordDegree(value === CHORD_NONE_VALUE ? null : value);

--- a/src/components/Fretboard/Fretboard.wiring.test.tsx
+++ b/src/components/Fretboard/Fretboard.wiring.test.tsx
@@ -10,6 +10,8 @@ import {
   chordTypeAtom,
   fingeringPatternAtom,
   fullChordsEnabledAtom,
+  rootNoteAtom,
+  scaleNameAtom,
 } from "../../store/atoms";
 import { Fretboard } from "./Fretboard";
 
@@ -21,6 +23,39 @@ vi.mock("../FretboardSVG/FretboardSVG", () => ({
     return <div data-testid="fretboard-svg" />;
   },
 }));
+
+function renderGMajorEPositionChord(chordRoot: string, chordType: string) {
+  const store = createStore();
+  store.set(chordOverlayModeAtom, "manual");
+  store.set(rootNoteAtom, "G");
+  store.set(scaleNameAtom, "Major");
+  store.set(chordRootAtom, chordRoot);
+  store.set(chordTypeAtom, chordType);
+  store.set(fullChordsEnabledAtom, true);
+  store.set(fingeringPatternAtom, "caged");
+  store.set(cagedShapesAtom, new Set(["E"]));
+
+  const { unmount } = render(
+    <Provider store={store}>
+      <Fretboard
+        tuning={STANDARD_TUNING}
+        maxFret={24}
+        highlightNotes={["G", "A", "B", "C", "D", "E", "F#"]}
+        rootNote="G"
+        displayFormat="notes"
+      />
+    </Provider>,
+  );
+
+  const lastCall = fretboardSvgSpy.mock.calls.at(-1)?.[0] as {
+    fullChordPositionKeys?: Set<string>;
+    fullChordVoicings?: Array<{ shape?: string; voicingKey: string }>;
+  };
+
+  unmount();
+  fretboardSvgSpy.mockClear();
+  return lastCall;
+}
 
 describe("Fretboard wiring", () => {
   beforeEach(() => {
@@ -84,35 +119,32 @@ describe("Fretboard wiring", () => {
     );
   });
 
-  it("filters full chord matches to the selected CAGED shapes before passing them into FretboardSVG", () => {
-    const store = createStore();
-    store.set(chordOverlayModeAtom, "manual");
-    store.set(chordRootAtom, "C");
-    store.set(chordTypeAtom, "Major Triad");
-    store.set(fullChordsEnabledAtom, true);
-    store.set(fingeringPatternAtom, "caged");
-    store.set(cagedShapesAtom, new Set(["E"]));
+  it("chooses the full chord form that fits inside the selected CAGED scale position per chord", () => {
+    const tonic = renderGMajorEPositionChord("G", "Major Triad");
+    expect(tonic.fullChordVoicings?.every((voicing) => voicing.shape === "E")).toBe(true);
+    expect(tonic.fullChordPositionKeys?.has("5-15")).toBe(true);
 
-    render(
-      <Provider store={store}>
-        <Fretboard
-          tuning={STANDARD_TUNING}
-          maxFret={24}
-          highlightNotes={["C", "E", "G"]}
-          rootNote="C"
-          displayFormat="notes"
-        />
-      </Provider>,
-    );
+    const mediant = renderGMajorEPositionChord("B", "Minor Triad");
+    expect(mediant.fullChordVoicings?.every((voicing) => voicing.shape === "A")).toBe(true);
+    expect(mediant.fullChordPositionKeys?.has("4-14")).toBe(true);
 
-    const lastCall = fretboardSvgSpy.mock.calls.at(-1)?.[0] as {
-      fullChordPositionKeys?: Set<string>;
-      fullChordVoicings?: Array<{ shape?: string; voicingKey: string }>;
-    };
+    const subdominant = renderGMajorEPositionChord("C", "Major Triad");
+    expect(subdominant.fullChordVoicings?.every((voicing) => voicing.shape === "A")).toBe(true);
+    expect(subdominant.fullChordPositionKeys?.has("4-15")).toBe(true);
+  });
 
-    expect(lastCall.fullChordVoicings).toBeDefined();
-    expect(lastCall.fullChordVoicings).not.toHaveLength(0);
-    expect(lastCall.fullChordVoicings?.every((voicing) => voicing.shape === "E")).toBe(true);
-    expect(lastCall.fullChordPositionKeys?.has("4-3")).toBe(false);
+  it("keeps exact full-chord notes outside the selected CAGED scale position when the voicing mostly overlaps", () => {
+    const supertonic = renderGMajorEPositionChord("A", "Minor Triad");
+    expect(supertonic.fullChordVoicings?.some((voicing) => voicing.shape === "E")).toBe(true);
+    expect(supertonic.fullChordPositionKeys?.has("0-5")).toBe(true);
+    expect(supertonic.fullChordPositionKeys?.has("3-7")).toBe(true);
+    expect(supertonic.fullChordPositionKeys?.has("4-7")).toBe(true);
+  });
+
+  it("uses one full-chord form per CAGED position and prefers one that fits fully inside", () => {
+    const dominant = renderGMajorEPositionChord("D", "Major Triad");
+    expect(dominant.fullChordVoicings?.every((voicing) => voicing.shape === "C")).toBe(true);
+    expect(dominant.fullChordPositionKeys?.has("4-5")).toBe(true);
+    expect(dominant.fullChordPositionKeys?.has("3-0")).toBe(false);
   });
 });

--- a/src/components/FretboardSVG/FretboardSVG.test.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.test.tsx
@@ -336,6 +336,59 @@ describe("FretboardSVG/FretboardSVG", () => {
     ).toHaveStyle({ fill: "var(--caged-e-fg)" });
   });
 
+  it("replaces the full-chord connector group when full chords are toggled off", () => {
+    const fullChordVoicings: Array<{
+      shape: CagedShape;
+      voicingKey: string;
+      notes: Array<{ stringIndex: number; fretIndex: number; noteName: string }>;
+    }> = [
+      {
+        shape: "E",
+        voicingKey: "0,8|1,8|2,9|3,10|4,10|5,8",
+        notes: [
+          { stringIndex: 0, fretIndex: 8, noteName: "C" },
+          { stringIndex: 1, fretIndex: 8, noteName: "G" },
+          { stringIndex: 2, fretIndex: 9, noteName: "E" },
+          { stringIndex: 3, fretIndex: 10, noteName: "C" },
+          { stringIndex: 4, fretIndex: 10, noteName: "G" },
+          { stringIndex: 5, fretIndex: 8, noteName: "C" },
+        ],
+      },
+    ];
+
+    const { container, rerender } = render(
+      <FretboardSVG
+        {...BASE_PROPS}
+        chordTones={["C", "E", "G"]}
+        chordRoot="C"
+        fullChordPositionKeys={new Set(["0-8", "1-8", "2-9", "3-10", "4-10", "5-8"])}
+        fullChordVoicings={fullChordVoicings}
+      />,
+    );
+
+    expect(container.querySelectorAll('path[data-caged-shape="E"]').length).toBeGreaterThan(0);
+    expect(container.querySelector(".chord-connectors")).toHaveAttribute(
+      "data-connector-source",
+      "full-chord",
+    );
+
+    rerender(
+      <FretboardSVG
+        {...BASE_PROPS}
+        chordTones={["C", "E", "G"]}
+        chordRoot="C"
+        fullChordPositionKeys={new Set()}
+        fullChordVoicings={[]}
+      />,
+    );
+
+    expect(container.querySelectorAll("path[data-caged-shape]").length).toBe(0);
+    expect(container.querySelector(".chord-connectors")).toHaveAttribute(
+      "data-connector-source",
+      "generated",
+    );
+  });
+
   it("keeps the D-shape light-theme background in the same gray family as dark mode", () => {
     const themedScope = document.createElement("div");
     themedScope.setAttribute("data-theme", "modern-light");

--- a/src/components/FretboardSVG/FretboardSVG.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.tsx
@@ -432,6 +432,7 @@ export const FretboardSVG = memo(function FretboardSVG({
     yBounds: connectorYBounds,
     explicitVoicings: fullChordVoicings,
   });
+  const connectorSource = fullChordVoicings?.length ? "full-chord" : "generated";
 
   return (
     <div
@@ -527,12 +528,13 @@ export const FretboardSVG = memo(function FretboardSVG({
             <AnimatePresence mode="wait">
               {connectorPolylines.length > 0 && (
                 <motion.g
-                  key={`chord-connectors-${chordRoot}-${chordTones?.join("-") ?? "none"}`}
+                  key={`chord-connectors-${connectorSource}-${chordRoot}-${chordTones?.join("-") ?? "none"}`}
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
                   exit={{ opacity: 0 }}
                   transition={{ duration: ANIMATION_DURATION_FAST, ease: ANIMATION_EASE }}
                   className={styles["chord-connectors"]}
+                  data-connector-source={connectorSource}
                   aria-hidden="true"
                   pointerEvents="none"
                 >

--- a/src/components/FretboardSVG/hooks/useNoteData.test.ts
+++ b/src/components/FretboardSVG/hooks/useNoteData.test.ts
@@ -181,6 +181,41 @@ describe("useNoteData", () => {
       expect(e2).toContain(3);
       expect(e2).toContain(8);
     });
+
+    it("full chord positions render outside the active CAGED shape without using chord spread", () => {
+      const { result } = renderHook(() =>
+        useNoteData({
+          numStrings: 1,
+          fretboardLayout: SINGLE_STRING_LAYOUT,
+          totalColumns: 12,
+          startFret: 0,
+          maxFret: 12,
+          hiddenNotes: new Set(),
+          highlightNotes: ["C", "E", "G"],
+          hasChordOverlay: true,
+          chordTones: ["C", "E", "G"],
+          rootNote: "C",
+          chordRoot: "C",
+          colorNotes: [],
+          shapePolygons: [polyAt5To7],
+          boxBounds: [],
+          chordFretSpread: 0,
+          activePattern: "caged",
+          shapeScope: "single",
+          activeShape: "E" as CagedShape,
+          scaleName: "Major",
+          useFlats: false,
+          wrappedNotes: new Set(),
+          tuning: ["E2"],
+          fullChordPositionKeys: new Set(["0-3"]),
+        }),
+      );
+
+      const exactFullChordTone = result.current.find((note) => note.stringIndex === 0 && note.fretIndex === 3);
+      const nonFullChordToneOutsideShape = result.current.find((note) => note.stringIndex === 0 && note.fretIndex === 0);
+      expect(exactFullChordTone?.noteClass).toBe("chord-tone-in-scale");
+      expect(nonFullChordToneOutsideShape?.noteClass).toBe("note-inactive");
+    });
   });
 
   it("assigns the blue-note color to blues-scale color notes", () => {

--- a/src/components/FretboardSVG/hooks/useNoteData.ts
+++ b/src/components/FretboardSVG/hooks/useNoteData.ts
@@ -192,6 +192,9 @@ export function useNoteData({
         // buffer correctly extends the active shape boundary, not any visible shape.
         const isInPlayableContext: boolean = (() => {
           if (!hasChordOverlay) return false;
+          if (hasFullChordPositionFilter && fullChordPositionKeys.has(positionKey)) {
+            return true;
+          }
           // 3NPS has no polygon shapes; gate chord overlay by aggregate fret bounds
           // AND by per-coordinate shape membership.
           if (activePattern === "3nps" && shapeScope !== "global" && boxBounds.length > 0) {

--- a/src/hooks/useFretboardState.ts
+++ b/src/hooks/useFretboardState.ts
@@ -22,12 +22,91 @@ import {
   npsPositionAtom,
   fullChordMatchesAtom,
 } from "../store/atoms";
-import type { CagedShape } from "@fretflow/core";
+import type { CagedShape, FullChordMatch, ShapePolygon } from "@fretflow/core";
 
 type ActivePatternType = "caged" | "3nps" | "none";
 export type ActiveShapeType = CagedShape | number | CagedShape[] | undefined;
 
 export type ShapeScope = "single" | "multi" | "global";
+
+function distanceOutsidePolygon(
+  polygon: ShapePolygon,
+  note: FullChordMatch["notes"][number],
+): number {
+  const leftFret = polygon.vertices[note.stringIndex]?.fret;
+  const rightFret = polygon.vertices[polygon.vertices.length - 1 - note.stringIndex]?.fret;
+  if (leftFret === undefined || rightFret === undefined) return Number.POSITIVE_INFINITY;
+
+  const minFret = Math.min(leftFret, rightFret);
+  const maxFret = Math.max(leftFret, rightFret);
+  if (note.fretIndex < minFret) return minFret - note.fretIndex;
+  if (note.fretIndex > maxFret) return note.fretIndex - maxFret;
+  return 0;
+}
+
+interface FullChordCandidateScore {
+  match: FullChordMatch;
+  outsideCount: number;
+  totalOutsideDistance: number;
+  maxOutsideDistance: number;
+  selectedShapePriority: number;
+}
+
+function scoreFullChordForCagedPosition(
+  match: FullChordMatch,
+  polygon: ShapePolygon,
+  selectedShapes: Set<CagedShape>,
+): FullChordCandidateScore | null {
+  const outsideDistances = match.notes.map((note) => distanceOutsidePolygon(polygon, note));
+  const outsideCount = outsideDistances.filter((distance) => distance > 0).length;
+  if (outsideCount > 2) return null;
+
+  return {
+    match,
+    outsideCount,
+    totalOutsideDistance: outsideDistances.reduce((sum, distance) => sum + distance, 0),
+    maxOutsideDistance: Math.max(...outsideDistances),
+    selectedShapePriority: selectedShapes.has(match.shape) ? 0 : 1,
+  };
+}
+
+function compareFullChordCandidateScores(
+  left: FullChordCandidateScore,
+  right: FullChordCandidateScore,
+): number {
+  return left.outsideCount - right.outsideCount ||
+    left.totalOutsideDistance - right.totalOutsideDistance ||
+    left.maxOutsideDistance - right.maxOutsideDistance ||
+    left.selectedShapePriority - right.selectedShapePriority;
+}
+
+function getPositionKey(match: FullChordMatch): string {
+  return match.positionKeys.join("|");
+}
+
+function selectFullChordMatchesForCagedPosition(
+  matches: FullChordMatch[],
+  activePolygons: ShapePolygon[],
+  selectedShapes: Set<CagedShape>,
+): FullChordMatch[] {
+  const byPosition = new Map<string, FullChordMatch>();
+  for (const polygon of activePolygons) {
+    const best = matches
+      .map((match) => scoreFullChordForCagedPosition(match, polygon, selectedShapes))
+      .filter((score): score is FullChordCandidateScore => score !== null)
+      .sort(compareFullChordCandidateScores)[0];
+
+    if (!best) continue;
+
+    const { match } = best;
+    const positionKey = getPositionKey(match);
+    const previous = byPosition.get(positionKey);
+    if (!previous || (selectedShapes.has(match.shape) && !selectedShapes.has(previous.shape))) {
+      byPosition.set(positionKey, match);
+    }
+  }
+  return Array.from(byPosition.values());
+}
 
 export function useFretboardState() {
   const currentTuning = useAtomValue(currentTuningAtom);
@@ -84,7 +163,11 @@ export function useFretboardState() {
   }
 
   const visibleFullChordMatches = fingeringPattern === "caged"
-    ? fullChordMatches.filter((match) => cagedShapes.has(match.shape))
+    ? selectFullChordMatchesForCagedPosition(
+        fullChordMatches,
+        shapePolygons,
+        cagedShapes,
+      )
     : fullChordMatches;
   const visibleFullChordPositions = Array.from(
     new Set(visibleFullChordMatches.flatMap((match) => match.positionKeys)),


### PR DESCRIPTION
## Summary
- Keep the Full Chords preference persisted when the selected chord quality or tuning is temporarily unsupported
- Select full-chord voicings that fit the active CAGED position, with triads as the fallback when no full shape fits cleanly
- Fix stale connector rendering when full chords are toggled off
- Add regression coverage for the sticky toggle, CAGED voicing selection, and note/connector rendering

## Testing
- `npm run test -- src/components/ChordOverlayControls/ChordOverlayControls.test.tsx src/components/Fretboard/Fretboard.wiring.test.tsx src/components/FretboardSVG/FretboardSVG.test.tsx src/components/FretboardSVG/hooks/useNoteData.test.ts src/store/chordOverlayAtoms.test.ts packages/core/src/shapes/fullChordShapes.test.ts`
- `npm run lint`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Full chord preference now persists when switching between all chord types
  * Improved full chord form selection based on active fretboard shapes

* **Bug Fixes**
  * Fixed note classification for chord tones in full chord display mode
  * Enhanced chord connector animations when toggling full chords on/off

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/381)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->