### PR TITLE
chore(progression-controls): remove dead data-compact CSS rules

### DIFF
--- a/src/components/ProgressionControls/ProgressionControls.module.css
+++ b/src/components/ProgressionControls/ProgressionControls.module.css
@@ -95,12 +95,3 @@
   justify-content: center;
   gap: 0.3rem;
 }
-
-.progression-controls[data-compact="true"] {
-  gap: 0.65rem;
-}
-
-.progression-controls[data-compact="true"] .step-row {
-  min-height: 2.15rem;
-  padding: 0.32rem 0.45rem;
-}


### PR DESCRIPTION
## Summary

The `data-compact` attribute was removed from the `.progression-controls` root `<div>` in commit `d2d4555d` (Task 7 of the DAW Shell Phase 1 plan). The two `[data-compact="true"]` rule blocks in `ProgressionControls.module.css` no longer match any element, so they are removed.

## Test plan

- [x] `npm run lint` passes
- [x] Pre-push hooks (type-check + vitest, 1801 tests) pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbhFdv9D7cYaqvqLHraqU9)_