### PR TITLE
fix(progressions): theme-adaptive DAW track faceplate + balanced select padding

### DIFF
--- a/src/components/ProgressionTrack/ProgressionTrack.module.css
+++ b/src/components/ProgressionTrack/ProgressionTrack.module.css
@@ -13,17 +13,20 @@
  * ------------------------------------------------------------------------- */
 
 .track {
-  --track-accent: var(--neon-cyan, #4DE4FF);
+  composes: faceplate from "../shared/shared.module.css";
+
+  /* Map track tokens → theme-adaptive faceplate tokens */
+  --track-accent: var(--faceplate-accent, #4DE4FF);
   --track-accent-dim: rgb(77 228 255 / 0.55);
   --track-accent-faint: rgb(77 228 255 / 0.16);
   --track-warm: var(--neon-orange, #FF9A4D);
   --track-warm-dim: rgb(255 154 77 / 0.55);
   --track-warm-faint: rgb(255 154 77 / 0.16);
-  --track-bg: #0a121d;
-  --track-bg-elevated: #0d1726;
+  --track-bg: var(--faceplate-bg);
+  --track-bg-elevated: var(--faceplate-bg-elevated);
   --track-bg-readout: #050a13;
-  --track-border: rgb(77 228 255 / 0.12);
-  --track-divider: rgb(255 255 255 / 0.06);
+  --track-border: var(--faceplate-border);
+  --track-divider: var(--faceplate-divider);
   --track-text-dim: rgb(193 218 235 / 0.55);
   --track-text-muted: rgb(193 218 235 / 0.32);
 
@@ -33,17 +36,187 @@
   flex-direction: column;
   gap: 0.45rem;
   padding: 0.55rem 0.7rem 0.5rem;
-  border: 1px solid var(--track-border);
-  border-radius: 12px;
-  background:
-    radial-gradient(120% 200% at 0% 0%, rgb(77 228 255 / 0.04), transparent 55%),
-    linear-gradient(180deg, var(--track-bg-elevated), var(--track-bg));
-  box-shadow:
-    0 1px 0 rgb(255 255 255 / 0.02) inset,
-    0 18px 40px -28px rgb(0 0 0 / 0.7);
   color: var(--track-text-dim);
   font-family: var(--font-sans);
 }
+
+/* =========================================================================
+ * Light-mode overrides
+ *
+ * Dark mode uses neon glows, high-opacity transparent overlays on a navy
+ * substrate, and bright-on-dark text. Light mode flips the contract:
+ * definition comes from borders and shadows, not luminance; accents shift
+ * to the dimmer teal (#2EB5CC), and text is dark slate on pale grey-blue.
+ * ========================================================================= */
+
+/* stylelint-disable selector-pseudo-class-no-unknown */
+:global([data-theme="modern-light"]) .track {
+  --track-accent-dim: rgb(46 181 204 / 0.6);
+  --track-accent-faint: rgb(46 181 204 / 0.12);
+  --track-warm: #cc7a3d;
+  --track-warm-dim: rgb(204 122 61 / 0.6);
+  --track-warm-faint: rgb(204 122 61 / 0.12);
+  --track-bg-readout: #e3e8ed;
+  --track-text-dim: rgb(15 23 42 / 0.7);
+  --track-text-muted: rgb(15 23 42 / 0.42);
+}
+
+/* Transport buttons: teal-tinted with subtle depth instead of neon glow */
+:global([data-theme="modern-light"]) .transportButton {
+  --tb-fg: rgb(46 181 204 / 0.7);
+  --tb-border: rgb(46 181 204 / 0.3);
+  --tb-bg: rgb(46 181 204 / 0.05);
+}
+
+:global([data-theme="modern-light"]) .transportButton:hover:not(:disabled) {
+  --tb-fg: #2EB5CC;
+  --tb-border: rgb(46 181 204 / 0.55);
+  --tb-bg: rgb(46 181 204 / 0.1);
+}
+
+:global([data-theme="modern-light"]) .transportButton:focus-visible {
+  --tb-border: #2EB5CC;
+  box-shadow:
+    0 0 0 1px #2EB5CC,
+    0 0 6px rgb(46 181 204 / 0.25);
+}
+
+:global([data-theme="modern-light"]) .transportButton--accent {
+  --tb-fg: #2EB5CC;
+  --tb-border: rgb(46 181 204 / 0.65);
+  --tb-bg: rgb(46 181 204 / 0.1);
+
+  box-shadow:
+    0 0 0 1px rgb(46 181 204 / 0.45),
+    0 2px 8px rgb(46 181 204 / 0.15);
+}
+
+/* Status dots: opaque on light surface instead of luminous glow */
+:global([data-theme="modern-light"]) .statusDot {
+  background: rgb(15 23 42 / 0.15);
+  box-shadow: inset 0 0 0 1px rgb(15 23 42 / 0.1);
+}
+
+:global([data-theme="modern-light"]) .statusLight[data-active="true"] .statusDot {
+  background: #2EB5CC;
+  box-shadow: 0 0 4px rgb(46 181 204 / 0.35);
+}
+
+/* Cluster divider */
+:global([data-theme="modern-light"]) .clusterDivider {
+  background: linear-gradient(to bottom, transparent, rgb(15 23 42 / 0.12), transparent);
+}
+
+/* Digit readouts: remove text-shadow glows, use solid accent */
+:global([data-theme="modern-light"]) .digitBar {
+  text-shadow: none;
+}
+
+:global([data-theme="modern-light"]) .tempoValue {
+  text-shadow: none;
+}
+
+/* Scale primary text: dark instead of near-white */
+:global([data-theme="modern-light"]) .scalePrimary {
+  color: rgb(15 23 42 / 0.88);
+}
+
+/* Select arrow: dark chevron on light bg */
+:global([data-theme="modern-light"]) .genreSelect,
+:global([data-theme="modern-light"]) .instrumentSelect,
+:global([data-theme="modern-light"]) .patternSelect {
+  background-image:
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' fill='none'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%230f172a' stroke-opacity='.45' stroke-width='1.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+
+:global([data-theme="modern-light"]) .genreSelect:hover,
+:global([data-theme="modern-light"]) .instrumentSelect:hover,
+:global([data-theme="modern-light"]) .patternSelect:hover {
+  border-color: rgb(46 181 204 / 0.55);
+}
+
+/* Ruler: darker ticks and baseline for definition on light surface */
+:global([data-theme="modern-light"]) .ruler::after {
+  background: rgb(15 23 42 / 0.1);
+}
+
+:global([data-theme="modern-light"]) .rulerBarTick {
+  background: rgb(15 23 42 / 0.2);
+}
+
+:global([data-theme="modern-light"]) .rulerTick {
+  background: rgb(15 23 42 / 0.08);
+}
+
+:global([data-theme="modern-light"]) .rulerTick--beat {
+  background: rgb(15 23 42 / 0.15);
+}
+
+/* Chord blocks: crisp borders on pale surface */
+:global([data-theme="modern-light"]) .block {
+  --block-border: rgb(15 23 42 / 0.1);
+  --block-bg: rgb(255 255 255 / 0.45);
+  --block-fg: rgb(15 23 42 / 0.6);
+  --block-name-fg: rgb(15 23 42 / 0.85);
+  --block-badge-fg: rgb(15 23 42 / 0.5);
+}
+
+:global([data-theme="modern-light"]) .block:hover:not([data-active="true"]) {
+  --block-border: rgb(15 23 42 / 0.18);
+  --block-bg: rgb(255 255 255 / 0.65);
+}
+
+:global([data-theme="modern-light"]) .block:focus-visible {
+  --block-border: #2EB5CC;
+  box-shadow: 0 0 0 1px #2EB5CC, 0 0 6px rgb(46 181 204 / 0.2);
+}
+
+:global([data-theme="modern-light"]) .block[data-active="true"] {
+  --block-border: rgb(204 122 61 / 0.5);
+  --block-bg: rgb(255 180 120 / 0.14);
+  --block-fg: rgb(140 70 20 / 0.85);
+  --block-name-fg: rgb(120 55 10 / 0.92);
+  --block-badge-fg: #cc7a3d;
+
+  border-block-color: rgb(204 122 61 / 0.5);
+  border-inline-start-color: rgb(204 122 61 / 0.5);
+  box-shadow:
+    inset 0 0 16px rgb(204 122 61 / 0.08),
+    0 2px 8px rgb(204 122 61 / 0.1);
+}
+
+:global([data-theme="modern-light"]) .block[data-active="true"] + .block {
+  border-inline-start-color: rgb(204 122 61 / 0.5);
+}
+
+:global([data-theme="modern-light"]) .block[data-active="true"]:last-of-type {
+  border-inline-end-color: rgb(204 122 61 / 0.5);
+}
+
+:global([data-theme="modern-light"]) .block[data-active="true"] .degreeBadge {
+  border-color: rgb(204 122 61 / 0.45);
+  background: rgb(204 122 61 / 0.08);
+}
+
+:global([data-theme="modern-light"]) .block[data-active="true"] .duration {
+  color: rgb(140 70 20 / 0.6);
+}
+
+:global([data-theme="modern-light"]) .degreeBadge {
+  background: rgb(255 255 255 / 0.5);
+}
+
+/* Playhead: solid teal with soft shadow instead of neon glow */
+:global([data-theme="modern-light"]) .playheadArrow {
+  border-block-start-color: #2EB5CC;
+  filter: drop-shadow(0 0 2px rgb(46 181 204 / 0.4));
+}
+
+:global([data-theme="modern-light"]) .playheadLine {
+  background: linear-gradient(180deg, #2EB5CC 0%, rgb(46 181 204 / 0.5) 100%);
+  box-shadow: 0 0 4px rgb(46 181 204 / 0.35);
+}
+/* stylelint-enable selector-pseudo-class-no-unknown */
 
 /* ----------------------------------------------------------------------------
  * Transport row
@@ -409,10 +582,13 @@
   flex: 0 0 auto;
   min-width: 0;
   max-width: 9rem;
-  padding: 0.22rem 0.4rem;
+  appearance: none;
+  padding: 0.22rem 1.3rem 0.22rem 0.5rem;
   border: 1px solid var(--track-border);
   border-radius: 6px;
-  background: var(--track-bg-readout);
+  background: var(--track-bg-readout)
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' fill='none'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%23c1daeb' stroke-opacity='.55' stroke-width='1.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")
+    no-repeat right 0.4rem center;
   color: var(--track-text-dim);
   font-family: var(--font-sans);
   font-size: 0.68rem;


### PR DESCRIPTION
## Summary

- **Light mode faceplate**: The ProgressionTrack hardcoded dark-mode colors (`#0a121d`, `#050a13`, etc.) for every element, making it unreadable in light mode. Now composes from the shared `.faceplate` class and maps `--track-*` tokens to theme-adaptive `--faceplate-*` tokens. Added comprehensive light-mode overrides for all track-specific elements: transport buttons, ruler ticks, chord blocks, digit readouts, playhead, status dots, and select chevrons.
- **Select padding**: Native `<select>` dropdown arrow created lopsided padding. Fixed with `appearance: none`, a custom SVG chevron via `background-image`, and asymmetric padding to visually balance text against the arrow.

## Test plan

- [x] Build passes
- [x] All 1860 tests pass
- [x] Stylelint clean
- [ ] Visual check: light mode faceplate surface, text contrast, transport buttons, chord blocks, ruler, playhead
- [ ] Visual check: dark mode unchanged (neon glows, navy substrate intact)
- [ ] Visual check: select inputs have balanced padding in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)