### PR TITLE
fix: restore progression playhead sampling during playback

### DIFF
--- a/src/components/ProgressionTrack/ProgressionPlayhead.test.tsx
+++ b/src/components/ProgressionTrack/ProgressionPlayhead.test.tsx
@@ -120,4 +120,51 @@ describe("ProgressionPlayhead", () => {
     });
     expect(playhead.style.left).toBe("37.5%");
   });
+
+  it("starts moving when playback begins before the audio timeline is armed", () => {
+    let mockTime = 0;
+    const audioContext = {
+      get currentTime() {
+        return mockTime;
+      },
+      createGain: () => ({
+        gain: {
+          value: 1,
+          cancelScheduledValues: vi.fn(),
+          setValueAtTime: vi.fn(),
+          linearRampToValueAtTime: vi.fn(),
+        },
+        connect: vi.fn(),
+      }),
+      destination: {},
+    };
+
+    (window as unknown as { AudioContext: unknown }).AudioContext =
+      vi.fn(function () {
+        return audioContext;
+      }) as unknown as typeof AudioContext;
+
+    ensureProgressionAudio();
+
+    const { container } = render(
+      <ProgressionPlayhead
+        playing={true}
+        stepStartBar={1}
+        totalDurationBars={4}
+        totalBarsForDisplay={4}
+      />
+    );
+
+    const playhead = container.querySelector("[data-testid='progression-playhead']") as HTMLElement;
+    expect(playhead.style.left).toBe("0%");
+
+    setActiveStep(0, 0, 1.0, 0, 4.0);
+
+    act(() => {
+      mockTime = 0.5;
+      vi.advanceTimersByTime(16);
+    });
+
+    expect(playhead.style.left).toBe("12.5%");
+  });
 });

--- a/src/components/ProgressionTrack/ProgressionPlayhead.tsx
+++ b/src/components/ProgressionTrack/ProgressionPlayhead.tsx
@@ -14,12 +14,17 @@ interface ProgressionPlayheadProps {
   totalBarsForDisplay: number;
 }
 
+/** ~60 Hz position write interval. Keeping this interval alive while playing
+ * lets the playhead recover when playback starts before the audio timeline is
+ * armed by the sibling audio effect. */
+const TICK_MS = 16;
+
 /**
  * Renders the playhead and drives its horizontal motion by sampling the
- * shared audio-clock `timeline` once per frame. Reads `AudioContext.currentTime`
- * indirectly via `getTimelinePosition()`, so the visual position is locked
- * to whatever the user is hearing — the metronome's audible click and the
- * arrow's pixel position cannot drift.
+ * shared audio-clock `timeline` at roughly 60 Hz. Reads
+ * `AudioContext.currentTime` indirectly via `getTimelinePosition()`, so the
+ * visual position is locked to whatever the user is hearing — the metronome's
+ * audible click and the arrow's pixel position cannot drift.
  *
  * Style writes happen directly on the DOM ref to avoid React reconciliation
  * cost on every animation frame; the component renders only when its props
@@ -46,8 +51,6 @@ export function ProgressionPlayhead({
     if (!el) return;
     el.style.transition = "none";
 
-    let rafId: number | null = null;
-
     const write = () => {
       const tl = getTimelinePosition();
       const {
@@ -63,23 +66,19 @@ export function ProgressionPlayhead({
         // Uses globalFraction which is perfectly continuous across audio steps.
         const pct = (tl.globalFraction * currentTotalDurationBars / safeDisplayTotal) * 100;
         el.style.left = `${Math.max(0, Math.min(100, pct))}%`;
-        rafId = requestAnimationFrame(write);
       } else {
         // Paused or stopped: snap to current chord's start bar.
         const bar = currentStepStartBar;
         const pct = ((bar - 1) / safeDisplayTotal) * 100;
         el.style.left = `${Math.max(0, Math.min(100, pct))}%`;
-        rafId = null;
       }
     };
 
     write();
 
-    return () => {
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
-      }
-    };
+    if (!playing) return;
+    const id = window.setInterval(write, TICK_MS);
+    return () => window.clearInterval(id);
   }, [playing]);
 
   return (


### PR DESCRIPTION
## Summary
- Restore the progression playhead animation loop so it keeps sampling while playback is active, even if the audio timeline is armed a tick later by the sibling audio effect.
- Add a regression test that covers the start-of-playback race where the playhead previously stayed stuck at `0%`.

## Testing
- `npm test -- --run src/components/ProgressionTrack/ProgressionTrack.test.tsx src/components/ProgressionTrack/ProgressionPlayhead.test.tsx src/components/ProgressionTrack/ProgressionPositionReadout.test.tsx src/hooks/useProgressionPlaybackLoop.test.tsx src/progressions/audio/timeline.test.ts`
- `npm run lint`
- Verified the playhead advances in a local Playwright/browser check after playback starts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for `ProgressionPlayhead` animation behavior.

* **Refactor**
  * Updated animation timing mechanism for improved stability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/396)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->