### PR TITLE
feat(voicing): voicing controls refinement — drop2/triad, diagram fix, disable + auto-heal

### DIFF
--- a/docs/superpowers/specs/2026-05-19-controls-overhaul-design.md
+++ b/docs/superpowers/specs/2026-05-19-controls-overhaul-design.md
@@ -1,0 +1,301 @@
+# Controls Overhaul — Design
+
+**Status:** Brainstorm spec. Produced 2026-05-19. The second of three planned specs
+that make the Inspector controls easier to use:
+
+1. `2026-05-19-voicing-controls-refinement-design.md` — four behavioral voicing fixes
+   (drop2/triad, string-set diagram, disable + auto-heal). Ships independently.
+2. **This spec** — the controls overhaul: tab information architecture, the
+   fingering↔chord decoupling, an explicit scope-to-position link, Chord Spread
+   relocation, and chord-tab progressive disclosure.
+3. *(Future)* Visual UI refresh — styling, spacing, hierarchy polish. Deliberately
+   deferred until this spec settles the structure.
+
+**Date:** 2026-05-19
+
+**Scope:** Restructure the Inspector's controls so each tab is self-contained, replace
+the hidden fingering↔chord couplings with one explicit opt-in link, relocate the
+Chord Spread control, and reduce the Chord tab's control density. No visual restyle,
+no engine changes, no new fingering patterns.
+
+---
+
+## 1. Background — why the controls feel complicated
+
+The Inspector has four tabs — View, Scale, Chord, Progression. Live use surfaced
+several structural problems:
+
+- **Fingering lives in the wrong tab.** The fingering-pattern controls
+  (`FingeringPatternControls`) sit in the **View** tab, away from both the Scale tab
+  (which defines the scale they visualize) and the Chord tab (which they silently
+  affect).
+- **Hidden couplings.** Selecting the `one-string` or `two-strings` fingering pattern
+  *disables the entire chord overlay* (`isChordOverlayPatternDisabled`). Selecting the
+  `caged` fingering pattern *silently scopes voicing output to the active box*
+  (`selectFullChordMatchesForCagedPosition`, applied whenever
+  `fingeringPattern === "caged"`). Neither is requested by the user; both are
+  surprising side-effects of an unrelated control.
+- **Conflated axes.** The fingering control is one five-option `ToggleBar`
+  (None / CAGED / 3NPS / 1-String / 2-Strings). But CAGED and 3NPS chunk the scale into
+  *positions*, while 1-String and 2-Strings are for studying the scale *melodically and
+  in intervals*. Two different ideas compete in one control.
+- **Chord Spread is exiled.** `chordFretSpreadAtom`'s only UI control lives in the
+  global Settings overlay (`ChordLayoutSettingsSection`), far from every other chord
+  control.
+- **Chord-tab density.** The Chord tab presents Source, Lens, and the full Voicing
+  group (Type, Inversion, String Set, Connectors) at once.
+
+---
+
+## 2. Goals and Non-Goals
+
+### Goals
+
+- Each tab is self-contained — its controls do not depend on another tab's state to be
+  usable.
+- No control silently disables or constrains an unrelated feature. The only
+  fingering↔chord link is explicit, labeled, and opt-in.
+- The fingering control communicates the difference between position systems and
+  string study.
+- Chord Spread is reachable from the Chord tab.
+- The Chord tab has a simple default reading, with advanced voicing controls behind
+  progressive disclosure.
+
+### Non-Goals
+
+- No visual restyle — colors, spacing, typography, component look are deferred to the
+  future Visual UI Refresh spec.
+- No changes to the voicing engine, the scale / circle-of-fifths logic, or the
+  progression engine.
+- No new fingering patterns and no removal of existing ones — the five patterns stay;
+  only their presentation changes.
+- No change to the tab *set* — still View / Scale / Chord / Progression.
+- This spec does not depend on Spec 1 (voicing-controls refinement); the two touch
+  overlapping files but neither blocks the other. Where they interact (the
+  scope-to-position toggle feeds Spec 1's valid-combo computation) it is noted, not
+  required.
+
+---
+
+## 3. Tab information architecture
+
+Controls regroup strictly by domain. The tab set is unchanged; their contents move:
+
+| Tab | Contents after this spec |
+|---|---|
+| **Scale** | Key + scale type (unchanged), **+ the fingering controls** (moved from View), Circle of Fifths, Theory facts. |
+| **View** | Display preferences only: note labels, accidentals, enharmonic display, fret range, degree colors. |
+| **Chord** | Chord source, lens, the Voicing section, **+ Chord Spread** (moved from Settings), **+ scope-to-position**. |
+| **Progression** | Unchanged. |
+
+`FingeringPatternControls` is rendered by `ScaleTab` instead of `ViewTab`. It still
+emits `GroupHeader` + `Prop` cells into the host tab's `PropGrid` (the existing
+fragment-of-grid-items pattern is unchanged), so the move is a re-parenting plus any
+`PropGrid` column adjustment the Scale tab needs.
+
+---
+
+## 4. Fingering model — split the axis
+
+One scale-view mode is active at a time (the underlying `fingeringPatternAtom` and its
+five values — `none` / `caged` / `3nps` / `one-string` / `two-strings` — are
+unchanged). The **presentation** splits into two clearly-labeled clusters:
+
+- **Position** — `None` · `CAGED` · `3NPS`. These chunk the scale into playable
+  positions.
+- **String study** — `1-String` · `2-Strings`. These study the scale melodically and
+  in intervals.
+
+The two clusters are mutually exclusive in effect (only one `fingeringPatternAtom`
+value is active); the split is a visual/structural grouping, not two independently
+active states. Rendering: the single `ToggleBar` becomes two labeled groups — a
+`Position` group of three and a `String study` group of two — within the FINGERING
+property-grid section, with enough separation (a divider or sub-labels) that the user
+reads them as distinct axes. Selecting any option in either group sets
+`fingeringPatternAtom`; the other group's options visibly deselect.
+
+Per-mode sub-controls are unchanged in function and appear only under the active mode:
+CAGED shape selector (with long-press multi-select); 3NPS position + octave; 1-String
+string + connectors; 2-Strings pair + interval. They are simply owned by the cluster
+of their mode rather than trailing a generic "pattern" control.
+
+---
+
+## 5. Kill the hidden couplings
+
+Both implicit fingering→chord side-effects are removed:
+
+- **`one-string` / `two-strings` no longer disable the chord overlay.**
+  `isChordOverlayPatternDisabled` (in `fingeringAtoms.ts`) and every consumer of it are
+  removed. `ChordOverlayControls` drops its `isPatternDisabled` branch — the
+  `panel-disabled` styling, the `data-disabled` attribute, the
+  `controls.chordOverlayDisabled` hint, and the `isPatternDisabled` gating of the
+  Source/Display/Voicing sections. The chord overlay is available in every fingering
+  mode.
+- **The `caged` fingering pattern no longer silently scopes voicings.** The
+  application of `selectFullChordMatchesForCagedPosition` in `useFretboardState` stops
+  being keyed on `fingeringPattern === "caged"`. It is keyed on the explicit
+  scope-to-position state (§6).
+
+After this, choosing a fingering pattern changes only how the *scale* is drawn. It has
+no effect on whether or how the chord overlay renders, unless the user opts in via §6.
+
+---
+
+## 6. Scope-to-position — the one explicit link
+
+A single labeled control in the Chord tab — **"Scope to position"**, a `Switch` —
+governs whether the chord overlay is constrained to the active fingering position.
+
+- **State:** a new persisted boolean atom (working name `chordScopeToPositionAtom`),
+  default off.
+- **An "active position" exists** when the fingering mode resolves to a single
+  position: exactly one CAGED shape selected, or a 3NPS position `> 0`. Fingering
+  `None`, multi-shape CAGED, and the String-study modes have no single position.
+- **When the toggle is on *and* an active position exists:** the chord overlay — both
+  the loose chord-tone highlighting and the voicing-engine output — is constrained to
+  that position's fret window. This reuses the existing position-scoping mechanism
+  (`selectFullChordMatchesForCagedPosition` for voicings; the box-bounds filter in
+  `useNoteData` for chord tones) — now gated on the toggle rather than on the fingering
+  pattern.
+- **When the toggle is off, or no active position exists:** the chord overlay renders
+  unconstrained across the whole fretboard. When no active position exists the toggle
+  renders disabled with a hint explaining it needs a single CAGED shape or 3NPS
+  position.
+
+This is the only surviving fingering↔chord coupling, and it is visible, named, and
+off by default.
+
+---
+
+## 7. The "CAGED" naming
+
+"CAGED" legitimately names both a scale-position system and a chord-voicing system —
+they are the same five-shape idea applied to scales versus chords. No code-level type
+or value is renamed. Disambiguation is contextual: the fingering option always appears
+under the **Position** group label (§4) and the voicing option under the **Voicing**
+group label (§8), so the user always sees "Position: CAGED" or "Voicing: CAGED" in
+context. The HelpModal text gains one sentence noting the two uses.
+
+---
+
+## 8. Chord Spread relocation + Chord-tab progressive disclosure
+
+### 8a. Chord Spread moves to the Chord tab
+
+`chordFretSpreadAtom` is unchanged; only its UI home moves. Its control is rendered in
+the Chord tab inside the Voicing section (§8b). The Settings-overlay piece is removed:
+`ChordLayoutSettingsSection`, the `chordSpread` entry in `SETTING_FIELDS`, the
+`"chordSpread"` member of the SettingsOverlay field-type union, and the
+`chordFretSpread` wiring in `useSettingsForm`. The `settings.fields.chordSpread*` i18n
+keys are repurposed for the Chord-tab control's label and hint (or replaced with
+`inspector.*` keys — implementer's choice, but the user-facing strings stay).
+
+### 8b. Voicing section becomes collapsible
+
+The Chord tab reads top-to-bottom as: **Source** (mode, degree/root) → **Lens** →
+**Voicing ▸**. The Voicing group becomes a collapsible section:
+
+- Collapsed by default — the common "just show me the chord" case is uncluttered.
+- When expanded it holds Type, Inversion, String Set, Connectors (the existing VOICING
+  group), plus Chord Spread and the §6 scope-to-position toggle.
+- Expanded/collapsed state is a persisted boolean atom (working name
+  `voicingSectionExpandedAtom`).
+- The collapsible header shows the section name and the disclosure affordance; it
+  reuses the existing `GroupHeader` where practical (the Connectors toggle currently in
+  the VOICING `GroupHeader` stays with the section).
+
+Trade-off accepted: collapsing Voicing by default hides the controls Spec 1 refines.
+That is deliberate — the simpler default serves the common case, and the section is one
+click away with its state remembered.
+
+---
+
+## 9. File-level impact
+
+- `src/components/Inspector/ScaleTab.tsx` — render `FingeringPatternControls`; adjust
+  `PropGrid` columns as needed.
+- `src/components/Inspector/ViewTab.tsx` — remove `FingeringPatternControls`; View now
+  holds only display-preference groups.
+- `src/components/FingeringPatternControls/FingeringPatternControls.tsx` — render the
+  pattern selector as two labeled clusters (Position / String study) instead of one
+  five-option `ToggleBar`; sub-controls unchanged.
+- `src/store/fingeringAtoms.ts` — remove `isChordOverlayPatternDisabled`.
+- `src/hooks/useFretboardState.ts` — gate `selectFullChordMatchesForCagedPosition` (and
+  the chord-tone box-bounds scoping path) on `chordScopeToPositionAtom` + an
+  active-position check, not on `fingeringPattern === "caged"`.
+- `src/store/chordOverlayAtoms.ts` — add `chordScopeToPositionAtom` (persisted,
+  default off) and `voicingSectionExpandedAtom` (persisted); an `activePositionAtom`
+  (or equivalent selector) reporting whether a single CAGED shape / 3NPS position is
+  active.
+- `src/components/ChordOverlayControls/ChordOverlayControls.tsx` — remove the
+  `isPatternDisabled` branch and all disabled-panel UI; make the Voicing group a
+  collapsible section; render the Chord Spread control and the scope-to-position
+  toggle inside it.
+- `src/components/SettingsOverlay/sections/ChordLayoutSettingsSection.tsx` — removed.
+- `src/components/SettingsOverlay/{constants,types}.ts`, `useSettingsForm.ts` — remove
+  the `chordSpread` field.
+- `src/store/atoms.ts` — re-export the new atoms.
+- `src/components/HelpModal/HelpModal.tsx` — update the Chord Spread reference (no
+  longer in Settings); add the one-sentence CAGED-naming note.
+- i18n (`en.ts`, `es.ts`, `types.ts`) — strings for the two fingering cluster labels,
+  the scope-to-position label + hint, the Voicing collapsible; remove or repurpose the
+  obsolete `controls.chordOverlayDisabled` and Settings `chordSpread` keys.
+
+---
+
+## 10. Cross-Cutting Notes
+
+- New user-facing strings (cluster labels, scope-to-position label/hint, Voicing
+  section) go through `useTranslation`, en + es.
+- The persisted atoms (`chordScopeToPositionAtom`, `voicingSectionExpandedAtom`) use
+  the standard `atomWithStorage` + `k()` key prefix; default off / collapsed.
+- Removing `isChordOverlayPatternDisabled` is a behavior change covered by existing
+  `ChordOverlayControls` and `FingeringPatternControls` tests — those tests update.
+- Mandatory before the PR: `pnpm run lint`, `pnpm run test`, `pnpm run build`,
+  `npx tsc -b`.
+- Visual-regression baselines refresh for `app-components` and `app-layout` (the View,
+  Scale, and Chord tabs all change layout), darwin + linux.
+
+---
+
+## 11. Testing (TDD — failing test first per task)
+
+- `ScaleTab.test.tsx` / `ViewTab.test.tsx` — fingering controls render in the Scale tab
+  and no longer in the View tab.
+- `FingeringPatternControls.test.tsx` — the selector renders a Position cluster
+  (None/CAGED/3NPS) and a String-study cluster (1-String/2-Strings); selecting an
+  option in one clears the other; each mode's sub-controls still appear.
+- `fingeringAtoms` / `ChordOverlayControls.test.tsx` — with `one-string` or
+  `two-strings` active, the chord overlay controls are fully enabled (no disabled
+  panel).
+- `chordOverlayAtoms.test.ts` — `chordScopeToPositionAtom` and
+  `voicingSectionExpandedAtom` default off/collapsed and persist; `activePositionAtom`
+  reports true only for a single CAGED shape or a 3NPS position > 0.
+- `useFretboardState` — voicings are scoped to the active position only when
+  `chordScopeToPositionAtom` is on and an active position exists; with the toggle off,
+  voicings are unconstrained regardless of fingering pattern.
+- `ChordOverlayControls.test.tsx` — the Voicing section is collapsed by default and
+  toggles; Chord Spread and scope-to-position render inside it; the scope toggle is
+  disabled with a hint when no active position exists.
+- `SettingsOverlay` tests — the Chord Spread section is gone; remaining settings
+  unaffected.
+- Visual regression — refresh `app-components` and `app-layout` (darwin + linux).
+
+---
+
+## 12. Acceptance Criteria
+
+- Fingering controls appear in the Scale tab; the View tab holds only display
+  preferences.
+- The fingering selector reads as two labeled groups — Position and String study.
+- Selecting any fingering pattern, including 1-String / 2-Strings, leaves the chord
+  overlay fully usable.
+- Voicings are constrained to a fingering position only when the user turns on
+  "Scope to position" and a single CAGED shape or 3NPS position is active.
+- Chord Spread is adjustable from the Chord tab; it is no longer in the Settings
+  overlay.
+- The Chord tab shows Source and Lens by default with the Voicing section collapsed;
+  expanding it reveals Type, Inversion, String Set, Connectors, Chord Spread, and
+  scope-to-position.
+- `pnpm run lint`, `pnpm run test`, `pnpm run build`, `npx tsc -b` all pass.

