### PR TITLE
test: fix flaky note-button focus-visible e2e test

### DIFF
--- a/e2e/theme-contract.spec.ts
+++ b/e2e/theme-contract.spec.ts
@@ -475,7 +475,7 @@ test.describe("Theme Contract", () => {
           }
         });
 
-        test("note buttons should have correct hover and focus behavior", async ({ page }) => {
+        test("note buttons should have correct hover styling", async ({ page }) => {
           // The Note selector lives in the Inspector's Scale tab.
           await page.getByRole("tab", { name: "Scale" }).click();
           const noteBtn = page
@@ -484,13 +484,8 @@ test.describe("Theme Contract", () => {
             .first();
           await expect(noteBtn).toBeVisible();
 
-          // Clicking the Scale tab leaves focus on the (pointer-focused) tab
-          // trigger, which would make a subsequent programmatic focus inherit a
-          // non-:focus-visible state. Blur it so the note button focus below is
-          // treated as keyboard-style focus and the :focus-visible rule applies.
-          await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
-
-          // Hover state
+          // Hover state — pointer modality is fine here since we only assert
+          // hover styles (color, borderColor), not :focus-visible.
           await noteBtn.hover();
           const hoverStyles = await noteBtn.evaluate((el) => {
             const cs = getComputedStyle(el);
@@ -507,17 +502,38 @@ test.describe("Theme Contract", () => {
             expect(hoverStyles.color.replace(/\s/g, "")).toBe("rgb(255,255,255)");
             expect(isCyanLike(hoverStyles.borderColor)).toBe(true);
           }
+        });
 
-          // Focus state — the :focus-visible note-btn rule only engages for
-          // keyboard-driven focus. A programmatic .focus() after the pointer
-          // hover above keeps pointer input modality, so drive focus with the
-          // keyboard: focus the note grid, then arrow onto a (still unpressed)
-          // sibling so the :focus-visible heuristic applies. Measure the
-          // currently keyboard-focused button via document.activeElement.
+        test("note buttons should have correct focus-visible styling", async ({ page }) => {
+          // The Note selector lives in the Inspector's Scale tab.
+          await page.getByRole("tab", { name: "Scale" }).click();
+          const noteGroup = page.getByRole("group", { name: "Note selector" });
+          await expect(noteGroup).toBeVisible();
+
+          // Target an unpressed (non-root) note button.
+          const noteBtn = noteGroup.getByRole("button", { pressed: false }).first();
+          await expect(noteBtn).toBeVisible();
+
+          // Chromium's :focus-visible heuristic keys off whether the focus
+          // change ITSELF came from a keyboard event — a programmatic .focus()
+          // never satisfies it, no matter what Tab presses preceded it. So the
+          // FINAL action that lands focus on the note button must be a real
+          // keyboard event.
+          //
+          // Move focus into the button's vicinity programmatically, then do a
+          // Shift+Tab / Tab round-trip: Shift+Tab keyboard-moves focus to the
+          // previous element, and Tab keyboard-moves it forward, landing back
+          // ON the note button via a genuine keyboard event so :focus-visible
+          // activates.
           await noteBtn.focus();
-          await noteBtn.press("ArrowRight");
-          const focusStyles = await page.evaluate(() => {
-            const el = document.activeElement as HTMLElement;
+          await page.keyboard.press("Shift+Tab");
+          await page.keyboard.press("Tab");
+
+          // Assert keyboard focus actually landed on the target note button
+          // before reading its computed styles.
+          await expect(noteBtn).toBeFocused();
+
+          const focusStyles = await noteBtn.evaluate((el) => {
             const cs = getComputedStyle(el);
             return {
               outlineStyle: cs.outlineStyle,
@@ -526,7 +542,8 @@ test.describe("Theme Contract", () => {
               pressed: el.getAttribute("aria-pressed"),
             };
           });
-          // The arrowed-to note must still be unpressed (not the active root).
+
+          // The button must still be unpressed (we only focused, not selected it).
           expect(focusStyles.pressed).toBe("false");
 
           if (theme === "light") {


### PR DESCRIPTION
## Summary

- `note buttons should have correct hover and focus behavior` in `e2e/theme-contract.spec.ts` was a long-standing flake (failed ~10% of runs, and failed on `main`).
- Root cause: the test did `.hover()` then a programmatic `.focus()` before asserting `:focus-visible` CSS. Chromium's `:focus-visible` heuristic only activates when the focus change itself is keyboard-driven — a programmatic `.focus()` after a pointer-modality `.hover()` did not reliably qualify.
- Fix (test-only): split into two deterministic tests — one for hover styling, one for focus-visible styling. The focus-visible test lands focus on the note button via a real keyboard event (`Shift+Tab` then `Tab`) and guards with `expect(noteBtn).toBeFocused()`, so `:focus-visible` activates reliably. All original assertions (hover + focus-visible, light + dark theme) are preserved.

## Test Plan

- [x] `npx playwright test e2e/theme-contract.spec.ts -g "note buttons" --config playwright.config.production.ts --repeat-each 10` — 80/80 green across two consecutive runs
- [x] `npm run lint` — clean
- [x] `npm run test` — 1806/1806 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)