### PR TITLE
fix: align chord timeline segments and repeat metronome accents per bar

### DIFF
--- a/src/components/ProgressionTrack/ProgressionBlock.tsx
+++ b/src/components/ProgressionTrack/ProgressionBlock.tsx
@@ -8,6 +8,8 @@ interface ProgressionBlockProps {
   index: number;
   active: boolean;
   durationBars: number;
+  startPercent: number;
+  widthPercent: number;
   onSelect: (index: number) => void;
 }
 
@@ -34,6 +36,8 @@ function ProgressionBlockComponent({
   index,
   active,
   durationBars,
+  startPercent,
+  widthPercent,
   onSelect,
 }: ProgressionBlockProps) {
   const duration = formatProgressionDurationLabel(step.duration);
@@ -41,7 +45,11 @@ function ProgressionBlockComponent({
     <button
       type="button"
       className={styles.block}
-      style={{ "--duration-bars": String(durationBars) } as CSSProperties}
+      style={{
+        "--duration-bars": String(durationBars),
+        left: `${startPercent}%`,
+        width: `${widthPercent}%`,
+      } as CSSProperties}
       data-active={active ? "true" : undefined}
       data-unavailable={step.unavailable ? "true" : undefined}
       onClick={() => onSelect(index)}

--- a/src/components/ProgressionTrack/ProgressionTrack.module.css
+++ b/src/components/ProgressionTrack/ProgressionTrack.module.css
@@ -482,15 +482,14 @@
 }
 
 .blocks {
-  display: flex;
-  align-items: stretch;
-  gap: 0;
+  position: relative;
   min-height: 2.5rem;
 }
 
 .blockSpacer {
   --duration-bars: 0;
-  flex: var(--duration-bars) 1 0;
+  position: absolute;
+  inset-block: 0;
   min-width: 0;
 }
 
@@ -543,8 +542,8 @@
   --block-name-fg: rgb(232 243 252 / 0.92);
   --block-badge-fg: rgb(232 243 252 / 0.6);
 
-  position: relative;
-  flex: var(--duration-bars) 1 0;
+  position: absolute;
+  inset-block: 0;
   min-width: 0;
   display: flex;
   align-items: center;

--- a/src/components/ProgressionTrack/ProgressionTrack.test.tsx
+++ b/src/components/ProgressionTrack/ProgressionTrack.test.tsx
@@ -26,6 +26,13 @@ const beatDurationProgression = [
   { id: "bar-step", degree: "V", duration: { value: 1, unit: "bar" }, qualityOverride: null },
 ] as const;
 
+const twoBarLeadingProgression = [
+  { id: "one", degree: "I", duration: { value: 2, unit: "bar" }, qualityOverride: null },
+  { id: "two", degree: "V", duration: { value: 1, unit: "bar" }, qualityOverride: null },
+  { id: "three", degree: "vi", duration: { value: 1, unit: "bar" }, qualityOverride: null },
+  { id: "four", degree: "IV", duration: { value: 1, unit: "bar" }, qualityOverride: null },
+] as const;
+
 describe("ProgressionTrack", () => {
   it("renders transport, status, position, tempo, scale, ruler, and chord blocks", () => {
     renderWithAtoms(<ProgressionTrack />, [
@@ -116,6 +123,28 @@ describe("ProgressionTrack", () => {
     ]);
 
     expect(container.querySelector<HTMLElement>("[data-testid='progression-playhead']")?.style.left).toBe("20%");
+  });
+
+  it("positions chord blocks by exact cumulative bar percentages", () => {
+    renderWithAtoms(<ProgressionTrack />, [
+      [progressionEnabledAtom, true],
+      [progressionStepsAtom, twoBarLeadingProgression],
+      [beatsPerBarAtom, 4],
+    ]);
+
+    const first = screen.getByRole("button", { name: /Step 1, I, C Major Triad, 2 bars, active/i });
+    const second = screen.getByRole("button", { name: /Step 2, V, G Major Triad, 1 bar/i });
+    const third = screen.getByRole("button", { name: /Step 3, vi, A Minor Triad, 1 bar/i });
+    const fourth = screen.getByRole("button", { name: /Step 4, IV, F Major Triad, 1 bar/i });
+
+    expect(first.style.left).toBe("0%");
+    expect(first.style.width).toBe("40%");
+    expect(second.style.left).toBe("40%");
+    expect(second.style.width).toBe("20%");
+    expect(third.style.left).toBe("60%");
+    expect(third.style.width).toBe("20%");
+    expect(fourth.style.left).toBe("80%");
+    expect(fourth.style.width).toBe("20%");
   });
 
   it("disables playback when progression playback is blocked", () => {

--- a/src/components/ProgressionTrack/ProgressionTrack.tsx
+++ b/src/components/ProgressionTrack/ProgressionTrack.tsx
@@ -31,6 +31,24 @@ function durationToBars(
   return duration.unit === "bar" ? duration.value : duration.value / beatsPerBar;
 }
 
+function getProgressionBlockLayouts(
+  steps: readonly { duration: { value: number; unit: "bar" | "beat" } }[],
+  beatsPerBar: number,
+  totalBarsForDisplay: number,
+): Array<{ durationBars: number; startPercent: number; widthPercent: number }> {
+  let elapsedBars = 0;
+  return steps.map((step) => {
+    const durationBars = durationToBars(step.duration, beatsPerBar);
+    const layout = {
+      durationBars,
+      startPercent: (elapsedBars / totalBarsForDisplay) * 100,
+      widthPercent: (durationBars / totalBarsForDisplay) * 100,
+    };
+    elapsedBars += durationBars;
+    return layout;
+  });
+}
+
 export function ProgressionTrack() {
   const {
     progressionTempoBpm,
@@ -65,6 +83,11 @@ export function ProgressionTrack() {
   const totalBarsForDisplay = Math.max(1, Math.ceil(totalProgressionBars));
   const scale = splitScaleLabel(scaleLabel);
   const subdivisionsPerBar = Math.max(1, Math.floor(beatsPerBar));
+  const blockLayouts = getProgressionBlockLayouts(
+    resolvedProgressionSteps,
+    beatsPerBar,
+    totalBarsForDisplay,
+  );
 
   // Stable callback so memoized ProgressionBlock children don't re-render on
   // every parent render of this component.
@@ -246,20 +269,33 @@ export function ProgressionTrack() {
             totalDurationBars={totalDurationBars}
           />
           <div className={styles.blocks}>
-            {resolvedProgressionSteps.map((step, index) => (
-              <ProgressionBlock
-                key={step.id}
-                step={step}
-                index={index}
-                active={index === activeProgressionStepIndex}
-                durationBars={durationToBars(step.duration, beatsPerBar)}
-                onSelect={selectStep}
-              />
-            ))}
+            {resolvedProgressionSteps.map((step, index) => {
+              const layout = blockLayouts[index] ?? {
+                durationBars: 0,
+                startPercent: 0,
+                widthPercent: 0,
+              };
+              return (
+                <ProgressionBlock
+                  key={step.id}
+                  step={step}
+                  index={index}
+                  active={index === activeProgressionStepIndex}
+                  durationBars={layout.durationBars}
+                  startPercent={layout.startPercent}
+                  widthPercent={layout.widthPercent}
+                  onSelect={selectStep}
+                />
+              );
+            })}
             {totalBarsForDisplay > totalDurationBars ? (
               <span
                 className={styles.blockSpacer}
-                style={{ "--duration-bars": String(totalBarsForDisplay - totalDurationBars) } as CSSProperties}
+                style={{
+                  "--duration-bars": String(totalBarsForDisplay - totalDurationBars),
+                  left: `${(totalDurationBars / totalBarsForDisplay) * 100}%`,
+                  width: `${((totalBarsForDisplay - totalDurationBars) / totalBarsForDisplay) * 100}%`,
+                } as CSSProperties}
                 aria-hidden="true"
               />
             ) : null}

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -3,6 +3,7 @@ import {
   buildMetronomePattern,
   clipPatternToBeats,
   POP_STRUM_PATTERN,
+  repeatPatternToBeats,
   ROCK_DRUM_PATTERN,
 } from "./patterns";
 
@@ -26,6 +27,35 @@ describe("clipPatternToBeats", () => {
     // POP_STRUM_PATTERN has hits at 0, 1, 1.5, 2.5, 3, 3.5.
     const clipped = clipPatternToBeats(POP_STRUM_PATTERN, 3);
     expect(clipped.map((h) => h.beat)).toEqual([0, 1, 1.5, 2.5]);
+  });
+});
+
+describe("repeatPatternToBeats", () => {
+  it("repeats a one-bar strum pattern across a multi-bar step", () => {
+    const repeated = repeatPatternToBeats(POP_STRUM_PATTERN, 8, 4);
+
+    expect(repeated.map((h) => h.beat)).toEqual([
+      0, 1, 1.5, 2.5, 3, 3.5,
+      4, 5, 5.5, 6.5, 7, 7.5,
+    ]);
+  });
+
+  it("clips repeated pattern hits to partial final bars", () => {
+    const repeated = repeatPatternToBeats(POP_STRUM_PATTERN, 5, 4);
+
+    expect(repeated.map((h) => h.beat)).toEqual([
+      0, 1, 1.5, 2.5, 3, 3.5,
+      4,
+    ]);
+  });
+
+  it("uses the active meter as the repeat length", () => {
+    const repeated = repeatPatternToBeats(POP_STRUM_PATTERN, 6, 3);
+
+    expect(repeated.map((h) => h.beat)).toEqual([
+      0, 1, 1.5, 2.5,
+      3, 4, 4.5, 5.5,
+    ]);
   });
 });
 

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -2,8 +2,8 @@
  * Beat-level patterns for the progression backing track.
  *
  * Every pattern is expressed in **beat fractions** within a bar (0 inclusive,
- * `beatsPerBar` exclusive), letting the scheduler scale a pattern to any
- * meter and tempo without owning timing math.
+ * `beatsPerBar` exclusive), letting the scheduler repeat/clip a pattern to
+ * any meter and tempo without owning timing math.
  *
  * Patterns are intentionally small and audition-friendly: a default rock
  * strum, a default rock drum beat, a four-on-the-floor metronome. They
@@ -37,7 +37,8 @@ export interface DrumPattern {
 /**
  * Eighth-note pop strum: D _ D U _ U D U.
  * Beats are emphasised; off-beats use a lighter velocity.
- * Designed for 4/4; the scheduler will skip hits past `beatsPerBar`.
+ * Designed for 4/4; the scheduler will repeat it per bar and skip hits past
+ * the active `beatsPerBar`.
  */
 export const POP_STRUM_PATTERN: readonly StrumHit[] = [
   { beat: 0, velocity: 0.95, direction: "down" },
@@ -50,8 +51,9 @@ export const POP_STRUM_PATTERN: readonly StrumHit[] = [
 
 /**
  * Steady rock beat for 4/4: kick on 1 and 3, snare on 2 and 4, eighth-note
- * closed hats throughout. The scheduler clips hits past `beatsPerBar`, so
- * 3/4 reads as the first three beats of the same groove.
+ * closed hats throughout. The scheduler repeats it per bar and clips hits
+ * past `beatsPerBar`, so 3/4 reads as the first three beats of the same
+ * groove.
  */
 export const ROCK_DRUM_PATTERN: DrumPattern = {
   kicks: [
@@ -98,4 +100,28 @@ export function clipPatternToBeats<T extends { beat: number }>(
 ): T[] {
   if (beatsAvailable <= 0) return [];
   return pattern.filter((hit) => hit.beat < beatsAvailable);
+}
+
+/**
+ * Repeat a one-bar pattern across the requested beat window. The repeat
+ * length is the active meter, so a 2-bar chord in 4/4 receives the same
+ * strum/drum/click pattern at beats 0..3.5 and 4..7.5, while a partial final
+ * bar is clipped to the chord duration.
+ */
+export function repeatPatternToBeats<T extends { beat: number }>(
+  pattern: readonly T[],
+  beatsAvailable: number,
+  beatsPerBar: number,
+): T[] {
+  if (beatsAvailable <= 0 || beatsPerBar <= 0) return [];
+  const hits: T[] = [];
+  for (let barStart = 0; barStart < beatsAvailable; barStart += beatsPerBar) {
+    for (const hit of pattern) {
+      if (hit.beat >= beatsPerBar) continue;
+      const beat = barStart + hit.beat;
+      if (beat >= beatsAvailable) continue;
+      hits.push({ ...hit, beat });
+    }
+  }
+  return hits;
 }

--- a/src/progressions/audio/scheduler.test.ts
+++ b/src/progressions/audio/scheduler.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { scheduleProgressionStep } from "./scheduler";
+import { _metronomeInternals } from "./metronome";
 
 // Web Audio mock — counts node creations so tests can assert "drums scheduled
 // X hits" without depending on real audio timing.
@@ -70,6 +71,7 @@ interface MockCtx {
   ctx: any;
   oscCount: () => number;
   bufferSourceCount: () => number;
+  oscillators: () => ReturnType<typeof createMockOsc>[];
 }
 
 function buildMockCtx(): MockCtx {
@@ -97,6 +99,7 @@ function buildMockCtx(): MockCtx {
     ctx,
     oscCount: () => oscillators.length,
     bufferSourceCount: () => sources.length,
+    oscillators: () => oscillators,
   };
 }
 
@@ -207,5 +210,44 @@ describe("scheduleProgressionStep", () => {
       enable: { strum: true, bass: false, drums: false, metronome: false },
     });
     expect(mock.oscCount()).toBe(1);
+  });
+
+  it("repeats strum hits once per bar for multi-bar chords", () => {
+    scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
+      voicing: ["C3"],
+      bassNote: null,
+      beatsAvailable: 8,
+      beatsPerBar: 4,
+      secondsPerBeat: 0.5,
+      startTime: 0,
+      enable: { strum: true, bass: false, drums: false, metronome: false },
+    });
+    expect(mock.oscCount()).toBe(12);
+  });
+
+  it("accents each bar downbeat when metronome repeats over multi-bar chords", () => {
+    scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
+      voicing: [],
+      bassNote: null,
+      beatsAvailable: 8,
+      beatsPerBar: 4,
+      secondsPerBeat: 0.5,
+      startTime: 0,
+      enable: { strum: false, bass: false, drums: false, metronome: true },
+    });
+
+    const frequencies = mock.oscillators().map((osc) =>
+      osc.frequency.setValueAtTime.mock.calls[0]?.[0],
+    );
+    expect(frequencies).toEqual([
+      _metronomeInternals.ACCENT_FREQ,
+      _metronomeInternals.NORMAL_FREQ,
+      _metronomeInternals.NORMAL_FREQ,
+      _metronomeInternals.NORMAL_FREQ,
+      _metronomeInternals.ACCENT_FREQ,
+      _metronomeInternals.NORMAL_FREQ,
+      _metronomeInternals.NORMAL_FREQ,
+      _metronomeInternals.NORMAL_FREQ,
+    ]);
   });
 });

--- a/src/progressions/audio/scheduler.ts
+++ b/src/progressions/audio/scheduler.ts
@@ -18,8 +18,8 @@ import { scheduleHiHat, scheduleKick, scheduleSnare } from "./drumKit";
 import { scheduleClick } from "./metronome";
 import {
   buildMetronomePattern,
-  clipPatternToBeats,
   POP_STRUM_PATTERN,
+  repeatPatternToBeats,
   ROCK_DRUM_PATTERN,
 } from "./patterns";
 import { pluckString, type PluckedVoiceHandle } from "./string";
@@ -73,7 +73,11 @@ export function scheduleProgressionStep(
 
   // Strum: trigger each pattern hit, voicing notes spread across STRUM_LAG.
   if (enable.strum && input.voicing.length > 0) {
-    const hits = clipPatternToBeats(POP_STRUM_PATTERN, beatsAvailable);
+    const hits = repeatPatternToBeats(
+      POP_STRUM_PATTERN,
+      beatsAvailable,
+      beatsPerBar,
+    );
     for (const hit of hits) {
       const hitTime = startTime + hit.beat * secondsPerBeat;
       const ordered =
@@ -93,12 +97,16 @@ export function scheduleProgressionStep(
   if (enable.bass && input.bassNote) {
     const bassFreq = getNoteFrequency(input.bassNote);
     if (Number.isFinite(bassFreq) && bassFreq > 0) {
-      const bassHits: Array<{ beat: number; velocity: number }> = [
+      const bassPattern: Array<{ beat: number; velocity: number }> = [
         { beat: 0, velocity: 1 },
+        { beat: 2, velocity: 0.85 },
       ];
-      if (beatsAvailable > 2) bassHits.push({ beat: 2, velocity: 0.85 });
+      const bassHits = repeatPatternToBeats(
+        bassPattern,
+        beatsAvailable,
+        beatsPerBar,
+      );
       for (const hit of bassHits) {
-        if (hit.beat >= beatsAvailable) continue;
         voices.push(
           scheduleBassNote(
             ctx,
@@ -117,17 +125,32 @@ export function scheduleProgressionStep(
 
   // Drums: fire-and-forget — no live handles needed.
   if (enable.drums) {
-    for (const hit of clipPatternToBeats(ROCK_DRUM_PATTERN.kicks, beatsAvailable)) {
+    const kicks = repeatPatternToBeats(
+      ROCK_DRUM_PATTERN.kicks,
+      beatsAvailable,
+      beatsPerBar,
+    );
+    const snares = repeatPatternToBeats(
+      ROCK_DRUM_PATTERN.snares,
+      beatsAvailable,
+      beatsPerBar,
+    );
+    const hats = repeatPatternToBeats(
+      ROCK_DRUM_PATTERN.hats,
+      beatsAvailable,
+      beatsPerBar,
+    );
+    for (const hit of kicks) {
       scheduleKick(ctx, bus, startTime + hit.beat * secondsPerBeat, {
         velocity: hit.velocity,
       });
     }
-    for (const hit of clipPatternToBeats(ROCK_DRUM_PATTERN.snares, beatsAvailable)) {
+    for (const hit of snares) {
       scheduleSnare(ctx, bus, startTime + hit.beat * secondsPerBeat, {
         velocity: hit.velocity,
       });
     }
-    for (const hit of clipPatternToBeats(ROCK_DRUM_PATTERN.hats, beatsAvailable)) {
+    for (const hit of hats) {
       scheduleHiHat(ctx, bus, startTime + hit.beat * secondsPerBeat, {
         velocity: hit.velocity,
       });
@@ -135,13 +158,15 @@ export function scheduleProgressionStep(
   }
 
   if (enable.metronome) {
-    const clicks = clipPatternToBeats(
+    const clicks = repeatPatternToBeats(
       buildMetronomePattern(beatsPerBar),
       beatsAvailable,
+      beatsPerBar,
     );
     for (const hit of clicks) {
+      const beatInBar = hit.beat % beatsPerBar;
       scheduleClick(ctx, bus, startTime + hit.beat * secondsPerBeat, {
-        accent: hit.beat === 0,
+        accent: Math.abs(beatInBar) < 1e-9,
         velocity: hit.velocity,
       });
     }


### PR DESCRIPTION
## Summary
- Repeat backing-track patterns across every bar of a multi-bar chord so strums, drums, bass, and metronome hits follow the full duration.
- Accent metronome downbeats by bar position, so a 2-bar chord still emphasizes beat 1 of each bar.
- Position progression blocks with exact cumulative percentages instead of flex sizing, which keeps the ruler and chord segments aligned.
- Added regression coverage for multi-bar pattern repetition, bar-level metronome accents, and exact block placement math.

## Testing
- `npm test -- --run src/progressions/audio/patterns.test.ts src/progressions/audio/scheduler.test.ts src/components/ProgressionTrack/ProgressionTrack.test.tsx src/progressions/audio/timeline.test.ts`
- `npm run lint`
- `npm run build`