### PR TITLE
fix: keep progression playback and metronome synced on toggle changes

### DIFF
--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -46,12 +46,23 @@ interface SchedulerInputs {
   };
 }
 
+type EnableFlags = SchedulerInputs["enable"];
+
+function sameEnableFlags(a: EnableFlags | null, b: EnableFlags): boolean {
+  return !!a
+    && a.strum === b.strum
+    && a.bass === b.bass
+    && a.drums === b.drums
+    && a.metronome === b.metronome;
+}
+
 function buildSegment(
   ctx: AudioContext,
   bus: AudioNode,
   stepIndex: number,
   startTime: number,
   inputs: SchedulerInputs,
+  scheduleFromTime?: number,
 ): ScheduledSegment | null {
   const step = inputs.steps[stepIndex];
   if (!step || step.unavailable || !step.root || !step.quality) return null;
@@ -72,6 +83,7 @@ function buildSegment(
     beatsPerBar: inputs.beatsPerBar,
     secondsPerBeat,
     startTime,
+    scheduleFromTime,
     enable: inputs.enable,
   });
 
@@ -117,6 +129,7 @@ export function useProgressionAudioPlayback() {
   // current chord from `now`) from "mid-playback dep change" (we keep the
   // current chord intact and apply the new params on the next bar).
   const wasPlayingRef = useRef<boolean>(false);
+  const lastEnableRef = useRef<EnableFlags | null>(null);
 
   useEffect(() => {
     if (!Array.isArray(segmentsRef.current)) segmentsRef.current = [];
@@ -126,6 +139,7 @@ export function useProgressionAudioPlayback() {
       segmentsRef.current = [];
       silenceProgressionBus();
       lastStepRef.current = null;
+      lastEnableRef.current = null;
     };
 
     if (
@@ -165,6 +179,7 @@ export function useProgressionAudioPlayback() {
 
     const now = audio.ctx.currentTime;
     const justStarted = !wasPlayingRef.current;
+    const enableChanged = !sameEnableFlags(lastEnableRef.current, inputs.enable);
     wasPlayingRef.current = true;
 
     const isStepTransition =
@@ -187,13 +202,30 @@ export function useProgressionAudioPlayback() {
       segmentsRef.current = segmentsRef.current.filter(
         (s) => s.stepIndex === activeProgressionStepIndex,
       );
+    } else if (enableChanged) {
+      // Instrument toggles are direct performance controls. Rebuild the
+      // active segment at its original start time so the timeline keeps its
+      // place, while the scheduler only recreates future hits.
+      const activeSegmentStart = segmentsRef.current.find(
+        (s) => s.stepIndex === activeProgressionStepIndex,
+      )?.startTime;
+      segmentsRef.current.forEach((s) => s.handle.cancelAll());
+      segmentsRef.current = [];
+      if (activeSegmentStart !== undefined) {
+        const seg = buildSegment(
+          audio.ctx,
+          audio.bus,
+          activeProgressionStepIndex,
+          activeSegmentStart,
+          inputs,
+          now + SCHEDULE_LEAD_SECONDS,
+        );
+        if (seg) segmentsRef.current.push(seg);
+      }
     } else {
-      // Mid-step dep change (layer toggle / tempo / meter): preserve the
+      // Mid-step dep change (tempo / meter / progression data): preserve the
       // currently-playing segment unchanged so the bar doesn't restart, and
-      // cancel only the pre-scheduled "next" segment. The user-toggled
-      // layer takes effect on the next bar boundary, which matches a
-      // hardware DAW's "punch-in" model and avoids audible double hits
-      // from a mid-bar restart.
+      // cancel only the pre-scheduled "next" segment.
       const keepers: ScheduledSegment[] = [];
       for (const s of segmentsRef.current) {
         if (s.stepIndex === activeProgressionStepIndex) {
@@ -255,6 +287,7 @@ export function useProgressionAudioPlayback() {
     }
 
     lastStepRef.current = activeProgressionStepIndex;
+    lastEnableRef.current = inputs.enable;
   }, [
     progressionEnabled,
     progressionPlaying,

--- a/src/progressions/audio/drumKit.ts
+++ b/src/progressions/audio/drumKit.ts
@@ -46,6 +46,32 @@ export interface DrumHitOptions {
   velocity?: number;
 }
 
+export interface DrumVoiceHandle {
+  cancel: () => void;
+}
+
+function createDrumVoiceHandle(
+  ctx: AudioContext,
+  sources: readonly AudioScheduledSourceNode[],
+  nodes: readonly AudioNode[],
+): DrumVoiceHandle {
+  let canceled = false;
+  return {
+    cancel: () => {
+      if (canceled) return;
+      canceled = true;
+      for (const source of sources) {
+        try {
+          source.stop(ctx.currentTime);
+        } catch {
+          // Source may already have ended or had an earlier stop time.
+        }
+      }
+      disposeNodes(...nodes);
+    },
+  };
+}
+
 /**
  * Schedule a kick drum hit at `time`. Models a punchy 808-style kick: sine
  * oscillator with a fast exponential pitch drop and a short click transient.
@@ -55,11 +81,11 @@ export function scheduleKick(
   dest: AudioNode,
   time: number,
   options: DrumHitOptions = {},
-): void {
+): DrumVoiceHandle {
   const velocity = clampVelocity(options.velocity);
   // Zero velocity → silent hit. Bail before scheduling so we never pass 0
   // into exponentialRampToValueAtTime (which throws on non-positive targets).
-  if (velocity <= 0) return;
+  if (velocity <= 0) return { cancel: () => {} };
 
   // Body
   const osc = ctx.createOscillator();
@@ -87,6 +113,12 @@ export function scheduleKick(
   click.start(time);
   click.stop(time + 0.05);
   click.onended = () => disposeNodes(click, clickGain);
+
+  return createDrumVoiceHandle(
+    ctx,
+    [osc, click],
+    [osc, gain, click, clickGain],
+  );
 }
 
 /**
@@ -98,9 +130,9 @@ export function scheduleSnare(
   dest: AudioNode,
   time: number,
   options: DrumHitOptions = {},
-): void {
+): DrumVoiceHandle {
   const velocity = clampVelocity(options.velocity);
-  if (velocity <= 0) return;
+  if (velocity <= 0) return { cancel: () => {} };
 
   // Noise rattle
   const noise = ctx.createBufferSource();
@@ -130,6 +162,12 @@ export function scheduleSnare(
   body.start(time);
   body.stop(time + 0.15);
   body.onended = () => disposeNodes(body, bodyGain);
+
+  return createDrumVoiceHandle(
+    ctx,
+    [noise, body],
+    [noise, noiseFilter, noiseGain, body, bodyGain],
+  );
 }
 
 export interface HiHatOptions extends DrumHitOptions {
@@ -147,9 +185,9 @@ export function scheduleHiHat(
   dest: AudioNode,
   time: number,
   options: HiHatOptions = {},
-): void {
+): DrumVoiceHandle {
   const velocity = clampVelocity(options.velocity);
-  if (velocity <= 0) return;
+  if (velocity <= 0) return { cancel: () => {} };
   const decay = options.open ? 0.3 : 0.05;
 
   const noise = ctx.createBufferSource();
@@ -173,6 +211,12 @@ export function scheduleHiHat(
   noise.start(time);
   noise.stop(time + decay + 0.05);
   noise.onended = () => disposeNodes(noise, hp, bp, gain);
+
+  return createDrumVoiceHandle(
+    ctx,
+    [noise],
+    [noise, hp, bp, gain],
+  );
 }
 
 export function _resetDrumKitForTests(): void {

--- a/src/progressions/audio/metronome.ts
+++ b/src/progressions/audio/metronome.ts
@@ -16,17 +16,21 @@ export interface ClickOptions {
   velocity?: number;
 }
 
+export interface ClickHandle {
+  cancel: () => void;
+}
+
 /** Schedule a single metronome click at the supplied AudioContext time. */
 export function scheduleClick(
   ctx: AudioContext,
   dest: AudioNode,
   time: number,
   options: ClickOptions = {},
-): void {
+): ClickHandle {
   const velocity = Math.max(0, Math.min(1, options.velocity ?? 0.6));
   // Silent clicks would feed 0 into exponentialRampToValueAtTime, which
   // throws. Skip scheduling entirely — there's nothing to hear anyway.
-  if (velocity <= 0) return;
+  if (velocity <= 0) return { cancel: () => {} };
   const frequency = options.accent ? ACCENT_FREQ : NORMAL_FREQ;
 
   const osc = ctx.createOscillator();
@@ -48,6 +52,27 @@ export function scheduleClick(
     } catch {
       // already disconnected
     }
+  };
+
+  let canceled = false;
+  return {
+    cancel: () => {
+      if (canceled) return;
+      canceled = true;
+      try {
+        gain.gain.cancelScheduledValues(ctx.currentTime);
+        gain.gain.setValueAtTime(Math.max(gain.gain.value, 0.0001), ctx.currentTime);
+        gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.01);
+        osc.stop(ctx.currentTime + 0.012);
+      } catch {
+        try {
+          osc.disconnect();
+          gain.disconnect();
+        } catch {
+          // already disconnected
+        }
+      }
+    },
   };
 }
 

--- a/src/progressions/audio/scheduler.test.ts
+++ b/src/progressions/audio/scheduler.test.ts
@@ -73,6 +73,7 @@ interface MockCtx {
   oscCount: () => number;
   bufferSourceCount: () => number;
   oscillators: () => ReturnType<typeof createMockOsc>[];
+  bufferSources: () => ReturnType<typeof createMockBufferSource>[];
 }
 
 function buildMockCtx(): MockCtx {
@@ -101,6 +102,7 @@ function buildMockCtx(): MockCtx {
     oscCount: () => oscillators.length,
     bufferSourceCount: () => sources.length,
     oscillators: () => oscillators,
+    bufferSources: () => sources,
   };
 }
 
@@ -204,6 +206,44 @@ describe("scheduleProgressionStep", () => {
     expect(mock.oscCount()).toBe(4);
   });
 
+  it("cancels scheduled metronome clicks when the step handle is cancelled", () => {
+    const handle = scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
+      voicing: [],
+      bassNotes: [],
+      beatsAvailable: 4,
+      beatsPerBar: 4,
+      secondsPerBeat: 0.5,
+      startTime: 3,
+      enable: { strum: false, bass: false, drums: false, metronome: true },
+    });
+
+    const scheduledSources = mock.oscillators();
+    expect(scheduledSources).toHaveLength(4);
+    expect(scheduledSources.every((source) => source.stop.mock.calls.length === 1))
+      .toBe(true);
+
+    handle.cancelAll();
+
+    expect(scheduledSources.every((source) => source.stop.mock.calls.length >= 2))
+      .toBe(true);
+  });
+
+  it("keeps step timing but skips past hits when rescheduling from a cutoff", () => {
+    scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
+      voicing: [],
+      bassNotes: [],
+      beatsAvailable: 4,
+      beatsPerBar: 4,
+      secondsPerBeat: 0.5,
+      startTime: 10,
+      scheduleFromTime: 10.76,
+      enable: { strum: false, bass: false, drums: false, metronome: true },
+    });
+
+    const startTimes = mock.oscillators().map((source) => source.start.mock.calls[0]?.[0]);
+    expect(startTimes).toEqual([11, 11.5]);
+  });
+
   it("uses buffer sources for the drum kit (kick adds oscillators, snare/hat add buffers)", () => {
     scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
       voicing: [],
@@ -220,6 +260,31 @@ describe("scheduleProgressionStep", () => {
     expect(mock.oscCount()).toBeGreaterThanOrEqual(6);
     // Snares + hats use noise buffers — at minimum 2 snares + 8 hats = 10.
     expect(mock.bufferSourceCount()).toBeGreaterThanOrEqual(10);
+  });
+
+  it("cancels scheduled drum hits when the step handle is cancelled", () => {
+    const handle = scheduleProgressionStep(mock.ctx, bus as unknown as AudioNode, {
+      voicing: [],
+      bassNotes: [],
+      beatsAvailable: 4,
+      beatsPerBar: 4,
+      secondsPerBeat: 0.5,
+      startTime: 3,
+      enable: { strum: false, bass: false, drums: true, metronome: false },
+    });
+
+    const scheduledSources = [
+      ...mock.oscillators(),
+      ...mock.bufferSources(),
+    ];
+    expect(scheduledSources.length).toBeGreaterThan(0);
+    expect(scheduledSources.every((source) => source.stop.mock.calls.length === 1))
+      .toBe(true);
+
+    handle.cancelAll();
+
+    expect(scheduledSources.every((source) => source.stop.mock.calls.length >= 2))
+      .toBe(true);
   });
 
   it("clips strum hits past the available beats", () => {

--- a/src/progressions/audio/scheduler.ts
+++ b/src/progressions/audio/scheduler.ts
@@ -6,16 +6,20 @@
  * the per-beat work in Web Audio time, so the strum + drum + bass groove
  * stays locked to the audio clock instead of drifting with React renders.
  *
- * On pause/stop the hook calls `silenceProgressionBus()` upstream — that's
- * the single kill switch. `cancelAll()` here additionally releases the live
- * pluck/bass voices so their oscillators tear down promptly instead of
- * waiting for their full envelope.
+ * On pause/stop the hook calls `silenceProgressionBus()` upstream for an
+ * immediate fade. `cancelAll()` here also cancels pending scheduled voices
+ * so future hits do not leak into resumed playback.
  */
 
 import { getNoteFrequency } from "@fretflow/core";
 import { scheduleBassNote, type BassVoiceHandle } from "./bass";
-import { scheduleHiHat, scheduleKick, scheduleSnare } from "./drumKit";
-import { scheduleClick } from "./metronome";
+import {
+  scheduleHiHat,
+  scheduleKick,
+  scheduleSnare,
+  type DrumVoiceHandle,
+} from "./drumKit";
+import { scheduleClick, type ClickHandle } from "./metronome";
 import {
   buildMetronomePattern,
   POP_STRUM_PATTERN,
@@ -45,6 +49,10 @@ export interface SchedulerStepInput {
   secondsPerBeat: number;
   /** AudioContext time at which the step begins. */
   startTime: number;
+  /** Optional lower bound for scheduled events, used when rebuilding a
+   *  still-playing step after an instrument toggle without moving the
+   *  timeline back to beat 0. */
+  scheduleFromTime?: number;
   enable: SchedulerEnableFlags;
 }
 
@@ -65,12 +73,23 @@ export function scheduleProgressionStep(
   bus: AudioNode,
   input: SchedulerStepInput,
 ): ScheduledStepHandle {
-  const voices: Array<PluckedVoiceHandle | BassVoiceHandle> = [];
-  const { startTime, secondsPerBeat, beatsAvailable, beatsPerBar, enable } = input;
+  const voices: Array<
+    PluckedVoiceHandle | BassVoiceHandle | DrumVoiceHandle | ClickHandle
+  > = [];
+  const {
+    startTime,
+    secondsPerBeat,
+    beatsAvailable,
+    beatsPerBar,
+    enable,
+    scheduleFromTime = startTime,
+  } = input;
 
   if (beatsAvailable <= 0 || secondsPerBeat <= 0) {
     return { cancelAll: () => {} };
   }
+
+  const shouldScheduleHit = (time: number) => time >= scheduleFromTime;
 
   // Strum: trigger each pattern hit, voicing notes spread across STRUM_LAG.
   if (enable.strum && input.voicing.length > 0) {
@@ -81,6 +100,7 @@ export function scheduleProgressionStep(
     );
     for (const hit of hits) {
       const hitTime = startTime + hit.beat * secondsPerBeat;
+      if (!shouldScheduleHit(hitTime)) continue;
       const ordered =
         hit.direction === "up" ? [...input.voicing].reverse() : input.voicing;
       ordered.forEach((note, i) => {
@@ -108,12 +128,14 @@ export function scheduleProgressionStep(
           : input.bassNotes[0];
       const bassFreq = getNoteFrequency(note);
       if (Number.isFinite(bassFreq) && bassFreq > 0) {
+        const hitTime = startTime + hit.beat * secondsPerBeat;
+        if (!shouldScheduleHit(hitTime)) continue;
         voices.push(
           scheduleBassNote(
             ctx,
             bus,
             bassFreq,
-            startTime + hit.beat * secondsPerBeat,
+            hitTime,
             {
               velocity: hit.velocity,
               durationSec: Math.min(0.9, secondsPerBeat * 1.4),
@@ -124,7 +146,8 @@ export function scheduleProgressionStep(
     }
   }
 
-  // Drums: fire-and-forget — no live handles needed.
+  // Drums: scheduled source nodes are tracked so pause/resume can cancel
+  // future hits before rebuilding the bar from beat 0.
   if (enable.drums) {
     const kicks = repeatPatternToBeats(
       ROCK_DRUM_PATTERN.kicks,
@@ -142,19 +165,31 @@ export function scheduleProgressionStep(
       beatsPerBar,
     );
     for (const hit of kicks) {
-      scheduleKick(ctx, bus, startTime + hit.beat * secondsPerBeat, {
-        velocity: hit.velocity,
-      });
+      const hitTime = startTime + hit.beat * secondsPerBeat;
+      if (!shouldScheduleHit(hitTime)) continue;
+      voices.push(
+        scheduleKick(ctx, bus, hitTime, {
+          velocity: hit.velocity,
+        }),
+      );
     }
     for (const hit of snares) {
-      scheduleSnare(ctx, bus, startTime + hit.beat * secondsPerBeat, {
-        velocity: hit.velocity,
-      });
+      const hitTime = startTime + hit.beat * secondsPerBeat;
+      if (!shouldScheduleHit(hitTime)) continue;
+      voices.push(
+        scheduleSnare(ctx, bus, hitTime, {
+          velocity: hit.velocity,
+        }),
+      );
     }
     for (const hit of hats) {
-      scheduleHiHat(ctx, bus, startTime + hit.beat * secondsPerBeat, {
-        velocity: hit.velocity,
-      });
+      const hitTime = startTime + hit.beat * secondsPerBeat;
+      if (!shouldScheduleHit(hitTime)) continue;
+      voices.push(
+        scheduleHiHat(ctx, bus, hitTime, {
+          velocity: hit.velocity,
+        }),
+      );
     }
   }
 
@@ -166,10 +201,14 @@ export function scheduleProgressionStep(
     );
     for (const hit of clicks) {
       const beatInBar = hit.beat % beatsPerBar;
-      scheduleClick(ctx, bus, startTime + hit.beat * secondsPerBeat, {
-        accent: Math.abs(beatInBar) < 1e-9,
-        velocity: hit.velocity,
-      });
+      const hitTime = startTime + hit.beat * secondsPerBeat;
+      if (!shouldScheduleHit(hitTime)) continue;
+      voices.push(
+        scheduleClick(ctx, bus, hitTime, {
+          accent: Math.abs(beatInBar) < 1e-9,
+          velocity: hit.velocity,
+        }),
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- Cancel scheduled drum and metronome hits on pause/resume so old audio does not bleed into the next playback cycle.
- Preserve the active bar position when toggling backing-track layers instead of rebasing the timeline to the bar start.
- Add regression coverage for cancellable drum/metronome scheduling and cutoff-based rescheduling.

## Testing
- `npm run test -- src/progressions/audio/scheduler.test.ts src/progressions/audio/timeline.test.ts`
- `npm exec tsc -- --noEmit`
- `npm run lint`
- `npm run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audio toggles (strum, bass, drums, metronome) now refresh during playback without disrupting the timeline.
  * Stopping/pausing now reliably cancels scheduled drum and metronome sounds for cleaner stop behavior.

* **New Features**
  * Scheduling supports rebuilding future hits from the current timeline position so rescheduled events preserve timing.

* **Tests**
  * Improved test coverage for scheduling and cancellation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/386)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->