### PR TITLE
test: consolidate duplicated tests across 5 files (-1.1k LOC)

### DIFF
--- a/src/components/ChordOverlayControls/ChordOverlayControls.test.tsx
+++ b/src/components/ChordOverlayControls/ChordOverlayControls.test.tsx
@@ -276,31 +276,19 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
     });
   });
 
-  describe("6. a11y: no violations in degree mode and manual mode", () => {
-    it("degree mode has no a11y violations", async () => {
-      const { container } = renderWithAtoms(<ChordOverlayControls />, [...DEGREE_MODE_SEEDS]);
+  describe("a11y + group labels", () => {
+    it.each([
+      { label: "degree mode", seeds: DEGREE_MODE_SEEDS },
+      { label: "manual mode", seeds: MANUAL_MODE_SEEDS },
+    ])("$label has no a11y violations", async ({ seeds }) => {
+      const { container } = renderWithAtoms(<ChordOverlayControls />, [...seeds]);
       expect(await axe(container)).toHaveNoViolations();
     });
 
-    it("manual mode has no a11y violations", async () => {
-      const { container } = renderWithAtoms(<ChordOverlayControls />, [...MANUAL_MODE_SEEDS]);
-      expect(await axe(container)).toHaveNoViolations();
-    });
-
-    it("degree mode has Chord degree group with correct aria-label", () => {
-      renderWithAtoms(<ChordOverlayControls />, [...DEGREE_MODE_SEEDS]);
-      expect(screen.getByRole("group", { name: "Chord degree" })).toBeInTheDocument();
-    });
-
-    it("Chord overlay mode ToggleBar has correct aria-label", () => {
+    it("degree mode exposes the expected group labels and 7 diatonic degrees", () => {
       renderWithAtoms(<ChordOverlayControls />, [...DEGREE_MODE_SEEDS]);
       expect(screen.getByRole("group", { name: "Chord overlay mode" })).toBeInTheDocument();
-    });
-
-    it("degree ToggleBar exposes 7 diatonic degrees (no Off sentinel)", () => {
-      renderWithAtoms(<ChordOverlayControls />, [...DEGREE_MODE_SEEDS]);
       const degreeGroup = screen.getByRole("group", { name: "Chord degree" });
-      // I, ii, iii, IV, V, vi, vii° = 7 buttons (Off moved to Chord Mode)
       expect(within(degreeGroup).queryByRole("button", { name: "Off" })).not.toBeInTheDocument();
       expect(within(degreeGroup).getByRole("button", { name: "I" })).toBeInTheDocument();
       expect(within(degreeGroup).getByRole("button", { name: "vii°" })).toBeInTheDocument();
@@ -351,34 +339,12 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
       ).toBeInTheDocument();
     });
 
-    it("renders all 15 chord-type buttons (no Off sentinel) in manual mode", () => {
+    it("renders all 15 chord-type buttons in CHORD_TYPE_DISPLAY_ORDER (no Off sentinel)", () => {
       renderWithAtoms(<ChordOverlayControls />, [...MANUAL_MODE_SEEDS]);
       const chordTypeGroup = screen.getByRole("group", { name: "Chord Type" });
-      // No Off sentinel (moved to Chord Mode)
       expect(within(chordTypeGroup).queryByRole("button", { name: "Off" })).not.toBeInTheDocument();
-      // All quality types
-      expect(within(chordTypeGroup).getByRole("button", { name: "Maj" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getByRole("button", { name: "min" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getByRole("button", { name: "dim" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getByRole("button", { name: "M7" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getByRole("button", { name: "m7" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getByRole("button", { name: "7" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getByRole("button", { name: "sus4" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getByRole("button", { name: "5" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getByRole("button", { name: "M6" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getByRole("button", { name: "aug" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getByRole("button", { name: "sus2" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getByRole("button", { name: "m6" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getByRole("button", { name: "dim7" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getByRole("button", { name: "m7♭5" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getByRole("button", { name: "mM7" })).toBeInTheDocument();
-      expect(within(chordTypeGroup).getAllByRole("button")).toHaveLength(15);
-    });
-
-    it("chord-type buttons appear in CHORD_TYPE_DISPLAY_ORDER order (Maj first)", () => {
-      renderWithAtoms(<ChordOverlayControls />, [...MANUAL_MODE_SEEDS]);
-      const chordTypeGroup = screen.getByRole("group", { name: "Chord Type" });
       const buttons = within(chordTypeGroup).getAllByRole("button");
+      expect(buttons).toHaveLength(EXPECTED_CHORD_TYPE_LABELS.length);
       EXPECTED_CHORD_TYPE_LABELS.forEach((label, i) => {
         expect(buttons[i]).toHaveAccessibleName(label);
       });
@@ -448,82 +414,31 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
     });
   });
 
-  describe("15. panel-level disable removed (Task 4 — controls always enabled)", () => {
-    it("panel root never has data-disabled when fingeringPattern is one-string", () => {
+  describe("Task 4: controls always enabled regardless of fingering pattern", () => {
+    const PATTERNS = ["one-string", "two-strings", "caged", "none"] as const;
+
+    it.each(PATTERNS)("panel root has no data-disabled when fingeringPattern is %s", (pattern) => {
       const { container } = renderWithAtoms(<ChordOverlayControls />, [
         ...DEGREE_MODE_SEEDS,
-        [fingeringPatternAtom, "one-string"],
+        [fingeringPatternAtom, pattern],
       ]);
-      const root = container.firstChild as HTMLElement;
-      expect(root).not.toHaveAttribute("data-disabled");
+      expect(container.firstChild as HTMLElement).not.toHaveAttribute("data-disabled");
     });
 
-    it("panel root never has data-disabled when fingeringPattern is two-strings", () => {
-      const { container } = renderWithAtoms(<ChordOverlayControls />, [
-        ...DEGREE_MODE_SEEDS,
-        [fingeringPatternAtom, "two-strings"],
-      ]);
-      const root = container.firstChild as HTMLElement;
-      expect(root).not.toHaveAttribute("data-disabled");
-    });
+    it.each(["one-string", "two-strings", "caged"] as const)(
+      "Chord Mode buttons stay enabled when fingeringPattern is %s",
+      (pattern) => {
+        renderWithAtoms(<ChordOverlayControls />, [
+          ...DEGREE_MODE_SEEDS,
+          [fingeringPatternAtom, pattern],
+        ]);
+        const modeGroup = screen.getByRole("group", { name: "Chord overlay mode" });
+        expect(within(modeGroup).getByRole("button", { name: "Degree" })).not.toBeDisabled();
+        expect(within(modeGroup).getByRole("button", { name: "Manual" })).not.toBeDisabled();
+      },
+    );
 
-    it("panel root does not have data-disabled when fingeringPattern is caged", () => {
-      const { container } = renderWithAtoms(<ChordOverlayControls />, [
-        ...DEGREE_MODE_SEEDS,
-        [fingeringPatternAtom, "caged"],
-      ]);
-      const root = container.firstChild as HTMLElement;
-      expect(root).not.toHaveAttribute("data-disabled");
-    });
-
-    it("panel root does not have data-disabled when fingeringPattern is none", () => {
-      const { container } = renderWithAtoms(<ChordOverlayControls />, [
-        ...DEGREE_MODE_SEEDS,
-        [fingeringPatternAtom, "none"],
-      ]);
-      const root = container.firstChild as HTMLElement;
-      expect(root).not.toHaveAttribute("data-disabled");
-    });
-  });
-
-  describe("14. chord controls always enabled — no pattern-disabled behavior (Task 4)", () => {
-    it("Chord Mode buttons are enabled when fingeringPattern is one-string", () => {
-      renderWithAtoms(<ChordOverlayControls />, [
-        ...DEGREE_MODE_SEEDS,
-        [fingeringPatternAtom, "one-string"],
-      ]);
-      const modeGroup = screen.getByRole("group", { name: "Chord overlay mode" });
-      const degreeButton = within(modeGroup).getByRole("button", { name: "Degree" });
-      const manualButton = within(modeGroup).getByRole("button", { name: "Manual" });
-      expect(degreeButton).not.toBeDisabled();
-      expect(manualButton).not.toBeDisabled();
-    });
-
-    it("Chord Mode buttons are enabled when fingeringPattern is two-strings", () => {
-      renderWithAtoms(<ChordOverlayControls />, [
-        ...DEGREE_MODE_SEEDS,
-        [fingeringPatternAtom, "two-strings"],
-      ]);
-      const modeGroup = screen.getByRole("group", { name: "Chord overlay mode" });
-      const degreeButton = within(modeGroup).getByRole("button", { name: "Degree" });
-      const manualButton = within(modeGroup).getByRole("button", { name: "Manual" });
-      expect(degreeButton).not.toBeDisabled();
-      expect(manualButton).not.toBeDisabled();
-    });
-
-    it("Chord Mode buttons are enabled when fingeringPattern is caged", () => {
-      renderWithAtoms(<ChordOverlayControls />, [
-        ...DEGREE_MODE_SEEDS,
-        [fingeringPatternAtom, "caged"],
-      ]);
-      const modeGroup = screen.getByRole("group", { name: "Chord overlay mode" });
-      const degreeButton = within(modeGroup).getByRole("button", { name: "Degree" });
-      const manualButton = within(modeGroup).getByRole("button", { name: "Manual" });
-      expect(degreeButton).not.toBeDisabled();
-      expect(manualButton).not.toBeDisabled();
-    });
-
-    it("first Chord Mode button always shows 'Off' label regardless of fingering pattern", () => {
+    it("first Chord Mode button always shows 'Off' (no 'Disabled' label)", () => {
       renderWithAtoms(<ChordOverlayControls />, [
         ...DEGREE_MODE_SEEDS,
         [fingeringPatternAtom, "one-string"],
@@ -634,53 +549,34 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
       [voicingSectionExpandedAtom, true],
     ] as const;
 
-    it("caged voicing type: Inversion control and String Set are NOT in the document", () => {
-      renderWithAtoms(<ChordOverlayControls />, [
-        ...TRIAD_MANUAL_SEEDS,
-        [voicingTypeAtom, "caged"],
-      ]);
-      expect(screen.queryByLabelText("Voicing inversion")).not.toBeInTheDocument();
-      expect(screen.queryByRole("radiogroup", { name: /String Set/i })).not.toBeInTheDocument();
+    it.each<{ label: string; extras: readonly (readonly [unknown, unknown])[]; visible: boolean }>([
+      { label: "caged", extras: [[voicingTypeAtom, "caged"]], visible: false },
+      { label: "triad", extras: [[voicingTypeAtom, "triad"]], visible: true },
+      { label: "drop2 (Major 7th)", extras: [[voicingTypeAtom, "drop2"], [chordQualityOverrideAtom, "Major 7th"]], visible: true },
+    ])("$label voicing: Inversion + String Set visibility = $visible", ({ extras, visible }) => {
+      renderWithAtoms(<ChordOverlayControls />, [...TRIAD_MANUAL_SEEDS, ...extras] as never);
+      const inv = screen.queryByLabelText("Voicing inversion");
+      const ss = screen.queryByRole("radiogroup", { name: /String Set/i });
+      if (visible) {
+        expect(inv).toBeInTheDocument();
+        expect(ss).toBeInTheDocument();
+      } else {
+        expect(inv).not.toBeInTheDocument();
+        expect(ss).not.toBeInTheDocument();
+      }
     });
 
-    it("triad voicing type: Inversion control and String Set ARE in the document", () => {
-      renderWithAtoms(<ChordOverlayControls />, [
-        ...TRIAD_MANUAL_SEEDS,
-        [voicingTypeAtom, "triad"],
-      ]);
-      expect(screen.queryByLabelText("Voicing inversion")).toBeInTheDocument();
-      expect(screen.queryByRole("radiogroup", { name: /String Set/i })).toBeInTheDocument();
-    });
-
-    it("drop2 voicing type: Inversion control and String Set ARE in the document", () => {
-      renderWithAtoms(<ChordOverlayControls />, [
-        ...TRIAD_MANUAL_SEEDS,
-        [voicingTypeAtom, "drop2"],
-        [chordQualityOverrideAtom, "Major 7th"],
-      ]);
-      expect(screen.queryByLabelText("Voicing inversion")).toBeInTheDocument();
-      expect(screen.queryByRole("radiogroup", { name: /String Set/i })).toBeInTheDocument();
-    });
-
-    it("triad chord (3 tones) shows 5 radio cards in the String Set picker", () => {
-      renderWithAtoms(<ChordOverlayControls />, [
-        ...TRIAD_MANUAL_SEEDS,
-        [voicingTypeAtom, "triad"],
-      ]);
+    it.each<{ label: string; extras: readonly (readonly [unknown, unknown])[]; count: number }>([
+      { label: "3-tone (triad)", extras: [[voicingTypeAtom, "triad"]], count: 5 },
+      {
+        label: "4-tone (Major 7th)",
+        extras: [[voicingTypeAtom, "triad"], [chordQualityOverrideAtom, "Major 7th"]],
+        count: 4,
+      },
+    ])("$label chord shows $count radio cards in the String Set picker", ({ extras, count }) => {
+      renderWithAtoms(<ChordOverlayControls />, [...TRIAD_MANUAL_SEEDS, ...extras] as never);
       const radiogroup = screen.getByRole("radiogroup", { name: /String Set/i });
-      // 3-tone chord: 6 - 3 + 1 = 4 windows + 1 All = 5 total
-      expect(within(radiogroup).getAllByRole("radio")).toHaveLength(5);
-    });
-
-    it("4-tone chord (Major 7th) shows 4 radio cards in the String Set picker", () => {
-      renderWithAtoms(<ChordOverlayControls />, [
-        ...TRIAD_MANUAL_SEEDS,
-        [voicingTypeAtom, "triad"],
-        [chordQualityOverrideAtom, "Major 7th"],
-      ]);
-      const radiogroup = screen.getByRole("radiogroup", { name: /String Set/i });
-      // 4-tone chord: 6 - 4 + 1 = 3 windows + 1 All = 4 total
-      expect(within(radiogroup).getAllByRole("radio")).toHaveLength(4);
+      expect(within(radiogroup).getAllByRole("radio")).toHaveLength(count);
     });
 
     it("normalizer: switching from triad to 4-tone chord removes the stale '4·5·6' string set option", async () => {
@@ -891,62 +787,38 @@ describe("ChordOverlayControls/ChordOverlayControls", () => {
     });
   });
 
-  describe("Task 4: no disabled UI for one-string/two-strings fingering", () => {
-    it("does not disable any control when fingering is one-string (Task 4)", () => {
-      renderWithAtoms(<ChordOverlayControls />, [
-        ...DEGREE_MODE_SEEDS,
-        [fingeringPatternAtom, "one-string"],
-      ]);
-      expect(screen.queryByText(/chord overlay disabled/i)).toBeNull();
-      expect(document.querySelector("[data-disabled=\"true\"]")).toBeNull();
-    });
-  });
-
   describe("Task 9: Chord Spread stepper and Scope to position switch", () => {
-    it("renders the Chord Spread stepper inside the Voicing section (Task 9)", () => {
-      renderWithAtoms(<ChordOverlayControls />, [
-        [scaleNameAtom, "Major"],
-        [rootNoteAtom, "C"],
-        [chordOverlayModeAtom, "manual"],
-        [chordRootOverrideAtom, "C"],
-        [chordQualityOverrideAtom, "Major Triad"],
-        [progressionStepsAtom, []],
-        [voicingSectionExpandedAtom, true],
-      ]);
-      // The Prop cell renders a label "Chord Spread"; the StepperControl exposes its label as a group aria-label.
+    const VOICING_SEEDS = [
+      [scaleNameAtom, "Major"],
+      [rootNoteAtom, "C"],
+      [chordOverlayModeAtom, "manual"],
+      [chordRootOverrideAtom, "C"],
+      [chordQualityOverrideAtom, "Major Triad"],
+      [progressionStepsAtom, []],
+      [voicingSectionExpandedAtom, true],
+    ] as const;
+
+    it("renders the Chord Spread stepper inside the Voicing section", () => {
+      renderWithAtoms(<ChordOverlayControls />, [...VOICING_SEEDS]);
       expect(screen.getByText(/chord spread/i)).toBeInTheDocument();
     });
 
-    it("renders the Scope to position switch and disables it when no active position (Task 9)", () => {
-      renderWithAtoms(<ChordOverlayControls />, [
-        [scaleNameAtom, "Major"],
-        [rootNoteAtom, "C"],
-        [chordOverlayModeAtom, "manual"],
-        [chordRootOverrideAtom, "C"],
-        [chordQualityOverrideAtom, "Major Triad"],
-        [fingeringPatternAtom, "none"],
-        [progressionStepsAtom, []],
-        [voicingSectionExpandedAtom, true],
-      ]);
+    it.each<{ label: string; extras: readonly (readonly [unknown, unknown])[]; disabled: boolean }>([
+      {
+        label: "no active position (fingering=none) → disabled",
+        extras: [[fingeringPatternAtom, "none"]],
+        disabled: true,
+      },
+      {
+        label: "single CAGED shape active → enabled",
+        extras: [[fingeringPatternAtom, "caged"], [cagedShapesAtom, new Set(["C"])]],
+        disabled: false,
+      },
+    ])("Scope to position switch: $label", ({ extras, disabled }) => {
+      renderWithAtoms(<ChordOverlayControls />, [...VOICING_SEEDS, ...extras] as never);
       const sw = screen.getByRole("switch", { name: /scope to position/i }) as HTMLInputElement;
-      expect(sw).toBeInTheDocument();
-      expect(sw).toBeDisabled();
-    });
-
-    it("enables the Scope to position switch when a single CAGED shape is active (Task 9)", () => {
-      renderWithAtoms(<ChordOverlayControls />, [
-        [scaleNameAtom, "Major"],
-        [rootNoteAtom, "C"],
-        [chordOverlayModeAtom, "manual"],
-        [chordRootOverrideAtom, "C"],
-        [chordQualityOverrideAtom, "Major Triad"],
-        [fingeringPatternAtom, "caged"],
-        [cagedShapesAtom, new Set(["C"])],
-        [progressionStepsAtom, []],
-        [voicingSectionExpandedAtom, true],
-      ]);
-      const sw = screen.getByRole("switch", { name: /scope to position/i }) as HTMLInputElement;
-      expect(sw).not.toBeDisabled();
+      if (disabled) expect(sw).toBeDisabled();
+      else expect(sw).not.toBeDisabled();
     });
   });
 

--- a/src/components/ChordPracticeBar/ChordPracticeBar.test.tsx
+++ b/src/components/ChordPracticeBar/ChordPracticeBar.test.tsx
@@ -397,126 +397,41 @@ describe("ChordPracticeBar/ChordPracticeBar", () => {
   });
 
   describe("accessibility", () => {
-    it("has no a11y violations (targets lens)", async () => {
+    it.each([
+      { lens: "targets", title: "D Minor 7", lensLabel: "Chord Tones", chord: dmin7ChordGroup, landOn: dmin7LandOnGroup },
+      { lens: "guide-tones", title: "G7", lensLabel: "Guide Tones", chord: dmin7ChordGroup, landOn: g7GuideToneLandOn },
+      { lens: "tension", title: "C# Minor Triad", lensLabel: "Tension", chord: cSharpMinorChordGroup, landOn: cSharpMinorTensionLandOn },
+    ])("has no a11y violations ($lens lens)", async ({ title, lensLabel, chord, landOn }) => {
       const { container } = render(
-        <ChordPracticeBar
-          title="D Minor 7"
-          lensLabel="Chord Tones"
-          chordGroup={dmin7ChordGroup}
-          landOnGroup={dmin7LandOnGroup}
-        />,
-      );
-      expect(await axe(container)).toHaveNoViolations();
-    });
-
-    it("has no a11y violations (guide-tones lens)", async () => {
-      const { container } = render(
-        <ChordPracticeBar
-          title="G7"
-          lensLabel="Guide Tones"
-          chordGroup={dmin7ChordGroup}
-          landOnGroup={g7GuideToneLandOn}
-        />,
-      );
-      expect(await axe(container)).toHaveNoViolations();
-    });
-
-    it("has no a11y violations (tension lens)", async () => {
-      const { container } = render(
-        <ChordPracticeBar
-          title="C# Minor Triad"
-          lensLabel="Tension"
-          chordGroup={cSharpMinorChordGroup}
-          landOnGroup={cSharpMinorTensionLandOn}
-        />,
+        <ChordPracticeBar title={title} lensLabel={lensLabel} chordGroup={chord} landOnGroup={landOn} />,
       );
       expect(await axe(container)).toHaveNoViolations();
     });
   });
 
   describe("visibility toggle (eye button + pill clicks)", () => {
-    it("renders an eye button with stable aria-label when visible", () => {
-      renderWithAtoms(
+    function renderWithHidden(hidden: boolean) {
+      return renderWithAtoms(
         <ChordPracticeBar
           title="D Minor 7"
           chordGroup={dmin7ChordGroup}
           landOnGroup={dmin7LandOnGroup}
         />,
-        [[chordOverlayHiddenAtom, false]],
+        [[chordOverlayHiddenAtom, hidden]],
       );
-      expect(
-        screen.getByRole("button", { name: "Toggle visibility of chord overlay" }),
-      ).toBeTruthy();
-    });
+    }
 
-    it("renders the same stable aria-label when hidden", () => {
-      renderWithAtoms(
-        <ChordPracticeBar
-          title="D Minor 7"
-          chordGroup={dmin7ChordGroup}
-          landOnGroup={dmin7LandOnGroup}
-        />,
-        [[chordOverlayHiddenAtom, true]],
-      );
-      expect(
-        screen.getByRole("button", { name: "Toggle visibility of chord overlay" }),
-      ).toBeTruthy();
-    });
-
-    it("eye button has aria-pressed=false when overlay is visible", () => {
-      const { container } = renderWithAtoms(
-        <ChordPracticeBar
-          title="D Minor 7"
-          chordGroup={dmin7ChordGroup}
-          landOnGroup={dmin7LandOnGroup}
-        />,
-        [[chordOverlayHiddenAtom, false]],
-      );
+    it.each<{ hidden: boolean; pressed: "true" | "false"; iconShown: string; iconHidden: string }>([
+      { hidden: false, pressed: "false", iconShown: ".lucide-eye", iconHidden: ".lucide-eye-off" },
+      { hidden: true, pressed: "true", iconShown: ".lucide-eye-off", iconHidden: ".lucide-eye" },
+    ])("eye button aria-pressed=$pressed and matching icon when hidden=$hidden", ({ hidden, pressed, iconShown, iconHidden }) => {
+      const { container } = renderWithHidden(hidden);
+      // Stable aria-label across visible/hidden
+      expect(screen.getByRole("button", { name: "Toggle visibility of chord overlay" })).toBeTruthy();
       const eyeBtn = container.querySelector(".practice-bar-eye-toggle");
-      expect(eyeBtn?.getAttribute("aria-pressed")).toBe("false");
-    });
-
-    it("eye button has aria-pressed=true when overlay is hidden", () => {
-      const { container } = renderWithAtoms(
-        <ChordPracticeBar
-          title="D Minor 7"
-          chordGroup={dmin7ChordGroup}
-          landOnGroup={dmin7LandOnGroup}
-        />,
-        [[chordOverlayHiddenAtom, true]],
-      );
-      const eyeBtn = container.querySelector(".practice-bar-eye-toggle");
-      expect(eyeBtn?.getAttribute("aria-pressed")).toBe("true");
-    });
-
-    it("renders eye-open icon when overlay is visible", () => {
-      const { container } = renderWithAtoms(
-        <ChordPracticeBar
-          title="D Minor 7"
-          chordGroup={dmin7ChordGroup}
-          landOnGroup={dmin7LandOnGroup}
-        />,
-        [[chordOverlayHiddenAtom, false]],
-      );
-      const eyeBtn = container.querySelector(".practice-bar-eye-toggle");
-      expect(eyeBtn?.getAttribute("aria-pressed")).toBe("false");
-      expect(eyeBtn?.querySelector('.lucide-eye')).toBeTruthy();
-      expect(eyeBtn?.querySelector('.lucide-eye-off')).toBeNull();
-    });
-
-    it("renders eye-closed icon when overlay is hidden", () => {
-      const { container } = renderWithAtoms(
-        <ChordPracticeBar
-          title="D Minor 7"
-          chordGroup={dmin7ChordGroup}
-          landOnGroup={dmin7LandOnGroup}
-        />,
-        [[chordOverlayHiddenAtom, true]],
-      );
-      const eyeBtn = container.querySelector(".practice-bar-eye-toggle");
-      expect(eyeBtn?.getAttribute("aria-pressed")).toBe("true");
-      expect(eyeBtn?.querySelector('.lucide-eye-off')).toBeTruthy();
-      expect(eyeBtn?.querySelector('.lucide-eye')).toBeNull();
+      expect(eyeBtn?.getAttribute("aria-pressed")).toBe(pressed);
+      expect(eyeBtn?.querySelector(iconShown)).toBeTruthy();
+      expect(eyeBtn?.querySelector(iconHidden)).toBeNull();
     });
 
     it("sets data-collapsed='true' on the section when hidden", () => {
@@ -557,78 +472,35 @@ describe("ChordPracticeBar/ChordPracticeBar", () => {
       expect(container.querySelector(".chord-practice-bar-groups")).toBeNull();
     });
 
-    it("clicking the eye button toggles chordOverlayHiddenAtom from false to true", () => {
+    it.each<{ initial: boolean; expected: boolean }>([
+      { initial: false, expected: true },
+      { initial: true, expected: false },
+    ])("clicking the eye button toggles chordOverlayHiddenAtom $initial → $expected", ({ initial, expected }) => {
       const store = makeAtomStore([
-        [chordOverlayHiddenAtom, false],
+        [chordOverlayHiddenAtom, initial],
         [chordOverlayModeAtom, "manual"],
         [chordRootOverrideAtom, "D"],
         [chordQualityOverrideAtom, "Minor 7th"],
       ]);
       renderWithStore(
-        <ChordPracticeBar
-          title="D Minor 7"
-          chordGroup={dmin7ChordGroup}
-          landOnGroup={dmin7LandOnGroup}
-        />,
+        <ChordPracticeBar title="D Minor 7" chordGroup={dmin7ChordGroup} landOnGroup={dmin7LandOnGroup} />,
         store,
       );
       fireEvent.click(screen.getByRole("button", { name: "Toggle visibility of chord overlay" }));
-      expect(store.get(chordOverlayHiddenAtom)).toBe(true);
+      expect(store.get(chordOverlayHiddenAtom)).toBe(expected);
     });
 
-    it("clicking the eye button toggles chordOverlayHiddenAtom from true to false", () => {
-      const store = makeAtomStore([[chordOverlayHiddenAtom, true]]);
-      renderWithStore(
-        <ChordPracticeBar
-          title="D Minor 7"
-          chordGroup={dmin7ChordGroup}
-          landOnGroup={dmin7LandOnGroup}
-        />,
-        store,
-      );
-      fireEvent.click(screen.getByRole("button", { name: "Toggle visibility of chord overlay" }));
-      expect(store.get(chordOverlayHiddenAtom)).toBe(false);
-    });
-
-    it("clicking a pill toggles only that note in chordHiddenNotesAtom", () => {
+    it("clicking a pill toggles only that note in chordHiddenNotesAtom (round-trip)", () => {
       const store = makeAtomStore([[chordOverlayHiddenAtom, false]]);
       const { container } = renderWithStore(
-        <ChordPracticeBar
-          title="D Minor 7"
-          chordGroup={dmin7ChordGroup}
-          landOnGroup={dmin7LandOnGroup}
-        />,
+        <ChordPracticeBar title="D Minor 7" chordGroup={dmin7ChordGroup} landOnGroup={dmin7LandOnGroup} />,
         store,
       );
-      // Click the D pill (chord-root pill in the chord/land-on group)
-      const dPill = container.querySelector<HTMLButtonElement>(
-        '.practice-bar-pill[data-chord-root="true"]',
-      );
+      const dPill = container.querySelector<HTMLButtonElement>('.practice-bar-pill[data-chord-root="true"]');
       expect(dPill).toBeTruthy();
       fireEvent.click(dPill!);
       expect(store.get(chordHiddenNotesAtom).has("D")).toBe(true);
-      // Eye state untouched
-      expect(store.get(chordOverlayHiddenAtom)).toBe(false);
-    });
-
-    it("clicking a pill again restores that note (toggle off)", () => {
-      const store = makeAtomStore([[chordOverlayHiddenAtom, false]]);
-      const { container } = renderWithStore(
-        <ChordPracticeBar
-          title="D Minor 7"
-          chordGroup={dmin7ChordGroup}
-          landOnGroup={dmin7LandOnGroup}
-        />,
-        store,
-      );
-      const dPill = container.querySelector<HTMLButtonElement>(
-        '.practice-bar-pill[data-chord-root="true"]',
-      );
-      expect(dPill).toBeTruthy();
-      // First click → hide
-      fireEvent.click(dPill!);
-      expect(store.get(chordHiddenNotesAtom).has("D")).toBe(true);
-      // Aria-label is stable, so click again to toggle off
+      expect(store.get(chordOverlayHiddenAtom)).toBe(false); // eye state untouched
       fireEvent.click(dPill!);
       expect(store.get(chordHiddenNotesAtom).has("D")).toBe(false);
     });

--- a/src/components/FretboardSVG/FretboardSVG.test.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.test.tsx
@@ -445,103 +445,52 @@ describe("FretboardSVG/FretboardSVG", () => {
   });
 
   describe("role-based shapes", () => {
-    it("chord-root notes have data-note-shape=squircle", () => {
-      const { container } = render(
-        <FretboardSVG
-          {...BASE_PROPS}
-          chordTones={["C", "E", "G"]}
-          chordRoot="C"
-          rootNote="C"
-          highlightNotes={["C", "E", "G"]}
-        />
-      );
-      const chordRootNotes = container.querySelectorAll('.chord-root[data-note-shape="squircle"]');
-      expect(chordRootNotes.length).toBeGreaterThan(0);
-    });
+    const SCALE_CEG = { rootNote: "C", highlightNotes: ["C", "E", "G"] };
+    const DORIAN = {
+      rootNote: "D",
+      highlightNotes: ["D", "E", "F", "G", "A", "B", "C"],
+      colorNotes: ["B"],
+    };
 
-    it("chord-tone-in-scale notes have data-note-shape=squircle", () => {
-      const { container } = render(
-        <FretboardSVG
-          {...BASE_PROPS}
-          chordTones={["C", "E", "G"]}
-          chordRoot="C"
-          rootNote="C"
-          highlightNotes={["C", "E", "G"]}
-        />
-      );
-      const inScaleTones = container.querySelectorAll('.chord-tone-in-scale[data-note-shape="squircle"]');
-      expect(inScaleTones.length).toBeGreaterThan(0);
-    });
-
-    it("chord-tone-outside-scale notes have data-note-shape=diamond", () => {
-      const { container } = render(
-        <FretboardSVG
-          {...BASE_PROPS}
-          chordTones={["C", "E", "G", "A#"]}
-          chordRoot="C"
-          rootNote="C"
-          highlightNotes={["C", "E", "G"]}
-        />
-      );
-      const outsideTones = container.querySelectorAll('.chord-tone-outside-scale[data-note-shape="diamond"]');
-      expect(outsideTones.length).toBeGreaterThan(0);
-    });
-
-    it("scale-only notes have data-note-shape=circle", () => {
-      const { container } = render(
-        <FretboardSVG
-          {...BASE_PROPS}
-          chordTones={["C"]}
-          chordRoot="C"
-          rootNote="C"
-          highlightNotes={["C", "E", "G"]}
-        />
-      );
-      const scaleOnly = container.querySelectorAll('.scale-only[data-note-shape="circle"]');
-      expect(scaleOnly.length).toBeGreaterThan(0);
-    });
-
-    it("note-active notes (no chord overlay) have data-note-shape=circle", () => {
-      const { container } = render(
-        <FretboardSVG
-          {...BASE_PROPS}
-          rootNote="C"
-          highlightNotes={["C", "E", "G"]}
-        />
-      );
-      const activeNotes = container.querySelectorAll('.note-active[data-note-shape="circle"]');
-      expect(activeNotes.length).toBeGreaterThan(0);
-    });
-
-    it("color-tone notes have data-note-shape=hexagon when chord overlay active", () => {
-      // D Dorian scale: D E F G A B C. colorNote=B. chordTones=D F A (Dm triad).
-      // B is in scale, is a color note, NOT a chord tone → color-tone (hexagon, scale-owned)
-      const { container } = render(
-        <FretboardSVG
-          {...BASE_PROPS}
-          rootNote="D"
-          highlightNotes={["D", "E", "F", "G", "A", "B", "C"]}
-          colorNotes={["B"]}
-          chordTones={["D", "F", "A"]}
-          chordRoot="D"
-        />
-      );
-      const colorToneHexagons = container.querySelectorAll('.color-tone[data-note-shape="hexagon"]');
-      expect(colorToneHexagons.length).toBeGreaterThan(0);
-    });
-
-    it("note-blue notes (scale color notes, no chord overlay) have data-note-shape=hexagon", () => {
-      const { container } = render(
-        <FretboardSVG
-          {...BASE_PROPS}
-          rootNote="D"
-          highlightNotes={["D", "E", "F", "G", "A", "B", "C"]}
-          colorNotes={["B"]}
-        />
-      );
-      // No chord overlay: color notes → note-blue with hexagon shape
-      const colorNoteHexagons = container.querySelectorAll('.note-blue[data-note-shape="hexagon"]');
-      expect(colorNoteHexagons.length).toBeGreaterThan(0);
+    it.each<{ role: string; shape: string; props: Record<string, unknown> }>([
+      {
+        role: "chord-root",
+        shape: "squircle",
+        props: { ...SCALE_CEG, chordTones: ["C", "E", "G"], chordRoot: "C" },
+      },
+      {
+        role: "chord-tone-in-scale",
+        shape: "squircle",
+        props: { ...SCALE_CEG, chordTones: ["C", "E", "G"], chordRoot: "C" },
+      },
+      {
+        role: "chord-tone-outside-scale",
+        shape: "diamond",
+        props: { ...SCALE_CEG, chordTones: ["C", "E", "G", "A#"], chordRoot: "C" },
+      },
+      {
+        role: "scale-only",
+        shape: "circle",
+        props: { ...SCALE_CEG, chordTones: ["C"], chordRoot: "C" },
+      },
+      {
+        role: "note-active",
+        shape: "circle",
+        props: { ...SCALE_CEG },
+      },
+      {
+        role: "color-tone",
+        shape: "hexagon",
+        props: { ...DORIAN, chordTones: ["D", "F", "A"], chordRoot: "D" },
+      },
+      {
+        role: "note-blue",
+        shape: "hexagon",
+        props: { ...DORIAN },
+      },
+    ])("$role notes have data-note-shape=$shape", ({ role, shape, props }) => {
+      const { container } = render(<FretboardSVG {...BASE_PROPS} {...props} />);
+      expect(container.querySelectorAll(`.${role}[data-note-shape="${shape}"]`).length).toBeGreaterThan(0);
     });
 
     it("chord role wins over color-tone when a note is both", () => {

--- a/src/components/FretboardSVG/hooks/useChordConnectorPolylines.test.ts
+++ b/src/components/FretboardSVG/hooks/useChordConnectorPolylines.test.ts
@@ -52,6 +52,25 @@ function makeNote(
   };
 }
 
+type NoteSpec = [si: number, fi: number, name: string, role?: string];
+const notes = (specs: NoteSpec[]): NoteData[] =>
+  specs.map(([si, fi, name, role]) => makeNote(si, fi, name, role ?? "chord-tone-in-scale"));
+
+function build(
+  noteData: NoteData[],
+  chordToneNames: string[],
+  rootNote: string = "C",
+) {
+  return buildChordConnectorPolylines(
+    noteData,
+    chordToneNames,
+    fretCenterX,
+    stringYAt,
+    STRING_ROW_PX,
+    rootNote,
+  );
+}
+
 describe("buildChordConnectorPolylines", () => {
   // -------------------------------------------------------------------------
   // Edge cases — empty / insufficient data
@@ -62,507 +81,255 @@ describe("buildChordConnectorPolylines", () => {
     expect(result).toEqual([]);
   });
 
-  describe("useChordConnectorPolylines", () => {
-    it("builds exactly one connector from an explicit 6-string E-shape voicing with repeated roots", () => {
-      const explicitVoicings: Array<{
-        shape: CagedShape;
-        voicingKey: string;
-        notes: Array<{ stringIndex: number; fretIndex: number; noteName: string }>;
-      }> = [
-        {
-          shape: "E",
-          voicingKey: "e-shape-c-major",
-          notes: [
-            { stringIndex: 0, fretIndex: 8, noteName: "C" },
-            { stringIndex: 1, fretIndex: 8, noteName: "G" },
-            { stringIndex: 2, fretIndex: 9, noteName: "E" },
-            { stringIndex: 3, fretIndex: 10, noteName: "C" },
-            { stringIndex: 4, fretIndex: 10, noteName: "G" },
-            { stringIndex: 5, fretIndex: 8, noteName: "C" },
-          ],
-        },
-      ];
-
-      const { result } = renderHook(() =>
+  describe("useChordConnectorPolylines explicit voicings", () => {
+    type ExplicitNote = { stringIndex: number; fretIndex: number; noteName: string };
+    const renderExplicit = (notes: ExplicitNote[], voicingKey = "e-shape-c-major") =>
+      renderHook(() =>
         useChordConnectorPolylines({
           noteData: [],
           chordToneNames: ["C", "E", "G"],
-          fretCenterX,
-          stringYAt,
-          stringRowPx: STRING_ROW_PX,
-          chordRoot: "C",
-          explicitVoicings,
+          fretCenterX, stringYAt, stringRowPx: STRING_ROW_PX, chordRoot: "C",
+          explicitVoicings: [{ shape: "E" as CagedShape, voicingKey, notes }],
         }),
-      );
+      ).result;
 
-      expect(result.current).toHaveLength(1);
-      expect(result.current[0]?.voicingKey).toBe("e-shape-c-major");
-      expect(result.current[0]?.shape).toBe("E");
-      expect(result.current[0]?.vertices).toHaveLength(6);
+    const inOrder: ExplicitNote[] = [
+      { stringIndex: 0, fretIndex: 8, noteName: "C" },
+      { stringIndex: 1, fretIndex: 8, noteName: "G" },
+      { stringIndex: 2, fretIndex: 9, noteName: "E" },
+      { stringIndex: 3, fretIndex: 10, noteName: "C" },
+      { stringIndex: 4, fretIndex: 10, noteName: "G" },
+      { stringIndex: 5, fretIndex: 8, noteName: "C" },
+    ];
+    const shuffled = [inOrder[5]!, inOrder[3]!, inOrder[1]!, inOrder[4]!, inOrder[0]!, inOrder[2]!];
+
+    it("builds exactly one connector from an explicit 6-string E-shape voicing", () => {
+      const r = renderExplicit(inOrder);
+      expect(r.current).toHaveLength(1);
+      expect(r.current[0]?.voicingKey).toBe("e-shape-c-major");
+      expect(r.current[0]?.shape).toBe("E");
+      expect(r.current[0]?.vertices).toHaveLength(6);
     });
 
     it("orders explicit voicing geometry by string index even when notes are passed out of order", () => {
-      const explicitVoicings: Array<{
-        shape: CagedShape;
-        voicingKey: string;
-        notes: Array<{ stringIndex: number; fretIndex: number; noteName: string }>;
-      }> = [
-        {
-          shape: "E",
-          voicingKey: "e-shape-c-major-shuffled",
-          notes: [
-            { stringIndex: 5, fretIndex: 8, noteName: "C" },
-            { stringIndex: 3, fretIndex: 10, noteName: "C" },
-            { stringIndex: 1, fretIndex: 8, noteName: "G" },
-            { stringIndex: 4, fretIndex: 10, noteName: "G" },
-            { stringIndex: 0, fretIndex: 8, noteName: "C" },
-            { stringIndex: 2, fretIndex: 9, noteName: "E" },
-          ],
-        },
-      ];
-
-      const { result } = renderHook(() =>
-        useChordConnectorPolylines({
-          noteData: [],
-          chordToneNames: ["C", "E", "G"],
-          fretCenterX,
-          stringYAt,
-          stringRowPx: STRING_ROW_PX,
-          chordRoot: "C",
-          explicitVoicings,
-        }),
-      );
-
-      expect(result.current[0]?.vertices.map((vertex) => vertex.y)).toEqual([
-        0, 20, 40, 60, 80, 100,
-      ]);
+      const r = renderExplicit(shuffled, "e-shape-c-major-shuffled");
+      expect(r.current[0]?.vertices.map((v) => v.y)).toEqual([0, 20, 40, 60, 80, 100]);
     });
   });
 
-  it("returns [] when chordToneNames has fewer than 2 entries", () => {
-    const noteData = [makeNote(0, 5, "C"), makeNote(1, 5, "E")];
-    const result = buildChordConnectorPolylines(noteData, ["C"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toEqual([]);
+  it.each<{ label: string; specs: NoteSpec[]; chord: string[] }>([
+    {
+      label: "chordToneNames has fewer than 2 entries",
+      specs: [[0, 5, "C"], [1, 5, "E"]],
+      chord: ["C"],
+    },
+    {
+      label: "all noteData entries have non-chord-tone noteClass",
+      specs: [[0, 3, "C", "note-active"], [1, 5, "E", "note-active"]],
+      chord: ["C", "E", "G"],
+    },
+    {
+      label: "all chord-tone entries are note-inactive (shape-filtered)",
+      specs: [[0, 3, "C", "note-inactive"], [1, 5, "E", "note-inactive"], [2, 3, "G", "note-inactive"]],
+      chord: ["C", "E", "G"],
+    },
+  ])("returns [] when $label", ({ specs, chord }) => {
+    expect(build(notes(specs), chord)).toEqual([]);
   });
 
-  it("returns [] when all noteData entries have non-chord-tone noteClass", () => {
-    const noteData = [
-      makeNote(0, 3, "C", "note-active"),
-      makeNote(1, 5, "E", "note-active"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toEqual([]);
-  });
-
-  it("returns [] when chord-tone entries are all note-inactive (shape-filtered)", () => {
-    const noteData = [
-      makeNote(0, 3, "C", "note-inactive"),
-      makeNote(1, 5, "E", "note-inactive"),
-      makeNote(2, 3, "G", "note-inactive"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toEqual([]);
-  });
-
-  it("documents shape-scoped CAGED behavior: different active chord-tone sets can produce different voicings", () => {
-    const eShapeLikeNotes = [
-      makeNote(0, 3, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-    ];
-    const gShapeLikeNotes = [
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "C", "chord-root"),
-      makeNote(3, 5, "G", "chord-tone-in-scale"),
-    ];
-
-    const eShape = buildChordConnectorPolylines(
-      eShapeLikeNotes,
+  it("shape-scoped CAGED behavior: different active chord-tone sets produce different voicings", () => {
+    const eShape = build(
+      notes([[0, 3, "C", "chord-root"], [1, 5, "E"], [2, 5, "G"]]),
       ["C", "E", "G"],
-      fretCenterX,
-      stringYAt,
-      STRING_ROW_PX,
-      "C",
     );
-    const gShape = buildChordConnectorPolylines(
-      gShapeLikeNotes,
+    const gShape = build(
+      notes([[1, 5, "E"], [2, 5, "C", "chord-root"], [3, 5, "G"]]),
       ["C", "E", "G"],
-      fretCenterX,
-      stringYAt,
-      STRING_ROW_PX,
-      "C",
     );
-
-    expect(eShape.map((voicing) => voicing.voicingKey)).not.toEqual(
-      gShape.map((voicing) => voicing.voicingKey),
-    );
+    expect(eShape.map((v) => v.voicingKey)).not.toEqual(gShape.map((v) => v.voicingKey));
   });
 
-  // -------------------------------------------------------------------------
-  // (a) Triad on a 3-string window emits 1 voicing connecting 3 strings
-  // -------------------------------------------------------------------------
-
-  it("(a) triad on 3 strings: emits 1 voicing with 3 vertices covering all 3 chord tones", () => {
-    // C major triad: C on string 0, E on string 1, G on string 2, all at fret 5.
-    const noteData = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
+  it("(a) triad on 3 strings: emits 1 voicing with 3 vertices spanning strings 0-2", () => {
+    const result = build(
+      notes([[0, 5, "C", "chord-root"], [1, 5, "E"], [2, 5, "G"]]),
+      ["C", "E", "G"],
+    );
     expect(result).toHaveLength(1);
     expect(result[0]!.vertices).toHaveLength(3);
-    // Vertices are polar-sorted; all should have y values from strings 0, 1, 2: 0, 20, 40.
     const yValues = result[0]!.vertices.map((v) => v.y).sort((a, b) => a - b);
     expect(yValues).toEqual([0, 20, 40]);
   });
 
-  // -------------------------------------------------------------------------
-  // (b) Triad with multiple candidates emits expected voicings
-  // -------------------------------------------------------------------------
-
-  it("(b) 4 candidate positions across 3 strings: emits voicings covering all 3 chord tones", () => {
-    // String 0: C at fret 3
-    // String 1: E at fret 3, also E at fret 5 (two candidates for E)
-    // String 2: G at fret 3
-    // The valid voicing picks one per string such that {C, E, G} are all covered.
-    const noteData = [
-      makeNote(0, 3, "C", "chord-root"),
-      makeNote(1, 3, "E", "chord-tone-in-scale"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 3, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    // At least one voicing should be emitted covering all three chord tones.
+  it("(b) multiple candidate positions emit voicings covering all chord tones", () => {
+    // String 1 has both E@3 and E@5 → algorithm picks one to form a valid (C,E,G) triad.
+    const result = build(
+      notes([[0, 3, "C", "chord-root"], [1, 3, "E"], [1, 5, "E"], [2, 3, "G"]]),
+      ["C", "E", "G"],
+    );
     expect(result.length).toBeGreaterThanOrEqual(1);
-    // Every emitted voicing should be 3 vertices long (one per string).
-    result.forEach((voicing) => expect(voicing.vertices).toHaveLength(3));
-    // All emitted voicings contain each chord tone.
-    // Check that each voicing spans 3 strings.
+    result.forEach((v) => expect(v.vertices).toHaveLength(3));
     const yValues = result[0]!.vertices.map((v) => v.y);
-    expect(yValues).toContain(stringYAt(0, fretCenterX(3)));  // string 0
-    expect(yValues).toContain(stringYAt(2, fretCenterX(3)));  // string 2
+    expect(yValues).toContain(stringYAt(0, fretCenterX(3)));
+    expect(yValues).toContain(stringYAt(2, fretCenterX(3)));
   });
 
-  // -------------------------------------------------------------------------
-  // (c) Shape filter: note-inactive excluded
-  // -------------------------------------------------------------------------
-
-  it("(c) shape filter: note-inactive chord tones are excluded from voicings", () => {
-    // String 0: C — active
-    // String 1: E — active
-    // String 2: G — INACTIVE (outside current CAGED shape)
-    // String 3: B — active (but now we need G for the triad, so no valid voicing on strings 0-2)
-    const noteData = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "note-inactive"),        // excluded by shape filter
-      makeNote(3, 5, "B", "chord-tone-in-scale"),
-    ];
-    // Triad C-E-G: G is inactive → no complete voicing possible on strings 0-2.
-    // Even if we extend to strings 1-3 (E, G-inactive, B), still missing G.
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
+  it("(c) shape filter: note-inactive chord tones blocked from voicings", () => {
+    // String 2 G is inactive → triad C-E-G has no candidate for the third tone
+    // on any consecutive 3-string window.
+    const result = build(
+      notes([[0, 5, "C", "chord-root"], [1, 5, "E"], [2, 5, "G", "note-inactive"], [3, 5, "B"]]),
+      ["C", "E", "G"],
+    );
     expect(result).toHaveLength(0);
   });
 
-  it("(c) shape filter: active shape gives valid voicings, inactive positions skipped", () => {
-    // Three strings with one valid chord-tone position each, one extra inactive position.
-    const noteData = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-      makeNote(2, 7, "A", "note-inactive"),  // inactive — should not appear
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
+  it("(c) inactive positions on the same string skipped; active ones still form a voicing", () => {
+    const result = build(
+      notes([[0, 5, "C", "chord-root"], [1, 5, "E"], [2, 5, "G"], [2, 7, "A", "note-inactive"]]),
+      ["C", "E", "G"],
+    );
     expect(result).toHaveLength(1);
-    // Verify x=70 (fret 7) is NOT in the voicing (only fret-5 is active).
     expect(result[0]!.vertices.some((v) => v.x === fretCenterX(7))).toBe(false);
   });
 
   // -------------------------------------------------------------------------
-  // (d) MAX_PLAYABLE_FRET_POSITIONS boundary (fret-positions-inclusive filter)
+  // (d) Playability filter — voicings span at most MAX_PLAYABLE_FRET_POSITIONS
+  // fretted positions; open strings are excluded from the span calculation.
   // -------------------------------------------------------------------------
 
-  it(`(d) voicing with exactly MAX_PLAYABLE_FRET_POSITIONS (${MAX_PLAYABLE_FRET_POSITIONS}) fret positions inclusive is emitted`, () => {
-    // C at fret 2, E at fret 3, G at fret 4.
-    // Fretted positions {2,3,4} → count = 3 = MAX_PLAYABLE_FRET_POSITIONS → kept.
-    const noteData = [
-      makeNote(0, 2, "C", "chord-root"),
-      makeNote(1, 3, "E", "chord-tone-in-scale"),
-      makeNote(2, 4, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(1);
+  it.each<{ label: string; specs: NoteSpec[]; chord: string[]; expected: 0 | 1 }>([
+    {
+      label: `exactly MAX_PLAYABLE_FRET_POSITIONS (${MAX_PLAYABLE_FRET_POSITIONS}) positions → kept`,
+      specs: [[0, 2, "C", "chord-root"], [1, 3, "E"], [2, 4, "G"]],
+      chord: ["C", "E", "G"],
+      expected: 1,
+    },
+    {
+      label: `MAX_PLAYABLE_FRET_POSITIONS + 1 positions → dropped`,
+      specs: [[0, 2, "C", "chord-root"], [1, 3, "E"], [2, 5, "G"]],
+      chord: ["C", "E", "G"],
+      expected: 0,
+    },
+    {
+      label: "UAT-ISSUE-1: Cm7 frets [5,6,8,8] (4 positions) → dropped",
+      specs: [[0, 8, "G"], [1, 5, "C", "chord-root"], [2, 8, "A#"], [3, 6, "D#"]],
+      chord: ["C", "D#", "G", "A#"],
+      expected: 0,
+    },
+    {
+      label: "UAT-ISSUE-2: Cm7 frets [4,5,5,6] (3 positions) → kept",
+      specs: [[0, 6, "A#"], [1, 4, "D#"], [2, 5, "C", "chord-root"], [3, 5, "G"]],
+      chord: ["C", "D#", "G", "A#"],
+      expected: 1,
+    },
+    {
+      label: "all-open strings (no fretted notes) → kept",
+      specs: [[0, 0, "C", "chord-root"], [1, 0, "E"]],
+      chord: ["C", "E"],
+      expected: 1,
+    },
+    {
+      label: "one fretted note (span 0) → kept",
+      specs: [[0, 0, "C", "chord-root"], [1, 3, "E"]],
+      chord: ["C", "E"],
+      expected: 1,
+    },
+    {
+      label: "open string + frets [2,3] (2 fretted positions) → kept",
+      specs: [[0, 0, "C", "chord-root"], [1, 2, "E"], [2, 3, "G"]],
+      chord: ["C", "E", "G"],
+      expected: 1,
+    },
+    {
+      label: "frets [1,5,5] (5 inclusive positions) → dropped",
+      specs: [[0, 1, "C", "chord-root"], [1, 5, "E"], [2, 5, "G"]],
+      chord: ["C", "E", "G"],
+      expected: 0,
+    },
+  ])("(d) playability: $label", ({ specs, chord, expected }) => {
+    expect(build(notes(specs), chord)).toHaveLength(expected);
   });
 
-  it(`(d) voicing with MAX_PLAYABLE_FRET_POSITIONS + 1 (${MAX_PLAYABLE_FRET_POSITIONS + 1}) fret positions inclusive is NOT emitted`, () => {
-    // Fretted notes at frets {2,3,4,5}: position count = 4 > MAX_PLAYABLE_FRET_POSITIONS → dropped.
-    // Note: all notes must still be within MAX_FRET_SPAN of the anchor so the
-    // candidate-gathering window can find them; the voicing is dropped only by
-    // the playability filter, not the cluster window.
-    const noteData = [
-      makeNote(0, 2, "C", "chord-root"),
-      makeNote(1, 3, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(0);
-  });
-
-  it("(d) UAT-ISSUE-1: Cm7 voicing frets [5,6,8,8] (4 positions inclusive) is NOT emitted", () => {
-    // Real-world UAT case: D#@str4-fret6, A#@str3-fret8, C@str2-fret5, G@str1-fret8
-    // Fretted positions {5,6,7,8} → count = 4 > MAX_PLAYABLE_FRET_POSITIONS → dropped.
-    const noteData = [
-      makeNote(0, 8, "G", "chord-tone-in-scale"),  // G (str1 in guitar numbering)
-      makeNote(1, 5, "C", "chord-root"),            // C (str2)
-      makeNote(2, 8, "A#", "chord-tone-in-scale"),  // A# (str3)
-      makeNote(3, 6, "D#", "chord-tone-in-scale"),  // D# (str4)
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "D#", "G", "A#"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(0);
-  });
-
-  it("(d) UAT-ISSUE-2: Cm7 voicing frets [4,5,5,6] (3 positions inclusive) is emitted", () => {
-    // Real-world UAT case: A#@str0-fret6, D#@str1-fret4, C@str2-fret5, G@str3-fret5
-    // Fretted positions {4,5,6} → count = 3 = MAX_PLAYABLE_FRET_POSITIONS → kept.
-    const noteData = [
-      makeNote(0, 6, "A#", "chord-tone-in-scale"),  // A# (str1 in guitar numbering)
-      makeNote(1, 4, "D#", "chord-tone-in-scale"),  // D# (str2)
-      makeNote(2, 5, "C", "chord-root"),             // C (str3)
-      makeNote(3, 5, "G", "chord-tone-in-scale"),   // G (str4)
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "D#", "G", "A#"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(1);
-  });
-
-  // -------------------------------------------------------------------------
-  // (d) Playability filter — open-string and single-fretted-note edge cases
-  // -------------------------------------------------------------------------
-
-  it("(d) voicing with all-open strings [0,0,0,0,0,0] → kept (fretted span undefined / no fretted notes)", () => {
-    // Six open strings: no fretted note → fretted span = 0 → not filtered.
-    // chordToneNames must match the open-string notes; use a 2-note chord to
-    // satisfy N>=2 without needing 6 distinct tones.
-    const noteData = [
-      makeNote(0, 0, "C", "chord-root"),
-      makeNote(1, 0, "E", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(1);
-  });
-
-  it("(d) voicing with one fretted note → kept (single fretted note, span 0)", () => {
-    // Open C on string 0 (fret 0) + E on string 1 at fret 3. Only one fretted
-    // note → frettedSpan = 0 → not filtered out. Both notes must fit within the
-    // same cluster window (anchor=0 covers frets 0..MAX_FRET_SPAN=5).
-    const noteData = [
-      makeNote(0, 0, "C", "chord-root"),
-      makeNote(1, 3, "E", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(1);
-  });
-
-  it("(d) voicing with open string + frets [2,3]: 2 fret positions inclusive → kept", () => {
-    // Open C (excluded from span) + E@fret2 + G@fret3.
-    // Fretted positions {2,3} → count = 2 ≤ MAX_PLAYABLE_FRET_POSITIONS → kept.
-    const noteData = [
-      makeNote(0, 0, "C", "chord-root"),
-      makeNote(1, 2, "E", "chord-tone-in-scale"),
-      makeNote(2, 3, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(1);
-  });
-
-  it("(d) voicing with frets [1,5,5,5]: 5 fret positions inclusive → dropped", () => {
-    // Fretted notes: {1,5} → positions {1,2,3,4,5} → count = 5 > MAX_PLAYABLE_FRET_POSITIONS → dropped.
-    const noteData = [
-      makeNote(0, 1, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(0);
+  it.each<{ label: string; specs: NoteSpec[]; chord: string[]; count: number; verts: number }>([
+    {
+      label: "(e) repeated shape across 6 strings → 4 voicings (one per N-string window)",
+      specs: [[0, 5, "C", "chord-root"], [1, 5, "E"], [2, 5, "G"],
+        [3, 5, "C", "chord-root"], [4, 5, "E"], [5, 5, "G"]],
+      chord: ["C", "E", "G"],
+      count: 4,
+      verts: 3,
+    },
+    {
+      label: "(e) two isolated regions (skipping string 3) → 2 separate voicings",
+      specs: [[0, 5, "C", "chord-root"], [1, 5, "E"], [2, 5, "G"],
+        [4, 5, "C", "chord-root"], [5, 5, "E"], [6, 5, "G"]],
+      chord: ["C", "E", "G"],
+      count: 2,
+      verts: 3,
+    },
+    {
+      label: "(f) Cmaj7 on 4-string window → 1 voicing, 4 vertices",
+      specs: [[0, 3, "C", "chord-root"], [1, 4, "E"], [2, 3, "G"], [3, 4, "B"]],
+      chord: ["C", "E", "G", "B"],
+      count: 1,
+      verts: 4,
+    },
+  ])("$label", ({ specs, chord, count, verts }) => {
+    const result = build(notes(specs), chord);
+    expect(result).toHaveLength(count);
+    result.forEach((v) => expect(v.vertices).toHaveLength(verts));
   });
 
   // -------------------------------------------------------------------------
-  // (e) Repeating shapes across multiple string windows
+  // (g) No valid voicing — insufficient strings or non-adjacent string windows
   // -------------------------------------------------------------------------
 
-  it("(e) same chord shape repeated across 6 strings emits voicings for each N-string window", () => {
-    // C major triad (N=3) across strings 0-5, all at fret 5.
-    // Each chord tone name appears on 2 strings (C on 0,3; E on 1,4; G on 2,5).
-    // Valid N=3 consecutive-string windows that cover C+E+G: [0,1,2], [1,2,3], [2,3,4], [3,4,5].
-    //   - [0,1,2]: C@0, E@1, G@2 → {C,E,G} ✓
-    //   - [1,2,3]: E@1, G@2, C@3 → {E,G,C} ✓
-    //   - [2,3,4]: G@2, C@3, E@4 → {G,C,E} ✓
-    //   - [3,4,5]: C@3, E@4, G@5 → {C,E,G} ✓
-    // Each is a distinct voicing (different string sets) → 4 total.
-    const noteData = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-      makeNote(3, 5, "C", "chord-root"),
-      makeNote(4, 5, "E", "chord-tone-in-scale"),
-      makeNote(5, 5, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    // 4 valid consecutive-string windows each covering all 3 chord tones.
-    expect(result).toHaveLength(4);
-    result.forEach((voicing) => expect(voicing.vertices).toHaveLength(3));
+  it.each<{ label: string; specs: NoteSpec[] }>([
+    {
+      label: "(g) chord tone missing from candidates (only C,E present, G needed)",
+      specs: [[0, 5, "C", "chord-root"], [1, 5, "E"]],
+    },
+    {
+      label: "(g) all 3 tones on only 2 strings → no triad (N=3 needs 3 strings)",
+      specs: [[0, 3, "C", "chord-root"], [0, 5, "G"], [1, 4, "E"]],
+    },
+    {
+      label: "non-adjacent strings (skip string 1) → no consecutive-window voicing",
+      specs: [[0, 5, "C", "chord-root"], [2, 5, "E"], [3, 5, "G"]],
+    },
+  ])("$label → empty result", ({ specs }) => {
+    expect(build(notes(specs), ["C", "E", "G"])).toHaveLength(0);
   });
-
-  it("(e) two isolated chord positions on non-overlapping string sets emit 2 voicings", () => {
-    // C major triad on strings 0-2 (region 1) and strings 4-6 (region 2).
-    // String 3 has no chord tones → the two regions are isolated.
-    // Window [0,1,2] → valid voicing. Window [4,5,6] → valid voicing.
-    const noteData = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-      // string 3: no chord tones
-      makeNote(4, 5, "C", "chord-root"),
-      makeNote(5, 5, "E", "chord-tone-in-scale"),
-      makeNote(6, 5, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    // Two isolated string windows → 2 separate voicings.
-    expect(result).toHaveLength(2);
-    result.forEach((voicing) => expect(voicing.vertices).toHaveLength(3));
-  });
-
-  // -------------------------------------------------------------------------
-  // (f) 7th chord (4 chord tones) on a 4-string window
-  // -------------------------------------------------------------------------
-
-  it("(f) 7th chord on 4-string window emits 4-vertex voicings", () => {
-    // Cmaj7: C, E, G, B across strings 0-3.
-    const noteData = [
-      makeNote(0, 3, "C", "chord-root"),
-      makeNote(1, 4, "E", "chord-tone-in-scale"),
-      makeNote(2, 3, "G", "chord-tone-in-scale"),
-      makeNote(3, 4, "B", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G", "B"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(1);
-    expect(result[0]!.vertices).toHaveLength(4);
-  });
-
-  // -------------------------------------------------------------------------
-  // (g) Missing chord tone → no valid voicing for triad
-  // -------------------------------------------------------------------------
-
-  it("(g) chord tone present on only 2 strings → no valid voicing for triad → empty", () => {
-    // C is on string 0, E is on string 1, but G is missing entirely.
-    const noteData = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(0);
-  });
-
-  it("(g) all 3 chord tones on same 2 strings → no valid voicing for triad (N=3 needs 3 strings)", () => {
-    // Both C and G appear on string 0; E is on string 1. A triad needs 3 distinct strings.
-    const noteData = [
-      makeNote(0, 3, "C", "chord-root"),
-      makeNote(0, 5, "G", "chord-tone-in-scale"),
-      makeNote(1, 4, "E", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(0);
-  });
-
-  // -------------------------------------------------------------------------
-  // Deduplication — same voicing from two anchor frets is only emitted once
-  // -------------------------------------------------------------------------
 
   it("deduplicated: same voicing reached via two anchor frets appears only once", () => {
     // C@fret3/string0, E@fret3/string1, G@fret4/string2.
-    // Anchor=3: cluster covers frets 3-8 → valid voicing (C,E,G) at (3,3,4).
-    // Anchor=4: cluster covers frets 4-9 → same combo is NOT in anchor=4 range
-    //           because C and E are at fret 3 which is < 4. So only one emission.
-    const noteData = [
-      makeNote(0, 3, "C", "chord-root"),
-      makeNote(1, 3, "E", "chord-tone-in-scale"),
-      makeNote(2, 4, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
+    // Anchor=3 includes all three; anchor=4 excludes C,E (fret 3 < 4) so no dup.
+    const result = build(
+      notes([[0, 3, "C", "chord-root"], [1, 3, "E"], [2, 4, "G"]]),
+      ["C", "E", "G"],
+    );
     expect(result).toHaveLength(1);
     expect(result[0]!.vertices).toHaveLength(3);
   });
 
-  // -------------------------------------------------------------------------
-  // Non-adjacent string window: a chord tone on non-adjacent strings does NOT
-  // form a voicing unless all N consecutive strings are covered
-  // -------------------------------------------------------------------------
-
-  it("chord tones on strings 0 and 2 only (skipping string 1) → no valid triad voicing", () => {
-    // String 1 has no chord tone, so no N=3 consecutive-string window can be completed.
-    const noteData = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(2, 5, "E", "chord-tone-in-scale"),
-      makeNote(3, 5, "G", "chord-tone-in-scale"),
-    ];
-    // Window [0,1,2]: string 1 has no candidates → invalid.
-    // Window [1,2,3]: string 1 has no candidates → invalid.
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(0);
+  it("CHORD_TONE_CLASSES contains chord-tone roles and excludes non-chord roles", () => {
+    const inSet = ["note-blue", "chord-tone-outside-scale", "chord-tone-in-scale",
+      "note-diatonic-chord", "chord-root", "key-tonic"];
+    const outSet = ["note-inactive", "note-active", "scale-only"];
+    inSet.forEach((role) => expect(CHORD_TONE_CLASSES.has(role)).toBe(true));
+    outSet.forEach((role) => expect(CHORD_TONE_CLASSES.has(role)).toBe(false));
   });
 
-  // -------------------------------------------------------------------------
-  // CHORD_TONE_CLASSES set covers the expected roles
-  // -------------------------------------------------------------------------
-
-  it("CHORD_TONE_CLASSES includes all expected chord-tone roles", () => {
-    expect(CHORD_TONE_CLASSES.has("note-blue")).toBe(true);
-    expect(CHORD_TONE_CLASSES.has("chord-tone-outside-scale")).toBe(true);
-    expect(CHORD_TONE_CLASSES.has("chord-tone-in-scale")).toBe(true);
-    expect(CHORD_TONE_CLASSES.has("note-diatonic-chord")).toBe(true);
-    expect(CHORD_TONE_CLASSES.has("chord-root")).toBe(true);
-    expect(CHORD_TONE_CLASSES.has("key-tonic")).toBe(true);
-    // Non-chord roles must NOT be included.
-    expect(CHORD_TONE_CLASSES.has("note-inactive")).toBe(false);
-    expect(CHORD_TONE_CLASSES.has("note-active")).toBe(false);
-    expect(CHORD_TONE_CLASSES.has("scale-only")).toBe(false);
-  });
-
-  it("non-chord-tone roles mixed with chord-tones are ignored", () => {
-    // String 0: C (chord-root), string 1: note-active (ignored), string 2: E (chord-tone)
-    // With chordTones ["C","E","G"], we need G too — not present, so empty.
-    const noteData = [
-      makeNote(0, 2, "C", "chord-root"),
-      makeNote(1, 4, "D", "note-active"),
-      makeNote(2, 6, "E", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    // G is missing → no complete voicing.
-    expect(result).toHaveLength(0);
-  });
-
-  it("non-chord-tone roles ignored, valid 2-tone chord still works with 2 chord tones", () => {
-    // chordTones = ["C","E"] → N=2; note-active on string 1 is ignored.
-    const noteData = [
-      makeNote(0, 2, "C", "chord-root"),
-      makeNote(1, 4, "D", "note-active"),   // ignored
-      makeNote(2, 6, "E", "chord-tone-in-scale"),
-    ];
-    // N=2: window [0,1] — string 1 has no chord tone → invalid.
-    // Window [1,2] — string 1 has no chord tone → invalid.
-    // Window [0,2] — not consecutive.
-    // Actually with N=2, window is [0,1] and [1,2] and [2,3]... string 1 never has chord tone.
-    // So expect 0.
-    const result = buildChordConnectorPolylines(noteData, ["C", "E"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(0);
+  it("non-chord-tone roles on intermediate strings break consecutive-string voicings", () => {
+    // String 1 has a note-active D (ignored as a candidate). No consecutive window
+    // can include string 1 as a chord-tone vertex → no triad and no 2-tone voicing.
+    const specs: NoteSpec[] = [[0, 2, "C", "chord-root"], [1, 4, "D", "note-active"], [2, 6, "E"]];
+    expect(build(notes(specs), ["C", "E", "G"])).toHaveLength(0);
+    expect(build(notes(specs), ["C", "E"])).toHaveLength(0);
   });
 
   it("2-tone chord on consecutive strings emits 1 voicing", () => {
-    const noteData = [
-      makeNote(0, 2, "C", "chord-root"),
-      makeNote(1, 4, "E", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
+    const result = build(notes([[0, 2, "C", "chord-root"], [1, 4, "E"]]), ["C", "E"]);
     expect(result).toHaveLength(1);
     expect(result[0]!.vertices).toHaveLength(2);
   });
@@ -665,178 +432,59 @@ describe("buildChordConnectorPolylines", () => {
 
   // -------------------------------------------------------------------------
   // Contour smoke tests (fat polyline geometry)
+  // Every voicing path: starts with M, ends with Z, fill === outline.
+  // Non-collinear voicings dispatch to a rounded tube; collinear voicings
+  // dispatch to an inflated capsule. Both produce arc commands ('A').
   // -------------------------------------------------------------------------
 
-  it("triad voicing (3 different frets): paths.fill is a rounded tube visiting all 3 vertices", () => {
-    // C major triad on 3 different frets — non-collinear, so
-    // offsetOpenPolylinePath emits a rounded tube tracing the voicing
-    // order: a round arc on the outside of the bend at V_1, a mitered
-    // intersection on the inside, plus a semicircular cap at each end.
-    // fill === outline (byte-identical).
-    const noteData = [
-      makeNote(0, 3, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 4, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
+  it.each<{ label: string; specs: NoteSpec[]; chord: string[]; root: string; arcs: number }>([
+    {
+      label: "non-collinear triad (3 vertices) → tube with 1 corner + 2 caps",
+      specs: [[0, 3, "C", "chord-root"], [1, 5, "E"], [2, 4, "G"]],
+      chord: ["C", "E", "G"], root: "C", arcs: 3,
+    },
+    {
+      label: "non-collinear Cmaj7 (4 vertices) → tube with 2 corners + 2 caps",
+      specs: [[0, 3, "C", "chord-root"], [1, 4, "E"], [2, 4, "G"], [3, 5, "B"]],
+      chord: ["C", "E", "G", "B"], root: "C", arcs: 4,
+    },
+    {
+      label: "collinear same-fret triad → capsule (arcs present)",
+      specs: [[0, 5, "C", "chord-root"], [1, 5, "E"], [2, 5, "G"]],
+      chord: ["C", "E", "G"], root: "C", arcs: -1, // capsule path; just assert presence
+    },
+    {
+      label: "(regression) collinear diagonal G-E-C → capsule (arcs present)",
+      specs: [[4, 5, "G"], [5, 6, "E"], [6, 7, "C", "chord-root"]],
+      chord: ["C", "E", "G"], root: "C", arcs: -1,
+    },
+  ])("contour: $label", ({ specs, chord, root, arcs }) => {
+    const result = build(notes(specs), chord, root);
     expect(result).toHaveLength(1);
     const { paths } = result[0]!;
-    expect(paths.fill).not.toBe("");
     expect(paths.fill.startsWith("M")).toBe(true);
     expect(paths.fill.endsWith("Z")).toBe(true);
-    // Non-collinear triad → 1 outside corner arc + 2 end caps = 3 A commands.
-    const aCount = (paths.fill.match(/\bA\b/g) ?? []).length;
-    expect(aCount).toBe(3);
-    // fill and outline are byte-identical for every voicing.
     expect(paths.fill).toBe(paths.outline);
-  });
-
-  it("7th chord voicing (4 vertices): paths.fill is a rounded tube visiting all 4 vertices", () => {
-    // Cmaj7: C, E, G, B across 4 strings within 3 fret positions.
-    // Frets [3,4,4,5]: positions {3,4,5} → count 3 ≤ MAX_PLAYABLE_FRET_POSITIONS → kept.
-    // Non-collinear 4-vertex tube (fill === outline).
-    const noteData = [
-      makeNote(0, 3, "C", "chord-root"),
-      makeNote(1, 4, "E", "chord-tone-in-scale"),
-      makeNote(2, 4, "G", "chord-tone-in-scale"),
-      makeNote(3, 5, "B", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G", "B"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(1);
-    const { paths } = result[0]!;
-    expect(paths.fill).not.toBe("");
-    expect(paths.fill.startsWith("M")).toBe(true);
-    expect(paths.fill.endsWith("Z")).toBe(true);
-    // 4 vertices with 2 interior corners → 2 outside corner arcs + 2 end caps.
-    const aCount = (paths.fill.match(/\bA\b/g) ?? []).length;
-    expect(aCount).toBe(4);
-    // fill and outline are byte-identical.
-    expect(paths.fill).toBe(paths.outline);
-  });
-
-  it("collinear voicing (same fret, 3 adjacent strings): paths are inflated capsule with arc commands", () => {
-    // All 3 notes at the exact same fret → same x coordinate → collinear.
-    // Collinear dispatch → inflatedCapsulePath → contains arc 'A' commands.
-    // fretCenterX(5) = 50; all x values equal 50.
-    const noteData = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(1);
-    const { paths } = result[0]!;
-    expect(paths.fill).not.toBe("");
-    // Capsule path contains arc commands.
     expect(paths.fill).toContain("A");
-    expect(paths.outline).toContain("A");
-    // fill and outline are byte-identical for collinear voicings too.
-    expect(paths.fill).toBe(paths.outline);
+    if (arcs >= 0) {
+      const aCount = (paths.fill.match(/\bA\b/g) ?? []).length;
+      expect(aCount).toBe(arcs);
+    }
   });
-
-  // -------------------------------------------------------------------------
-  // Regression: near-collinear diagonal triad G-E-C
-  //
-  // G(string 4, fret 5) → E(string 5, fret 6) → C(string 6, fret 7):
-  // x=50,y=80; x=60,y=100; x=70,y=120 — exactly collinear (shoelace area = 0).
-  // Dispatch → inflatedCapsulePath → capsule with arc 'A' commands.
-  // The capsule envelops all 3 vertices without dropping any.
-  // -------------------------------------------------------------------------
-
-  it("(regression) near-collinear diagonal G-E-C: paths are capsule (all 3 vertices enveloped)", () => {
-    // Voicing: G(string 4, fret 5) → E(string 5, fret 6) → C(string 6, fret 7).
-    // Frets [5,6,7]: positions {5,6,7} → count 3 ≤ MAX_PLAYABLE_FRET_POSITIONS → kept.
-    // With fretCenterX(fi)=fi*10 and stringYAt(si)=si*20:
-    //   G: x=50, y=80   E: x=60, y=100   C: x=70, y=120 — exactly collinear.
-    // Capsule path envelops all vertices; arc 'A' commands confirm capsule dispatch.
-    const noteData = [
-      makeNote(4, 5, "G", "chord-tone-in-scale"),
-      makeNote(5, 6, "E", "chord-tone-in-scale"),
-      makeNote(6, 7, "C", "chord-root"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(1);
-    const { paths } = result[0]!;
-    expect(paths.fill).not.toBe("");
-    // Collinear diagonal → capsule dispatch → arc commands present.
-    expect(paths.fill).toContain("A");
-    expect(paths.fill).toBe(paths.outline);
-  });
-
-  // -------------------------------------------------------------------------
-  // New: non-collinear fill === outline (byte-identical)
-  // -------------------------------------------------------------------------
-
-  it("non-collinear voicing: fill and outline paths are byte-identical", () => {
-    // Use 3 notes at different frets to guarantee non-collinear polygon.
-    const noteData = [
-      makeNote(0, 3, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 4, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(
-      noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C",
-    );
-    expect(result).toHaveLength(1);
-    expect(result[0]!.paths.fill).toBe(result[0]!.paths.outline);
-    expect(result[0]!.paths.fill).toContain("Z"); // closed polygon
-  });
-
-  // -------------------------------------------------------------------------
-  // New: collinear voicing capsule arcs
-  // -------------------------------------------------------------------------
-
-  it("collinear voicing: both fill and outline are inflated capsule paths", () => {
-    // Use 3 notes at same fret to guarantee collinear input.
-    const noteData = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(
-      noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C",
-    );
-    expect(result).toHaveLength(1);
-    expect(result[0]!.paths.fill).toContain("A");    // arc command from capsule
-    expect(result[0]!.paths.outline).toContain("A");
-    expect(result[0]!.paths.fill).toBe(result[0]!.paths.outline);
-  });
-
-  // -------------------------------------------------------------------------
-  // Regression: open-string acute triad — formerly rendered as an awkward
-  // convex-hull triangle. Under the new path-offset geometry the contour is
-  // a smooth tube tracing the voicing across strings, so no acute external
-  // corner remains.
-  // -------------------------------------------------------------------------
 
   it("(regression) open-string acute triad uses tube geometry, not a triangle hull", () => {
-    // D(open) on string 3, A#(fret 1) on string 4, G(fret 3) on string 5 —
-    // a skinny, acutely-angled 3-note voicing. The tube path has two
-    // outside arc at the bend plus two semicircular end caps; the inside
-    // corner is mitered so it does not twist through the turn. A convex-hull offset would
-    // emit three corner arcs around the hull, producing a visible acute
-    // angle at A#.
-    const noteData = [
-      makeNote(3, 0, "D", "chord-root"),
-      makeNote(4, 1, "A#", "chord-tone-in-scale"),
-      makeNote(5, 3, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(
-      noteData, ["D", "A#", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "D",
+    // Skinny acute voicing: tube has 1 outside arc + 2 end caps = 3 A;
+    // a convex-hull offset would emit 3 A but only 3 L (one per hull edge),
+    // so an L-count ≥ 4 distinguishes the tube path.
+    const result = build(
+      notes([[3, 0, "D", "chord-root"], [4, 1, "A#"], [5, 3, "G"]]),
+      ["D", "A#", "G"],
+      "D",
     );
     expect(result).toHaveLength(1);
-    const { paths } = result[0]!;
-    expect(paths.fill.startsWith("M")).toBe(true);
-    expect(paths.fill.endsWith("Z")).toBe(true);
-    // Tube: 1 outside corner arc + 2 end caps = 3 A.
-    const aCount = (paths.fill.match(/\bA\b/g) ?? []).length;
-    expect(aCount).toBe(3);
-    // Tube has 2 forward-side L's + 2 backward-side L's = 4 L commands when
-    // both inside and outside corner transitions use arcs. A convex-hull
-    // offset would emit 3 (one per hull edge), so a count ≥ 4 distinguishes
-    // the tube geometry without depending on a specific bevel/miter detail.
-    const lCount = (paths.fill.match(/\bL\b/g) ?? []).length;
-    expect(lCount).toBeGreaterThanOrEqual(4);
+    const { fill } = result[0]!.paths;
+    expect((fill.match(/\bA\b/g) ?? []).length).toBe(3);
+    expect((fill.match(/\bL\b/g) ?? []).length).toBeGreaterThanOrEqual(4);
   });
 });
 
@@ -868,159 +516,73 @@ describe("buildChordConnectorPolylines", () => {
 // -------------------------------------------------------------------------
 
 describe("regression: 3NPS Position 2 bottom-string voicing", () => {
-  it("emits C@str3-fret10 / G@str4-fret10 / E@str5-fret12 voicing when out-of-position notes are inactive", () => {
-    // Fixed noteData: out-of-position chord tones are note-inactive.
-    // In-position chord tones for 3NPS Position 2 (C major, frets 10–15):
-    //   str3: C@10 (chord-root), E@14 (chord-tone-in-scale)
-    //   str4: G@10 (chord-tone-in-scale)
-    //   str5: E@12 (chord-tone-in-scale)
-    // Out-of-position (now note-inactive after the fix):
-    //   str4: C@15 (would be chord-root in-band but out of position → inactive)
-    //   str5: G@15 (would be chord-tone-in-scale in-band but out of position → inactive)
-    const noteData = [
-      // Upper strings (in-position chord tones — upper voicings still work)
-      makeNote(0, 12, "E", "chord-tone-in-scale"),
-      makeNote(0, 15, "G", "chord-tone-in-scale"),
-      makeNote(1, 13, "C", "chord-root"),
-      makeNote(2, 12, "G", "chord-tone-in-scale"),
-      // Bottom strings — in-position
-      makeNote(3, 10, "C", "chord-root"),
-      makeNote(3, 14, "E", "chord-tone-in-scale"),
-      makeNote(4, 10, "G", "chord-tone-in-scale"),
-      makeNote(4, 15, "C", "note-inactive"),   // out-of-position, now inactive
-      makeNote(5, 12, "E", "chord-tone-in-scale"),
-      makeNote(5, 15, "G", "note-inactive"),   // out-of-position, now inactive
-    ];
+  // 3NPS Position 2 (C major, frets 10-15). Out-of-position chord tones at
+  // str4-f15 and str5-f15 are now note-inactive. The bottom-string in-position
+  // voicing (C@str3-f10 / G@str4-f10 / E@str5-f12) must be emitted; the
+  // tighter out-of-position one using fret-15 must not.
+  const position2Notes = notes([
+    [0, 12, "E"], [0, 15, "G"],
+    [1, 13, "C", "chord-root"],
+    [2, 12, "G"],
+    [3, 10, "C", "chord-root"], [3, 14, "E"],
+    [4, 10, "G"], [4, 15, "C", "note-inactive"],
+    [5, 12, "E"], [5, 15, "G", "note-inactive"],
+  ]);
 
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-
-    // The bottom-string voicing must be present.
-    const bottomVoicing = result.find(
-      (voicing) =>
-        voicing.vertices.length === 3 &&
-        voicing.vertices.some((v) => v.y === stringYAt(3, fretCenterX(10)) && v.x === fretCenterX(10)) &&
-        voicing.vertices.some((v) => v.y === stringYAt(4, fretCenterX(10)) && v.x === fretCenterX(10)) &&
-        voicing.vertices.some((v) => v.y === stringYAt(5, fretCenterX(12)) && v.x === fretCenterX(12)),
+  it("emits the in-position bottom voicing and drops the fret-15 out-of-position voicing", () => {
+    const result = build(position2Notes, ["C", "E", "G"]);
+    const bottom = result.find((v) =>
+      v.vertices.length === 3 &&
+      v.vertices.some((p) => p.y === stringYAt(3, fretCenterX(10)) && p.x === fretCenterX(10)) &&
+      v.vertices.some((p) => p.y === stringYAt(4, fretCenterX(10)) && p.x === fretCenterX(10)) &&
+      v.vertices.some((p) => p.y === stringYAt(5, fretCenterX(12)) && p.x === fretCenterX(12)),
     );
-    expect(bottomVoicing, "bottom-string voicing C@str3-f10 / G@str4-f10 / E@str5-f12 not emitted").toBeDefined();
-    expect(bottomVoicing!.vertices).toHaveLength(3);
-  });
-
-  it("does NOT emit the tighter out-of-position voicing E@str3-f14 / C@str4-f15 / G@str5-f15 when those notes are inactive", () => {
-    // Same fixed noteData as above.
-    const noteData = [
-      makeNote(0, 12, "E", "chord-tone-in-scale"),
-      makeNote(0, 15, "G", "chord-tone-in-scale"),
-      makeNote(1, 13, "C", "chord-root"),
-      makeNote(2, 12, "G", "chord-tone-in-scale"),
-      makeNote(3, 10, "C", "chord-root"),
-      makeNote(3, 14, "E", "chord-tone-in-scale"),
-      makeNote(4, 10, "G", "chord-tone-in-scale"),
-      makeNote(4, 15, "C", "note-inactive"),
-      makeNote(5, 12, "E", "chord-tone-in-scale"),
-      makeNote(5, 15, "G", "note-inactive"),
-    ];
-
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-
-    // The out-of-position voicing must NOT be present.
-    const outOfPositionVoicing = result.find(
-      (voicing) =>
-        voicing.vertices.some((v) => v.y === stringYAt(4, fretCenterX(15)) && v.x === fretCenterX(15)) ||
-        voicing.vertices.some((v) => v.y === stringYAt(5, fretCenterX(15)) && v.x === fretCenterX(15)),
+    expect(bottom, "in-position bottom voicing not emitted").toBeDefined();
+    const outOfPosition = result.find((v) =>
+      v.vertices.some((p) => p.y === stringYAt(4, fretCenterX(15)) && p.x === fretCenterX(15)) ||
+      v.vertices.some((p) => p.y === stringYAt(5, fretCenterX(15)) && p.x === fretCenterX(15)),
     );
-    expect(outOfPositionVoicing, "out-of-position voicing using fret-15 notes must not be emitted").toBeUndefined();
+    expect(outOfPosition, "out-of-position voicing must not be emitted").toBeUndefined();
   });
 });
 
 describe("paletteIndex field", () => {
-  it("includes paletteIndex in returned voicing objects", () => {
-    const noteData = [
-      makeNote(0, 0, "C"),
-      makeNote(1, 2, "E"),
-      makeNote(2, 4, "G"),
-    ];
-    const result = buildChordConnectorPolylines(
-      noteData,
-      ["C", "E", "G"],
-      fretCenterX,
-      stringYAt,
-      STRING_ROW_PX,
-      "C",
-    );
+  it("paletteIndex is a 0..7 integer present on every voicing", () => {
+    const result = build(notes([[0, 0, "C"], [1, 2, "E"], [2, 4, "G"]]), ["C", "E", "G"]);
     expect(result.length).toBeGreaterThan(0);
-    expect(result[0]).toHaveProperty("paletteIndex");
-    expect(typeof result[0]!.paletteIndex).toBe("number");
-    expect(result[0]!.paletteIndex).toBeGreaterThanOrEqual(0);
-    expect(result[0]!.paletteIndex).toBeLessThan(8);
+    const idx = result[0]!.paletteIndex;
+    expect(typeof idx).toBe("number");
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(idx).toBeLessThan(8);
   });
 
-  it("assigns same paletteIndex when the bass note is the same across positions", () => {
-    // Both voicings have G in the bass (stringIndex 2 = lowest pick) → same
-    // inversion → same color, regardless of absolute fret position.
-    const noteDataPos1 = [
-      makeNote(0, 0, "C"), makeNote(1, 2, "E"), makeNote(2, 4, "G"),
-    ];
-    // Position 2: frets 12, 13, 14 → fret positions {12,13,14} → count 3 (within limit).
-    const noteDataPos2 = [
-      makeNote(0, 12, "C"), makeNote(1, 13, "E"), makeNote(2, 14, "G"),
-    ];
-
-    const result1 = buildChordConnectorPolylines(
-      noteDataPos1, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C",
-    );
-    const result2 = buildChordConnectorPolylines(
-      noteDataPos2, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C",
-    );
-
-    expect(result1[0]!.paletteIndex).toBe(result2[0]!.paletteIndex);
-    // G is the 5th (inversion 2 of a triad) → INVERSION_SLOTS[3][2] = 6.
-    expect(result1[0]!.paletteIndex).toBe(6);
-  });
-
-  it("assigns different paletteIndex when bass note differs (different inversions of same chord)", () => {
-    // Same chord (C major), different inversions:
-    // - Voicing A: G in bass (5th in bass — second inversion). Bass interval = 7.
-    // - Voicing B: C in bass (root in bass — root position). Bass interval = 0.
-    const voicingGBass = [
-      makeNote(0, 0, "C"), makeNote(1, 2, "E"), makeNote(2, 4, "G"),
-    ];
-    const voicingCBass = [
-      makeNote(0, 0, "G"), makeNote(1, 2, "E"), makeNote(2, 4, "C"),
-    ];
-
-    const r1 = buildChordConnectorPolylines(
-      voicingGBass, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C",
-    );
-    const r2 = buildChordConnectorPolylines(
-      voicingCBass, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C",
-    );
-
-    expect(r1[0]!.paletteIndex).not.toBe(r2[0]!.paletteIndex);
-    expect(r1[0]!.paletteIndex).toBe(6); // 5th in bass → INVERSION_SLOTS[3][2]
-    expect(r2[0]!.paletteIndex).toBe(0); // root in bass → INVERSION_SLOTS[3][0]
-  });
-
-  it("assigns same paletteIndex across different chord qualities when bass note role is the same", () => {
-    // C major triad with G in bass (5th in bass, interval 7).
-    // F major triad with C in bass (5th in bass, interval 7).
-    // Both are 2nd-inversion → same palette index.
-    const cMajorGBass = [
-      makeNote(0, 0, "C"), makeNote(1, 0, "E"), makeNote(2, 0, "G"),
-    ];
-    const fMajorCBass = [
-      makeNote(0, 0, "F"), makeNote(1, 0, "A"), makeNote(2, 0, "C"),
-    ];
-
-    const r1 = buildChordConnectorPolylines(
-      cMajorGBass, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C",
-    );
-    const r2 = buildChordConnectorPolylines(
-      fMajorCBass, ["F", "A", "C"], fretCenterX, stringYAt, STRING_ROW_PX, "F",
-    );
-
-    expect(r1[0]!.paletteIndex).toBe(r2[0]!.paletteIndex);
-    expect(r1[0]!.paletteIndex).toBe(6);
+  // Bass note (lowest-numbered string in the voicing) determines paletteIndex:
+  // the *interval from chord root* picks a slot in INVERSION_SLOTS. Same bass
+  // role → same index regardless of absolute fret or chord quality.
+  it.each<{ label: string; specs: NoteSpec[]; chord: string[]; root: string; expected: number }>([
+    {
+      label: "G-bass voicing (low position, 2nd inversion)",
+      specs: [[0, 0, "C"], [1, 2, "E"], [2, 4, "G"]],
+      chord: ["C", "E", "G"], root: "C", expected: 6,
+    },
+    {
+      label: "G-bass voicing (high position) → same index as low-position G-bass",
+      specs: [[0, 12, "C"], [1, 13, "E"], [2, 14, "G"]],
+      chord: ["C", "E", "G"], root: "C", expected: 6,
+    },
+    {
+      label: "C-bass voicing (root position) → different index from G-bass",
+      specs: [[0, 0, "G"], [1, 2, "E"], [2, 4, "C"]],
+      chord: ["C", "E", "G"], root: "C", expected: 0,
+    },
+    {
+      label: "F major with C-bass (5th in bass) → same index as C major with G-bass",
+      specs: [[0, 0, "F"], [1, 0, "A"], [2, 0, "C"]],
+      chord: ["F", "A", "C"], root: "F", expected: 6,
+    },
+  ])("$label → paletteIndex $expected", ({ specs, chord, root, expected }) => {
+    const result = build(notes(specs), chord, root);
+    expect(result[0]!.paletteIndex).toBe(expected);
   });
 });
 
@@ -1043,94 +605,39 @@ describe("paletteIndex field", () => {
 // -------------------------------------------------------------------------
 
 describe("per-voicing offset: determinism and paletteIndex independence", () => {
-  // Voicing A: C major, G in bass, frets 1-2-3 on strings 0-1-2.
-  // Singleton cluster → offsetPx = 0.
-  const voicingANotes = [
-    makeNote(0, 1, "C", "chord-root"),
-    makeNote(1, 2, "E", "chord-tone-in-scale"),
-    makeNote(2, 3, "G", "chord-tone-in-scale"),
-  ];
-
-  // Voicing B: same note names, same bass (G on str2) → same paletteIndex.
-  // Frets 2-3-4 on strings 0-1-2. Singleton cluster → offsetPx = 0.
-  // Different fret positions → different vertex coordinates → different path.
-  const voicingBNotes = [
-    makeNote(0, 2, "C", "chord-root"),
-    makeNote(1, 3, "E", "chord-tone-in-scale"),
-    makeNote(2, 4, "G", "chord-tone-in-scale"),
-  ];
+  // Two C-major triads with G in bass — same paletteIndex, different fret positions.
+  const voicingA = notes([[0, 1, "C", "chord-root"], [1, 2, "E"], [2, 3, "G"]]);
+  const voicingB = notes([[0, 2, "C", "chord-root"], [1, 3, "E"], [2, 4, "G"]]);
 
   it("(a) same paletteIndex but different canonicalKey → different paths.fill strings", () => {
-    const rA = buildChordConnectorPolylines(voicingANotes, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    const rB = buildChordConnectorPolylines(voicingBNotes, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-
-    expect(rA).toHaveLength(1);
-    expect(rB).toHaveLength(1);
-
-    // Confirm same paletteIndex (same inversion — G in bass for both).
+    const rA = build(voicingA, ["C", "E", "G"]);
+    const rB = build(voicingB, ["C", "E", "G"]);
     expect(rA[0]!.paletteIndex).toBe(rB[0]!.paletteIndex);
-
-    // Different fret positions → different vertex coordinates → different path strings,
-    // even though both receive offset 0 as singleton clusters.
     expect(rA[0]!.paths.fill).not.toBe(rB[0]!.paths.fill);
   });
 
-  it("(b) same canonicalKey always produces the same paths.fill string (deterministic)", () => {
-    const result1 = buildChordConnectorPolylines(voicingANotes, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    const result2 = buildChordConnectorPolylines(voicingANotes, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-
-    expect(result1).toHaveLength(1);
-    expect(result2).toHaveLength(1);
-    expect(result1[0]!.paths.fill).toBe(result2[0]!.paths.fill);
+  it("(b) same input always produces the same paths.fill string (deterministic)", () => {
+    const r1 = build(voicingA, ["C", "E", "G"]);
+    const r2 = build(voicingA, ["C", "E", "G"]);
+    expect(r1[0]!.paths.fill).toBe(r2[0]!.paths.fill);
   });
 
   it("(c) adaptive radius factors use compact, medium, and max widths", () => {
-    expect(CHORD_CONNECTOR_RADIUS_FACTORS).toEqual({
-      compact: 0.34,
-      medium: 0.38,
-      max: 0.42,
-    });
+    expect(CHORD_CONNECTOR_RADIUS_FACTORS).toEqual({ compact: 0.34, medium: 0.38, max: 0.42 });
   });
 
-  it("(c) all voicings use the same uniform base radius regardless of fretted position count", () => {
-    const sameFret = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-    ];
-    const twoPositions = [
-      makeNote(0, 2, "C", "chord-root"),
-      makeNote(1, 2, "E", "chord-tone-in-scale"),
-      makeNote(2, 3, "G", "chord-tone-in-scale"),
-    ];
-    const threePositions = [
-      makeNote(0, 2, "C", "chord-root"),
-      makeNote(1, 3, "E", "chord-tone-in-scale"),
-      makeNote(2, 4, "G", "chord-tone-in-scale"),
-    ];
-
-    const r1 = computeChordConnectorRadiusPx(sameFret, STRING_ROW_PX, 0);
-    const r2 = computeChordConnectorRadiusPx(twoPositions, STRING_ROW_PX, 0);
-    const r3 = computeChordConnectorRadiusPx(threePositions, STRING_ROW_PX, 0);
-
+  it("(c) uniform base radius regardless of fretted position count; offset adds linearly", () => {
+    const sameFret = notes([[0, 5, "C", "chord-root"], [1, 5, "E"], [2, 5, "G"]]);
+    const twoPositions = notes([[0, 2, "C", "chord-root"], [1, 2, "E"], [2, 3, "G"]]);
+    const threePositions = notes([[0, 2, "C", "chord-root"], [1, 3, "E"], [2, 4, "G"]]);
     // Uniform base: 0.42 × 36 = 15.12, above the 11.47 floor.
-    expect(r1).toBeCloseTo(15.12);
-    expect(r2).toBeCloseTo(15.12);
-    expect(r3).toBeCloseTo(15.12);
-    expect(r1).toBeGreaterThan(chordRootVisualRadiusPx(STRING_ROW_PX));
-  });
-
-  it("(c) offset only inflates radius when explicitly applied", () => {
-    const combo = [
-      makeNote(0, 2, "C", "chord-root"),
-      makeNote(1, 3, "E", "chord-tone-in-scale"),
-      makeNote(2, 4, "G", "chord-tone-in-scale"),
-    ];
-
-    const base = computeChordConnectorRadiusPx(combo, STRING_ROW_PX, 0);
-    const withOffset = computeChordConnectorRadiusPx(combo, STRING_ROW_PX, 3);
-
-    expect(withOffset).toBeCloseTo(base + 3);
+    for (const combo of [sameFret, twoPositions, threePositions]) {
+      expect(computeChordConnectorRadiusPx(combo, STRING_ROW_PX, 0)).toBeCloseTo(15.12);
+    }
+    expect(computeChordConnectorRadiusPx(sameFret, STRING_ROW_PX, 0))
+      .toBeGreaterThan(chordRootVisualRadiusPx(STRING_ROW_PX));
+    const base = computeChordConnectorRadiusPx(threePositions, STRING_ROW_PX, 0);
+    expect(computeChordConnectorRadiusPx(threePositions, STRING_ROW_PX, 3)).toBeCloseTo(base + 3);
   });
 
   it("clamps connector radius to the available SVG y bounds", () => {
@@ -1244,143 +751,53 @@ describe("useChordConnectorPolylines", () => {
 
 describe("adjacency-aware offset assignment", () => {
   // -------------------------------------------------------------------------
-  // (1) Two AABB-overlapping voicings get different offsets.
-  //
-  // Two voicings from adjacent string windows at the same fret — V1 on
-  // strings 0-1-2 and V2 on strings 1-2-3, both at fret 5.
-  // Same x (fret 5 = x 50); y ranges [0,40] and [20,60] share strings 1-2.
-  // inflateBy ≈ 27 px → inflated y ranges [-26.92,66.92] and [-6.92,86.92]
-  // → pairwise AABB-overlap ✓.
-  // Cluster of size 2: sorted by canonicalKey → member 0 gets OFFSET_BUCKET[0]=0,
-  // member 1 gets OFFSET_BUCKET[1]=2 → different radii → different path strings.
+  // Overlapping voicings (sharing strings at the same fret) form an AABB
+  // cluster and receive distinct OFFSET_BUCKET entries → pairwise distinct
+  // paths. Non-overlapping voicings stay as singleton clusters with offset 0
+  // (matching their solo baselines). Outputs are deterministic across re-runs.
   // -------------------------------------------------------------------------
-  it("(1) two AABB-overlapping voicings receive distinct offsets", () => {
-    // Adjacent string windows at fret 5:
-    //   str0=C, str1=E, str2=G, str3=C  → windows [0,1,2] and [1,2,3]
-    const noteData = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-      makeNote(3, 5, "C", "chord-root"),
-    ];
 
-    const result = buildChordConnectorPolylines(
-      noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C",
-    );
-
-    expect(result).toHaveLength(2);
-    // Both voicings are emitted; their overlapping AABBs → cluster of size 2.
-    // Different OFFSET_BUCKET entries → different path strings.
-    expect(result[0]!.paths.fill).not.toBe(result[1]!.paths.fill);
+  it.each<{ n: number; specs: NoteSpec[] }>([
+    {
+      n: 2,
+      specs: [[0, 5, "C", "chord-root"], [1, 5, "E"], [2, 5, "G"], [3, 5, "C", "chord-root"]],
+    },
+    {
+      n: 3,
+      specs: [[0, 5, "C", "chord-root"], [1, 5, "E"], [2, 5, "G"],
+        [3, 5, "C", "chord-root"], [4, 5, "E"]],
+    },
+  ])("$n AABB-overlapping voicings receive $n distinct path strings", ({ n, specs }) => {
+    const result = build(notes(specs), ["C", "E", "G"]);
+    expect(result).toHaveLength(n);
+    expect(new Set(result.map((v) => v.paths.fill)).size).toBe(n);
   });
 
-  // -------------------------------------------------------------------------
-  // (2) Three overlapping voicings get three distinct offsets.
-  //
-  // Three voicings from adjacent string windows at fret 5 — windows
-  // [0,1,2], [1,2,3], [2,3,4]. All pairwise AABB-overlap:
-  //   [0-2] inflated y max = 40+27 = 67 > [2-4] inflated y min = 40-27 = 13 ✓
-  // Cluster of size 3 → three distinct OFFSET_BUCKET entries → pairwise distinct paths.
-  // -------------------------------------------------------------------------
-  it("(2) three AABB-overlapping voicings receive three distinct offsets", () => {
-    // str0=C, str1=E, str2=G, str3=C, str4=E → windows [0,1,2],[1,2,3],[2,3,4]
-    const noteData = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-      makeNote(3, 5, "C", "chord-root"),
-      makeNote(4, 5, "E", "chord-tone-in-scale"),
-    ];
-
-    const result = buildChordConnectorPolylines(
-      noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C",
+  it("non-overlapping voicings get offset 0 (matching singleton baselines)", () => {
+    const baseline1 = build(notes([[0, 1, "C", "chord-root"], [1, 2, "E"], [2, 3, "G"]]), ["C", "E", "G"]);
+    const baseline2 = build(notes([[0, 9, "C", "chord-root"], [1, 10, "E"], [2, 11, "G"]]), ["C", "E", "G"]);
+    const combined = build(
+      notes([
+        [0, 1, "C", "chord-root"], [1, 2, "E"], [2, 3, "G"],
+        [0, 9, "C", "chord-root"], [1, 10, "E"], [2, 11, "G"],
+      ]),
+      ["C", "E", "G"],
     );
-
-    expect(result).toHaveLength(3);
-    const fillPaths = result.map((v) => v.paths.fill);
-    // All three paths must be pairwise distinct.
-    const uniquePaths = new Set(fillPaths);
-    expect(uniquePaths.size).toBe(3);
+    const v1 = combined.find((v) => v.vertices.some((p) => p.x === fretCenterX(1)));
+    const v2 = combined.find((v) => v.vertices.some((p) => p.x === fretCenterX(9)));
+    expect(v1!.paths.fill).toBe(baseline1[0]!.paths.fill);
+    expect(v2!.paths.fill).toBe(baseline2[0]!.paths.fill);
   });
 
-  // -------------------------------------------------------------------------
-  // (3) Non-overlapping voicings both get offset 0.
-  //
-  // Two voicings on strings 0-1-2 at frets 1-2-3 and frets 9-10-11.
-  // Fret gap ≈ 8 frets > 5.4 fret overlap threshold → separate singleton
-  // clusters → both receive OFFSET_BUCKET[0] = 0.
-  //
-  // Baseline: a single voicing at frets 1-2-3 also receives offset 0 (singleton).
-  // The two-voicing call should produce paths byte-identical to their
-  // respective single-voicing baselines.
-  // -------------------------------------------------------------------------
-  it("(3) non-overlapping voicings both receive offset 0 (same as singleton baseline)", () => {
-    // Baseline: single voicing at frets 1-2-3 → offset 0.
-    const baseline1 = buildChordConnectorPolylines(
-      [makeNote(0, 1, "C", "chord-root"), makeNote(1, 2, "E", "chord-tone-in-scale"), makeNote(2, 3, "G", "chord-tone-in-scale")],
-      ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C",
-    );
-    // Baseline: single voicing at frets 9-10-11 → offset 0.
-    const baseline2 = buildChordConnectorPolylines(
-      [makeNote(0, 9, "C", "chord-root"), makeNote(1, 10, "E", "chord-tone-in-scale"), makeNote(2, 11, "G", "chord-tone-in-scale")],
-      ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C",
-    );
-
-    expect(baseline1).toHaveLength(1);
-    expect(baseline2).toHaveLength(1);
-
-    // Combined: two far-apart voicings in one call.
-    const combined = buildChordConnectorPolylines(
-      [
-        makeNote(0, 1, "C", "chord-root"),
-        makeNote(1, 2, "E", "chord-tone-in-scale"),
-        makeNote(2, 3, "G", "chord-tone-in-scale"),
-        makeNote(0, 9, "C", "chord-root"),
-        makeNote(1, 10, "E", "chord-tone-in-scale"),
-        makeNote(2, 11, "G", "chord-tone-in-scale"),
-      ],
-      ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C",
-    );
-
-    expect(combined.length).toBeGreaterThanOrEqual(2);
-
-    const voicing1 = combined.find((v) => v.vertices.some((p) => p.x === fretCenterX(1)));
-    const voicing2 = combined.find((v) => v.vertices.some((p) => p.x === fretCenterX(9)));
-    expect(voicing1).toBeDefined();
-    expect(voicing2).toBeDefined();
-
-    // Both non-overlapping voicings should have the same path as their singleton baselines.
-    expect(voicing1!.paths.fill).toBe(baseline1[0]!.paths.fill);
-    expect(voicing2!.paths.fill).toBe(baseline2[0]!.paths.fill);
-  });
-
-  // -------------------------------------------------------------------------
-  // (4) Determinism: identical inputs always produce identical per-voicing offsets.
-  //
-  // Run buildChordConnectorPolylines twice with the same noteData. Assert that
-  // per-index paths.fill strings match exactly.
-  // -------------------------------------------------------------------------
-  it("(4) determinism: same inputs produce identical per-voicing offsets across re-runs", () => {
-    // Three adjacent string windows at fret 5 (same data as test 2).
-    const noteData = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-      makeNote(3, 5, "C", "chord-root"),
-      makeNote(4, 5, "E", "chord-tone-in-scale"),
-    ];
-
-    const run1 = buildChordConnectorPolylines(
-      noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C",
-    );
-    const run2 = buildChordConnectorPolylines(
-      noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C",
-    );
-
+  it("determinism: same inputs produce identical per-voicing paths across re-runs", () => {
+    const noteData = notes([
+      [0, 5, "C", "chord-root"], [1, 5, "E"], [2, 5, "G"],
+      [3, 5, "C", "chord-root"], [4, 5, "E"],
+    ]);
+    const run1 = build(noteData, ["C", "E", "G"]);
+    const run2 = build(noteData, ["C", "E", "G"]);
     expect(run1.length).toBe(run2.length);
-    run1.forEach((v, i) => {
-      expect(v.paths.fill).toBe(run2[i]!.paths.fill);
-    });
+    run1.forEach((v, i) => expect(v.paths.fill).toBe(run2[i]!.paths.fill));
   });
 
   // -------------------------------------------------------------------------
@@ -1490,102 +907,48 @@ describe("G major triad overlap offsets (full neck)", () => {
     return false;
   }
 
-  it("produces voicings in both the fret 7–10 and 19–22 regions", () => {
-    const result = buildChordConnectorPolylines(
-      gMajorChordTones(), ["G", "B", "D"], fretCenterX, stringYAt, STRING_ROW_PX, "G",
-    );
+  function expectPositionSharingPairsDiffer(
+    group: ReturnType<typeof buildChordConnectorPolylines>,
+    context: string,
+  ) {
+    for (let i = 0; i < group.length; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        if (keysSharePosition(group[i]!.voicingKey, group[j]!.voicingKey)) {
+          expect(
+            group[i]!.paths.fill,
+            `${context}: "${group[i]!.voicingKey}" and "${group[j]!.voicingKey}" share a position but have identical paths`,
+          ).not.toBe(group[j]!.paths.fill);
+        }
+      }
+    }
+  }
 
+  it("low (frets 7-10) and high (19-22) regions both emit ≥3 voicings of equal count", () => {
+    const result = build(gMajorChordTones(), ["G", "B", "D"], "G");
     const low = voicingsInFretRange(result, 7, 10);
     const high = voicingsInFretRange(result, 19, 22);
-
     expect(low.length).toBeGreaterThanOrEqual(3);
     expect(high.length).toBeGreaterThanOrEqual(3);
+    expect(low.length).toBe(high.length);
   });
 
-  it("frets 7–10: overlapping voicings have distinct paths", () => {
-    const result = buildChordConnectorPolylines(
-      gMajorChordTones(), ["G", "B", "D"], fretCenterX, stringYAt, STRING_ROW_PX, "G",
-    );
-
-    const group = voicingsInFretRange(result, 7, 10);
-    // Every pair that shares a position must have different paths.
-    for (let i = 0; i < group.length; i++) {
-      for (let j = i + 1; j < group.length; j++) {
-        if (keysSharePosition(group[i]!.voicingKey, group[j]!.voicingKey)) {
-          expect(
-            group[i]!.paths.fill,
-            `frets 7-10: voicings "${group[i]!.voicingKey}" and "${group[j]!.voicingKey}" share a position but have identical paths (same radius)`,
-          ).not.toBe(group[j]!.paths.fill);
-        }
-      }
-    }
-  });
-
-  it("frets 19–22: overlapping voicings have distinct paths", () => {
-    const result = buildChordConnectorPolylines(
-      gMajorChordTones(), ["G", "B", "D"], fretCenterX, stringYAt, STRING_ROW_PX, "G",
-    );
-
-    const group = voicingsInFretRange(result, 19, 22);
-    // Every pair that shares a position must have different paths.
-    for (let i = 0; i < group.length; i++) {
-      for (let j = i + 1; j < group.length; j++) {
-        if (keysSharePosition(group[i]!.voicingKey, group[j]!.voicingKey)) {
-          expect(
-            group[i]!.paths.fill,
-            `frets 19-22: voicings "${group[i]!.voicingKey}" and "${group[j]!.voicingKey}" share a position but have identical paths (same radius)`,
-          ).not.toBe(group[j]!.paths.fill);
-        }
-      }
-    }
-  });
-
-  it("non-overlapping voicings do not receive conflict-graph inflation", () => {
-    const result = buildChordConnectorPolylines(
-      gMajorChordTones(), ["G", "B", "D"], fretCenterX, stringYAt, STRING_ROW_PX, "G",
-    );
-
-    const group = voicingsInFretRange(result, 7, 10);
-    const base = STRING_ROW_PX * CHORD_CONNECTOR_BASE_RADIUS_FACTOR;
-    for (const v of group) {
-      const rx = parseFloat(v.paths.fill.match(/A ([\d.]+)/)?.[1] ?? "0");
-      expect(rx).toBeLessThanOrEqual(base + 15);
-    }
-  });
-
-  it("frets 7-10 and 19-22 produce the same number of voicings", () => {
-    const result = buildChordConnectorPolylines(
-      gMajorChordTones(), ["G", "B", "D"], fretCenterX, stringYAt, STRING_ROW_PX, "G",
-    );
-
-    const group7 = voicingsInFretRange(result, 7, 10);
-    const group19 = voicingsInFretRange(result, 19, 22);
-
-    expect(group7.length).toBe(group19.length);
-    expect(group7.length).toBeGreaterThanOrEqual(2);
-  });
-
-  it("yBounds clamping does not erase offset differentiation", () => {
-    // With yBounds, edge voicings (touching str0 or str5) get clamped.
-    // The post-clamp fix should ensure overlapping pairs still differ.
-    // stringYAt = si * 20 → str0=0, str5=100. neckHeight = 100.
-    const yBounds = { minY: 0, maxY: 100 };
-
+  it.each<{ label: string; min: number; max: number; yBounds?: { minY: number; maxY: number } }>([
+    { label: "frets 7-10 unbounded", min: 7, max: 10 },
+    { label: "frets 19-22 unbounded", min: 19, max: 22 },
+    { label: "frets 19-22 with yBounds clamping", min: 19, max: 22, yBounds: { minY: 0, maxY: 100 } },
+  ])("$label: overlapping voicings have distinct paths", ({ label, min, max, yBounds }) => {
     const result = buildChordConnectorPolylines(
       gMajorChordTones(), ["G", "B", "D"], fretCenterX, stringYAt, STRING_ROW_PX, "G", yBounds,
     );
+    expectPositionSharingPairsDiffer(voicingsInFretRange(result, min, max), label);
+  });
 
-    const group = voicingsInFretRange(result, 19, 22);
-    // Every pair sharing a position must have distinct paths even after clamping.
-    for (let i = 0; i < group.length; i++) {
-      for (let j = i + 1; j < group.length; j++) {
-        if (keysSharePosition(group[i]!.voicingKey, group[j]!.voicingKey)) {
-          expect(
-            group[i]!.paths.fill,
-            `yBounds clamped: "${group[i]!.voicingKey}" and "${group[j]!.voicingKey}" share a position but have identical paths`,
-          ).not.toBe(group[j]!.paths.fill);
-        }
-      }
+  it("non-overlapping voicings do not receive conflict-graph inflation (radius near base)", () => {
+    const result = build(gMajorChordTones(), ["G", "B", "D"], "G");
+    const base = STRING_ROW_PX * CHORD_CONNECTOR_BASE_RADIUS_FACTOR;
+    for (const v of voicingsInFretRange(result, 7, 10)) {
+      const rx = parseFloat(v.paths.fill.match(/A ([\d.]+)/)?.[1] ?? "0");
+      expect(rx).toBeLessThanOrEqual(base + 15);
     }
   });
 });
@@ -1595,69 +958,33 @@ describe("G major triad overlap offsets (full neck)", () => {
 // -------------------------------------------------------------------------
 
 describe("voicingKey field", () => {
-  it("voicingKey stability: same vertex set on two separate calls produces identical voicingKey values", () => {
-    const noteData = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-    ];
-    const result1 = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    const result2 = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result1).toHaveLength(1);
-    expect(result2).toHaveLength(1);
-    expect(result1[0]!.voicingKey).toBe(result2[0]!.voicingKey);
+  const fret5Triad: NoteSpec[] = [[0, 5, "C", "chord-root"], [1, 5, "E"], [2, 5, "G"]];
+
+  it("stable: same vertex set across calls yields the same voicingKey", () => {
+    const r1 = build(notes(fret5Triad), ["C", "E", "G"]);
+    const r2 = build(notes(fret5Triad), ["C", "E", "G"]);
+    expect(r1[0]!.voicingKey).toBe(r2[0]!.voicingKey);
   });
 
-  it("voicingKey uniqueness: two voicings with distinct vertex sets produce different keys", () => {
-    // Two distinct positions: strings 0-1-2 at fret 5, and strings 0-1-2 at fret 7.
-    // Both are separate calls so each emits 1 voicing with a different key.
-    const noteDataA = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 5, "G", "chord-tone-in-scale"),
-    ];
-    const noteDataB = [
-      makeNote(0, 7, "C", "chord-root"),
-      makeNote(1, 7, "E", "chord-tone-in-scale"),
-      makeNote(2, 7, "G", "chord-tone-in-scale"),
-    ];
-    const rA = buildChordConnectorPolylines(noteDataA, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    const rB = buildChordConnectorPolylines(noteDataB, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(rA).toHaveLength(1);
-    expect(rB).toHaveLength(1);
+  it("unique: distinct vertex sets yield different voicingKeys", () => {
+    const rA = build(notes(fret5Triad), ["C", "E", "G"]);
+    const rB = build(notes([[0, 7, "C", "chord-root"], [1, 7, "E"], [2, 7, "G"]]), ["C", "E", "G"]);
     expect(rA[0]!.voicingKey).not.toBe(rB[0]!.voicingKey);
   });
 
-  it("canonicalKey order-independence: supplying the same vertices in a different order yields the same key", () => {
-    // Forward order: string 0, 1, 2.
-    const noteDataForward = [
-      makeNote(0, 3, "C", "chord-root"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(2, 4, "G", "chord-tone-in-scale"),
-    ];
-    // Reverse order: string 2, 1, 0 — NoteData ordering should not affect the key.
-    const noteDataReverse = [
-      makeNote(2, 4, "G", "chord-tone-in-scale"),
-      makeNote(1, 5, "E", "chord-tone-in-scale"),
-      makeNote(0, 3, "C", "chord-root"),
-    ];
-    const rFwd = buildChordConnectorPolylines(noteDataForward, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    const rRev = buildChordConnectorPolylines(noteDataReverse, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(rFwd).toHaveLength(1);
-    expect(rRev).toHaveLength(1);
-    expect(rFwd[0]!.voicingKey).toBe(rRev[0]!.voicingKey);
+  it("order-independent: NoteData ordering does not affect voicingKey", () => {
+    const forward: NoteSpec[] = [[0, 3, "C", "chord-root"], [1, 5, "E"], [2, 4, "G"]];
+    const reverse: NoteSpec[] = [[2, 4, "G"], [1, 5, "E"], [0, 3, "C", "chord-root"]];
+    expect(build(notes(forward), ["C", "E", "G"])[0]!.voicingKey)
+      .toBe(build(notes(reverse), ["C", "E", "G"])[0]!.voicingKey);
   });
 
   it("voicingKey is a non-empty string containing the expected coordinate pairs", () => {
-    const noteData = [
-      makeNote(0, 5, "C", "chord-root"),
-      makeNote(1, 7, "E", "chord-tone-in-scale"),
-      makeNote(2, 6, "G", "chord-tone-in-scale"),
-    ];
-    const result = buildChordConnectorPolylines(noteData, ["C", "E", "G"], fretCenterX, stringYAt, STRING_ROW_PX, "C");
-    expect(result).toHaveLength(1);
+    const result = build(
+      notes([[0, 5, "C", "chord-root"], [1, 7, "E"], [2, 6, "G"]]),
+      ["C", "E", "G"],
+    );
     const key = result[0]!.voicingKey;
-    expect(typeof key).toBe("string");
     expect(key.length).toBeGreaterThan(0);
     // Key must contain each (stringIndex,fretIndex) pair in sorted order joined by "|".
     // Sorted: "0,5" < "1,7" < "2,6" → sorted: "0,5", "1,7", "2,6".
@@ -1745,46 +1072,25 @@ describe("voicingKey field", () => {
 });
 
 describe("useChordConnectorPolylines — voicingSourceActive guard", () => {
-  // Three chord-tone positions across three adjacent strings within fret 5.
-  // The legacy buildChordConnectorPolylines generator produces a non-empty
-  // result for this noteData.
-  const chordNoteData = [
-    makeNote(0, 5, "C", "chord-root"),
-    makeNote(1, 5, "E", "chord-tone-in-scale"),
-    makeNote(2, 5, "G", "chord-tone-in-scale"),
-  ];
-  const chordToneNames = ["C", "E", "G"];
-  const chordRoot = "C";
+  const chordNoteData = notes([[0, 5, "C", "chord-root"], [1, 5, "E"], [2, 5, "G"]]);
 
-  it("returns [] when voicingSourceActive is true and explicitVoicings is empty, even if noteData has chord-tone positions", () => {
+  it.each<{ active: boolean; expectEmpty: boolean }>([
+    { active: true, expectEmpty: true },
+    { active: false, expectEmpty: false },
+  ])("voicingSourceActive=$active + empty explicitVoicings → legacy generator gated", ({ active, expectEmpty }) => {
     const { result } = renderHook(() =>
       useChordConnectorPolylines({
         noteData: chordNoteData,
-        chordToneNames,
+        chordToneNames: ["C", "E", "G"],
         fretCenterX,
         stringYAt,
         stringRowPx: STRING_ROW_PX,
-        chordRoot,
+        chordRoot: "C",
         explicitVoicings: [],
-        voicingSourceActive: true,
+        voicingSourceActive: active,
       }),
     );
-    expect(result.current).toEqual([]);
-  });
-
-  it("still runs the legacy generator when voicingSourceActive is false and explicitVoicings is empty", () => {
-    const { result } = renderHook(() =>
-      useChordConnectorPolylines({
-        noteData: chordNoteData,
-        chordToneNames,
-        fretCenterX,
-        stringYAt,
-        stringRowPx: STRING_ROW_PX,
-        chordRoot,
-        explicitVoicings: [],
-        voicingSourceActive: false,
-      }),
-    );
-    expect(result.current.length).toBeGreaterThan(0);
+    if (expectEmpty) expect(result.current).toEqual([]);
+    else expect(result.current.length).toBeGreaterThan(0);
   });
 });

--- a/src/store/practiceLens.test.ts
+++ b/src/store/practiceLens.test.ts
@@ -40,63 +40,22 @@ describe("practiceLensAtom", () => {
   });
 
   it("defaults to targets", () => {
-    const store = makeStore();
-    expect(store.get(practiceLensAtom)).toBe("targets");
+    expect(makeStore().get(practiceLensAtom)).toBe("targets");
   });
 
-  it("reads stored value", () => {
-    localStorage.setItem(k("practiceLens"), "targets");
+  it.each<{ label: string; key: string; value: string; expected: string }>([
+    { label: "reads stored value", key: "practiceLens", value: "targets", expected: "targets" },
+    { label: "migrates viewMode=chord → targets", key: "viewMode", value: "chord", expected: "targets" },
+    { label: "migrates viewMode=outside → tension", key: "viewMode", value: "outside", expected: "tension" },
+    { label: "migrates viewMode=compare → targets (default)", key: "viewMode", value: "compare", expected: "targets" },
+    { label: "migrates stored targets-color → targets (removed lens)", key: "practiceLens", value: "targets-color", expected: "targets" },
+    { label: "migrates stored color → targets (removed lens)", key: "practiceLens", value: "color", expected: "targets" },
+    { label: "ignores invalid stored value, falls back to default", key: "practiceLens", value: "invalid-lens", expected: "targets" },
+  ])("$label", ({ key, value, expected }) => {
+    localStorage.setItem(k(key), value);
     const store = makeStore();
     const unsub = store.sub(practiceLensAtom, () => {});
-    expect(store.get(practiceLensAtom)).toBe("targets");
-    unsub();
-  });
-
-  it("migrates old viewMode=chord to targets lens", () => {
-    localStorage.setItem(k("viewMode"), "chord");
-    const store = makeStore();
-    const unsub = store.sub(practiceLensAtom, () => {});
-    expect(store.get(practiceLensAtom)).toBe("targets");
-    unsub();
-  });
-
-  it("migrates old viewMode=outside to tension lens", () => {
-    localStorage.setItem(k("viewMode"), "outside");
-    const store = makeStore();
-    const unsub = store.sub(practiceLensAtom, () => {});
-    expect(store.get(practiceLensAtom)).toBe("tension");
-    unsub();
-  });
-
-  it("migrates old viewMode=compare to targets lens (default)", () => {
-    localStorage.setItem(k("viewMode"), "compare");
-    const store = makeStore();
-    const unsub = store.sub(practiceLensAtom, () => {});
-    expect(store.get(practiceLensAtom)).toBe("targets");
-    unsub();
-  });
-
-  it("migrates stored targets-color to targets (removed lens)", () => {
-    localStorage.setItem(k("practiceLens"), "targets-color");
-    const store = makeStore();
-    const unsub = store.sub(practiceLensAtom, () => {});
-    expect(store.get(practiceLensAtom)).toBe("targets");
-    unsub();
-  });
-
-  it("migrates stored color to targets (removed lens)", () => {
-    localStorage.setItem(k("practiceLens"), "color");
-    const store = makeStore();
-    const unsub = store.sub(practiceLensAtom, () => {});
-    expect(store.get(practiceLensAtom)).toBe("targets");
-    unsub();
-  });
-
-  it("ignores invalid stored value and falls back to default", () => {
-    localStorage.setItem(k("practiceLens"), "invalid-lens");
-    const store = makeStore();
-    const unsub = store.sub(practiceLensAtom, () => {});
-    expect(store.get(practiceLensAtom)).toBe("targets");
+    expect(store.get(practiceLensAtom)).toBe(expected);
     unsub();
   });
 });
@@ -198,41 +157,22 @@ describe("practiceCuesAtom", () => {
       store.set(practiceLensAtom, "tension");
       const cues = store.get(practiceCuesAtom);
       const kinds = cues.map((c) => c.kind);
-      expect(kinds).toContain("land-on");
-      expect(kinds).toContain("tension");
+      expect(kinds).toEqual(["land-on", "tension"]);
     });
 
-    it("tension notes include outside chord root (semantic fix)", () => {
-      const store = makeStore();
-      store.set(rootNoteAtom, "C");
-      store.set(scaleNameAtom, "Major");
-      store.set(chordRootAtom, "C#");
-      store.set(chordTypeAtom, "Minor Triad");
-      store.set(practiceLensAtom, "tension");
-      const cues = store.get(practiceCuesAtom);
-      const tensionCue = cues.find((c) => c.kind === "tension");
+    it("tension notes include outside chord root and have resolvesTo targets", () => {
+      const store = makeChordStore("Major", "C", "Minor Triad", "tension");
+      store.set(chordRootAtom, "C#"); // outside the C major scale
+      const tensionCue = store.get(practiceCuesAtom).find((c) => c.kind === "tension");
       expect(tensionCue).toBeDefined();
-      const tensionNotes = tensionCue!.notes.map((n) => n.internalNote);
-      expect(tensionNotes).toContain("C#");
-    });
-
-    it("tension notes have resolution targets (resolvesTo)", () => {
-      const store = makeStore();
-      store.set(rootNoteAtom, "C");
-      store.set(scaleNameAtom, "Major");
-      store.set(chordRootAtom, "C#");
-      store.set(chordTypeAtom, "Minor Triad");
-      store.set(practiceLensAtom, "tension");
-      const cues = store.get(practiceCuesAtom);
-      const tensionCue = cues.find((c) => c.kind === "tension");
-      const hasResolution = tensionCue!.notes.some((n) => n.resolvesTo !== undefined);
-      expect(hasResolution).toBe(true);
+      const notes = tensionCue!.notes;
+      expect(notes.map((n) => n.internalNote)).toContain("C#");
+      expect(notes.some((n) => n.resolvesTo !== undefined)).toBe(true);
     });
 
     it("returns only land-on when chord is fully in-scale (no outside tones)", () => {
       const store = makeChordStore("Major", "C", "Major Triad", "tension");
-      const cues = store.get(practiceCuesAtom);
-      const kinds = cues.map((c) => c.kind);
+      const kinds = store.get(practiceCuesAtom).map((c) => c.kind);
       expect(kinds).toContain("land-on");
       expect(kinds).not.toContain("tension");
     });
@@ -244,23 +184,8 @@ describe("practiceCuesAtom", () => {
       store.set(chordRootAtom, "D");
       store.set(chordTypeAtom, "Minor Triad");
       store.set(practiceLensAtom, "tension");
-      const cues = store.get(practiceCuesAtom);
-      const tensionCue = cues.find((c) => c.kind === "tension");
-      expect(tensionCue).toBeDefined();
-      const dTension = tensionCue!.notes.find((n) => n.internalNote === "D");
-      expect(dTension?.resolvesTo).toBeDefined();
-    });
-
-    it("tension and land-on cues appear together in correct order", () => {
-      const store = makeStore();
-      store.set(rootNoteAtom, "C");
-      store.set(scaleNameAtom, "Major");
-      store.set(chordRootAtom, "C#");
-      store.set(chordTypeAtom, "Minor Triad");
-      store.set(practiceLensAtom, "tension");
-      const cues = store.get(practiceCuesAtom);
-      const kinds = cues.map((c) => c.kind);
-      expect(kinds).toEqual(["land-on", "tension"]);
+      const tensionCue = store.get(practiceCuesAtom).find((c) => c.kind === "tension");
+      expect(tensionCue!.notes.find((n) => n.internalNote === "D")?.resolvesTo).toBeDefined();
     });
   });
 


### PR DESCRIPTION
## Summary

Second test consolidation pass, in the same spirit as PR #420. Five highest-leverage targets, all repeated setup/assertion blocks flattened into parameterized cases or single broader tests.

**-1,076 LOC net (5 files, 1,684 deletions, 608 insertions). Tests: 1782 → 1778, same coverage.**

## LOC saved per file

| File | Before | After | Δ |
|---|---:|---:|---:|
| `useChordConnectorPolylines.test.ts` | 1,790 | 1,096 | **−694 (−39%)** |
| `ChordOverlayControls.test.tsx` | 1,051 | 923 | −128 |
| `ChordPracticeBar.test.tsx` | 735 | 607 | −128 |
| `practiceLens.test.ts` | 886 | 813 | −75 |
| `FretboardSVG.test.tsx` | 1,471 | 1,420 | −51 |

## Patterns collapsed

These were the obvious "same shape, different inputs" clusters:

**`useChordConnectorPolylines.test.ts`** (the big one):
- Playability filter — 8 tests of `result.toHaveLength(0|1)` differing only in fret positions → one `it.each`
- Palette index — 4 inversion tests → one `it.each` parameterized by bass note role
- AABB offset clusters — 3 tests where only the cluster size differs → one `it.each`
- Contour smoke tests — 6 tests asserting the same `M...Z`, `A`, `fill === outline` invariants → one `it.each` driven by vertex specs
- voicingKey stability/uniqueness/order — 4 tests → 3 tighter ones using a shared fixture
- Frets 7–10 vs 19–22 overlap tests (with and without `yBounds`) — 3 near-identical loops → one `it.each` + extracted helper
- Added `notes(specs)` helper + `build()` wrapper to eliminate ~30 instances of 6-argument `buildChordConnectorPolylines(...)` calls

**`ChordOverlayControls.test.tsx`**:
- Task 4 "no disabled state" — 4 `fingeringPattern` cases for panel-root + 3 for chord-mode buttons → two `it.each` blocks
- a11y by lens (degree/manual) → one `it.each`
- Chord-type buttons rendered + ordering (was 2 tests, one listing all 15 button names) → one test driven by the existing `EXPECTED_CHORD_TYPE_LABELS` array
- Voicing type → Inversion/String Set visibility (caged/triad/drop2) → one `it.each`
- String set radio count (3-tone vs 4-tone chord) → one `it.each`
- Scope-to-position switch enabled/disabled by context → one `it.each`

**`ChordPracticeBar.test.tsx`**:
- a11y by lens (targets/guide-tones/tension) → one `it.each`
- Eye-button visible/hidden symmetry (6 tests covering aria-label, aria-pressed, eye-open vs eye-closed icon) → one `it.each`
- Eye-button toggle (false→true and true→false were two near-identical tests) → one `it.each`
- Pill toggle (separate "hide" and "restore" tests sharing setup) → one round-trip test

**`practiceLens.test.ts`**:
- `practiceLensAtom` storage migrations — 7 localStorage cases (legacy `viewMode` values + removed lens ids + invalid value fallback) → one `it.each`
- Three near-identical tension-lens setup tests → one consolidated test reusing the `makeChordStore` helper

**`FretboardSVG.test.tsx`**:
- Role→shape mapping — 7 tests of "X role has data-note-shape=Y" → one `it.each` with shared scale/chord fixtures

## What I didn't touch

- Tests with genuinely different setup or assertions, even when the topic was similar
- Snapshot tests (none in this file set anyway)
- Anything where consolidation would obscure a specific regression case

## Verification

- `pnpm run lint` ✅
- `pnpm run build` ✅
- `pnpm run test` ✅ 1778/1778 tests pass

## Test plan

- [ ] CI green
- [ ] Coverage report shows no regression on the affected files

https://claude.ai/code/session_01BrK9qpBCeteJz3oCt6XJR3

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrK9qpBCeteJz3oCt6XJR3)_