### PR TITLE
fix: resolve pentatonic and blues progression chords through parent harmony

### DIFF
--- a/packages/core/src/degrees.test.ts
+++ b/packages/core/src/degrees.test.ts
@@ -196,10 +196,26 @@ describe('getDegreesForScale', () => {
       });
     });
 
-    it('falls back gracefully for Blues scale', () => {
+    it('returns pentatonic degree labels for Minor Blues', () => {
       const degrees = getDegreesForScale('Minor Blues');
-      expect(degrees).toBeDefined();
-      expect(degrees[0]).toBeDefined(); // Has a root
+      expect(degrees).toEqual({
+        0: "i",
+        3: "III",
+        5: "iv",
+        7: "v",
+        10: "VII",
+      });
+    });
+
+    it('returns pentatonic degree labels for Major Blues', () => {
+      const degrees = getDegreesForScale('Major Blues');
+      expect(degrees).toEqual({
+        0: "I",
+        2: "ii",
+        4: "iii",
+        7: "V",
+        9: "vi",
+      });
     });
   });
 
@@ -218,6 +234,24 @@ describe('getDegreesForScale', () => {
       expect(getQualityForDegree("iv", "Minor Pentatonic")).toBe("Minor Triad");
       expect(getQualityForDegree("v", "Minor Pentatonic")).toBe("Minor Triad");
       expect(getQualityForDegree("VII", "Minor Pentatonic")).toBe("Major Triad");
+    });
+
+    it('returns chord qualities for Major Blues degrees', () => {
+      expect(getQualityForDegree("I", "Major Blues")).toBe("Major Triad");
+      expect(getQualityForDegree("ii", "Major Blues")).toBe("Minor Triad");
+      expect(getQualityForDegree("iii", "Major Blues")).toBe("Minor Triad");
+      expect(getQualityForDegree("V", "Major Blues")).toBe("Major Triad");
+      expect(getQualityForDegree("vi", "Major Blues")).toBe("Minor Triad");
+      expect(getQualityForDegree("b3", "Major Blues")).toBeUndefined();
+    });
+
+    it('returns chord qualities for Minor Blues degrees', () => {
+      expect(getQualityForDegree("i", "Minor Blues")).toBe("Minor Triad");
+      expect(getQualityForDegree("III", "Minor Blues")).toBe("Major Triad");
+      expect(getQualityForDegree("iv", "Minor Blues")).toBe("Minor Triad");
+      expect(getQualityForDegree("v", "Minor Blues")).toBe("Minor Triad");
+      expect(getQualityForDegree("VII", "Minor Blues")).toBe("Major Triad");
+      expect(getQualityForDegree("b5", "Minor Blues")).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/degrees.ts
+++ b/packages/core/src/degrees.ts
@@ -68,6 +68,11 @@ const PENTATONIC_DEGREES: Record<string, Record<number, string>> = {
   "Minor Pentatonic": { 0: "i", 3: "III", 5: "iv", 7: "v", 10: "VII" },
 };
 
+const BLUES_DEGREES: Record<string, Record<number, string>> = {
+  "Major Blues": PENTATONIC_DEGREES["Major Pentatonic"],
+  "Minor Blues": PENTATONIC_DEGREES["Minor Pentatonic"],
+};
+
 export const BLUE_NOTE_COLOR = "#0047ff";
 
 export const DEGREE_COLORS: Record<string, string> = {
@@ -116,6 +121,8 @@ const DEGREE_DIATONIC_QUALITY: Record<string, Record<number, string>> = {
   'Harmonic Minor': { 0: "Minor Triad", 2: "Diminished Triad", 3: "Major Triad", 5: "Minor Triad", 7: "Major Triad", 8: "Major Triad", 11: "Diminished Triad" },
   'Major Pentatonic': { 0: "Major Triad", 2: "Minor Triad", 4: "Minor Triad", 7: "Major Triad", 9: "Minor Triad" },
   'Minor Pentatonic': { 0: "Minor Triad", 3: "Major Triad", 5: "Minor Triad", 7: "Minor Triad", 10: "Major Triad" },
+  'Major Blues': { 0: "Major Triad", 2: "Minor Triad", 4: "Minor Triad", 7: "Major Triad", 9: "Minor Triad" },
+  'Minor Blues': { 0: "Minor Triad", 3: "Major Triad", 5: "Minor Triad", 7: "Minor Triad", 10: "Major Triad" },
 };
 
 /**
@@ -244,11 +251,11 @@ export function getDegreeSequence(scaleName: string): DegreeId[] {
  * For 7-note scales, Roman numerals are computed from the actual diatonic triad
  * built on each scale step (third + fifth intervals → quality → casing/suffix).
  *
- * **Non-7-note scale fallback:** Pentatonic uses explicit scale-step labels
- * because its visible chord-degree controls should expose only the pentatonic
- * tones. Blues and other non-7-note scales cannot form full diatonic triads on
- * every step, so true degree analysis does not apply there. They fall back to
- * the closest 7-note parent map:
+ * **Non-7-note scale fallback:** Pentatonic uses explicit scale-step labels,
+ * and blues uses the matching pentatonic degree set so blue notes remain color
+ * tones rather than chord-degree choices. Other non-7-note scales cannot form
+ * full diatonic triads on every step, so true degree analysis does not apply
+ * there. They fall back to the closest 7-note parent map:
  *   - Major degrees when interval 4 (major 3rd) is present (major quality).
  *   - Natural Minor degrees otherwise (minor quality).
  *
@@ -257,6 +264,7 @@ export function getDegreeSequence(scaleName: string): DegreeId[] {
 export function getDegreesForScale(scaleName: string): Record<number, string> {
   if (MODE_DEGREES[scaleName]) return MODE_DEGREES[scaleName];
   if (PENTATONIC_DEGREES[scaleName]) return PENTATONIC_DEGREES[scaleName];
+  if (BLUES_DEGREES[scaleName]) return BLUES_DEGREES[scaleName];
   const intervals = SCALES[scaleName];
   if (!intervals) return MODE_DEGREES["Natural Minor"];
 

--- a/packages/core/src/theory.test.ts
+++ b/packages/core/src/theory.test.ts
@@ -472,6 +472,24 @@ describe("getDiatonicChord", () => {
     });
   });
 
+  describe("Blues scales", () => {
+    it("v in C Minor Blues resolves to G Minor Triad", () => {
+      expect(getDiatonicChord("v", "Minor Blues", "C")).toEqual({ root: "G", quality: "Minor Triad" });
+    });
+
+    it("b5 in C Minor Blues is a color tone, not a chord degree", () => {
+      expect(getDiatonicChord("b5", "Minor Blues", "C")).toBeUndefined();
+    });
+
+    it("V in C Major Blues resolves to G Major Triad", () => {
+      expect(getDiatonicChord("V", "Major Blues", "C")).toEqual({ root: "G", quality: "Major Triad" });
+    });
+
+    it("b3 in C Major Blues is a color tone, not a chord degree", () => {
+      expect(getDiatonicChord("b3", "Major Blues", "C")).toBeUndefined();
+    });
+  });
+
   describe("Unknown degree guard", () => {
     it("i is not a degree in Major scale — returns undefined", () => {
       expect(getDiatonicChord("i", "Major", "C#")).toBeUndefined();

--- a/src/components/ProgressionControls/ProgressionControls.test.tsx
+++ b/src/components/ProgressionControls/ProgressionControls.test.tsx
@@ -157,6 +157,11 @@ describe("ProgressionControls PRESET", () => {
     const select = screen.getByRole("combobox", { name: "Preset" });
     expect(within(select).getAllByRole("option").map((option) => option.textContent)).toEqual([
       "Custom",
+      "I-V-vi-IV",
+      "ii-V-I",
+      "I-vi-IV-V",
+      "I-IV-V",
+      "12-bar blues",
     ]);
   });
 });

--- a/src/progressions/progressionDomain.test.ts
+++ b/src/progressions/progressionDomain.test.ts
@@ -61,10 +61,55 @@ describe("progressionDomain", () => {
     });
   });
 
+  it("resolves major pentatonic and blues progression chords through major harmony", () => {
+    const step = createProgressionStep(
+      { degree: "IV", duration: { value: 1, unit: "bar" }, qualityOverride: null },
+      "step-iv",
+    );
+
+    expect(resolveProgressionStep(step, "Major Pentatonic", "C")).toMatchObject({
+      root: "F",
+      quality: "Major Triad",
+      unavailable: false,
+    });
+    expect(resolveProgressionStep(step, "Major Blues", "C")).toMatchObject({
+      root: "F",
+      quality: "Major Triad",
+      unavailable: false,
+    });
+  });
+
+  it("resolves minor pentatonic and blues progression chords through natural-minor harmony", () => {
+    const step = createProgressionStep(
+      { degree: "VI", duration: { value: 1, unit: "bar" }, qualityOverride: null },
+      "step-vi",
+    );
+
+    expect(resolveProgressionStep(step, "Minor Pentatonic", "C")).toMatchObject({
+      root: "G#",
+      quality: "Major Triad",
+      unavailable: false,
+    });
+    expect(resolveProgressionStep(step, "Minor Blues", "C")).toMatchObject({
+      root: "G#",
+      quality: "Major Triad",
+      unavailable: false,
+    });
+  });
+
   it("remaps degree labels by scale-step ordinal when the scale changes", () => {
     expect(remapDegreeByOrdinal("I", "Natural Minor")).toBe("i");
     expect(remapDegreeByOrdinal("V", "Natural Minor")).toBe("v");
     expect(remapDegreeByOrdinal("vi", "Natural Minor")).toBe("VI");
+  });
+
+  it("remaps progression degrees for pentatonic and blues scales against their major/minor harmony parent", () => {
+    expect(remapDegreeByOrdinal("IV", "Major Pentatonic")).toBe("IV");
+    expect(remapDegreeByOrdinal("vi", "Major Blues")).toBe("vi");
+    expect(remapDegreeByOrdinal("I", "Minor Pentatonic")).toBe("i");
+    expect(remapDegreeByOrdinal("V", "Minor Blues")).toBe("v");
+    expect(remapDegreeByOrdinal("vi", "Minor Blues")).toBe("VI");
+    expect(remapDegreeByOrdinal("IV", "Minor Blues")).toBe("iv");
   });
 
   it("remaps all progression steps while preserving ids, durations, and overrides", () => {
@@ -119,8 +164,8 @@ describe("progressionDomain", () => {
     const oneFiveSixFour = PROGRESSION_PRESETS.find((preset) => preset.id === "one-five-six-four");
     expect(oneFiveSixFour).toBeDefined();
     expect(isProgressionPresetAvailableForScale(oneFiveSixFour!, "Major")).toBe(true);
-    expect(isProgressionPresetAvailableForScale(oneFiveSixFour!, "Minor Blues")).toBe(false);
-    expect(getAvailableProgressionPresets("Minor Blues")).toEqual([]);
+    expect(isProgressionPresetAvailableForScale(oneFiveSixFour!, "Minor Blues")).toBe(true);
+    expect(getAvailableProgressionPresets("Minor Blues")).toEqual(PROGRESSION_PRESETS);
   });
 });
 

--- a/src/progressions/progressionDomain.ts
+++ b/src/progressions/progressionDomain.ts
@@ -254,6 +254,17 @@ const ROMAN_ORDINALS: Record<string, number> = {
   VII: 6,
 };
 
+const PROGRESSION_HARMONY_SCALE: Record<string, string> = {
+  "Major Pentatonic": "Major",
+  "Major Blues": "Major",
+  "Minor Pentatonic": "Natural Minor",
+  "Minor Blues": "Natural Minor",
+};
+
+function getProgressionHarmonyScaleName(scaleName: string): string {
+  return PROGRESSION_HARMONY_SCALE[scaleName] ?? scaleName;
+}
+
 let fallbackId = 0;
 
 export function createProgressionStep(
@@ -306,7 +317,7 @@ export function getDegreeOrdinal(degree: DegreeId): number | null {
 
 export function remapDegreeByOrdinal(degree: DegreeId, toScaleName: string): DegreeId {
   const ordinal = getDegreeOrdinal(degree);
-  const targetDegrees = getDegreeSequence(toScaleName);
+  const targetDegrees = getDegreeSequence(getProgressionHarmonyScaleName(toScaleName));
   if (ordinal === null) return degree;
   return targetDegrees[ordinal] ?? degree;
 }
@@ -410,7 +421,11 @@ export function resolveProgressionStep(
   index = 0,
   useFlats = false,
 ): ResolvedProgressionStep {
-  const diatonic = getDiatonicChord(step.degree, scaleName, rootNote);
+  const diatonic = getDiatonicChord(
+    step.degree,
+    getProgressionHarmonyScaleName(scaleName),
+    rootNote,
+  );
   if (!diatonic) {
     return {
       ...step,


### PR DESCRIPTION
## Summary
- Route progression resolution for `Major Pentatonic` / `Major Blues` through `Major`, and `Minor Pentatonic` / `Minor Blues` through `Natural Minor`
- Keep scale-degree controls using the existing pentatonic/blues degree labels, while treating `b3` and `b5` as color tones rather than chord degrees
- Update preset availability and progression UI expectations so pentatonic/blues progressions are selectable instead of marked unavailable

## Testing
- Added and updated unit coverage for degree lookup, diatonic chord resolution, progression remapping, and preset availability
- Validated the affected test suites locally; targeted core, progression, and UI tests passed