### PR TITLE
fix: filter progression presets by selected scale

### DIFF
--- a/src/components/ProgressionControls/ProgressionControls.test.tsx
+++ b/src/components/ProgressionControls/ProgressionControls.test.tsx
@@ -136,6 +136,20 @@ describe("ProgressionControls PRESET", () => {
     expect(select.tagName).toBe("SELECT");
     expect(select.value).toBe("one-five-six-four"); // default I-V-vi-IV preset
   });
+
+  it("only lists presets that are available for the selected scale", () => {
+    const store = makeAtomStore([
+      [rootNoteAtom, "C"],
+      [scaleNameAtom, "Minor Blues"],
+      [progressionEnabledAtom, true],
+    ]);
+    renderWithStore(<ProgressionControls />, store);
+
+    const select = screen.getByRole("combobox", { name: "Preset" });
+    expect(within(select).getAllByRole("option").map((option) => option.textContent)).toEqual([
+      "Custom",
+    ]);
+  });
 });
 
 describe("ProgressionControls CHORDS list", () => {

--- a/src/components/ProgressionControls/ProgressionControls.tsx
+++ b/src/components/ProgressionControls/ProgressionControls.tsx
@@ -2,11 +2,11 @@ import { startTransition } from "react";
 import clsx from "clsx";
 import { ArrowDown, ArrowUp, Plus, Trash2 } from "lucide-react";
 import {
-  PROGRESSION_PRESETS,
   BEATS_PER_BAR_OPTIONS,
   MIN_PROGRESSION_STEP_DURATION_VALUE,
   MAX_PROGRESSION_STEP_DURATION_VALUE,
   formatProgressionDurationLabel,
+  getAvailableProgressionPresets,
 } from "../../progressions/progressionDomain";
 import { useProgressionState } from "../../hooks/useProgressionState";
 import { useScaleState } from "../../hooks/useScaleState";
@@ -45,6 +45,7 @@ export function ProgressionControls({ compact = false }: ProgressionControlsProp
   } = useProgressionState();
 
   const activeStep = progressionSteps[activeProgressionStepIndex] ?? null;
+  const availablePresets = getAvailableProgressionPresets(scaleName);
   const qualityValue = activeStep?.qualityOverride ?? CHORD_QUALITY_DIATONIC_VALUE;
   const degreeOptions = buildDegreeToggleOptions({
     scaleName,
@@ -98,7 +99,7 @@ export function ProgressionControls({ compact = false }: ProgressionControlsProp
           }}
           options={[
             { value: CUSTOM_PRESET_ID, label: "Custom", disabled: currentProgressionPresetId !== CUSTOM_PRESET_ID },
-            ...PROGRESSION_PRESETS.map((preset) => ({ value: preset.id, label: preset.label })),
+            ...availablePresets.map((preset) => ({ value: preset.id, label: preset.label })),
           ]}
           compact={compact}
         />

--- a/src/progressions/progressionDomain.test.ts
+++ b/src/progressions/progressionDomain.test.ts
@@ -10,7 +10,9 @@ import {
   formatProgressionPlaybackPosition,
   getProgressionDurationBeats,
   getProgressionDurationMs,
+  getAvailableProgressionPresets,
   isProgressionDuration,
+  isProgressionPresetAvailableForScale,
   migrateLegacyDuration,
   remapDegreeByOrdinal,
   remapProgressionStepsForScale,
@@ -111,6 +113,14 @@ describe("progressionDomain", () => {
     const blues = PROGRESSION_PRESETS.find((preset) => preset.id === "twelve-bar-blues");
     expect(blues?.steps).toHaveLength(12);
     expect(blues?.steps.every((step) => step.qualityOverride === "Dominant 7th")).toBe(true);
+  });
+
+  it("filters presets to scales where every preset degree can resolve", () => {
+    const oneFiveSixFour = PROGRESSION_PRESETS.find((preset) => preset.id === "one-five-six-four");
+    expect(oneFiveSixFour).toBeDefined();
+    expect(isProgressionPresetAvailableForScale(oneFiveSixFour!, "Major")).toBe(true);
+    expect(isProgressionPresetAvailableForScale(oneFiveSixFour!, "Minor Blues")).toBe(false);
+    expect(getAvailableProgressionPresets("Minor Blues")).toEqual([]);
   });
 });
 

--- a/src/progressions/progressionDomain.ts
+++ b/src/progressions/progressionDomain.ts
@@ -325,11 +325,42 @@ export function createStepsFromPreset(
   preset: ProgressionPreset,
   scaleName: string,
 ): ProgressionStep[] {
-  return preset.steps.map((step) =>
+  return getProgressionPresetStepsForScale(preset, scaleName).map((step) =>
     createProgressionStep({
       ...step,
-      degree: remapDegreeByOrdinal(step.degree, scaleName),
     }),
+  );
+}
+
+export function getProgressionPresetStepsForScale(
+  preset: ProgressionPreset,
+  scaleName: string,
+): Array<Omit<ProgressionStep, "id">> {
+  return preset.steps.map((step) => ({
+    ...step,
+    degree: remapDegreeByOrdinal(step.degree, scaleName),
+  }));
+}
+
+export function isProgressionPresetAvailableForScale(
+  preset: ProgressionPreset,
+  scaleName: string,
+): boolean {
+  return getProgressionPresetStepsForScale(preset, scaleName).every((step, index) => {
+    const resolved = resolveProgressionStep(
+      { id: `preset-availability-${index}`, ...step },
+      scaleName,
+      "C",
+    );
+    return !resolved.unavailable;
+  });
+}
+
+export function getAvailableProgressionPresets(
+  scaleName: string,
+): ProgressionPreset[] {
+  return PROGRESSION_PRESETS.filter((preset) =>
+    isProgressionPresetAvailableForScale(preset, scaleName),
   );
 }
 

--- a/src/store/progressionAtoms.test.ts
+++ b/src/store/progressionAtoms.test.ts
@@ -65,6 +65,7 @@ describe("progressionAtoms", () => {
       "iv",
     ]);
     expect(store.get(activeProgressionStepIndexAtom)).toBe(0);
+    expect(store.get(currentProgressionPresetIdAtom)).toBe("one-five-six-four");
   });
 
   it("updates the active step degree, duration, and quality", () => {
@@ -271,6 +272,12 @@ describe("derived progression atoms", () => {
   it("currentProgressionPresetIdAtom matches the I-V-vi-IV default", () => {
     const store = createStore();
     expect(store.get(currentProgressionPresetIdAtom)).toBe("one-five-six-four");
+  });
+
+  it("currentProgressionPresetIdAtom ignores presets unavailable for the active scale", () => {
+    const store = createStore();
+    store.set(scaleNameAtom, "Minor Blues");
+    expect(store.get(currentProgressionPresetIdAtom)).toBe("custom");
   });
 
   it("currentProgressionPresetIdAtom returns 'custom' after any edit", () => {

--- a/src/store/progressionAtoms.ts
+++ b/src/store/progressionAtoms.ts
@@ -11,6 +11,8 @@ import {
   createStepsFromPreset,
   findFirstResolvableStepIndex,
   findNextResolvableStepIndex,
+  getAvailableProgressionPresets,
+  getProgressionPresetStepsForScale,
   getProgressionDurationMs,
   isBeatsPerBar,
   isProgressionDuration,
@@ -184,7 +186,10 @@ export const CUSTOM_PRESET_ID = "custom" as const;
 
 export const currentProgressionPresetIdAtom = atom<string>((get) => {
   const steps = get(progressionStepsAtom);
-  const match = PROGRESSION_PRESETS.find((preset) => stepsMatchPreset(steps, preset.steps));
+  const scaleName = get(scaleNameAtom);
+  const match = getAvailableProgressionPresets(scaleName).find((preset) =>
+    stepsMatchPreset(steps, getProgressionPresetStepsForScale(preset, scaleName)),
+  );
   return match?.id ?? CUSTOM_PRESET_ID;
 });
 


### PR DESCRIPTION
## Summary
- Filter the progression preset dropdown to only show presets that can resolve in the active scale.
- Keep preset matching scale-aware so remapped presets still पहचान the correct preset instead of falling back to Custom.
- Add regression coverage for unavailable scales and the filtered UI state.

## Testing
- `vitest run` for progression domain, progression atoms, and `ProgressionControls` tests.
- `build:types` passed.