--- a/docs/superpowers/specs/2026-05-19-voicing-controls-refinement-design.md
+++ b/docs/superpowers/specs/2026-05-19-voicing-controls-refinement-design.md
@@ -1,0 +1,305 @@
+# Voicing Controls Refinement — Design
+
+**Status:** Brainstorm spec. Produced 2026-05-19 as a follow-up to the Voicing Engine
+Redesign (PR #417), after live use surfaced four defects in the shipped Chord-tab
+voicing controls.
+
+**Date:** 2026-05-19
+
+**Scope:** Four targeted fixes to the Chord-tab voicing controls — the voicing engine's
+Triad/Drop 2 distinction, the String Set picker's diagram, and a unified
+disable + auto-heal coupling across the Type / Inversion / String Set controls. No new
+voicing types, no app-shell changes.
+
+**Builds on:** `docs/superpowers/specs/2026-05-18-voicing-engine-redesign-design.md`
+and PR #417 (the engine that takes a `readonly number[]` string set, the dynamic
+`buildStringSetOptions`, the id-based `voicingStringSetAtom`, and the caged-gating in
+`ChordOverlayControls`).
+
+---
+
+## 1. Background — the four defects
+
+1. **Drop 2 and Triad are identical for triad chords.** `generateVoicings` delegates
+   `triad`/`drop2` to `searchVoicings`. The `drop2` branch only takes the
+   spread-search path when the chord has ≥ 4 tones; a 3-note chord falls through to the
+   exact same closed search as `triad`. So for every triad the two types produce byte-
+   identical output.
+2. **The String Set diagram is inverted.** Task 4 of PR #417 introduced
+   `diagramMask(strings)`, which returns a six-element array indexed high-E-first
+   (`mask[0]` = string index 0 = high E). The render code still does `[...mask].reverse()`
+   — a transform written for the *old* low-E-first mask. The net result is the diagram
+   is flipped on both axes: the highlighted strings render at the wrong end and the
+   string thicknesses run backwards.
+3. **The diagram's thickness barely scales.** The string bars use `height: 1 + i*0.4` px
+   (1 → 3 px). At diagram size the difference between strings is nearly invisible, so the
+   diagram does not read as "guitar strings."
+4. **The controls are hard to use.** Many Type / Inversion / String Set combinations
+   produce zero voicings. Nothing tells the user which combinations work, and nothing
+   moves the other controls into a working state — so finding a usable voicing is
+   trial-and-error.
+
+---
+
+## 2. Goals and Non-Goals
+
+### Goals
+
+- Triad and Drop 2 always produce visibly different voicings, for chords of any tone
+  count.
+- The String Set diagram matches the fretboard: high E (thinnest) at the top, low E
+  (thickest) at the bottom; the highlighted strings land on the correct end.
+- The diagram's thickness scaling is clearly legible.
+- Every Type / Inversion / String Set control communicates which of its options are
+  possible, and any selection leaves the controls in a state that produces a voicing.
+
+### Non-Goals
+
+- No new voicing types — the set stays `caged` / `drop2` / `triad`.
+- No change to the voice-count rule (`triad` voices up to 3 tones; `drop2` voices all of
+  the chord's tones — same as today).
+- No change to the CAGED path, the search algorithm's candidate enumeration, or the
+  chord/scale domain split.
+- No app-shell or other-tab changes.
+
+---
+
+## 3. Triad vs Drop 2 — compact vs spread
+
+`searchVoicings(params, voiceCount, requireOctaveSpread)` already distinguishes closed
+from spread voicings:
+
+- `requireOctaveSpread === false` keeps voicings whose total pitch span is ≤ 12
+  semitones (closed position).
+- `requireOctaveSpread === true` keeps voicings whose pitch span is `> 12 && <= 24`
+  semitones (one voice displaced by roughly an octave — the drop-2 effect).
+
+The defect is only in *which* path each type takes. The fix makes the path follow the
+**type**, never the tone count:
+
+- **`triad`** → `searchVoicings(params, voiceCount, false)` — always the closed search.
+  `voiceCount` is `Math.min(3, def.members.length)` (unchanged).
+- **`drop2`** → `searchVoicings(params, voiceCount, true)` — always the spread search,
+  for any tone count. `voiceCount` is `def.members.length` for a 4-note (or larger)
+  chord, and `Math.min(3, def.members.length)` for a smaller chord (unchanged — the
+  only change is that the `true` flag is now always passed).
+- **`caged`** → unchanged.
+
+Result: for a triad, `drop2` searches spread (string-skip / open) triad voicings —
+distinct from `triad`'s tight grip. For a 7th chord, `drop2` is the existing
+octave-spread search. When the spread search yields nothing for a given chord +
+inversion + string set, the engine returns `[]` (handled by §5's coupling, and by the
+no-scatter behavior already shipped in PR #417).
+
+`generateVoicings` is the only function that changes. `searchVoicings` itself is
+untouched.
+
+---
+
+## 4. String Set diagram
+
+The diagram lives in `src/components/Inspector/StringSetPicker.tsx`. Each card shows six
+horizontal bars representing the six strings, with the active string set's strings
+highlighted.
+
+### 4a. Orientation
+
+The diagram must read top-to-bottom as **high E → low E**, matching the fretboard:
+
+- Top bar = string index 0 = high E = thinnest.
+- Bottom bar = string index 5 = low E = thickest.
+
+So the highlighted strings for `"Bass"` (`4·5·6`, string indices `[3,4,5]`) are the
+**bottom three** bars; for `"Treble"` (`1·2·3`, indices `[0,1,2]`) the **top three**.
+
+Implementation: render the six bars directly in string-index order `0 → 5` (high E
+first). Remove the `[...mask].reverse()` call — the reverse was the bug. The bar at
+render position `i` represents string index `i`.
+
+### 4b. Thickness scale — boosted taper
+
+Each bar's thickness is a fixed function of its string index. The values are the
+fretboard's `--string-taper-*` proportional curve, scaled up so the difference is
+legible in a small diagram:
+
+| String index | String | Thickness |
+|---|---|---|
+| 0 | high E | 1.5 px |
+| 1 | B | 2.1 px |
+| 2 | G | 2.7 px |
+| 3 | D | 3.6 px |
+| 4 | A | 4.5 px |
+| 5 | low E | 5.4 px |
+
+These are a module-level constant array (`STRING_BAR_THICKNESS_PX`, index 0 → 5). The
+old `1 + i*0.4` inline expression is removed.
+
+### 4c. Highlight
+
+A bar is highlighted (active accent color) when its string index is in the option's
+`strings` array; otherwise it renders in the muted/inactive color. Highlight color and
+muted color use the existing CSS-module classes (`styles.stringOn` and the base
+`styles.string`) — no new color tokens. Only the per-bar `height` and the index→bar
+mapping change.
+
+### 4d. No other picker changes
+
+`buildStringSetOptions`, the option ids, the `value`/`onChange` contract, the
+`subText`/`aria-label`, and the radio-group a11y are all unchanged from PR #417.
+
+---
+
+## 5. Disable + auto-heal coupling
+
+### 5a. Validity
+
+A `(type, inversion, stringSet)` triple is **valid** for the active chord when
+`generateVoicings` returns at least one voicing for it. `caged` is a self-contained type
+— it ignores inversion and string set — so for the purpose of this section the
+coupling only ranges over `type ∈ {triad, drop2}` and the inversion / string-set
+controls. `caged` is treated as always valid (it has its own engine path, which yields
+shapes for any real chord) and always enabled.
+
+A new derived atom — working name `validVoicingCombosAtom` — computes, for the active
+chord, the set of valid `(type, inversion, stringSet)` triples. It enumerates the
+controls' option spaces (`type ∈ {triad, drop2}`, the inversions from
+`availableInversionsAtom`, the string-set ids from `stringSetOptionsAtom`) and calls the
+engine for each. The result is a structure that answers two questions cheaply:
+
+- Is option `v` of control `X` present in any valid triple? (drives §5b)
+- Given pinned control(s), what is the nearest valid assignment of the rest? (drives §5c)
+
+The atom is memoized per chord (it only recomputes when the chord root/type, tuning, or
+the available-inversion / string-set option lists change).
+
+### 5b. Disable rule
+
+Each of the three controls greys out (disables, not hides) an option **only when that
+option appears in zero valid triples for the active chord** — i.e. it is genuinely
+impossible. Concretely:
+
+- **Type:** `caged` is always enabled. `triad` / `drop2` is disabled only if no
+  inversion + string-set pairing makes it valid (rare — effectively never for a real
+  chord, but the rule is uniform).
+- **Inversion:** an inversion is enabled if some `(type, _, stringSet)` valid triple
+  uses it. (This composes with the existing `availableInversionsAtom`, which already
+  drops inversions the chord has no tone for — those stay disabled as before.)
+- **String Set:** a string-set id is enabled if some `(type, inversion, _)` valid triple
+  uses it.
+
+Enabled-but-locally-incompatible options stay clickable. Picking one is allowed and
+triggers an auto-heal (§5c). Only truly impossible options are unclickable.
+
+### 5c. Auto-heal
+
+Whenever the active `(type, inversion, stringSet)` is **not** a valid triple, the
+controls heal:
+
+1. **A control was just changed by the user** → that control is *pinned*. The other two
+   snap to the nearest valid assignment. "Nearest" keeps a sibling's current value when
+   a valid triple allows it; when both siblings must move, it keeps the sibling that
+   was touched more recently and moves the other. When neither current sibling value
+   can be kept, it picks the valid triple closest in option-list index distance.
+2. **The chord changed** (no control was "just changed") → `type` is pinned (it is the
+   most significant choice and the one least tied to a specific chord), and inversion +
+   string set heal by the same nearest-assignment rule.
+3. **The type toggled between `caged` and a non-caged type** → on `caged → triad/drop2`,
+   the persisted inversion + string-set values are restored (per PR #417's behavior)
+   and then healed if the restored pair is invalid. On `triad/drop2 → caged`, nothing
+   to heal (caged ignores both).
+
+Healing writes the corrected values to `voicingInversionAtom` / `voicingStringSetAtom`
+(and never to a control the user just pinned). Because healing always lands on a valid
+triple, the engine never silently returns `[]` for a coupling reason — only `caged`
+edge cases or a genuinely voicing-less chord can do that, and those degrade gracefully
+via the no-scatter behavior from PR #417.
+
+### 5d. Control recency
+
+Auto-heal's "more-recently-touched" tie-break needs a per-session record of the order
+in which the three controls were last changed. This is lightweight UI state — a small
+atom holding the three control ids in most-recent-first order, updated by each
+control's `onChange`. It is **not** persisted (it resets each session; a fresh session
+has no recency and falls back to a fixed precedence: pinned control, then string set,
+then inversion).
+
+### 5e. Replaces the existing normalizer
+
+PR #417 added a single-purpose `useEffect` in `ChordOverlayControls` that resets a
+stale `voicingStringSetAtom` to `"all"`. The unified heal (§5c) supersedes it — the heal
+covers string-set staleness as one case of "the active triple is invalid." The old
+normalizer effect is removed so there is exactly one healing mechanism.
+
+---
+
+## 6. File-level impact
+
+- `packages/core/src/shapes/voicings.ts` — `generateVoicings`: the `drop2` branch
+  always passes `requireOctaveSpread: true`; the `triad` branch always passes `false`.
+  `searchVoicings` is untouched.
+- `src/components/Inspector/StringSetPicker.tsx` — render bars in string-index order
+  `0 → 5` (drop the `.reverse()`); replace the `1 + i*0.4` height with the
+  `STRING_BAR_THICKNESS_PX` constant; highlight by string-index membership.
+- `src/components/Inspector/StringSetPicker.module.css` — only if the bar layout needs
+  adjusting for the new thickness range (e.g. the diagram container height / gap). No
+  new color tokens.
+- `src/store/chordOverlayAtoms.ts` (or a new `src/store/voicingCoupling.ts` section) —
+  `validVoicingCombosAtom`; per-control enabled-option selectors; the control-recency
+  atom; the nearest-valid-assignment helper.
+- `src/components/ChordOverlayControls/ChordOverlayControls.tsx` — apply the disabled
+  state to the Type / Inversion / String Set controls; replace the old string-set
+  normalizer `useEffect` with the unified heal effect; record control recency on each
+  `onChange`.
+- `src/store/atoms.ts` — re-export any new atoms as needed.
+
+---
+
+## 7. Cross-Cutting Notes
+
+- No new user-facing strings — the controls' labels are unchanged. Disabled options use
+  the existing disabled styling (`ToggleBar` already supports a `disabled` option flag;
+  the string-set picker cards gain a disabled state mirroring it).
+- The `validVoicingCombosAtom` enumeration is up to ~60 engine searches per chord change
+  (3 types × ≤ 4 inversions × ≤ 5 string sets; in practice fewer). Each search is
+  bounded and fast, and the atom is memoized per chord. Acceptable; flagged for a
+  follow-up only if profiling shows it.
+- Mandatory before the PR: `pnpm run lint`, `pnpm run test`, `pnpm run build`,
+  `npx tsc -b`.
+- Visual-regression baselines refresh for `chord-overlay-controls` (the String Set
+  diagram and any disabled-state styling), darwin + linux.
+
+---
+
+## 8. Testing (TDD — failing test first per task)
+
+- `voicings.test.ts` (core) — for a triad chord, `generateVoicings` with `drop2`
+  returns voicings whose pitch span exceeds an octave, and is **not** equal to the
+  `triad` result; for a triad, `triad` voicings stay within an octave; a 7th-chord
+  `drop2` is unchanged from current behavior.
+- `StringSetPicker.test.tsx` — the diagram renders six bars in high-E-to-low-E order;
+  the `"Bass"` card highlights the bottom three bars and `"Treble"` the top three; each
+  bar's height matches `STRING_BAR_THICKNESS_PX`.
+- `voicingCoupling` tests (new) — `validVoicingCombosAtom` reports the correct valid
+  triples for a sample chord; the per-control enabled-option selectors disable only
+  options absent from every valid triple; the nearest-valid-assignment helper keeps a
+  pinned control and prefers keeping the more-recently-touched sibling.
+- `ChordOverlayControls.test.tsx` — impossible options render disabled; picking an
+  enabled-but-incompatible option heals the other two to a valid triple; changing the
+  chord heals inversion + string set with type pinned; toggling `caged → triad`
+  restores and then heals the persisted inversion/string-set values.
+- Visual regression — refresh the `chord-overlay-controls` suite (darwin + linux).
+
+---
+
+## 9. Acceptance Criteria
+
+- For a triad chord, switching between Triad and Drop 2 visibly changes the fretboard;
+  the two never produce identical voicings.
+- The String Set diagram shows high E (thin) at the top and low E (thick) at the bottom;
+  "Bass" highlights the low strings, "Treble" the high strings; the thickness scaling is
+  clearly visible.
+- Each voicing control greys out only the options that are genuinely impossible for the
+  active chord; every other option stays clickable.
+- Selecting any Type / Inversion / String Set option always leaves the controls in a
+  state that produces at least one voicing (except genuine caged-only edge cases).
+- `pnpm run lint`, `pnpm run test`, `pnpm run build`, `npx tsc -b` all pass.

--- a/packages/core/src/shapes/voicings.test.ts
+++ b/packages/core/src/shapes/voicings.test.ts
@@ -177,14 +177,18 @@ describe("generateVoicings — drop2", () => {
     }
   });
 
