### PR TITLE
fix: reuse bass and metronome patterns in progression scheduler

### DIFF
--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -16,7 +16,7 @@ import {
   setActiveStep,
 } from "../progressions/audio/timeline";
 import { isMutedAtom } from "../store/atoms";
-import { resolveChordVoicing } from "../progressions/progressionAudio";
+import { resolveBassLineNotes, resolveChordVoicing } from "../progressions/progressionAudio";
 import {
   findNextResolvableStepIndex,
   type ResolvedProgressionStep,
@@ -26,10 +26,6 @@ import { useProgressionState } from "./useProgressionState";
 /** Lead between scheduling and audible hit; keeps Web Audio from dropping
  * the first event when `currentTime` and "now" are the same sample. */
 const SCHEDULE_LEAD_SECONDS = 0.02;
-
-/** Octave for the synthesized bass line. Two octaves below middle C sits
- * in the typical electric-bass register. */
-const BASS_OCTAVE = 2;
 
 interface ScheduledSegment {
   stepIndex: number;
@@ -61,7 +57,7 @@ function buildSegment(
   if (!step || step.unavailable || !step.root || !step.quality) return null;
 
   const voicing = resolveChordVoicing(step.root, step.quality);
-  const bassNote = step.root ? `${step.root}${BASS_OCTAVE}` : null;
+  const bassNotes = resolveBassLineNotes(step.root, step.quality);
   const secondsPerBeat = 60 / Math.max(1, inputs.tempo);
   const beatsAvailable =
     step.duration.unit === "bar"
@@ -71,7 +67,7 @@ function buildSegment(
 
   const handle = scheduleProgressionStep(ctx, bus, {
     voicing,
-    bassNote,
+    bassNotes,
     beatsAvailable,
     beatsPerBar: inputs.beatsPerBar,
     secondsPerBeat,

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -4,6 +4,7 @@ import {
   clipPatternToBeats,
   POP_STRUM_PATTERN,
   repeatPatternToBeats,
+  ROOT_FIFTH_BASS_PATTERN,
   ROCK_DRUM_PATTERN,
 } from "./patterns";
 
@@ -89,6 +90,15 @@ describe("ROCK_DRUM_PATTERN", () => {
     expect(ROCK_DRUM_PATTERN.hats).toHaveLength(8);
     expect(ROCK_DRUM_PATTERN.hats.map((h) => h.beat)).toEqual([
       0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5,
+    ]);
+  });
+});
+
+describe("ROOT_FIFTH_BASS_PATTERN", () => {
+  it("uses the same beat grid as the kick pattern with root then fifth roles", () => {
+    expect(ROOT_FIFTH_BASS_PATTERN).toEqual([
+      { beat: 0, velocity: 1, note: "root" },
+      { beat: 2, velocity: 0.85, note: "fifth" },
     ]);
   });
 });

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -27,6 +27,12 @@ export interface DrumHit {
   velocity: number;
 }
 
+export interface BassHit {
+  beat: number;
+  velocity: number;
+  note: "root" | "fifth";
+}
+
 export interface DrumPattern {
   kicks: readonly DrumHit[];
   snares: readonly DrumHit[];
@@ -47,6 +53,16 @@ export const POP_STRUM_PATTERN: readonly StrumHit[] = [
   { beat: 2.5, velocity: 0.55, direction: "up" },
   { beat: 3, velocity: 0.7, direction: "down" },
   { beat: 3.5, velocity: 0.5, direction: "up" },
+];
+
+/**
+ * Simple root-fifth bass pattern: root on beat 1, fifth on beat 3. The
+ * scheduler repeats it per bar and resolves note roles against the active
+ * chord, falling back to the root if a chord has no fifth.
+ */
+export const ROOT_FIFTH_BASS_PATTERN: readonly BassHit[] = [
+  { beat: 0, velocity: 1, note: "root" },
+  { beat: 2, velocity: 0.85, note: "fifth" },
 ];
 
 /**

--- a/src/progressions/audio/scheduler.test.ts
+++ b/src/progressions/audio/scheduler.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getNoteFrequency } from "@fretflow/core";
 import { scheduleProgressionStep } from "./scheduler";
 import { _metronomeInternals } from "./metronome";
 
@@ -115,7 +116,7 @@ describe("scheduleProgressionStep", () => {
   it("returns a no-op handle when beatsAvailable is 0", () => {
     const handle = scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
       voicing: ["C3"],
-      bassNote: "C2",
+      bassNotes: ["C2"],
       beatsAvailable: 0,
       beatsPerBar: 4,
       secondsPerBeat: 0.5,
@@ -129,7 +130,7 @@ describe("scheduleProgressionStep", () => {
   it("does not schedule any oscillators when all flags are off", () => {
     scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
       voicing: ["C3", "E3", "G3"],
-      bassNote: "C2",
+      bassNotes: ["C2"],
       beatsAvailable: 4,
       beatsPerBar: 4,
       secondsPerBeat: 0.5,
@@ -143,7 +144,7 @@ describe("scheduleProgressionStep", () => {
   it("schedules strum hits only when strum flag is on", () => {
     scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
       voicing: ["C3", "E3", "G3"],
-      bassNote: null,
+      bassNotes: [],
       beatsAvailable: 4,
       beatsPerBar: 4,
       secondsPerBeat: 0.5,
@@ -157,7 +158,7 @@ describe("scheduleProgressionStep", () => {
   it("schedules bass voices when bass flag is on", () => {
     scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
       voicing: [],
-      bassNote: "C2",
+      bassNotes: ["C2"],
       beatsAvailable: 4,
       beatsPerBar: 4,
       secondsPerBeat: 0.5,
@@ -168,10 +169,32 @@ describe("scheduleProgressionStep", () => {
     expect(mock.oscCount()).toBe(2);
   });
 
+  it("uses the second bass note on beat 3 when available", () => {
+    scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
+      voicing: [],
+      bassNotes: ["C2", "G2"],
+      beatsAvailable: 4,
+      beatsPerBar: 4,
+      secondsPerBeat: 0.5,
+      startTime: 0,
+      enable: { strum: false, bass: true, drums: false, metronome: false },
+    });
+
+    expect(mock.oscCount()).toBe(2);
+    expect(mock.oscillators()[0].frequency.setValueAtTime).toHaveBeenCalledWith(
+      getNoteFrequency("C2"),
+      0,
+    );
+    expect(mock.oscillators()[1].frequency.setValueAtTime).toHaveBeenCalledWith(
+      getNoteFrequency("G2"),
+      1,
+    );
+  });
+
   it("schedules metronome clicks (one per beat) only when flag is on", () => {
     scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
       voicing: [],
-      bassNote: null,
+      bassNotes: [],
       beatsAvailable: 4,
       beatsPerBar: 4,
       secondsPerBeat: 0.5,
@@ -184,7 +207,7 @@ describe("scheduleProgressionStep", () => {
   it("uses buffer sources for the drum kit (kick adds oscillators, snare/hat add buffers)", () => {
     scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
       voicing: [],
-      bassNote: null,
+      bassNotes: [],
       beatsAvailable: 4,
       beatsPerBar: 4,
       secondsPerBeat: 0.5,
@@ -202,7 +225,7 @@ describe("scheduleProgressionStep", () => {
   it("clips strum hits past the available beats", () => {
     scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
       voicing: ["C3"],
-      bassNote: null,
+      bassNotes: [],
       beatsAvailable: 1, // only beat 0 of POP_STRUM_PATTERN qualifies
       beatsPerBar: 4,
       secondsPerBeat: 0.5,
@@ -215,7 +238,7 @@ describe("scheduleProgressionStep", () => {
   it("repeats strum hits once per bar for multi-bar chords", () => {
     scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
       voicing: ["C3"],
-      bassNote: null,
+      bassNotes: [],
       beatsAvailable: 8,
       beatsPerBar: 4,
       secondsPerBeat: 0.5,
@@ -228,7 +251,7 @@ describe("scheduleProgressionStep", () => {
   it("accents each bar downbeat when metronome repeats over multi-bar chords", () => {
     scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
       voicing: [],
-      bassNote: null,
+      bassNotes: [],
       beatsAvailable: 8,
       beatsPerBar: 4,
       secondsPerBeat: 0.5,
@@ -248,6 +271,28 @@ describe("scheduleProgressionStep", () => {
       _metronomeInternals.NORMAL_FREQ,
       _metronomeInternals.NORMAL_FREQ,
       _metronomeInternals.NORMAL_FREQ,
+    ]);
+  });
+
+  it("repeats the root-fifth bass pattern once per bar for multi-bar chords", () => {
+    scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
+      voicing: [],
+      bassNotes: ["C2", "G2"],
+      beatsAvailable: 8,
+      beatsPerBar: 4,
+      secondsPerBeat: 0.5,
+      startTime: 0,
+      enable: { strum: false, bass: true, drums: false, metronome: false },
+    });
+
+    const scheduledNotes = mock.oscillators().map((osc) =>
+      osc.frequency.setValueAtTime.mock.calls[0],
+    );
+    expect(scheduledNotes).toEqual([
+      [getNoteFrequency("C2"), 0],
+      [getNoteFrequency("G2"), 1],
+      [getNoteFrequency("C2"), 2],
+      [getNoteFrequency("G2"), 3],
     ]);
   });
 });

--- a/src/progressions/audio/scheduler.ts
+++ b/src/progressions/audio/scheduler.ts
@@ -20,6 +20,7 @@ import {
   buildMetronomePattern,
   POP_STRUM_PATTERN,
   repeatPatternToBeats,
+  ROOT_FIFTH_BASS_PATTERN,
   ROCK_DRUM_PATTERN,
 } from "./patterns";
 import { pluckString, type PluckedVoiceHandle } from "./string";
@@ -34,8 +35,8 @@ export interface SchedulerEnableFlags {
 export interface SchedulerStepInput {
   /** Notes for the chord voicing (e.g. ["C3","E3","G3"]). Empty disables strum. */
   voicing: readonly string[];
-  /** Root note for the bass line (e.g. "C2"). Null disables bass for this step. */
-  bassNote: string | null;
+  /** Bass line notes, root first and optional fifth second (e.g. ["C2","G2"]). */
+  bassNotes: readonly string[];
   /** Step length expressed in beats (may be fractional for sub-bar steps). */
   beatsAvailable: number;
   /** Beats per bar at the current meter (used for metronome accent placement). */
@@ -93,20 +94,20 @@ export function scheduleProgressionStep(
     }
   }
 
-  // Bass: root note on beat 1, fifth-style pickup on beat 3 if room.
-  if (enable.bass && input.bassNote) {
-    const bassFreq = getNoteFrequency(input.bassNote);
-    if (Number.isFinite(bassFreq) && bassFreq > 0) {
-      const bassPattern: Array<{ beat: number; velocity: number }> = [
-        { beat: 0, velocity: 1 },
-        { beat: 2, velocity: 0.85 },
-      ];
-      const bassHits = repeatPatternToBeats(
-        bassPattern,
-        beatsAvailable,
-        beatsPerBar,
-      );
-      for (const hit of bassHits) {
+  // Bass: root note on beat 1, chord fifth on beat 3, repeated per bar.
+  if (enable.bass && input.bassNotes.length > 0) {
+    const bassHits = repeatPatternToBeats(
+      ROOT_FIFTH_BASS_PATTERN,
+      beatsAvailable,
+      beatsPerBar,
+    );
+    for (const hit of bassHits) {
+      const note =
+        hit.note === "fifth"
+          ? input.bassNotes[1] ?? input.bassNotes[0]
+          : input.bassNotes[0];
+      const bassFreq = getNoteFrequency(note);
+      if (Number.isFinite(bassFreq) && bassFreq > 0) {
         voices.push(
           scheduleBassNote(
             ctx,

--- a/src/progressions/progressionAudio.test.ts
+++ b/src/progressions/progressionAudio.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveChordVoicing } from "./progressionAudio";
+import { resolveBassLineNotes, resolveChordVoicing } from "./progressionAudio";
 
 describe("resolveChordVoicing", () => {
   it("stacks the C Major Triad as C-E-G at octave 3", () => {
@@ -48,5 +48,15 @@ describe("resolveChordVoicing", () => {
 
   it("returns 4 notes for seventh chords", () => {
     expect(resolveChordVoicing("D", "Minor 7th")).toHaveLength(4);
+  });
+});
+
+describe("resolveBassLineNotes", () => {
+  it("uses the chord root and perfect fifth in the bass octave", () => {
+    expect(resolveBassLineNotes("C", "Major Triad")).toEqual(["C2", "G2"]);
+  });
+
+  it("uses the altered fifth for diminished chords", () => {
+    expect(resolveBassLineNotes("B", "Diminished Triad")).toEqual(["B2", "F3"]);
   });
 });

--- a/src/progressions/progressionAudio.ts
+++ b/src/progressions/progressionAudio.ts
@@ -6,6 +6,7 @@ import { CHORD_DEFINITIONS, NOTES } from "@fretflow/core";
  * dipping into mud (G3-B3-D4 etc.) or shrieking in the high octaves.
  */
 export const PROGRESSION_CHORD_ROOT_OCTAVE = 3;
+export const PROGRESSION_BASS_ROOT_OCTAVE = 2;
 
 /**
  * Compute the note name (without octave) at `semitone` half-steps above
@@ -48,6 +49,29 @@ export function resolveChordVoicing(
     // Absolute distance from C0 in semitones, then split back into
     // note-name + octave so each chord tone sits above the previous root.
     const absolute = rootOctave * 12 + rootIndex + member.semitone;
+    const note = NOTES[((absolute % 12) + 12) % 12];
+    const octave = Math.floor(absolute / 12);
+    return `${note}${octave}`;
+  });
+}
+
+export function resolveBassLineNotes(
+  root: string,
+  quality: string,
+  rootOctave: number = PROGRESSION_BASS_ROOT_OCTAVE,
+): string[] {
+  const definition = CHORD_DEFINITIONS[quality];
+  if (!definition) return [];
+  const rootIndex = NOTES.indexOf(root);
+  if (rootIndex < 0) return [];
+
+  const fifth = definition.members.find((member) =>
+    member.name === "5" || member.name === "b5" || member.name === "#5"
+  );
+  const semitones = fifth ? [0, fifth.semitone] : [0];
+
+  return semitones.map((semitone) => {
+    const absolute = rootOctave * 12 + rootIndex + semitone;
     const note = NOTES[((absolute % 12) + 12) % 12];
     const octave = Math.floor(absolute / 12);
     return `${note}${octave}`;


### PR DESCRIPTION
## Summary
- Rebased onto `main` and aligned the progression scheduler with the existing pattern-driven timing model.
- Added a dedicated root-fifth bass pattern and resolve bass notes per hit instead of reusing one precomputed root pitch.
- Kept bass note selection chord-aware in `progressionAudio`, including altered fifths.
- Added tests for the bass pattern, per-hit bass scheduling, and multi-bar repetition.

## Testing
- `npm test` passed
- `npm run build` passed
- `npm run lint` passed
- `git diff --check --cached` passed