### PR TITLE
fix(audio): organ notes crescendo and sustain forever

### DIFF
--- a/src/progressions/audio/instruments/organVoice.test.ts
+++ b/src/progressions/audio/instruments/organVoice.test.ts
@@ -119,7 +119,9 @@ describe("organVoice", () => {
         ([target]: [number]) => target <= 0.01,
       ),
     );
-    expect(releasing.length).toBeGreaterThan(0);
+    // One gain node is the note merger (no release ramp); every other gain
+    // is a harmonic and must release.
+    expect(releasing.length).toBe(gains.length - 1);
   });
 
   it("calling cancel() does not throw", () => {

--- a/src/progressions/audio/instruments/organVoice.test.ts
+++ b/src/progressions/audio/instruments/organVoice.test.ts
@@ -78,6 +78,50 @@ describe("organVoice", () => {
     expect(ctx.createOscillator).toHaveBeenCalled();
   });
 
+  it("schedules a stop for every oscillator so notes self-terminate", () => {
+    const ctx = buildMockCtx();
+    const bus = createMockGain();
+
+    organVoice.scheduleChord(
+      ctx as unknown as AudioContext,
+      bus as unknown as AudioNode,
+      ["C3", "E3", "G3"],
+      0,
+      { velocity: 0.8 },
+    );
+
+    const oscs = ctx.createOscillator.mock.results.map((r) => r.value);
+    expect(oscs.length).toBeGreaterThan(0);
+    for (const osc of oscs) {
+      expect(osc.stop).toHaveBeenCalled();
+      const [stopTime] = osc.stop.mock.calls[0];
+      expect(Number.isFinite(stopTime)).toBe(true);
+    }
+  });
+
+  it("releases each harmonic gain back toward silence", () => {
+    const ctx = buildMockCtx();
+    const bus = createMockGain();
+
+    organVoice.scheduleChord(
+      ctx as unknown as AudioContext,
+      bus as unknown as AudioNode,
+      ["C3"],
+      0,
+      { velocity: 0.8 },
+    );
+
+    const gains = ctx.createGain.mock.results.map((r) => r.value);
+    // Every harmonic gain must ramp down to a near-silent target so the
+    // note ends on its own instead of sustaining at full level.
+    const releasing = gains.filter((g) =>
+      g.gain.exponentialRampToValueAtTime.mock.calls.some(
+        ([target]: [number]) => target <= 0.01,
+      ),
+    );
+    expect(releasing.length).toBeGreaterThan(0);
+  });
+
   it("calling cancel() does not throw", () => {
     const ctx = buildMockCtx();
     const bus = createMockGain();

--- a/src/progressions/audio/instruments/organVoice.ts
+++ b/src/progressions/audio/instruments/organVoice.ts
@@ -2,6 +2,12 @@ import { getNoteFrequency } from "@fretflow/core";
 import type { ChordVoice, ChordVoiceOptions, VoiceHandle } from "./types";
 
 const ATTACK = 0.008;
+// Organ notes hold at full level (sustained timbre) then release. The envelope
+// is bounded so a note self-terminates: the scheduler fires `scheduleChord`
+// once per chord-pattern hit, so without a release every hit would stack
+// another non-decaying voice and the chord would crescendo without end.
+const HOLD = 0.8;
+const RELEASE = 0.5;
 const FADE_OUT = 0.04;
 const ENVELOPE_MIN = 0.001;
 
@@ -32,12 +38,22 @@ function scheduleOrganNote(
     const gain = ctx.createGain();
     osc.type = "sine";
     osc.frequency.setValueAtTime(harmonicFreq, time);
+
+    // Attack up to the drawbar level, hold flat, then release to silence.
+    const level = DRAWBAR_LEVELS[i];
     gain.gain.setValueAtTime(ENVELOPE_MIN, time);
-    gain.gain.linearRampToValueAtTime(DRAWBAR_LEVELS[i], time + ATTACK);
+    gain.gain.linearRampToValueAtTime(level, time + ATTACK);
+    gain.gain.setValueAtTime(level, time + ATTACK + HOLD);
+    gain.gain.exponentialRampToValueAtTime(
+      ENVELOPE_MIN,
+      time + ATTACK + HOLD + RELEASE,
+    );
 
     osc.connect(gain);
     gain.connect(merger);
     osc.start(time);
+    // Self-terminate: stop the oscillator once its envelope has released.
+    osc.stop(time + ATTACK + HOLD + RELEASE + 0.05);
     oscs.push(osc);
     gains.push(gain);
   }


### PR DESCRIPTION
## Summary

The organ accompaniment instrument had a bug: notes kept getting louder and never stopped.

**Root cause:** `scheduleOrganNote` built each harmonic oscillator with only an attack ramp — no release envelope and no `osc.stop()`. Each oscillator played at full level indefinitely. The scheduler calls `voice.scheduleChord()` once per chord-pattern hit, so every hit stacked another non-decaying set of 18 oscillators onto the shared output — amplitudes summed (crescendo) and nothing terminated them except the scheduler's `cancelAll()` at the chord-step boundary (perpetual sustain if that path was missed).

Every other voice (`pianoVoice`, `strumVoice`, `bass`, `drumKit`) gives each note a bounded envelope ending at `ENVELOPE_MIN` plus a scheduled `osc.stop()`. The organ was the only voice missing both.

**Fix:** Each organ harmonic now gets a bounded attack → hold → release envelope (`HOLD` 0.8s, `RELEASE` 0.5s) ending at `ENVELOPE_MIN`, and `osc.stop()` is scheduled once the envelope completes. Notes self-terminate — repeated pattern hits overlap briefly (organ-like comping) but no longer accumulate, and a note can never sustain past its envelope. This also lets `onended` fire so the audio nodes are disposed instead of leaking.

## Test Plan

- [x] New failing tests reproduced the bug (no `osc.stop`, no release ramp), then pass after the fix
- [x] `npm run test` — 1862 passing
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [ ] Manual: select Organ chord instrument, play a multi-bar progression — confirm the chord holds steady and releases instead of crescendoing/ringing forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organ voice envelope with explicit hold and release phases for better sustain and fade-out behavior.
  * Enhanced voice self-termination to prevent hanging oscillators.

* **Tests**
  * Added test coverage for oscillator termination and harmonic gain ramping verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->