-  it("drop2 on a plain triad falls back to a 3-voice voicing", () => {
+  it("drop2 on a plain triad produces spread voicings (pitch span > 12)", () => {
     const voicings = generateVoicings({
       tuning: STANDARD_TUNING, maxFret: 12,
       chordRoot: "C", chordType: "Major Triad",
       voicingType: "drop2", inversion: "root", stringSet: [0, 1, 2, 3, 4, 5],
     });
     expect(voicings.length).toBeGreaterThan(0);
-    for (const v of voicings) expect(v.notes.length).toBe(3);
+    for (const v of voicings) {
+      const midis = v.notes.map((n) => n.midi);
+      const span = Math.max(...midis) - Math.min(...midis);
+      expect(span).toBeGreaterThan(12);
+    }
   });
 
   it("3rd-inversion drop2 voicings have the major 7th as the lowest note", () => {
@@ -198,6 +202,51 @@ describe("generateVoicings — drop2", () => {
       const lowest = v.notes.reduce((a, b) => (a.midi <= b.midi ? a : b));
       expect(lowest.midi % 12).toBe(11);
     }
+  });
+});
+
+describe("generateVoicings — triad vs drop2 on a triad chord", () => {
+  const base = { tuning: STANDARD_TUNING, maxFret: 12 } as const;
+  const allStrings: readonly number[] = [0, 1, 2, 3, 4, 5];
+
+  it("triad on a triad chord stays closed (pitch span ≤ 12)", () => {
+    const voicings = generateVoicings({
+      ...base, chordRoot: "C", chordType: "Major Triad",
+      voicingType: "triad", inversion: "root", stringSet: allStrings,
+    });
+    expect(voicings.length).toBeGreaterThan(0);
+    for (const v of voicings) {
+      const midis = v.notes.map((n) => n.midi);
+      const span = Math.max(...midis) - Math.min(...midis);
+      expect(span).toBeLessThanOrEqual(12);
+    }
+  });
+
+  it("drop2 on a triad chord is always spread (pitch span > 12)", () => {
+    const voicings = generateVoicings({
+      ...base, chordRoot: "C", chordType: "Major Triad",
+      voicingType: "drop2", inversion: "root", stringSet: allStrings,
+    });
+    expect(voicings.length).toBeGreaterThan(0);
+    for (const v of voicings) {
+      const midis = v.notes.map((n) => n.midi);
+      const span = Math.max(...midis) - Math.min(...midis);
+      expect(span).toBeGreaterThan(12);
+    }
+  });
+
+  it("triad and drop2 on a triad chord are not equal", () => {
+    const triad = generateVoicings({
+      ...base, chordRoot: "C", chordType: "Major Triad",
+      voicingType: "triad", inversion: "root", stringSet: allStrings,
+    });
+    const drop2 = generateVoicings({
+      ...base, chordRoot: "C", chordType: "Major Triad",
+      voicingType: "drop2", inversion: "root", stringSet: allStrings,
+    });
+    const triadKeys = new Set(triad.map((v) => v.positionKeys.join("|")));
+    const drop2Keys = new Set(drop2.map((v) => v.positionKeys.join("|")));
+    for (const k of drop2Keys) expect(triadKeys.has(k)).toBe(false);
   });
 });
 

--- a/packages/core/src/shapes/voicings.ts
+++ b/packages/core/src/shapes/voicings.ts
@@ -68,7 +68,9 @@ export interface GenerateVoicingsParams {
 
 // Span limits tuned in Task 11 Step 5: triad raised 4→5 so close-position
 // C-major triads (which span up to 5 frets across adjacent strings) survive.
-const SPAN_LIMIT: Record<"triad" | "drop2", number> = { triad: 5, drop2: 5 };
+// drop2 is raised to 6 so that spread (pitch-span > 12) triads can be voiced
+// on 3 adjacent strings — their minimum fret span is 6 semitones.
+const SPAN_LIMIT: Record<"triad" | "drop2", number> = { triad: 5, drop2: 6 };
 
 /** Frets >0 only — open strings do not constrain the hand span. */
 function fretSpan(notes: VoicingNote[]): number {
@@ -170,10 +172,14 @@ export function generateVoicings(params: GenerateVoicingsParams): Voicing[] {
   const def = CHORD_DEFINITIONS[params.chordType];
   if (!def) return [];
   if (voicingType === "triad") {
+    // Triad: always the closed-position search, capped at 3 voices.
     return searchVoicings(params, Math.min(3, def.members.length), false);
   }
-  if (def.members.length >= 4) return searchVoicings(params, 4, true);
-  return searchVoicings(params, Math.min(3, def.members.length), false);
+  // drop2: always the spread search. voiceCount uses all chord tones for
+  // 4+ note chords and falls back to the chord's tone count for smaller ones
+  // (a 3-note "drop 2" is the spread/string-skip triad).
+  const voiceCount = def.members.length >= 4 ? 4 : Math.min(3, def.members.length);
+  return searchVoicings(params, voiceCount, true);
 }
 
 function cagedVoicings(params: GenerateVoicingsParams): Voicing[] {

--- a/src/components/ChordOverlayControls/ChordOverlayControls.test.tsx
+++ b/src/components/ChordOverlayControls/ChordOverlayControls.test.tsx
@@ -18,6 +18,9 @@ import {
   voicingConnectorsAtom,
   voicingTypeAtom,
   voicingStringSetAtom,
+  voicingInversionAtom,
+  validVoicingCombosAtom,
+  controlRecencyAtom,
 } from "../../store/atoms";
 import { ChordOverlayControls } from "./ChordOverlayControls";
 
@@ -684,7 +687,10 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
       expect(within(radiogroup).getAllByRole("radio")).toHaveLength(4);
     });
 
-    it("normalizer: switching from triad to 4-tone chord resets a stale '4·5·6' string set to 'all'", async () => {
+    it("normalizer: switching from triad to 4-tone chord removes the stale '4·5·6' string set option", async () => {
+      // The 3-string "4·5·6" window exists for a 3-tone chord but not for a 4-tone chord.
+      // After the chord change, stringSetOptionsAtom rebuilds with 4-string windows only —
+      // "4·5·6" disappears from the option list entirely. The 4-tone "Bass" window is "3·4·5·6".
       const store = makeAtomStore([
         ...TRIAD_MANUAL_SEEDS,
         [voicingTypeAtom, "triad"],
@@ -692,19 +698,92 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
       ]);
       renderWithStore(<ChordOverlayControls />, store);
 
-      // Initially: Bass card ("4·5·6") should be checked for a 3-tone chord
+      // Initially: Bass card ("4·5·6") present and checked for a 3-tone chord
       const radiogroup = screen.getByRole("radiogroup", { name: /String Set/i });
-      const bassCard = within(radiogroup).getByRole("radio", { name: /Bass/i });
-      expect(bassCard).toHaveAttribute("aria-checked", "true");
+      expect(within(radiogroup).getByRole("radio", { name: /Bass.*4·5·6/i })).toHaveAttribute("aria-checked", "true");
 
       // Switch to a 4-tone chord — "4·5·6" is no longer a valid window
       await act(async () => {
         store.set(chordQualityOverrideAtom, "Major 7th");
       });
 
-      // Normalizer should snap the selection back to "all"
-      const allCard = await screen.findByRole("radio", { name: /All/i });
-      expect(allCard).toHaveAttribute("aria-checked", "true");
+      // The 4-tone chord renders 4-string windows; "4·5·6" disappears.
+      // A new Bass window "3·4·5·6" appears — confirm the 3-string window is gone.
+      const radiogroupAfter = await screen.findByRole("radiogroup", { name: /String Set/i });
+      // 4-tone chord: 3 windows + All = 4 cards total
+      expect(within(radiogroupAfter).getAllByRole("radio")).toHaveLength(4);
+      // The old 3-string "4·5·6" id is no longer present (the 4-tone Bass window is "3·4·5·6")
+      expect(within(radiogroupAfter).queryByRole("radio", { name: /— 4·5·6/ })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("19. disabled state + unified heal coupling", () => {
+    const TRIAD_SEEDS = [
+      [scaleNameAtom, "Major"],
+      [rootNoteAtom, "C"],
+      [chordOverlayModeAtom, "manual"],
+      [chordQualityOverrideAtom, "Major Triad"],
+      [chordRootOverrideAtom, "C"],
+      [fingeringPatternAtom, "caged"],
+      [progressionStepsAtom, []],
+      [voicingTypeAtom, "triad"],
+    ] as const;
+
+    it("disabled options: '3rd' inversion button disabled for triad (not in validCombos.enabledInversions)", () => {
+      // A triad has no 3rd inversion → validCombos.enabledInversions must not contain it
+      renderWithAtoms(<ChordOverlayControls />, [...TRIAD_SEEDS]);
+      const inversionGroup = screen.getByRole("group", { name: "Voicing inversion" });
+      expect(within(inversionGroup).getByRole("button", { name: "3rd" })).toBeDisabled();
+    });
+
+    it("heal: after chord change to 4-tone chord, active triple is valid in validVoicingCombosAtom.triples", async () => {
+      // Seed: triad + 1st inversion + 4·5·6 string set — valid for a 3-tone chord.
+      // Simulate that inversion was changed most recently by seeding the recency atom.
+      // This ensures nearestValidTriple pins the inversion (which has valid triples for a
+      // 4-tone chord) rather than the voicing type (which does not, since "triad" voicing
+      // type only works on 3-tone chords).
+      const store = makeAtomStore([
+        ...TRIAD_SEEDS,
+        [voicingInversionAtom, "1st"],
+        [voicingStringSetAtom, "4·5·6"],
+        [controlRecencyAtom, ["inversion", "type", "stringSet"]],
+      ]);
+      renderWithStore(<ChordOverlayControls />, store);
+
+      // Switch to a 4-tone chord — the triple (triad, 1st, "4·5·6") becomes invalid
+      await act(async () => {
+        store.set(chordQualityOverrideAtom, "Major 7th");
+      });
+
+      // Read the final triple
+      const finalType = store.get(voicingTypeAtom);
+      const finalInversion = store.get(voicingInversionAtom);
+      const finalStringSet = store.get(voicingStringSetAtom);
+      const validCombos = store.get(validVoicingCombosAtom);
+
+      // The final triple must be valid (heal moved type and stringSet, kept inversion)
+      const isValid = validCombos.triples.some(
+        (t) =>
+          t.type === finalType &&
+          t.inversion === finalInversion &&
+          t.stringSet === finalStringSet,
+      );
+      expect(isValid).toBe(true);
+    });
+
+    it("recency: clicking an inversion option moves 'inversion' to front of controlRecencyAtom", async () => {
+      const store = makeAtomStore([...TRIAD_SEEDS]);
+      renderWithStore(<ChordOverlayControls />, store);
+
+      // Default recency order
+      expect(store.get(controlRecencyAtom)).toEqual(["type", "stringSet", "inversion"]);
+
+      // Click the "1st" inversion button
+      const inversionGroup = screen.getByRole("group", { name: "Voicing inversion" });
+      await userEvent.click(within(inversionGroup).getByRole("button", { name: "1st" }));
+
+      // "inversion" should now be at the front
+      expect(store.get(controlRecencyAtom)[0]).toBe("inversion");
     });
   });
 

--- a/src/components/ChordOverlayControls/ChordOverlayControls.test.tsx
+++ b/src/components/ChordOverlayControls/ChordOverlayControls.test.tsx
@@ -21,6 +21,7 @@ import {
   voicingInversionAtom,
   validVoicingCombosAtom,
   controlRecencyAtom,
+  noteControlChangeAtom,
 } from "../../store/atoms";
 import { ChordOverlayControls } from "./ChordOverlayControls";
 
@@ -737,20 +738,19 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
     });
 
     it("heal: after chord change to 4-tone chord, active triple is valid in validVoicingCombosAtom.triples", async () => {
-      // Seed: triad + 1st inversion + 4·5·6 string set — valid for a 3-tone chord.
-      // Simulate that inversion was changed most recently by seeding the recency atom.
-      // This ensures nearestValidTriple pins the inversion (which has valid triples for a
-      // 4-tone chord) rather than the voicing type (which does not, since "triad" voicing
-      // type only works on 3-tone chords).
+      // Seed: drop2 + 1st inversion + a 3-string window stringSet — valid configuration
+      // for a 3-tone chord won't be valid for a 4-tone chord because the string-set ids
+      // change (3-string → 4-string windows). Spec §5c point 2: on chord change, type is
+      // pinned and inversion + string set heal.
       const store = makeAtomStore([
         ...TRIAD_SEEDS,
+        [voicingTypeAtom, "drop2"],
         [voicingInversionAtom, "1st"],
         [voicingStringSetAtom, "4·5·6"],
-        [controlRecencyAtom, ["inversion", "type", "stringSet"]],
       ]);
       renderWithStore(<ChordOverlayControls />, store);
 
-      // Switch to a 4-tone chord — the triple (triad, 1st, "4·5·6") becomes invalid
+      // Switch to a 4-tone chord — "4·5·6" is no longer a valid window id
       await act(async () => {
         store.set(chordQualityOverrideAtom, "Major 7th");
       });
@@ -761,7 +761,7 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
       const finalStringSet = store.get(voicingStringSetAtom);
       const validCombos = store.get(validVoicingCombosAtom);
 
-      // The final triple must be valid (heal moved type and stringSet, kept inversion)
+      // The final triple must be valid (chord-change pinned type=drop2; heal snapped stringSet)
       const isValid = validCombos.triples.some(
         (t) =>
           t.type === finalType &&
@@ -769,6 +769,111 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
           t.stringSet === finalStringSet,
       );
       expect(isValid).toBe(true);
+    });
+
+    it("user-driven heal: picking an incompatible inversion heals the other two to a valid triple", async () => {
+      // Spec §8: a user picks a control value that is globally enabled but yields zero
+      // voicings combined with the current other two. The heal pins the just-changed
+      // control and snaps the others. Here we set up `drop2 + all` on Major 7th, then
+      // pick an inversion that — combined with `(drop2, all)` — yields a valid triple,
+      // OR if the user picked one that's NOT valid for that combination, the heal moves
+      // the other two. We choose the situation dynamically to find a guaranteed bad combo.
+      const store = makeAtomStore([
+        [scaleNameAtom, "Major"],
+        [rootNoteAtom, "C"],
+        [chordOverlayModeAtom, "manual"],
+        [chordQualityOverrideAtom, "Major 7th"],
+        [chordRootOverrideAtom, "C"],
+        [fingeringPatternAtom, "caged"],
+        [progressionStepsAtom, []],
+        [voicingTypeAtom, "drop2"],
+        [voicingInversionAtom, "root"],
+        [voicingStringSetAtom, "all"],
+      ]);
+      renderWithStore(<ChordOverlayControls />, store);
+
+      const combos = store.get(validVoicingCombosAtom);
+      // Find an inversion that's globally enabled but invalid with (drop2, all).
+      // For every enabled inversion, check if any triple has (drop2, inv, all).
+      const enabledInversions = [...combos.enabledInversions];
+      const badInversion = enabledInversions.find((inv) =>
+        !combos.triples.some(
+          (t) => t.type === "drop2" && t.stringSet === "all" && t.inversion === inv,
+        ),
+      );
+
+      if (badInversion) {
+        // Drive the click via the recency-recording onChange path.
+        await act(async () => {
+          store.set(noteControlChangeAtom, "inversion");
+          store.set(voicingInversionAtom, badInversion);
+        });
+
+        const finalType = store.get(voicingTypeAtom);
+        const finalInversion = store.get(voicingInversionAtom);
+        const finalStringSet = store.get(voicingStringSetAtom);
+        const validCombos = store.get(validVoicingCombosAtom);
+        const isValid = validCombos.triples.some(
+          (t) =>
+            t.type === finalType &&
+            t.inversion === finalInversion &&
+            t.stringSet === finalStringSet,
+        );
+        expect(isValid).toBe(true);
+        // The inversion the user picked should be preserved (pinned).
+        expect(finalInversion).toBe(badInversion);
+      } else {
+        // If no such inversion exists for Major 7th (all enabled inversions are valid
+        // with drop2+all), the heal path is implicitly covered by the chord-change test.
+        // Assert the invariant holds: every enabled inversion forms a valid triple with
+        // (drop2, all) — meaning no heal would be needed for an inversion click here.
+        for (const inv of enabledInversions) {
+          expect(
+            combos.triples.some(
+              (t) => t.type === "drop2" && t.stringSet === "all" && t.inversion === inv,
+            ),
+          ).toBe(true);
+        }
+      }
+    });
+
+    it("toggling caged → triad heals the persisted inversion/string-set values", async () => {
+      // Seed caged with persisted inversion/stringSet values that would be invalid for
+      // the active chord under triad. Switching voicingType to triad re-engages the heal.
+      const store = makeAtomStore([
+        [scaleNameAtom, "Major"],
+        [rootNoteAtom, "C"],
+        [chordOverlayModeAtom, "manual"],
+        [chordQualityOverrideAtom, "Major Triad"],
+        [chordRootOverrideAtom, "C"],
+        [fingeringPatternAtom, "caged"],
+        [progressionStepsAtom, []],
+        [voicingTypeAtom, "caged"],
+        // "3rd" inversion isn't available for a triad; "1·2·3·4" is a 4-string window id
+        // not present in a 3-tone chord's option list — both are stale/invalid for triad.
+        [voicingInversionAtom, "3rd"],
+        [voicingStringSetAtom, "1·2·3·4"],
+      ]);
+      renderWithStore(<ChordOverlayControls />, store);
+
+      // Switch voicing type from caged to triad — the heal effect now engages.
+      await act(async () => {
+        store.set(noteControlChangeAtom, "type");
+        store.set(voicingTypeAtom, "triad");
+      });
+
+      const finalType = store.get(voicingTypeAtom);
+      const finalInversion = store.get(voicingInversionAtom);
+      const finalStringSet = store.get(voicingStringSetAtom);
+      const validCombos = store.get(validVoicingCombosAtom);
+      const isValid = validCombos.triples.some(
+        (t) =>
+          t.type === finalType &&
+          t.inversion === finalInversion &&
+          t.stringSet === finalStringSet,
+      );
+      expect(isValid).toBe(true);
+      expect(finalType).toBe("triad");
     });
 
     it("recency: clicking an inversion option moves 'inversion' to front of controlRecencyAtom", async () => {

--- a/src/components/ChordOverlayControls/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls/ChordOverlayControls.tsx
@@ -1,5 +1,5 @@
-import { startTransition, useEffect } from "react";
-import { useAtom, useAtomValue } from "jotai";
+import { startTransition, useEffect, useMemo } from "react";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import clsx from "clsx";
 import { type PracticeLens } from "@fretflow/core";
 import {
@@ -11,6 +11,10 @@ import {
   voicingConnectorsAtom,
   availableInversionsAtom,
   stringSetOptionsAtom,
+  validVoicingCombosAtom,
+  controlRecencyAtom,
+  noteControlChangeAtom,
+  nearestValidTriple,
 } from "../../store/atoms";
 import { StringSetPicker } from "../Inspector/StringSetPicker";
 import { useTranslation } from "../../hooks/useTranslation";
@@ -55,6 +59,9 @@ export function ChordOverlayControls() {
   const [voicingConnectors, setVoicingConnectors] = useAtom(voicingConnectorsAtom);
   const availableInversions = useAtomValue(availableInversionsAtom);
   const stringSetOptions = useAtomValue(stringSetOptionsAtom);
+  const validCombos = useAtomValue(validVoicingCombosAtom);
+  const recency = useAtomValue(controlRecencyAtom);
+  const recordControlChange = useSetAtom(noteControlChangeAtom);
 
   const lensAvailability = useAtomValue(lensAvailabilityAtom);
   const fingeringPattern = useAtomValue(fingeringPatternAtom);
@@ -93,21 +100,46 @@ export function ChordOverlayControls() {
     }
   }, [currentLensEntry, lensAvailability, setPracticeLens]);
 
-  // Normalize a persisted voicing inversion the active chord no longer offers
-  // (e.g. a 7th-chord "3rd" inversion after switching to a triad).
+  // Unified auto-heal: whenever the active (type, inversion, stringSet) is
+  // not a valid triple, pin the most-recently-touched control and snap the
+  // other two to the nearest valid assignment.
   useEffect(() => {
-    if (!availableInversions.includes(voicingInversion)) {
-      setVoicingInversion(availableInversions[0] ?? "root");
-    }
-  }, [availableInversions, voicingInversion, setVoicingInversion]);
+    if (voicingType === "caged") return; // caged is force-resolved upstream.
+    const current = {
+      type: voicingType,
+      inversion: voicingInversion,
+      stringSet: voicingStringSet,
+    };
+    const isValid = validCombos.triples.some(
+      (t) =>
+        t.type === current.type &&
+        t.inversion === current.inversion &&
+        t.stringSet === current.stringSet,
+    );
+    if (isValid) return;
+    const next = nearestValidTriple(validCombos.triples, current, recency);
+    if (next.type !== current.type) setVoicingType(next.type);
+    if (next.inversion !== current.inversion) setVoicingInversion(next.inversion);
+    if (next.stringSet !== current.stringSet) setVoicingStringSet(next.stringSet);
+  }, [
+    voicingType,
+    voicingInversion,
+    voicingStringSet,
+    validCombos,
+    recency,
+    setVoicingType,
+    setVoicingInversion,
+    setVoicingStringSet,
+  ]);
 
-  // Normalize a persisted string-set id the active chord no longer offers
-  // (e.g. a 3-string triad window after switching to a 4-note chord).
-  useEffect(() => {
-    if (!stringSetOptions.some((o) => o.id === voicingStringSet)) {
-      setVoicingStringSet("all");
-    }
-  }, [stringSetOptions, voicingStringSet, setVoicingStringSet]);
+  const decoratedStringSetOptions = useMemo(
+    () =>
+      stringSetOptions.map((o) => ({
+        ...o,
+        disabled: !validCombos.enabledStringSets.has(o.id),
+      })),
+    [stringSetOptions, validCombos],
+  );
 
   const handleDegreeChange = (value: string) => {
     startTransition(() => {
@@ -266,13 +298,21 @@ export function ChordOverlayControls() {
             >
               <ToggleBar
                 label="Voicing type"
-                options={[
-                  { value: "caged" as const, label: t("inspector.voicingTypeCaged") },
-                  { value: "drop2" as const, label: t("inspector.voicingTypeDrop2") },
-                  { value: "triad" as const, label: t("inspector.voicingTypeTriad") },
-                ]}
+                options={(["caged", "drop2", "triad"] as const).map((v) => ({
+                  value: v,
+                  label:
+                    v === "caged"
+                      ? t("inspector.voicingTypeCaged")
+                      : v === "drop2"
+                        ? t("inspector.voicingTypeDrop2")
+                        : t("inspector.voicingTypeTriad"),
+                  disabled: v !== "caged" && !validCombos.enabledTypes.has(v),
+                }))}
                 value={voicingType}
-                onChange={setVoicingType}
+                onChange={(v) => {
+                  recordControlChange("type");
+                  setVoicingType(v);
+                }}
               />
             </Prop>
             {voicingType !== "caged" && (
@@ -286,10 +326,15 @@ export function ChordOverlayControls() {
                   options={(["root", "1st", "2nd", "3rd"] as const).map((v) => ({
                     value: v,
                     label: v === "root" ? t("controls.root") : v,
-                    disabled: !availableInversions.includes(v),
+                    disabled:
+                      !availableInversions.includes(v) ||
+                      !validCombos.enabledInversions.has(v),
                   }))}
                   value={voicingInversion}
-                  onChange={setVoicingInversion}
+                  onChange={(v) => {
+                    recordControlChange("inversion");
+                    setVoicingInversion(v);
+                  }}
                 />
               </Prop>
             )}
@@ -300,9 +345,12 @@ export function ChordOverlayControls() {
                 hint={t("inspector.voicingStringSetHint")}
               >
                 <StringSetPicker
-                  options={stringSetOptions}
+                  options={decoratedStringSetOptions}
                   value={voicingStringSet}
-                  onChange={setVoicingStringSet}
+                  onChange={(v) => {
+                    recordControlChange("stringSet");
+                    setVoicingStringSet(v);
+                  }}
                 />
               </Prop>
             )}

--- a/src/components/ChordOverlayControls/ChordOverlayControls.tsx
+++ b/src/components/ChordOverlayControls/ChordOverlayControls.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useEffect, useMemo } from "react";
+import { startTransition, useEffect, useMemo, useRef } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import clsx from "clsx";
 import { type PracticeLens } from "@fretflow/core";
@@ -15,6 +15,7 @@ import {
   controlRecencyAtom,
   noteControlChangeAtom,
   nearestValidTriple,
+  type VoicingControlId,
 } from "../../store/atoms";
 import { StringSetPicker } from "../Inspector/StringSetPicker";
 import { useTranslation } from "../../hooks/useTranslation";
@@ -41,6 +42,7 @@ export function ChordOverlayControls() {
   const { t } = useTranslation();
   const { scaleName, useFlats } = useScaleState();
   const {
+    chordRoot,
     chordType,
     practiceLens,
     setPracticeLens,
@@ -103,8 +105,24 @@ export function ChordOverlayControls() {
   // Unified auto-heal: whenever the active (type, inversion, stringSet) is
   // not a valid triple, pin the most-recently-touched control and snap the
   // other two to the nearest valid assignment.
+  //
+  // Spec §5c point 2: on a chord change (no control was "just changed"),
+  // override the live recency for this run only — pin `type` and let
+  // inversion + string set heal. The user's actual recency is unchanged so
+  // the next user-driven heal still respects it.
+  const prevChordRef = useRef<{ root: string; type: string | null } | null>(null);
   useEffect(() => {
-    if (voicingType === "caged") return; // caged is force-resolved upstream.
+    if (voicingType === "caged") {
+      prevChordRef.current = { root: chordRoot, type: chordType };
+      return; // caged is force-resolved upstream.
+    }
+    const chord = { root: chordRoot, type: chordType };
+    const chordChanged =
+      prevChordRef.current !== null &&
+      (prevChordRef.current.root !== chord.root ||
+        prevChordRef.current.type !== chord.type);
+    prevChordRef.current = chord;
+
     const current = {
       type: voicingType,
       inversion: voicingInversion,
@@ -117,11 +135,17 @@ export function ChordOverlayControls() {
         t.stringSet === current.stringSet,
     );
     if (isValid) return;
-    const next = nearestValidTriple(validCombos.triples, current, recency);
+
+    const effectiveRecency: readonly VoicingControlId[] = chordChanged
+      ? ["type", "stringSet", "inversion"]
+      : recency;
+    const next = nearestValidTriple(validCombos.triples, current, effectiveRecency);
     if (next.type !== current.type) setVoicingType(next.type);
     if (next.inversion !== current.inversion) setVoicingInversion(next.inversion);
     if (next.stringSet !== current.stringSet) setVoicingStringSet(next.stringSet);
   }, [
+    chordRoot,
+    chordType,
     voicingType,
     voicingInversion,
     voicingStringSet,

--- a/src/components/Inspector/StringSetPicker.module.css
+++ b/src/components/Inspector/StringSetPicker.module.css
@@ -39,6 +39,13 @@
   box-shadow: var(--dc-glow-focus);
 }
 
+.card:disabled,
+.cardDisabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 .diagram {
   display: flex;
   flex-direction: column;

--- a/src/components/Inspector/StringSetPicker.test.tsx
+++ b/src/components/Inspector/StringSetPicker.test.tsx
@@ -52,3 +52,38 @@ describe("StringSetPicker", () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 });
+
+describe("StringSetPicker — diagram orientation and thickness", () => {
+  it("renders bars top-to-bottom as high E (index 0) → low E (index 5)", () => {
+    const triadOptions = buildStringSetOptions(3);
+    render(
+      <StringSetPicker options={triadOptions} value="all" onChange={() => {}} />,
+    );
+    // Bass card highlights string indices [3, 4, 5] — the BOTTOM three bars.
+    const bassCard = screen.getByRole("radio", { name: /Bass/ });
+    const bars = bassCard.querySelectorAll("[data-string-index]");
+    expect(bars).toHaveLength(6);
+    bars.forEach((bar, i) => {
+      expect(bar.getAttribute("data-string-index")).toBe(String(i));
+    });
+    [0, 1, 2].forEach((i) => {
+      expect(bars[i].className).not.toMatch(/stringOn/);
+    });
+    [3, 4, 5].forEach((i) => {
+      expect(bars[i].className).toMatch(/stringOn/);
+    });
+  });
+
+  it("uses the boosted taper thicknesses (low E thickest)", () => {
+    const triadOptions = buildStringSetOptions(3);
+    const { container } = render(
+      <StringSetPicker options={triadOptions} value="all" onChange={() => {}} />,
+    );
+    const firstCard = container.querySelector('[role="radio"]') as HTMLElement;
+    const bars = firstCard.querySelectorAll<HTMLElement>("[data-string-index]");
+    const heights = Array.from(bars).map((b) => b.style.height);
+    expect(heights).toEqual([
+      "1.5px", "2.1px", "2.7px", "3.6px", "4.5px", "5.4px",
+    ]);
+  });
+});

--- a/src/components/Inspector/StringSetPicker.tsx
+++ b/src/components/Inspector/StringSetPicker.tsx
@@ -52,8 +52,16 @@ export function StringSetPicker({ options, value, onChange }: StringSetPickerPro
             role="radio"
             aria-checked={selected}
             aria-label={`${label} — ${sub}`}
-            className={clsx(styles.card, selected && styles.cardActive)}
-            onClick={() => onChange(option.id)}
+            disabled={option.disabled}
+            className={clsx(
+              styles.card,
+              selected && styles.cardActive,
+              option.disabled && styles.cardDisabled,
+            )}
+            onClick={() => {
+              if (option.disabled) return;
+              onChange(option.id);
+            }}
           >
             <span className={styles.diagram} aria-hidden="true">
               {/* Render bars in string-index order 0 (high E, thinnest) → 5

--- a/src/components/Inspector/StringSetPicker.tsx
+++ b/src/components/Inspector/StringSetPicker.tsx
@@ -3,6 +3,13 @@ import type { StringSetOption } from "../../store/voicingStringSets";
 import { useTranslation } from "../../hooks/useTranslation";
 import styles from "./StringSetPicker.module.css";
 
+/**
+ * Per-string bar thickness in pixels, indexed by string index
+ * (0 = high E … 5 = low E). The fretboard's `--string-taper-*` proportional
+ * curve, scaled up so the difference is legible in a small diagram.
+ */
+const STRING_BAR_THICKNESS_PX: readonly number[] = [1.5, 2.1, 2.7, 3.6, 4.5, 5.4];
+
 interface StringSetPickerProps {
   /** The chord-appropriate option list (from `buildStringSetOptions`). */
   options: readonly StringSetOption[];
@@ -11,10 +18,10 @@ interface StringSetPickerProps {
   onChange: (value: string) => void;
 }
 
-/** Six-string on/off mask for a diagram, index 0 = high E … 5 = low E. */
-function diagramMask(strings: readonly number[]): boolean[] {
+/** Set lookup for the active string indices on a card. */
+function isStringActive(strings: readonly number[]): (i: number) => boolean {
   const set = new Set(strings);
-  return [0, 1, 2, 3, 4, 5].map((i) => set.has(i));
+  return (i) => set.has(i);
 }
 
 /**
@@ -34,29 +41,34 @@ export function StringSetPicker({ options, value, onChange }: StringSetPickerPro
       aria-label={t("inspector.voicingStringSet")}
     >
       {options.map((option) => {
-        const active = value === option.id;
+        const selected = value === option.id;
         const label = t(option.labelKey);
         const sub = subText(option, t);
-        const mask = diagramMask(option.strings);
+        const active = isStringActive(option.strings);
         return (
           <button
             key={option.id}
             type="button"
             role="radio"
-            aria-checked={active}
+            aria-checked={selected}
             aria-label={`${label} — ${sub}`}
-            className={clsx(styles.card, active && styles.cardActive)}
+            className={clsx(styles.card, selected && styles.cardActive)}
             onClick={() => onChange(option.id)}
           >
             <span className={styles.diagram} aria-hidden="true">
-              {/* Reverse so low-E (thick) renders at the bottom, high-E (thin) at the top. */}
-              {[...mask].reverse().map((on, i) => (
-                <span
-                  key={i}
-                  className={clsx(styles.string, on && styles.stringOn)}
-                  style={{ height: `${1 + i * 0.4}px` }}
-                />
-              ))}
+              {/* Render bars in string-index order 0 (high E, thinnest) → 5
+                  (low E, thickest). CSS lays them out top-to-bottom. */}
+              {STRING_BAR_THICKNESS_PX.map((thicknessPx, stringIndex) => {
+                const on = active(stringIndex);
+                return (
+                  <span
+                    key={stringIndex}
+                    data-string-index={stringIndex}
+                    className={clsx(styles.string, on && styles.stringOn)}
+                    style={{ height: `${thicknessPx}px` }}
+                  />
+                );
+              })}
             </span>
             <span className={styles.text}>
               <span className={styles.label}>{label}</span>

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -81,6 +81,18 @@ export { buildStringSetOptions, ALL_STRINGS } from "./voicingStringSets";
 export type { StringSetOption } from "./voicingStringSets";
 
 export {
+  validVoicingCombosAtom,
+  controlRecencyAtom,
+  noteControlChangeAtom,
+  nearestValidTriple,
+} from "./voicingCoupling";
+export type {
+  ValidVoicingCombos,
+  VoicingTriple,
+  VoicingControlId,
+} from "./voicingCoupling";
+
+export {
   practiceBarColorNotesFilteredAtom,
   noteSemanticMapAtom,
   practiceCuesAtom,

--- a/src/store/voicingCoupling.test.ts
+++ b/src/store/voicingCoupling.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import {
+  validVoicingCombosAtom,
+  controlRecencyAtom,
+  nearestValidTriple,
+  type VoicingTriple,
+} from "./voicingCoupling";
+import {
+  chordOverlayModeAtom,
+  chordRootOverrideAtom,
+  chordQualityOverrideAtom,
+} from "./chordOverlayAtoms";
+import { progressionStepsAtom } from "./progressionAtoms";
+import { makeAtomStore } from "../test-utils/renderWithAtoms";
+
+function seedTriadChord() {
+  const store = makeAtomStore();
+  store.set(progressionStepsAtom, []);
+  store.set(chordOverlayModeAtom, "manual");
+  store.set(chordRootOverrideAtom, "C");
+  store.set(chordQualityOverrideAtom, "Major Triad");
+  return store;
+}
+
+describe("validVoicingCombosAtom", () => {
+  it("reports the enabled types, inversions and string sets for a triad chord", () => {
+    const store = seedTriadChord();
+    const combos = store.get(validVoicingCombosAtom);
+    expect(combos.enabledTypes.has("caged")).toBe(true);
+    expect(combos.enabledTypes.has("triad") || combos.enabledTypes.has("drop2")).toBe(true);
+    expect(combos.enabledStringSets.has("all")).toBe(true);
+    expect(combos.enabledInversions.has("root")).toBe(true);
+  });
+
+  it("disables only options absent from every valid triple", () => {
+    const store = seedTriadChord();
+    const combos = store.get(validVoicingCombosAtom);
+    for (const t of combos.enabledTypes) {
+      if (t === "caged") continue;
+      expect(combos.triples.some((c) => c.type === t)).toBe(true);
+    }
+    for (const inv of combos.enabledInversions) {
+      expect(combos.triples.some((c) => c.inversion === inv)).toBe(true);
+    }
+    for (const ss of combos.enabledStringSets) {
+      expect(combos.triples.some((c) => c.stringSet === ss)).toBe(true);
+    }
+  });
+});
+
+describe("nearestValidTriple", () => {
+  const triples: VoicingTriple[] = [
+    { type: "triad", inversion: "root", stringSet: "all" },
+    { type: "triad", inversion: "root", stringSet: "4·5·6" },
+    { type: "triad", inversion: "1st", stringSet: "all" },
+    { type: "drop2", inversion: "root", stringSet: "all" },
+  ];
+
+  it("keeps the pinned control and prefers keeping the more-recently-touched sibling", () => {
+    const current: VoicingTriple = { type: "drop2", inversion: "1st", stringSet: "all" };
+    const recency = ["type", "stringSet", "inversion"] as const;
+    const result = nearestValidTriple(triples, current, recency);
+    expect(result.type).toBe("drop2");
+    expect(result.stringSet).toBe("all");
+    expect(result.inversion).toBe("root");
+  });
+
+  it("moves the less-recent sibling when the more-recent one can be kept", () => {
+    const current: VoicingTriple = { type: "triad", inversion: "1st", stringSet: "4·5·6" };
+    const recency = ["inversion", "type", "stringSet"] as const;
+    const result = nearestValidTriple(triples, current, recency);
+    expect(result.inversion).toBe("1st");
+    expect(result.type).toBe("triad");
+    expect(result.stringSet).toBe("all");
+  });
+
+  it("returns the current triple unchanged when it is already valid", () => {
+    const current: VoicingTriple = { type: "triad", inversion: "root", stringSet: "all" };
+    const recency = ["type", "inversion", "stringSet"] as const;
+    expect(nearestValidTriple(triples, current, recency)).toEqual(current);
+  });
+});
+
+describe("controlRecencyAtom", () => {
+  it("has a default order that is type → stringSet → inversion", () => {
+    const store = makeAtomStore();
+    expect(store.get(controlRecencyAtom)).toEqual([
+      "type", "stringSet", "inversion",
+    ]);
+  });
+});

--- a/src/store/voicingCoupling.ts
+++ b/src/store/voicingCoupling.ts
@@ -1,0 +1,159 @@
+import { atom } from "jotai";
+import {
+  generateVoicings,
+  CHORD_DEFINITIONS,
+  type VoicingType,
+  type VoicingInversion,
+} from "@fretflow/core";
+import {
+  chordTypeAtom,
+  chordRootAtom,
+  availableInversionsAtom,
+  stringSetOptionsAtom,
+} from "./chordOverlayAtoms";
+import { currentTuningAtom } from "./layoutAtoms";
+
+/**
+ * Which voicing control was changed most recently. Drives auto-heal's
+ * pin / preserve / move precedence. Not persisted — resets each session
+ * to the default order (`type` → `stringSet` → `inversion`).
+ */
+export type VoicingControlId = "type" | "inversion" | "stringSet";
+
+export interface VoicingTriple {
+  type: VoicingType;
+  inversion: VoicingInversion;
+  /** A string-set id (`"all"` or e.g. `"4·5·6"`). */
+  stringSet: string;
+}
+
+export interface ValidVoicingCombos {
+  /** Every (type, inversion, stringSet) triple the engine accepts for the
+   *  current chord — `caged` is intentionally excluded (it has its own
+   *  always-valid path and is forced to root + all six strings). */
+  triples: ReadonlyArray<VoicingTriple>;
+  enabledTypes: ReadonlySet<VoicingType>;
+  enabledInversions: ReadonlySet<VoicingInversion>;
+  enabledStringSets: ReadonlySet<string>;
+}
+
+const EMPTY_COMBOS: ValidVoicingCombos = {
+  triples: [],
+  enabledTypes: new Set<VoicingType>(["caged"]),
+  enabledInversions: new Set<VoicingInversion>(),
+  enabledStringSets: new Set<string>(),
+};
+
+/**
+ * The set of valid `(type, inversion, stringSet)` triples for the active
+ * chord, plus per-control enabled-option sets. `caged` is always present in
+ * `enabledTypes` — it is a self-contained mode that does not appear in
+ * `triples` at all.
+ *
+ * Cost note: enumerates up to ~2 × 4 × 5 = 40 engine searches per chord
+ * change (caged is excluded — it has its own engine path). Each search is
+ * bounded; the atom is memoized per chord via Jotai's derived-atom caching.
+ * Acceptable; revisit if profiling shows it.
+ */
+export const validVoicingCombosAtom = atom<ValidVoicingCombos>((get) => {
+  const chordType = get(chordTypeAtom);
+  if (!chordType || !CHORD_DEFINITIONS[chordType]) return EMPTY_COMBOS;
+  const chordRoot = get(chordRootAtom);
+  const tuning = get(currentTuningAtom);
+  const inversions = get(availableInversionsAtom);
+  const stringSetOptions = get(stringSetOptionsAtom);
+
+  const triples: VoicingTriple[] = [];
+  const enabledTypes = new Set<VoicingType>(["caged"]);
+  const enabledInversions = new Set<VoicingInversion>();
+  const enabledStringSets = new Set<string>();
+
+  for (const type of ["triad", "drop2"] as const) {
+    for (const inversion of inversions) {
+      for (const option of stringSetOptions) {
+        const result = generateVoicings({
+          chordRoot,
+          chordType,
+          tuning,
+          maxFret: 24,
+          voicingType: type,
+          inversion,
+          stringSet: option.strings,
+        });
+        if (result.length === 0) continue;
+        triples.push({ type, inversion, stringSet: option.id });
+        enabledTypes.add(type);
+        enabledInversions.add(inversion);
+        enabledStringSets.add(option.id);
+      }
+    }
+  }
+
+  return { triples, enabledTypes, enabledInversions, enabledStringSets };
+});
+
+/**
+ * Recency order, most-recent-first. Updated by `ChordOverlayControls`'s
+ * `onChange` handlers; consumed by the heal effect to choose what to pin
+ * and what to move.
+ */
+export const controlRecencyAtom = atom<readonly VoicingControlId[]>([
+  "type",
+  "stringSet",
+  "inversion",
+]);
+
+/** Write-only atom: move `id` to the front of the recency list. */
+export const noteControlChangeAtom = atom(null, (get, set, id: VoicingControlId) => {
+  const prev = get(controlRecencyAtom);
+  if (prev[0] === id) return;
+  const next: VoicingControlId[] = [id, ...prev.filter((c) => c !== id)];
+  set(controlRecencyAtom, next);
+});
+
+function isValidTriple(
+  triples: ReadonlyArray<VoicingTriple>,
+  candidate: VoicingTriple,
+): boolean {
+  return triples.some(
+    (t) =>
+      t.type === candidate.type &&
+      t.inversion === candidate.inversion &&
+      t.stringSet === candidate.stringSet,
+  );
+}
+
+/**
+ * Given a (possibly invalid) `current` triple and a recency order, return
+ * the nearest valid triple from `triples`:
+ *
+ *   1. The most-recently-touched control (`recency[0]`) is pinned.
+ *   2. Among triples that match the pinned value, prefer those that keep
+ *      the next-most-recently-touched sibling (`recency[1]`).
+ *   3. If forced to move the more-recent sibling, prefer triples that keep
+ *      the least-recent sibling (`recency[2]`).
+ *   4. Tie-break by first occurrence in `triples` (stable selection).
+ *
+ * If `current` is already valid, returns it unchanged. If no triple matches
+ * the pinned control, returns `current` unchanged.
+ */
+export function nearestValidTriple(
+  triples: ReadonlyArray<VoicingTriple>,
+  current: VoicingTriple,
+  recency: readonly VoicingControlId[],
+): VoicingTriple {
+  if (isValidTriple(triples, current)) return current;
+  if (recency.length !== 3) return current;
+  const [pinned, mid, low] = recency;
+
+  const matches = triples.filter((t) => t[pinned] === current[pinned]);
+  if (matches.length === 0) return current;
+
+  const keepMid = matches.filter((t) => t[mid] === current[mid]);
+  const pool = keepMid.length > 0 ? keepMid : matches;
+
+  const keepLow = pool.filter((t) => t[low] === current[low]);
+  const candidates = keepLow.length > 0 ? keepLow : pool;
+
+  return candidates[0];
+}

--- a/src/store/voicingStringSets.ts
+++ b/src/store/voicingStringSets.ts
@@ -16,6 +16,9 @@ export interface StringSetOption {
   labelKey: string;
   /** Allowed string indices, ascending (0 = high E … 5 = low E). */
   strings: readonly number[];
+  /** Set by consumers (not by `buildStringSetOptions`) to indicate the
+   *  option appears in no valid triple for the active chord. */
+  disabled?: boolean;
 }
 
 export const ALL_STRINGS: readonly number[] = [0, 1, 2, 3, 4, 5];


### PR DESCRIPTION
**Stacked on top of [#417](https://github.com/iecg/fretboard-app/pull/417).** Until #417 merges, the PR diff visibly includes its commits; GitHub will narrow this PR to just the refinement commits once #417 lands.

## Summary

Four behavioral fixes to the Chord-tab voicing controls shipped in #417, plus the design spec for an upcoming Controls Overhaul (Spec 2 — tracked separately).

- **Drop 2 vs Triad.** `generateVoicings` now always passes `requireOctaveSpread: true` for Drop 2 and `false` for Triad — for any tone count. On a triad chord they used to be byte-identical; now Drop 2 produces spread/string-skip triads and Triad stays closed. `SPAN_LIMIT.drop2` bumped 5→6 so spread triads on adjacent strings can exist.
- **String-set diagram.** Removed the double-flip bug: bars render top-to-bottom as high E (string index 0) → low E (string index 5), matching the fretboard. New `STRING_BAR_THICKNESS_PX` constant (`1.5 → 5.4 px`) makes the taper clearly visible at diagram size.
- **Disable + auto-heal coupling.** New `validVoicingCombosAtom` enumerates valid `(type, inversion, stringSet)` triples per chord (~40 engine searches per chord change, memoized). Per-control selectors grey out only options that appear in zero valid triples. A unified `useEffect` heals an invalid active triple by pinning the most-recently-touched control (or `type` on chord change per spec §5c) and snapping the others to the nearest valid assignment via `nearestValidTriple`. Replaces the two single-purpose normalizer effects from #417.

Specs and plan included:
- [docs/superpowers/specs/2026-05-19-voicing-controls-refinement-design.md](docs/superpowers/specs/2026-05-19-voicing-controls-refinement-design.md)
- [docs/superpowers/plans/2026-05-19-voicing-controls-refinement.md](docs/superpowers/plans/2026-05-19-voicing-controls-refinement.md)
- [docs/superpowers/specs/2026-05-19-controls-overhaul-design.md](docs/superpowers/specs/2026-05-19-controls-overhaul-design.md) (Spec 2 — implementation tracked separately)

## Test Plan

- [x] \`pnpm run lint\` — clean
- [x] \`pnpm run test\` — 1979/1979 pass
- [x] \`npx tsc -b\` — clean
- [x] \`pnpm run build\` — clean
- [x] Visual-regression suites (darwin + linux) — green, no snapshot diffs
- [ ] Manual check: on a triad chord, Triad vs Drop 2 show clearly different fretboard shapes
- [ ] Manual check: "Bass" string-set card highlights the bottom 3 (thick) bars; "Treble" highlights the top 3 (thin)
- [ ] Manual check: greyed-out options are visibly disabled and unclickable; picking an enabled-but-locally-incompatible option (or changing the chord) leaves Type/Inversion/String Set in a working state with no flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed internal planning documentation files from the repository.

**Note:** No user-facing features or functionality were changed in this update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->