### PR TITLE
perf(build): split vendor chunks to eliminate large bundle warning

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,21 @@ export default defineConfig({
   },
   build: {
     sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks(id: string) {
+          if (id.includes('node_modules')) {
+            if (id.includes('react-dom') || id.includes('react/') || id.includes('scheduler')) {
+              return 'vendor-react'
+            }
+            if (id.includes('motion-dom') || id.includes('motion-utils') || id.includes('framer-motion') || id.includes('/motion/')) {
+              return 'vendor-motion'
+            }
+            return 'vendor'
+          }
+        },
+      },
+    },
   },
   test: {
     globals: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,18 +24,26 @@ export default defineConfig({
   },
   build: {
     sourcemap: true,
-    rollupOptions: {
+    rolldownOptions: {
       output: {
-        manualChunks(id: string) {
-          if (id.includes('node_modules')) {
-            if (id.includes('react-dom') || id.includes('react/') || id.includes('scheduler')) {
-              return 'vendor-react'
-            }
-            if (id.includes('motion-dom') || id.includes('motion-utils') || id.includes('framer-motion') || id.includes('/motion/')) {
-              return 'vendor-motion'
-            }
-            return 'vendor'
-          }
+        codeSplitting: {
+          groups: [
+            {
+              name: 'vendor-react',
+              test: /node_modules[\\/](react-dom|react|scheduler)[\\/]/,
+              priority: 3,
+            },
+            {
+              name: 'vendor-motion',
+              test: /node_modules[\\/](framer-motion|motion-dom|motion-utils|motion)[\\/]/,
+              priority: 2,
+            },
+            {
+              name: 'vendor',
+              test: /node_modules[\\/]/,
+              priority: 1,
+            },
+          ],
         },
       },
     },


### PR DESCRIPTION
## Summary

- Configure `manualChunks` in Vite build config to split the single 482 kB index chunk into smaller vendor chunks
- `vendor-react` (189 kB): react, react-dom, scheduler
- `vendor-motion` (125 kB): motion, motion-dom, framer-motion, motion-utils
- `vendor` (18 kB): jotai, lucide-react, clsx, etc.
- `index` app code drops from 482 kB → 160 kB

## Why

The production build was approaching (and sometimes hitting) Vite's 500 kB chunk size warning. Splitting vendors also improves browser caching — vendor chunks change rarely between deploys, so returning users download less on updates.

## Test plan

- [x] `npm run build` — no chunk size warnings, all chunks under 200 kB
- [x] `npm run lint` — clean
- [x] `npm run test` — all 1804 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build configuration to implement explicit code splitting for external dependencies. React-related modules including scheduler are now bundled into their own chunk. Framer Motion and related packages are grouped into a separate chunk. All other vendor modules are placed in an additional chunk. Source map generation remains enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/391)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->