### PR TITLE
test: round 2 consolidation across 7 more files (-632 LOC)

### DIFF
--- a/src/components/CircleOfFifths/CircleOfFifths.test.tsx
+++ b/src/components/CircleOfFifths/CircleOfFifths.test.tsx
@@ -103,77 +103,22 @@ describe("CircleOfFifths/CircleOfFifths", () => {
   });
 
   describe("Scale-aware display", () => {
-    it("displays degrees for Major scale", () => {
-      render(
-        <CircleOfFifths
-          rootNote="C"
-          setRootNote={mockSetRootNote}
-          scaleName="Major"
-        />,
-      );
-
-      const svg = document.querySelector("svg");
-      expect(svg).toBeTruthy();
-      // Degree information should be rendered
-    });
-
-    it("displays degrees for Minor scale", () => {
-      render(
-        <CircleOfFifths
-          rootNote="A"
-          setRootNote={mockSetRootNote}
-          scaleName="Natural Minor"
-        />,
-      );
-
-      const svg = document.querySelector("svg");
-      expect(svg).toBeTruthy();
+    it.each([
+      { root: "C", scale: "Major" },
+      { root: "A", scale: "Natural Minor" },
+      { root: "F", scale: "Lydian" },
+      { root: "D", scale: "Dorian" },
+    ])("renders for $root $scale", ({ root, scale }) => {
+      render(<CircleOfFifths rootNote={root} setRootNote={mockSetRootNote} scaleName={scale} />);
+      expect(document.querySelector("svg")).toBeTruthy();
     });
 
     it("updates degrees when scale changes", () => {
       const { rerender } = render(
-        <CircleOfFifths
-          rootNote="C"
-          setRootNote={mockSetRootNote}
-          scaleName="Major"
-        />,
+        <CircleOfFifths rootNote="C" setRootNote={mockSetRootNote} scaleName="Major" />,
       );
-
-      rerender(
-        <CircleOfFifths
-          rootNote="C"
-          setRootNote={mockSetRootNote}
-          scaleName="Natural Minor"
-        />,
-      );
-
+      rerender(<CircleOfFifths rootNote="C" setRootNote={mockSetRootNote} scaleName="Natural Minor" />);
       expect(document.body).toBeTruthy();
-    });
-
-    it("displays degrees for Lydian mode", () => {
-      render(
-        <CircleOfFifths
-          rootNote="F"
-          setRootNote={mockSetRootNote}
-          scaleName="Lydian"
-        />,
-      );
-
-      const svg = document.querySelector("svg");
-      expect(svg).toBeTruthy();
-    });
-
-    it("displays degrees for Dorian mode", () => {
-      render(
-        <CircleOfFifths
-          rootNote="D"
-          setRootNote={mockSetRootNote}
-          scaleName="Dorian"
-        />,
-      );
-
-      const svg = document.querySelector("svg");
-      expect(svg).toBeTruthy();
     });
   });
 
@@ -181,70 +126,22 @@ describe("CircleOfFifths/CircleOfFifths", () => {
   // into the Scale tab's Theory column — see scaleTheoryDerivations.test.ts.
 
   describe("Accidentals", () => {
-    it("displays sharps by default", () => {
-      render(
-        <CircleOfFifths
-          rootNote="C"
-          setRootNote={mockSetRootNote}
-          useFlats={false}
-        />,
-      );
-
-      const textElements = document.querySelectorAll("text");
-      expect(textElements.length).toBeGreaterThan(0);
+    it.each([
+      { label: "sharps (default)", useFlats: false, rootNote: "C" },
+      { label: "flats when useFlats=true", useFlats: true, rootNote: "C" },
+    ])("renders text elements with $label", ({ useFlats, rootNote }) => {
+      render(<CircleOfFifths rootNote={rootNote} setRootNote={mockSetRootNote} useFlats={useFlats} />);
+      expect(document.querySelectorAll("text").length).toBeGreaterThan(0);
     });
 
-    it("displays flats when useFlats is true", () => {
-      render(
-        <CircleOfFifths
-          rootNote="C"
-          setRootNote={mockSetRootNote}
-          useFlats={true}
-        />,
-      );
-
-      const textElements = document.querySelectorAll("text");
-      expect(textElements.length).toBeGreaterThan(0);
-    });
-
-    it("switches between sharps and flats correctly", () => {
+    it.each([
+      { label: "switches between sharps and flats correctly", root: "C" },
+      { label: "displays enharmonic equivalents (C# / Db)", root: "C#" },
+    ])("$label", ({ root }) => {
       const { rerender } = render(
-        <CircleOfFifths
-          rootNote="C"
-          setRootNote={mockSetRootNote}
-          useFlats={false}
-        />,
+        <CircleOfFifths rootNote={root} setRootNote={mockSetRootNote} useFlats={false} />,
       );
-
-      rerender(
-        <CircleOfFifths
-          rootNote="C"
-          setRootNote={mockSetRootNote}
-          useFlats={true}
-        />,
-      );
-
-      expect(document.body).toBeTruthy();
-    });
-
-    it("displays enharmonic equivalents correctly", () => {
-      // C# and Db should display differently based on useFlats
-      const { rerender } = render(
-        <CircleOfFifths
-          rootNote="C#"
-          setRootNote={mockSetRootNote}
-          useFlats={false}
-        />,
-      );
-
-      rerender(
-        <CircleOfFifths
-          rootNote="C#"
-          setRootNote={mockSetRootNote}
-          useFlats={true}
-        />,
-      );
-
+      rerender(<CircleOfFifths rootNote={root} setRootNote={mockSetRootNote} useFlats={true} />);
       expect(document.body).toBeTruthy();
     });
   });

--- a/src/components/DegreeChipStrip/DegreeChipStrip.test.tsx
+++ b/src/components/DegreeChipStrip/DegreeChipStrip.test.tsx
@@ -198,36 +198,22 @@ describe('DegreeChipStrip/DegreeChipStrip', () => {
   });
 
   describe('visible prop (eye toggle)', () => {
-    it("default visible=true renders chip list", () => {
+    it.each([
+      { visible: true, listPresent: true, attr: "true" },
+      { visible: false, listPresent: false, attr: "false" },
+    ])("visible=$visible: chip list rendered=$listPresent and data-scale-visible=$attr", ({ visible, listPresent, attr }) => {
       const { container } = render(
-        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} />
+        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} visible={visible} />
       );
-      expect(container.querySelector('.degree-chip-strip-list')).toBeTruthy();
+      if (listPresent) expect(container.querySelector('.degree-chip-strip-list')).toBeTruthy();
+      else expect(container.querySelector('.degree-chip-strip-list')).toBeNull();
+      expect(container.querySelector('.degree-chip-strip')?.getAttribute('data-scale-visible')).toBe(attr);
     });
 
-    it("visible=false hides chip list", () => {
-      const { container } = render(
-        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} visible={false} />
-      );
-      expect(container.querySelector('.degree-chip-strip-list')).toBeNull();
-    });
-
-    it("visible=false sets data-scale-visible=false on section", () => {
-      const { container } = render(
-        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} visible={false} />
-      );
-      expect(container.querySelector('.degree-chip-strip')?.getAttribute('data-scale-visible')).toBe('false');
-    });
-
-    it("visible=true sets data-scale-visible=true on section", () => {
-      const { container } = render(
-        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} visible={true} />
-      );
-      expect(container.querySelector('.degree-chip-strip')?.getAttribute('data-scale-visible')).toBe('true');
-    });
-
-    it("chip buttons are enabled when onChipToggle provided and visible", () => {
-      const toggle = vi.fn();
+    it.each([
+      { label: "enabled when onChipToggle provided", toggle: vi.fn(), expectDisabled: false },
+      { label: "disabled when no onChipToggle provided", toggle: undefined, expectDisabled: true },
+    ])("chip buttons: $label", ({ toggle, expectDisabled }) => {
       const { getAllByRole } = render(
         <DegreeChipStrip
           scaleName="A Natural Minor"
@@ -237,58 +223,35 @@ describe('DegreeChipStrip/DegreeChipStrip', () => {
         />
       );
       const buttons = getAllByRole('button');
-      expect(buttons.every((b) => !b.hasAttribute('disabled'))).toBe(true);
+      expect(buttons.every((b) => b.hasAttribute('disabled'))).toBe(expectDisabled);
     });
 
-    it("chip buttons are disabled when no onChipToggle provided", () => {
-      const { getAllByRole } = render(
-        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} visible={true} />
-      );
-      const buttons = getAllByRole('button');
-      expect(buttons.every((b) => b.hasAttribute('disabled'))).toBe(true);
-    });
-
-    it("headerAction renders inside the strip", () => {
+    it.each([true, false])("headerAction renders inside the strip when visible=%s", (visible) => {
       const { getByTestId } = render(
         <DegreeChipStrip
           scaleName="A Natural Minor"
           chips={aMinorChips}
+          visible={visible}
           headerAction={<span data-testid="action-slot">ctrl</span>}
         />
       );
       expect(getByTestId('action-slot')).toBeTruthy();
     });
 
-    it("visible=false still renders headerAction", () => {
-      const { getByTestId } = render(
-        <DegreeChipStrip
-          scaleName="A Natural Minor"
-          chips={aMinorChips}
-          visible={false}
-          headerAction={<span data-testid="action-slot">ctrl</span>}
-        />
-      );
-      expect(getByTestId('action-slot')).toBeTruthy();
-    });
-
-    it("hidden chips show data-hidden when visible", () => {
+    it.each([
+      { label: "hidden chips show data-hidden when visible", hidden: new Set(['B']), expectedCount: 1 },
+      { label: "no data-hidden chips when no hiddenNotes passed", hidden: undefined, expectedCount: 0 },
+    ])("$label", ({ hidden, expectedCount }) => {
       const { container } = render(
         <DegreeChipStrip
           scaleName="A Natural Minor"
           chips={aMinorChips}
           visible={true}
-          hiddenNotes={new Set(['B'])}
+          hiddenNotes={hidden}
           onChipToggle={() => {}}
         />
       );
-      expect(container.querySelectorAll('[data-hidden="true"]').length).toBe(1);
-    });
-
-    it("no data-hidden chips rendered when no hiddenNotes passed", () => {
-      const { container } = render(
-        <DegreeChipStrip scaleName="A Natural Minor" chips={aMinorChips} visible={true} />
-      );
-      expect(container.querySelectorAll('[data-hidden="true"]').length).toBe(0);
+      expect(container.querySelectorAll('[data-hidden="true"]').length).toBe(expectedCount);
     });
   });
 

--- a/src/components/Fretboard/Fretboard.test.tsx
+++ b/src/components/Fretboard/Fretboard.test.tsx
@@ -276,126 +276,58 @@ describe("Fretboard/Fretboard", () => {
     });
   });
 
-  describe("Chord tones and filtering", () => {
-    it("can highlight chord tones separately", () => {
-      render(
-        <Fretboard
-          {...defaultProps}
-          highlightNotes={["C", "D", "E", "F", "G", "A", "B"]}
-          chordTones={["C", "E", "G"]}
-        />,
-      );
-      expect(document.body).toBeTruthy();
-    });
-
-    it("handles chord fret spread calculation", () => {
-      render(
-        <Fretboard
-          {...defaultProps}
-          chordTones={["C", "E", "G"]}
-          chordFretSpread={0}
-        />,
-      );
-
-      expect(document.body).toBeTruthy();
-    });
+  // Render-only smoke tests covering optional props that the Fretboard wrapper
+  // forwards to FretboardSVG. Detailed behavior is asserted in
+  // FretboardSVG.test.tsx; these only verify the wrapper accepts the shapes.
+  it.each<{ label: string; props: Record<string, unknown> }>([
+    {
+      label: "chord tones with scale highlights",
+      props: { highlightNotes: ["C", "D", "E", "F", "G", "A", "B"], chordTones: ["C", "E", "G"] },
+    },
+    {
+      label: "chord fret spread",
+      props: { chordTones: ["C", "E", "G"], chordFretSpread: 0 },
+    },
+    {
+      label: "shape polygons",
+      props: {
+        shapePolygons: [
+          {
+            vertices: [
+              { string: 0, fret: 0 }, { string: 1, fret: 2 }, { string: 2, fret: 2 },
+              { string: 3, fret: 2 }, { string: 4, fret: 0 }, { string: 5, fret: 0 },
+            ],
+            shape: "E", color: "#6366f1", truncated: false,
+            intendedMin: 0, intendedMax: 2, cagedLabel: "E Shape", modalLabel: "Ionian",
+          },
+        ],
+      },
+    },
+    { label: "wrappedNotes set", props: { wrappedNotes: new Set(["4-24", "3-25"]) } },
+    {
+      label: "colorNotes with full scale",
+      props: { highlightNotes: ["C", "D", "E", "F", "G", "A", "B"], colorNotes: ["F#", "B"] },
+    },
+  ])("renders with $label without crashing", ({ props }) => {
+    render(<Fretboard {...defaultProps} {...props} />);
+    expect(document.body).toBeTruthy();
   });
 
-  describe("Shape polygons and visualization", () => {
-    it("renders shape polygons when provided", () => {
-      const shapePolygons = [
-        {
-          vertices: [
-            { string: 0, fret: 0 },
-            { string: 1, fret: 2 },
-            { string: 2, fret: 2 },
-            { string: 3, fret: 2 },
-            { string: 4, fret: 0 },
-            { string: 5, fret: 0 },
-          ],
-          shape: "E" as const,
-          color: "#6366f1",
-          truncated: false,
-          intendedMin: 0,
-          intendedMax: 2,
-          cagedLabel: "E Shape",
-          modalLabel: "Ionian",
-        },
-      ];
-
-      render(
-        <Fretboard
-          {...defaultProps}
-          shapePolygons={shapePolygons}
-        />,
-      );
-
-      expect(document.body).toBeTruthy();
-    });
-  });
-
-  describe("Wrapped notes", () => {
-    it("handles wrapped notes set", () => {
-      const wrappedNotes = new Set(["4-24", "3-25"]);
-
-      render(<Fretboard {...defaultProps} wrappedNotes={wrappedNotes} />);
-
-      expect(document.body).toBeTruthy();
-    });
-
-    it("displays wrapped notes visually", () => {
-      const wrappedNotes = new Set(["0-2", "1-5"]);
-
-      const { container } = render(
-        <Fretboard {...defaultProps} wrappedNotes={wrappedNotes} />,
-      );
-
-      expect(container).toBeTruthy();
-    });
-  });
-
-  describe("Note coloring", () => {
-    it("colors notes based on colorNotes prop", () => {
-      render(
-        <Fretboard
-          {...defaultProps}
-          highlightNotes={["C", "D", "E", "F", "G", "A", "B"]}
-          colorNotes={["F#", "B"]}
-        />,
-      );
-
-      expect(document.body).toBeTruthy();
-    });
-
-    it("updates colors when colorNotes changes", () => {
-      const { rerender } = render(
-        <Fretboard {...defaultProps} colorNotes={["F", "B"]} />,
-      );
-
-      rerender(<Fretboard {...defaultProps} colorNotes={["F#", "C#"]} />);
-
-      expect(document.body).toBeTruthy();
-    });
+  it("re-renders without crashing when colorNotes changes", () => {
+    const { rerender } = render(<Fretboard {...defaultProps} colorNotes={["F", "B"]} />);
+    rerender(<Fretboard {...defaultProps} colorNotes={["F#", "C#"]} />);
+    expect(document.body).toBeTruthy();
   });
 
   describe("Accidentals", () => {
-    it("displays sharps by default", () => {
-      render(<Fretboard {...defaultProps} useFlats={false} />);
-      expect(document.body).toBeTruthy();
-    });
-
-    it("displays flats when useFlats is true", () => {
-      render(<Fretboard {...defaultProps} useFlats={true} />);
+    it.each([false, true])("renders with useFlats=%s", (useFlats) => {
+      render(<Fretboard {...defaultProps} useFlats={useFlats} />);
       expect(document.body).toBeTruthy();
     });
 
     it("updates display when useFlats changes", () => {
-      const { rerender } = render(
-        <Fretboard {...defaultProps} useFlats={false} />,
-      );
-
+      const { rerender } = render(<Fretboard {...defaultProps} useFlats={false} />);
       rerender(<Fretboard {...defaultProps} useFlats={true} />);
-
       expect(document.body).toBeTruthy();
     });
   });

--- a/src/components/FretboardSVG/FretboardNoteLayer.test.tsx
+++ b/src/components/FretboardSVG/FretboardNoteLayer.test.tsx
@@ -45,50 +45,51 @@ function makeNote(noteClass: NoteClass, overrides: Partial<NoteData> = {}): Note
   };
 }
 
+function renderLayer(
+  noteData: NoteData[],
+  opts: {
+    fretCenterX?: (fi: number) => number;
+    stringYAt?: (si: number, x: number) => number;
+    bubblePx?: number;
+    displayFormat?: "notes" | "none";
+  } = {},
+) {
+  const {
+    fretCenterX = () => 100,
+    stringYAt = () => 50,
+    bubblePx = 40,
+    displayFormat = "notes",
+  } = opts;
+  return render(
+    <svg>
+      <FretboardNoteLayer
+        noteData={noteData}
+        fretCenterX={fretCenterX}
+        stringYAt={stringYAt}
+        noteBubblePx={bubblePx}
+        displayFormat={displayFormat}
+      />
+    </svg>,
+  );
+}
+
 describe("FretboardNoteLayer", () => {
   it("has no accessibility violations", async () => {
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[makeNote("note-active")]}
-          fretCenterX={() => 100}
-          stringYAt={() => 50}
-          noteBubblePx={40}
-          displayFormat="notes"
-        />
-      </svg>,
-    );
+    const { container } = renderLayer([makeNote("note-active")]);
     expect(await axe(container)).toHaveNoViolations();
   });
 
-  it("renders squircle as a superellipse path, not a rounded rect", () => {
+  it("renders squircle as a superellipse path with halo for chord-root", () => {
     const noteBubblePx = 40;
-    const rawChordRootRadius = (noteBubblePx / 2) * 0.86;
-    const visualRadius = rawChordRootRadius - SQUIRCLE_RADIUS_REDUCTION_PX;
-
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[makeNote("chord-root")]}
-          fretCenterX={() => 100}
-          stringYAt={() => 50}
-          noteBubblePx={noteBubblePx}
-          displayFormat="notes"
-        />
-      </svg>,
-    );
+    const visualRadius = (noteBubblePx / 2) * 0.86 - SQUIRCLE_RADIUS_REDUCTION_PX;
+    const { container } = renderLayer([makeNote("chord-root")], { bubblePx: noteBubblePx });
 
     const paths = container.querySelectorAll("path");
     expect(paths.length).toBe(2);
-
-    const haloPath = paths[0]!;
-    const mainPath = paths[1]!;
-
-    expect(mainPath.getAttribute("d")).toBe(squirclePath(100, 50, visualRadius));
-    expect(haloPath.getAttribute("d")).toBe(
+    expect(paths[1]!.getAttribute("d")).toBe(squirclePath(100, 50, visualRadius));
+    expect(paths[0]!.getAttribute("d")).toBe(
       squirclePath(100, 50, visualRadius + CHORD_ROOT_HALO_RADIUS_PX),
     );
-
     expect(container.querySelectorAll("rect").length).toBe(0);
 
     const label = container.querySelector("text")!;
@@ -99,335 +100,136 @@ describe("FretboardNoteLayer", () => {
 
   it("reduces circular note geometry by CIRCLE_RADIUS_REDUCTION_PX", () => {
     const noteBubblePx = 40;
-    const rawCircleRadius = (noteBubblePx / 2) * 0.82;
-    const expectedCircleRadius = rawCircleRadius - CIRCLE_RADIUS_REDUCTION_PX;
-
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[makeNote("note-active")]}
-          fretCenterX={() => 100}
-          stringYAt={() => 50}
-          noteBubblePx={noteBubblePx}
-          displayFormat="notes"
-        />
-      </svg>,
-    );
-
-    const circle = container.querySelector("circle")!;
-    expect(Number(circle.getAttribute("r"))).toBeCloseTo(expectedCircleRadius);
+    const expectedCircleRadius = (noteBubblePx / 2) * 0.82 - CIRCLE_RADIUS_REDUCTION_PX;
+    const { container } = renderLayer([makeNote("note-active")], { bubblePx: noteBubblePx });
+    expect(Number(container.querySelector("circle")!.getAttribute("r"))).toBeCloseTo(expectedCircleRadius);
   });
 
   it("renders text label at note center coordinates", () => {
-    const cx = 120;
-    const cy = 60;
-
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[makeNote("note-active")]}
-          fretCenterX={() => cx}
-          stringYAt={() => cy}
-          noteBubblePx={40}
-          displayFormat="notes"
-        />
-      </svg>,
-    );
-
+    const cx = 120, cy = 60;
+    const { container } = renderLayer([makeNote("note-active")], {
+      fretCenterX: () => cx,
+      stringYAt: () => cy,
+    });
     const label = container.querySelector("text")!;
-    expect(label).toBeTruthy();
     expect(label.textContent).toBe("C");
     expect(label.getAttribute("x")).toBe(String(cx));
     expect(label.getAttribute("y")).toBe(String(cy));
   });
 
   it("omits text label when displayFormat is none", () => {
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[makeNote("note-active")]}
-          fretCenterX={() => 100}
-          stringYAt={() => 50}
-          noteBubblePx={40}
-          displayFormat="none"
-        />
-      </svg>,
-    );
-
+    const { container } = renderLayer([makeNote("note-active")], { displayFormat: "none" });
     expect(container.querySelectorAll("text").length).toBe(0);
   });
 
-  it("renders chord-root with squircle shape and halo, chord-tone with squircle but no halo", () => {
-    const noteBubblePx = 40;
-
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[
-            makeNote("chord-root", { stringIndex: 0, fretIndex: 1 }),
-            makeNote("chord-tone-in-scale", { stringIndex: 1, fretIndex: 2 }),
-          ]}
-          fretCenterX={(fi) => fi * 50}
-          stringYAt={(si) => si * 30}
-          noteBubblePx={noteBubblePx}
-          displayFormat="notes"
-        />
-      </svg>,
+  it("renders chord-root with squircle+halo and chord-tone with squircle but no halo", () => {
+    const { container } = renderLayer(
+      [
+        makeNote("chord-root", { stringIndex: 0, fretIndex: 1 }),
+        makeNote("chord-tone-in-scale", { stringIndex: 1, fretIndex: 2 }),
+      ],
+      { fretCenterX: (fi) => fi * 50, stringYAt: (si) => si * 30 },
     );
-
-    // chord-root: halo path + main path = 2 paths; chord-tone-in-scale: 1 path; total = 3
-    const paths = container.querySelectorAll("path");
-    expect(paths.length).toBe(3);
-
-    // No rect elements (squircles are paths, not rects)
+    expect(container.querySelectorAll("path").length).toBe(3); // chord-root halo+main, chord-tone main
     expect(container.querySelectorAll("rect").length).toBe(0);
-
-    // Two text labels
-    const labels = container.querySelectorAll("text");
-    expect(labels.length).toBe(2);
+    expect(container.querySelectorAll("text").length).toBe(2);
   });
 
-  it("renders note-active as circle, not a path or polygon", () => {
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[makeNote("note-active")]}
-          fretCenterX={() => 100}
-          stringYAt={() => 50}
-          noteBubblePx={40}
-          displayFormat="notes"
-        />
-      </svg>,
-    );
-
-    expect(container.querySelectorAll("circle").length).toBe(1);
-    expect(container.querySelectorAll("path").length).toBe(0);
-    expect(container.querySelectorAll("polygon").length).toBe(0);
-  });
-
-  it("renders chord-tone-outside-scale as diamond (polygon), not circle or path", () => {
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[makeNote("chord-tone-outside-scale")]}
-          fretCenterX={() => 100}
-          stringYAt={() => 50}
-          noteBubblePx={40}
-          displayFormat="notes"
-        />
-      </svg>,
-    );
-
-    expect(container.querySelectorAll("polygon").length).toBe(1);
-    expect(container.querySelectorAll("circle").length).toBe(0);
-    expect(container.querySelectorAll("path").length).toBe(0);
-  });
-
-  it("renders note-blue as hexagon (polygon), not circle or path", () => {
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[makeNote("note-blue")]}
-          fretCenterX={() => 100}
-          stringYAt={() => 50}
-          noteBubblePx={40}
-          displayFormat="notes"
-        />
-      </svg>,
-    );
-
-    expect(container.querySelectorAll("polygon").length).toBe(1);
-    expect(container.querySelectorAll("circle").length).toBe(0);
-    expect(container.querySelectorAll("path").length).toBe(0);
+  // Each role maps to a single SVG primitive — verify the others stay absent.
+  it.each<{ role: NoteClass; primitive: "circle" | "polygon" | "path"; count: number }>([
+    { role: "note-active", primitive: "circle", count: 1 },
+    { role: "chord-tone-outside-scale", primitive: "polygon", count: 1 },
+    { role: "note-blue", primitive: "polygon", count: 1 },
+  ])("$role renders exactly $count <$primitive> element with no other shape primitive", ({ role, primitive, count }) => {
+    const { container } = renderLayer([makeNote(role)]);
+    const other = (["circle", "polygon", "path"] as const).filter((p) => p !== primitive);
+    expect(container.querySelectorAll(primitive).length).toBe(count);
+    other.forEach((p) => expect(container.querySelectorAll(p).length).toBe(0));
   });
 
   it("applies correct data-note-role attribute for non-inactive notes", () => {
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[
-            makeNote("chord-root", { stringIndex: 0, fretIndex: 0 }),
-            makeNote("note-active", { stringIndex: 1, fretIndex: 1 }),
-            makeNote("note-inactive", { stringIndex: 2, fretIndex: 2 }),
-          ]}
-          fretCenterX={(fi) => fi * 50}
-          stringYAt={(si) => si * 30}
-          noteBubblePx={40}
-          displayFormat="notes"
-        />
-      </svg>,
+    const { container } = renderLayer(
+      [
+        makeNote("chord-root", { stringIndex: 0, fretIndex: 0 }),
+        makeNote("note-active", { stringIndex: 1, fretIndex: 1 }),
+        makeNote("note-inactive", { stringIndex: 2, fretIndex: 2 }),
+      ],
+      { fretCenterX: (fi) => fi * 50, stringYAt: (si) => si * 30 },
     );
-
-    const groups = container.querySelectorAll("g[data-note-role]");
     // note-inactive should NOT have data-note-role; chord-root and note-active should
+    const groups = container.querySelectorAll("g[data-note-role]");
     expect(groups.length).toBe(2);
-
     const roles = Array.from(groups).map((g) => g.getAttribute("data-note-role"));
     expect(roles).toContain("chord-root");
     expect(roles).toContain("note-active");
   });
 
   it("applies correct data-note-shape attribute for each shape type", () => {
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[
-            makeNote("chord-root", { stringIndex: 0, fretIndex: 0 }),
-            makeNote("note-active", { stringIndex: 1, fretIndex: 1 }),
-            makeNote("chord-tone-outside-scale", { stringIndex: 2, fretIndex: 2 }),
-            makeNote("note-blue", { stringIndex: 3, fretIndex: 3 }),
-          ]}
-          fretCenterX={(fi) => fi * 50}
-          stringYAt={(si) => si * 30}
-          noteBubblePx={40}
-          displayFormat="notes"
-        />
-      </svg>,
+    const { container } = renderLayer(
+      [
+        makeNote("chord-root", { stringIndex: 0, fretIndex: 0 }),
+        makeNote("note-active", { stringIndex: 1, fretIndex: 1 }),
+        makeNote("chord-tone-outside-scale", { stringIndex: 2, fretIndex: 2 }),
+        makeNote("note-blue", { stringIndex: 3, fretIndex: 3 }),
+      ],
+      { fretCenterX: (fi) => fi * 50, stringYAt: (si) => si * 30 },
     );
-
-    const getShapeFor = (role: string) =>
-      container
-        .querySelector(`g[data-note-role="${role}"]`)
-        ?.getAttribute("data-note-shape");
-
-    expect(getShapeFor("chord-root")).toBe("squircle");
-    expect(getShapeFor("note-active")).toBe("circle");
-    expect(getShapeFor("chord-tone-outside-scale")).toBe("diamond");
-    expect(getShapeFor("note-blue")).toBe("hexagon");
+    const shapeFor = (role: string) =>
+      container.querySelector(`g[data-note-role="${role}"]`)?.getAttribute("data-note-shape");
+    expect(shapeFor("chord-root")).toBe("squircle");
+    expect(shapeFor("note-active")).toBe("circle");
+    expect(shapeFor("chord-tone-outside-scale")).toBe("diamond");
+    expect(shapeFor("note-blue")).toBe("hexagon");
   });
 
-  it("chord-root squircle radius uses RADIUS_SCALE_CHORD_ROOT and SQUIRCLE_RADIUS_REDUCTION_PX", () => {
+  it.each<{ role: NoteClass; scale: number; pathIndex: number; totalPaths: number }>([
+    { role: "chord-root", scale: RADIUS_SCALE_CHORD_ROOT, pathIndex: 1, totalPaths: 2 },
+    { role: "chord-tone-in-scale", scale: RADIUS_SCALE_CHORD_TONE, pathIndex: 0, totalPaths: 1 },
+  ])("$role squircle radius reduced by SQUIRCLE_RADIUS_REDUCTION_PX", ({ role, scale, pathIndex, totalPaths }) => {
     const noteBubblePx = 40;
-    const rawRadius = (noteBubblePx / 2) * RADIUS_SCALE_CHORD_ROOT;
-    const expectedRadius = rawRadius - SQUIRCLE_RADIUS_REDUCTION_PX;
-
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[makeNote("chord-root")]}
-          fretCenterX={() => 100}
-          stringYAt={() => 50}
-          noteBubblePx={noteBubblePx}
-          displayFormat="notes"
-        />
-      </svg>,
-    );
-
+    const expectedRadius = (noteBubblePx / 2) * scale - SQUIRCLE_RADIUS_REDUCTION_PX;
+    const { container } = renderLayer([makeNote(role)], { bubblePx: noteBubblePx });
     const paths = container.querySelectorAll("path");
-    // paths[1] is the main squircle (paths[0] is the halo)
-    expect(paths[1]!.getAttribute("d")).toBe(squirclePath(100, 50, expectedRadius));
-  });
-
-  it("chord-tone-in-scale squircle radius uses RADIUS_SCALE_CHORD_TONE", () => {
-    const noteBubblePx = 40;
-    const rawRadius = (noteBubblePx / 2) * RADIUS_SCALE_CHORD_TONE;
-    const expectedRadius = rawRadius - SQUIRCLE_RADIUS_REDUCTION_PX;
-
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[makeNote("chord-tone-in-scale")]}
-          fretCenterX={() => 100}
-          stringYAt={() => 50}
-          noteBubblePx={noteBubblePx}
-          displayFormat="notes"
-        />
-      </svg>,
-    );
-
-    const paths = container.querySelectorAll("path");
-    // chord-tone-in-scale has no halo, so paths[0] is the main squircle
-    expect(paths.length).toBe(1);
-    expect(paths[0]!.getAttribute("d")).toBe(squirclePath(100, 50, expectedRadius));
+    expect(paths.length).toBe(totalPaths);
+    expect(paths[pathIndex]!.getAttribute("d")).toBe(squirclePath(100, 50, expectedRadius));
   });
 
   it("hidden notes do not render with data-note-role and are aria-hidden", () => {
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[makeNote("note-active", { isHidden: true })]}
-          fretCenterX={() => 100}
-          stringYAt={() => 50}
-          noteBubblePx={40}
-          displayFormat="notes"
-        />
-      </svg>,
-    );
-
-    const group = container.querySelector("g[aria-hidden='true']");
-    expect(group).toBeTruthy();
+    const { container } = renderLayer([makeNote("note-active", { isHidden: true })]);
+    expect(container.querySelector("g[aria-hidden='true']")).toBeTruthy();
   });
 
   it("lens emphasis radiusBoost scales the final rendered radius", () => {
-    const noteBubblePx = 40;
-    const radiusBoost = 1.15;
-    const rawRadius = (noteBubblePx / 2) * RADIUS_SCALE_NOTE_ACTIVE * radiusBoost;
-    const expectedRadius = rawRadius - CIRCLE_RADIUS_REDUCTION_PX;
-
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[
-            makeNote("note-active", {
-              applyLensEmphasis: { radiusBoost, opacityBoost: 1 },
-            }),
-          ]}
-          fretCenterX={() => 100}
-          stringYAt={() => 50}
-          noteBubblePx={noteBubblePx}
-          displayFormat="notes"
-        />
-      </svg>,
+    const noteBubblePx = 40, radiusBoost = 1.15;
+    const expectedRadius = (noteBubblePx / 2) * RADIUS_SCALE_NOTE_ACTIVE * radiusBoost - CIRCLE_RADIUS_REDUCTION_PX;
+    const { container } = renderLayer(
+      [makeNote("note-active", { applyLensEmphasis: { radiusBoost, opacityBoost: 1 } })],
+      { bubblePx: noteBubblePx },
     );
-
-    const circle = container.querySelector("circle")!;
-    expect(Number(circle.getAttribute("r"))).toBeCloseTo(expectedRadius);
+    expect(Number(container.querySelector("circle")!.getAttribute("r"))).toBeCloseTo(expectedRadius);
   });
 
-  it("filter='chord' renders only chord-class notes", () => {
+  it.each<{ filter: "chord" | "non-chord"; third: NoteClass }>([
+    { filter: "chord", third: "chord-tone-in-scale" },
+    { filter: "non-chord", third: "scale-only" },
+  ])("filter='$filter' renders only its matching notes", ({ filter, third }) => {
     const { container } = render(
       <svg>
         <FretboardNoteLayer
           noteData={[
             makeNote("chord-root", { stringIndex: 0, fretIndex: 0 }),
             makeNote("note-active", { stringIndex: 1, fretIndex: 1 }),
-            makeNote("chord-tone-in-scale", { stringIndex: 2, fretIndex: 2 }),
+            makeNote(third, { stringIndex: 2, fretIndex: 2 }),
           ]}
           fretCenterX={(fi) => fi * 50}
           stringYAt={(si) => si * 30}
           noteBubblePx={40}
           displayFormat="notes"
-          filter="chord"
+          filter={filter}
         />
       </svg>,
     );
-
-    const labels = container.querySelectorAll("text");
-    // Only chord-root and chord-tone should render
-    expect(labels.length).toBe(2);
-  });
-
-  it("filter='non-chord' renders only non-chord notes", () => {
-    const { container } = render(
-      <svg>
-        <FretboardNoteLayer
-          noteData={[
-            makeNote("chord-root", { stringIndex: 0, fretIndex: 0 }),
-            makeNote("note-active", { stringIndex: 1, fretIndex: 1 }),
-            makeNote("scale-only", { stringIndex: 2, fretIndex: 2 }),
-          ]}
-          fretCenterX={(fi) => fi * 50}
-          stringYAt={(si) => si * 30}
-          noteBubblePx={40}
-          displayFormat="notes"
-          filter="non-chord"
-        />
-      </svg>,
-    );
-
-    const labels = container.querySelectorAll("text");
-    // Only note-active and scale-only should render
-    expect(labels.length).toBe(2);
+    expect(container.querySelectorAll("text").length).toBe(2);
   });
 
   it("marks note groups with CSS animation mode", () => {
@@ -443,7 +245,6 @@ describe("FretboardNoteLayer", () => {
         />
       </svg>,
     );
-
     expect(container.querySelector('[data-motion="css"]')).toBeTruthy();
   });
 });

--- a/src/components/FretboardSVG/utils/pathGeometry.test.ts
+++ b/src/components/FretboardSVG/utils/pathGeometry.test.ts
@@ -6,6 +6,18 @@ import {
   offsetOpenPolylinePath,
 } from "./pathGeometry";
 
+/** Counts a literal SVG command (single uppercase or lowercase letter) in a path string. */
+function commandCount(path: string, cmd: string): number {
+  // Use word-boundary regex so 'A' doesn't match inside numbers etc.
+  return (path.match(new RegExp(`\\b${cmd}\\b`, "g")) ?? []).length;
+}
+
+function expectClosedPath(d: string) {
+  expect(d).not.toBe("");
+  expect(d.startsWith("M")).toBe(true);
+  expect(d.endsWith("Z")).toBe(true);
+}
+
 describe("polarSort", () => {
   it("sorts a non-monotonic triangle into counterclockwise order", () => {
     // Triangle with points in wrong order — right, top, left (non-monotonic).
@@ -136,42 +148,20 @@ describe("offsetOutlinePath", () => {
     expect(offsetOutlinePath([], 10)).toBe("");
   });
 
-  it("1-point input: returns a path containing M and two 'a' arc commands (circle)", () => {
-    const d = offsetOutlinePath([{ x: 50, y: 50 }], 20);
-    expect(d).not.toBe("");
-    expect(d.startsWith("M")).toBe(true);
-    expect(d.endsWith("Z")).toBe(true);
-    // Must contain two arc commands (lowercase 'a' for relative arcs).
-    const aCount = (d.match(/\ba\b/g) ?? []).length;
-    expect(aCount).toBe(2);
-  });
-
-  it("2-point input: returns a capsule path with 2 A arc commands and 2 L segment commands", () => {
-    const d = offsetOutlinePath([{ x: 50, y: 100 }, { x: 50, y: 200 }], 20);
-    expect(d).not.toBe("");
-    expect(d.startsWith("M")).toBe(true);
-    expect(d.endsWith("Z")).toBe(true);
-    const aCount = (d.match(/\bA\b/g) ?? []).length;
-    const lCount = (d.match(/\bL\b/g) ?? []).length;
-    expect(aCount).toBe(2);
-    expect(lCount).toBe(2);
-  });
-
-  it("3-point triangle hull: returns path with 3 A arc commands and line segments", () => {
-    const hull = [
-      { x: 0, y: 0 },
-      { x: 100, y: 0 },
-      { x: 50, y: 86.6 }, // approximately equilateral triangle
-    ];
-    const d = offsetOutlinePath(hull, 15);
-    expect(d).not.toBe("");
-    expect(d.startsWith("M")).toBe(true);
-    expect(d.endsWith("Z")).toBe(true);
-    const aCount = (d.match(/\bA\b/g) ?? []).length;
-    expect(aCount).toBe(3);
-    // Must have line segments (at least 3 L commands, one per edge between arcs).
-    const lCount = (d.match(/\bL\b/g) ?? []).length;
-    expect(lCount).toBeGreaterThanOrEqual(3);
+  it.each<{ label: string; hull: { x: number; y: number }[]; r: number; aCount: number; arcCmd: "A" | "a"; lMin?: number; lExact?: number }>([
+    { label: "1-point input → circle with two relative-arc commands", hull: [{ x: 50, y: 50 }], r: 20, aCount: 2, arcCmd: "a" },
+    { label: "2-point capsule → 2 absolute arcs + 2 line segments", hull: [{ x: 50, y: 100 }, { x: 50, y: 200 }], r: 20, aCount: 2, arcCmd: "A", lExact: 2 },
+    {
+      label: "3-point triangle hull → 3 absolute arcs + ≥3 line segments",
+      hull: [{ x: 0, y: 0 }, { x: 100, y: 0 }, { x: 50, y: 86.6 }],
+      r: 15, aCount: 3, arcCmd: "A", lMin: 3,
+    },
+  ])("$label", ({ hull, r, aCount, arcCmd, lMin, lExact }) => {
+    const d = offsetOutlinePath(hull, r);
+    expectClosedPath(d);
+    expect(commandCount(d, arcCmd)).toBe(aCount);
+    if (lExact !== undefined) expect(commandCount(d, "L")).toBe(lExact);
+    if (lMin !== undefined) expect(commandCount(d, "L")).toBeGreaterThanOrEqual(lMin);
   });
 
   it("spot-check: vertical collinear hull (2-vertex capsule) has correct arc radius and geometry", () => {
@@ -193,78 +183,28 @@ describe("offsetOutlinePath", () => {
     expect(d).toContain("119.8"); // 100 + 19.8
   });
 
-  it("spot-check: equilateral triangle r=30 — corner offset positions within 0.01", () => {
-    // Equilateral triangle with side 100, bottom-left at origin. Provided in
-    // CCW order (lower-left → lower-right → apex upward in SVG).
-    const hull = [
-      { x: 0, y: 0 },
-      { x: 100, y: 0 },
-      { x: 50, y: -86.60 },
-    ];
-    const r = 30;
+  it.each<{ label: string; hull: { x: number; y: number }[]; r: number; aCount: number }>([
+    { label: "CCW equilateral triangle r=30", hull: [{ x: 0, y: 0 }, { x: 100, y: 0 }, { x: 50, y: -86.60 }], r: 30, aCount: 3 },
+    { label: "r=0 degenerate offset", hull: [{ x: 10, y: 20 }, { x: 50, y: 20 }, { x: 30, y: 60 }], r: 0, aCount: 3 },
+    {
+      label: "thin near-collinear triangle keeps all 3 corners (no interior drops)",
+      hull: polarSort([{ x: 0, y: 0 }, { x: 50, y: 5 }, { x: 100, y: 0 }]),
+      r: 20, aCount: 3,
+    },
+  ])("3-vertex closed path with $aCount arcs: $label", ({ hull, r, aCount }) => {
     const d = offsetOutlinePath(hull, r);
-    expect(d).not.toBe("");
-    // For a CCW equilateral triangle, outgoing normal of bottom edge (0,0)→(100,0) is (0,-1) (upward in SVG).
-    // B_0 = (0 + 30*0, 0 + 30*(-1)) = (0, -30).
-    // Check that (0, -30) appears in the path (allowing for floating point at 2dp).
-    // The path starts with M ... which is A_0 (incoming normal of last edge).
-    // Let's just verify structural and non-empty.
-    expect(d).toContain("A");
-    const aCount = (d.match(/\bA\b/g) ?? []).length;
-    expect(aCount).toBe(3);
+    expectClosedPath(d);
+    if (r > 0) expect(commandCount(d, "A")).toBe(aCount);
   });
 
-  it("r=0 still produces a valid path shape (degenerate offset)", () => {
-    // Pre-ordered CCW triangle (the input was already non-degenerate, so
-    // convexHull would return it unchanged).
-    const hull = [{ x: 10, y: 20 }, { x: 50, y: 20 }, { x: 30, y: 60 }];
-    const d = offsetOutlinePath(hull, 0);
-    expect(d).not.toBe("");
-    expect(d.startsWith("M")).toBe(true);
-    expect(d.endsWith("Z")).toBe(true);
-  });
-
-  it("thin near-collinear triangle: all 3 corners produce 3 A arc commands", () => {
-    // Feed a polar-sorted near-collinear triangle — the kind that polarSort
-    // produces for the G-E-C diagonal triad.  The offset path must include
-    // one arc per vertex (3 total), confirming the middle vertex is not dropped.
-    const triangle = polarSort([
-      { x: 0, y: 0 },
-      { x: 50, y: 5 },
-      { x: 100, y: 0 },
-    ]);
-    const d = offsetOutlinePath(triangle, 20);
-    expect(d).not.toBe("");
-    expect(d.startsWith("M")).toBe(true);
-    expect(d.endsWith("Z")).toBe(true);
-    // One A arc command per vertex → 3 total.
-    const aCount = (d.match(/\bA\b/g) ?? []).length;
-    expect(aCount).toBe(3);
-  });
-
-  it("winding-agnostic: CW and CCW polygon produce outward (not inward) contours", () => {
-    // A right triangle fed in CCW order should produce the same-shape path as
-    // the same triangle reversed (CW order) — both contours must be outside the
-    // triangle (offset points further from centroid than original vertices).
-    const ccw = [
-      { x: 0, y: 0 },
-      { x: 100, y: 0 },
-      { x: 50, y: -86.6 }, // apex upward (negative y in SVG)
-    ];
+  it("winding-agnostic: CW and CCW polygon both produce outward 3-arc contours", () => {
+    const ccw = [{ x: 0, y: 0 }, { x: 100, y: 0 }, { x: 50, y: -86.6 }];
     const cw = [...ccw].reverse();
-
-    const r = 20;
-    const dCCW = offsetOutlinePath(ccw, r);
-    const dCW = offsetOutlinePath(cw, r);
-
-    // Both must produce 3 A arc commands.
-    expect((dCCW.match(/\bA\b/g) ?? []).length).toBe(3);
-    expect((dCW.match(/\bA\b/g) ?? []).length).toBe(3);
-    // Both must be non-empty closed paths.
-    expect(dCCW.startsWith("M")).toBe(true);
-    expect(dCW.startsWith("M")).toBe(true);
-    expect(dCCW.endsWith("Z")).toBe(true);
-    expect(dCW.endsWith("Z")).toBe(true);
+    for (const hull of [ccw, cw]) {
+      const d = offsetOutlinePath(hull, 20);
+      expectClosedPath(d);
+      expect(commandCount(d, "A")).toBe(3);
+    }
   });
 
   it("normals point OUTWARD: every coordinate in path is at least as far from centroid as the polygon vertices", () => {

--- a/src/store/atoms.test.ts
+++ b/src/store/atoms.test.ts
@@ -569,41 +569,18 @@ describe("atoms", () => {
       expect(store.get(fingeringPatternAtom)).toBe("caged");
     });
 
-    it("does NOT clear chordDegreeAtom when pattern changes to one-string", () => {
+    it.each<[string, "one-string" | "two-strings" | "caged" | "none" | "3nps"]>([
+      ["I", "one-string"],
+      ["V", "two-strings"],
+      ["IV", "caged"],
+      ["ii", "none"],
+      ["iii", "3nps"],
+    ])("preserves chordDegreeAtom='%s' across pattern change to %s", (degree, pattern) => {
       const store = makeStore();
-      store.set(chordDegreeAtom, "I" as import("@fretflow/core").DegreeId);
-      store.set(setFingeringPatternAtom, "one-string");
-      expect(store.get(fingeringPatternAtom)).toBe("one-string");
-      expect(store.get(chordDegreeAtom)).toBe("I");
-    });
-
-    it("does NOT clear chordDegreeAtom when pattern changes to two-strings", () => {
-      const store = makeStore();
-      store.set(chordDegreeAtom, "V" as import("@fretflow/core").DegreeId);
-      store.set(setFingeringPatternAtom, "two-strings");
-      expect(store.get(fingeringPatternAtom)).toBe("two-strings");
-      expect(store.get(chordDegreeAtom)).toBe("V");
-    });
-
-    it("does NOT clear chordDegreeAtom when pattern changes to caged", () => {
-      const store = makeStore();
-      store.set(chordDegreeAtom, "IV" as import("@fretflow/core").DegreeId);
-      store.set(setFingeringPatternAtom, "caged");
-      expect(store.get(chordDegreeAtom)).toBe("IV");
-    });
-
-    it("does NOT clear chordDegreeAtom when pattern changes to none", () => {
-      const store = makeStore();
-      store.set(chordDegreeAtom, "ii" as import("@fretflow/core").DegreeId);
-      store.set(setFingeringPatternAtom, "none");
-      expect(store.get(chordDegreeAtom)).toBe("ii");
-    });
-
-    it("does NOT clear chordDegreeAtom when pattern changes to 3nps", () => {
-      const store = makeStore();
-      store.set(chordDegreeAtom, "iii" as import("@fretflow/core").DegreeId);
-      store.set(setFingeringPatternAtom, "3nps");
-      expect(store.get(chordDegreeAtom)).toBe("iii");
+      store.set(chordDegreeAtom, degree as import("@fretflow/core").DegreeId);
+      store.set(setFingeringPatternAtom, pattern);
+      expect(store.get(fingeringPatternAtom)).toBe(pattern);
+      expect(store.get(chordDegreeAtom)).toBe(degree);
     });
   });
 

--- a/src/store/chordOverlayAtoms.test.ts
+++ b/src/store/chordOverlayAtoms.test.ts
@@ -47,43 +47,24 @@ describe("chordOverlayAtoms — degree mode (read path)", () => {
     localStorage.clear();
   });
 
-  it("chordRootAtom returns diatonic root for I in C Major", () => {
-    const store = makeAtomStore([
-      [chordDegreeAtom, "I"],
-      [chordOverlayModeAtom, "degree"],
-      [rootNoteAtom, "C"],
-      [scaleNameAtom, "Major"],
-    ]);
-    expect(store.get(chordRootAtom)).toBe("C");
-  });
+  const C_MAJOR_DEGREE_SEEDS = [
+    [progressionStepsAtom, []],
+    [chordOverlayModeAtom, "degree"],
+    [rootNoteAtom, "C"],
+    [scaleNameAtom, "Major"],
+  ] as const;
 
-  it("chordTypeAtom returns diatonic quality for I in C Major", () => {
-    const store = makeAtomStore([
-      [chordDegreeAtom, "I"],
-      [chordOverlayModeAtom, "degree"],
-      [rootNoteAtom, "C"],
-      [scaleNameAtom, "Major"],
-    ]);
-    expect(store.get(chordTypeAtom)).toBe("Major Triad");
-  });
-
-  it("chordRootAtom returns diatonic root for vi in C Major", () => {
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordDegreeAtom, "vi"],
-      [chordOverlayModeAtom, "degree"],
-      [rootNoteAtom, "C"],
-      [scaleNameAtom, "Major"],
-    ]);
-    expect(store.get(chordRootAtom)).toBe("A");
+  it.each<{ degree: string; root: string; type: string }>([
+    { degree: "I", root: "C", type: "Major Triad" },
+    { degree: "vi", root: "A", type: "Minor Triad" },
+  ])("degree=$degree → chordRoot=$root, chordType=$type (C Major)", ({ degree, root, type }) => {
+    const store = makeAtomStore([...C_MAJOR_DEGREE_SEEDS, [chordDegreeAtom, degree]]);
+    expect(store.get(chordRootAtom)).toBe(root);
+    expect(store.get(chordTypeAtom)).toBe(type);
   });
 
   it("chordTypeAtom returns null when chordDegree is null (overlay off)", () => {
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordDegreeAtom, null],
-      [chordOverlayModeAtom, "degree"],
-    ]);
+    const store = makeAtomStore([...C_MAJOR_DEGREE_SEEDS, [chordDegreeAtom, null]]);
     expect(store.get(chordTypeAtom)).toBeNull();
   });
 });
@@ -137,133 +118,71 @@ describe("chordOverlayAtoms — degree mode quality override", () => {
     localStorage.clear();
   });
 
-  it("read path: degree mode + override returns the override quality (V Dom7 in C Major)", () => {
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordDegreeAtom, "V"],
-      [chordOverlayModeAtom, "degree"],
-      [rootNoteAtom, "C"],
-      [scaleNameAtom, "Major"],
-      [chordQualityOverrideAtom, "Dominant 7th"],
-    ]);
-    expect(store.get(chordRootAtom)).toBe("G"); // V root from degree
-    expect(store.get(chordTypeAtom)).toBe("Dominant 7th"); // user override
-    expect(store.get(chordOverlayModeAtom)).toBe("degree"); // mode preserved
+  const V_IN_C_MAJOR = [
+    [progressionStepsAtom, []],
+    [chordDegreeAtom, "V"],
+    [chordOverlayModeAtom, "degree"],
+    [rootNoteAtom, "C"],
+    [scaleNameAtom, "Major"],
+  ] as const;
+
+  it("read path: degree mode resolves V to G/Major Triad (diatonic default) or to the override quality", () => {
+    const noOverride = makeAtomStore([...V_IN_C_MAJOR]);
+    expect(noOverride.get(chordRootAtom)).toBe("G");
+    expect(noOverride.get(chordTypeAtom)).toBe("Major Triad");
+
+    const withOverride = makeAtomStore([...V_IN_C_MAJOR, [chordQualityOverrideAtom, "Dominant 7th"]]);
+    expect(withOverride.get(chordRootAtom)).toBe("G");
+    expect(withOverride.get(chordTypeAtom)).toBe("Dominant 7th");
+    expect(withOverride.get(chordOverlayModeAtom)).toBe("degree");
   });
 
-  it("read path: degree mode without override returns diatonic default (V Major Triad in C Major)", () => {
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordDegreeAtom, "V"],
-      [chordOverlayModeAtom, "degree"],
-      [rootNoteAtom, "C"],
-      [scaleNameAtom, "Major"],
-      // chordQualityOverrideAtom intentionally not seeded → null
-    ]);
-    expect(store.get(chordRootAtom)).toBe("G");
-    expect(store.get(chordTypeAtom)).toBe("Major Triad"); // diatonic default
-  });
-
-  it("write path: writing chordTypeAtom in degree mode with active degree keeps mode = degree", () => {
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordDegreeAtom, "V"],
-      [chordOverlayModeAtom, "degree"],
-      [rootNoteAtom, "C"],
-      [scaleNameAtom, "Major"],
-    ]);
+  it("write path: writing chordTypeAtom in degree mode with active degree pins override, keeps mode = degree", () => {
+    const store = makeAtomStore([...V_IN_C_MAJOR]);
     store.set(chordTypeAtom, "Dominant 7th");
-    expect(store.get(chordOverlayModeAtom)).toBe("degree"); // NOT flipped to manual
+    expect(store.get(chordOverlayModeAtom)).toBe("degree");
     expect(store.get(chordQualityOverrideAtom)).toBe("Dominant 7th");
     expect(store.get(chordTypeAtom)).toBe("Dominant 7th");
-    expect(store.get(chordRootAtom)).toBe("G"); // V root still derived from degree
+    expect(store.get(chordRootAtom)).toBe("G");
   });
 
-  it("write path: writing chordTypeAtom in degree mode WITHOUT active degree falls through to manual", () => {
-    // Without a degree set, there's nothing to "preserve" — degree mode with a
-    // null degree means overlay-off, so writing a chord type explicitly should
-    // engage manual mode (current contract).
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordDegreeAtom, null],
-      [chordOverlayModeAtom, "degree"],
-    ]);
-    store.set(chordTypeAtom, "Dominant 7th");
-    expect(store.get(chordOverlayModeAtom)).toBe("manual");
-  });
-
-  it("write path: manual mode unchanged — writing chordTypeAtom keeps mode = manual", () => {
-    const store = makeAtomStore([
-      [chordOverlayModeAtom, "manual"],
-      [chordRootOverrideAtom, "C"],
-    ]);
+  it.each<{ label: string; seeds: readonly (readonly [unknown, unknown])[] }>([
+    {
+      label: "degree mode without active degree → falls through to manual",
+      seeds: [[progressionStepsAtom, []], [chordDegreeAtom, null], [chordOverlayModeAtom, "degree"]],
+    },
+    {
+      label: "already in manual mode → stays in manual",
+      seeds: [[chordOverlayModeAtom, "manual"], [chordRootOverrideAtom, "C"]],
+    },
+  ])("write path: writing chordTypeAtom — $label", ({ seeds }) => {
+    const store = makeAtomStore([...seeds] as never);
     store.set(chordTypeAtom, "Dominant 7th");
     expect(store.get(chordOverlayModeAtom)).toBe("manual");
     expect(store.get(chordTypeAtom)).toBe("Dominant 7th");
   });
 
-  it("setChordDegreeAtom: changing degree clears the quality override", () => {
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordDegreeAtom, "V"],
-      [chordOverlayModeAtom, "degree"],
-      [rootNoteAtom, "C"],
-      [scaleNameAtom, "Major"],
-      [chordQualityOverrideAtom, "Dominant 7th"],
-    ]);
-    expect(store.get(chordTypeAtom)).toBe("Dominant 7th");
-    store.set(setChordDegreeAtom, "ii");
-    expect(store.get(chordDegreeAtom)).toBe("ii");
+  it.each<{ label: string; next: "ii" | "V" | null; expectDegree: string | null; expectType: string | null; expectRoot?: string }>([
+    { label: "changing degree clears override (V→ii)", next: "ii", expectDegree: "ii", expectType: "Minor Triad", expectRoot: "D" },
+    { label: "re-selecting same degree clears override (V→V)", next: "V", expectDegree: "V", expectType: "Major Triad" },
+    { label: "turning overlay off (degree=null) clears override", next: null, expectDegree: null, expectType: null },
+  ])("setChordDegreeAtom: $label", ({ next, expectDegree, expectType, expectRoot }) => {
+    const store = makeAtomStore([...V_IN_C_MAJOR, [chordQualityOverrideAtom, "Dominant 7th"]]);
+    store.set(setChordDegreeAtom, next);
+    expect(store.get(chordDegreeAtom)).toBe(expectDegree);
     expect(store.get(chordQualityOverrideAtom)).toBeNull();
-    expect(store.get(chordTypeAtom)).toBe("Minor Triad"); // ii diatonic default
-    expect(store.get(chordRootAtom)).toBe("D");
-  });
-
-  it("setChordDegreeAtom: re-selecting the same degree clears the override", () => {
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordDegreeAtom, "V"],
-      [chordOverlayModeAtom, "degree"],
-      [rootNoteAtom, "C"],
-      [scaleNameAtom, "Major"],
-      [chordQualityOverrideAtom, "Dominant 7th"],
-    ]);
-    store.set(setChordDegreeAtom, "V"); // re-click same degree clears the pin
-    expect(store.get(chordDegreeAtom)).toBe("V");
-    expect(store.get(chordQualityOverrideAtom)).toBeNull();
-    expect(store.get(chordTypeAtom)).toBe("Major Triad"); // V diatonic default in C major
-  });
-
-  it("setChordDegreeAtom: turning overlay off (degree=null) clears override", () => {
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordDegreeAtom, "V"],
-      [chordOverlayModeAtom, "degree"],
-      [chordQualityOverrideAtom, "Dominant 7th"],
-    ]);
-    store.set(setChordDegreeAtom, null);
-    expect(store.get(chordDegreeAtom)).toBeNull();
-    expect(store.get(chordQualityOverrideAtom)).toBeNull();
+    if (expectType !== null) expect(store.get(chordTypeAtom)).toBe(expectType);
+    if (expectRoot) expect(store.get(chordRootAtom)).toBe(expectRoot);
   });
 
   it("scale change in degree mode preserves both degree and override (sticky on scale change)", () => {
-    // Use Major → Lydian — both define "V" at semitone 7 (Major Triad), so the
-    // degree resolves consistently across the scale change. Dorian etc. would
-    // remap V → v (minor) which is a different code path (cross-scale degree
-    // remapping is outside this fix's scope).
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordDegreeAtom, "V"],
-      [chordOverlayModeAtom, "degree"],
-      [rootNoteAtom, "C"],
-      [scaleNameAtom, "Major"],
-      [chordQualityOverrideAtom, "Dominant 7th"],
-    ]);
+    // Major → Lydian both define V at semitone 7 (Major Triad), so the degree
+    // remains stable across scales. Cross-scale remapping is out of scope here.
+    const store = makeAtomStore([...V_IN_C_MAJOR, [chordQualityOverrideAtom, "Dominant 7th"]]);
     store.set(scaleNameAtom, "Lydian");
     expect(store.get(chordOverlayModeAtom)).toBe("degree");
     expect(store.get(chordQualityOverrideAtom)).toBe("Dominant 7th");
     expect(store.get(chordTypeAtom)).toBe("Dominant 7th");
-    // V in C Lydian → G (degree-derived root re-resolves).
     expect(store.get(chordRootAtom)).toBe("G");
   });
 });
@@ -512,17 +431,17 @@ describe("chordOverlayAtoms — storage migration", () => {
     localStorage.clear();
   });
 
-  it("migration: overlay off (no legacy chordType) → degree=null, mode=degree", () => {
-    // localStorage is already clear (no legacy keys)
-    const store = createStore();
-    const unsubDegree = mount(store, chordDegreeAtom);
-    const unsubMode = mount(store, chordOverlayModeAtom);
+  function mountAtoms(store: ReturnType<typeof createStore>, atoms: ReadonlyArray<Parameters<typeof mount>[1]>) {
+    const unsubs = atoms.map((a) => mount(store, a));
+    return () => unsubs.forEach((u) => u());
+  }
 
+  it("migration: overlay off (no legacy chordType) → degree=null, mode=degree", () => {
+    const store = createStore();
+    const unmount = mountAtoms(store, [chordDegreeAtom, chordOverlayModeAtom]);
     expect(store.get(chordDegreeAtom)).toBeNull();
     expect(store.get(chordOverlayModeAtom)).toBe("degree");
-
-    unsubDegree();
-    unsubMode();
+    unmount();
   });
 
   it("migration: diatonic triad (C Major, I) → degree=I, mode=degree", () => {
@@ -530,34 +449,22 @@ describe("chordOverlayAtoms — storage migration", () => {
     localStorage.setItem(k("chordType"), "Major Triad");
     localStorage.setItem(k("rootNote"), "C");
     localStorage.setItem(k("scaleName"), "Major");
-
     const store = createStore();
-    const unsubDegree = mount(store, chordDegreeAtom);
-    const unsubMode = mount(store, chordOverlayModeAtom);
-
+    const unmount = mountAtoms(store, [chordDegreeAtom, chordOverlayModeAtom]);
     expect(store.get(chordDegreeAtom)).toBe("I");
     expect(store.get(chordOverlayModeAtom)).toBe("degree");
-
-    unsubDegree();
-    unsubMode();
+    unmount();
   });
 
-  it("migration: non-diatonic / seventh chord → mode=manual, overrides populated", () => {
-    // Seventh chords are not in DEGREE_DIATONIC_QUALITY — always manual mode. Intentional.
+  it("migration: non-diatonic / seventh chord → mode=manual, override populated", () => {
+    // Seventh chords are not in DEGREE_DIATONIC_QUALITY — always manual mode.
     localStorage.setItem(k("chordType"), "Major 7th");
     localStorage.setItem(k("chordRoot"), "D");
-
     const store = createStore();
-    const unsubMode = mount(store, chordOverlayModeAtom);
-    const unsubQuality = mount(store, chordQualityOverrideAtom);
-    const unsubRoot = mount(store, chordRootOverrideAtom);
-
+    const unmount = mountAtoms(store, [chordOverlayModeAtom, chordQualityOverrideAtom, chordRootOverrideAtom]);
     expect(store.get(chordOverlayModeAtom)).toBe("manual");
     expect(store.get(chordQualityOverrideAtom)).toBe("Major 7th");
-
-    unsubMode();
-    unsubQuality();
-    unsubRoot();
+    unmount();
   });
 
   it("migration round-trip: load → save → reload yields same in-memory state", () => {
@@ -773,27 +680,19 @@ describe("chord overlay independent of fingering pattern (Task 3 regression)", (
     localStorage.clear();
   });
 
-  it("chord tones still render with one-string fingering", () => {
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordOverlayModeAtom, "manual"],
-      [chordRootOverrideAtom, "C"],
-      [chordQualityOverrideAtom, "Major Triad"],
-      [fingeringPatternAtom, "one-string"],
-    ]);
-    expect(store.get(chordTonesAtom).length).toBeGreaterThan(0);
-  });
-
-  it("chord tones still render with two-strings fingering", () => {
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordOverlayModeAtom, "manual"],
-      [chordRootOverrideAtom, "C"],
-      [chordQualityOverrideAtom, "Major Triad"],
-      [fingeringPatternAtom, "two-strings"],
-    ]);
-    expect(store.get(chordTonesAtom).length).toBeGreaterThan(0);
-  });
+  it.each(["one-string", "two-strings"] as const)(
+    "chord tones still render with %s fingering",
+    (pattern) => {
+      const store = makeAtomStore([
+        [progressionStepsAtom, []],
+        [chordOverlayModeAtom, "manual"],
+        [chordRootOverrideAtom, "C"],
+        [chordQualityOverrideAtom, "Major Triad"],
+        [fingeringPatternAtom, pattern],
+      ]);
+      expect(store.get(chordTonesAtom).length).toBeGreaterThan(0);
+    },
+  );
 
   it("progression is the active chord source even with one-string fingering", () => {
     const store = makeAtomStore([
@@ -815,61 +714,35 @@ describe("voicing string set", () => {
     localStorage.clear();
   });
 
-  it("exposes tone-count-appropriate string-set options for a triad", () => {
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordOverlayModeAtom, "manual"],
-      [chordRootOverrideAtom, "C"],
-      [chordQualityOverrideAtom, "Major Triad"],
-    ]);
-    const optionsTriad = store.get(stringSetOptionsAtom);
-    expect(optionsTriad.map((o) => o.id)).toEqual([
-      "all", "4·5·6", "3·4·5", "2·3·4", "1·2·3",
-    ]);
+  const MANUAL_C = [
+    [progressionStepsAtom, []],
+    [chordOverlayModeAtom, "manual"],
+    [chordRootOverrideAtom, "C"],
+  ] as const;
+
+  it.each<{ quality: string; ids: string[] }>([
+    { quality: "Major Triad", ids: ["all", "4·5·6", "3·4·5", "2·3·4", "1·2·3"] },
+    { quality: "Major 7th", ids: ["all", "3·4·5·6", "2·3·4·5", "1·2·3·4"] },
+  ])("string-set options match tone count for $quality", ({ quality, ids }) => {
+    const store = makeAtomStore([...MANUAL_C, [chordQualityOverrideAtom, quality]]);
+    expect(store.get(stringSetOptionsAtom).map((o) => o.id)).toEqual(ids);
   });
 
-  it("exposes tone-count-appropriate string-set options for a seventh chord", () => {
+  it.each<{ label: string; quality: string; expected: number[] }>([
+    { label: "valid stored id resolves to its string-index array", quality: "Major Triad", expected: [3, 4, 5] },
+    { label: "invalid stored id for chord falls back to all six strings", quality: "Major 7th", expected: [0, 1, 2, 3, 4, 5] },
+  ])("effectiveStringSetAtom: $label", ({ quality, expected }) => {
     const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordOverlayModeAtom, "manual"],
-      [chordRootOverrideAtom, "C"],
-      [chordQualityOverrideAtom, "Major 7th"],
-    ]);
-    const optionsSeventh = store.get(stringSetOptionsAtom);
-    expect(optionsSeventh.map((o) => o.id)).toEqual([
-      "all", "3·4·5·6", "2·3·4·5", "1·2·3·4",
-    ]);
-  });
-
-  it("resolves a valid stored id to its string-index array", () => {
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordOverlayModeAtom, "manual"],
-      [chordRootOverrideAtom, "C"],
-      [chordQualityOverrideAtom, "Major Triad"],
+      ...MANUAL_C,
+      [chordQualityOverrideAtom, quality],
       [voicingStringSetAtom, "4·5·6"],
     ]);
-    expect(store.get(effectiveStringSetAtom)).toEqual([3, 4, 5]);
-  });
-
-  it("falls back to all six strings when the stored id is invalid for the chord", () => {
-    // "4·5·6" is a valid triad window but not a valid 7th-chord window, so it
-    // falls back to all-strings when the chord switches to a seventh chord.
-    const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordOverlayModeAtom, "manual"],
-      [chordRootOverrideAtom, "C"],
-      [chordQualityOverrideAtom, "Major 7th"],
-      [voicingStringSetAtom, "4·5·6"],
-    ]);
-    expect(store.get(effectiveStringSetAtom)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(store.get(effectiveStringSetAtom)).toEqual(expected);
   });
 
   it("voicingMatchesAtom returns engine output for a valid triad window", () => {
     const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordOverlayModeAtom, "manual"],
-      [chordRootOverrideAtom, "C"],
+      ...MANUAL_C,
       [chordQualityOverrideAtom, "Major Triad"],
       [voicingTypeAtom, "triad"],
       [voicingStringSetAtom, "4·5·6"],
@@ -883,9 +756,7 @@ describe("voicing string set", () => {
 
   it("ignores the string set and inversion while voicingType is caged", () => {
     const store = makeAtomStore([
-      [progressionStepsAtom, []],
-      [chordOverlayModeAtom, "manual"],
-      [chordRootOverrideAtom, "C"],
+      ...MANUAL_C,
       [chordQualityOverrideAtom, "Major Triad"],
       [voicingTypeAtom, "caged"],
       [voicingStringSetAtom, "1·2·3"],
@@ -906,30 +777,17 @@ describe("voicing atoms", () => {
     localStorage.clear();
   });
 
-  it("availableInversionsAtom excludes 3rd for a triad", () => {
-    const store = createStore();
-    store.set(chordRootOverrideAtom, "C");
-    store.set(chordQualityOverrideAtom, "Major Triad");
-    store.set(chordOverlayModeAtom, "manual");
-    expect(store.get(availableInversionsAtom)).toEqual(["root", "1st", "2nd"]);
-  });
-
-  it("availableInversionsAtom includes 3rd for a seventh chord", () => {
+  it.each<{ quality: string; inversions: string[] }>([
+    { quality: "Major Triad", inversions: ["root", "1st", "2nd"] },
+    { quality: "Major 7th", inversions: ["root", "1st", "2nd", "3rd"] },
+    { quality: "Power Chord (5)", inversions: ["root"] },
+  ])("availableInversionsAtom for $quality → $inversions", ({ quality, inversions }) => {
     const store = createStore();
     store.set(progressionStepsAtom, []);
     store.set(chordRootOverrideAtom, "C");
-    store.set(chordQualityOverrideAtom, "Major 7th");
+    store.set(chordQualityOverrideAtom, quality);
     store.set(chordOverlayModeAtom, "manual");
-    expect(store.get(availableInversionsAtom)).toEqual(["root", "1st", "2nd", "3rd"]);
-  });
-
-  it("availableInversionsAtom exposes only root for a dyad", () => {
-    const store = createStore();
-    store.set(progressionStepsAtom, []);
-    store.set(chordRootOverrideAtom, "C");
-    store.set(chordQualityOverrideAtom, "Power Chord (5)");
-    store.set(chordOverlayModeAtom, "manual");
-    expect(store.get(availableInversionsAtom)).toEqual(["root"]);
+    expect(store.get(availableInversionsAtom)).toEqual(inversions);
   });
 
   it("voicingMatchesAtom returns engine output when a chord is active, regardless of Full Chords", () => {


### PR DESCRIPTION
## Summary

Round 2 of test consolidation, after PR #430. Same `it.each`-style pass on 7 test files PR #430 didn't touch.

**−632 LOC net (994 deletions, 362 insertions). 1789/1789 tests pass.**

## LOC saved per file

| File | Before | After | Δ |
|---|---:|---:|---:|
| `FretboardNoteLayer.test.tsx` | 449 | 250 | **−199 (−44%)** |
| `chordOverlayAtoms.test.ts` | 949 | 807 | −142 |
| `CircleOfFifths.test.tsx` | 607 | 504 | −103 |
| `Fretboard.test.tsx` | 721 | 653 | −68 |
| `pathGeometry.test.ts` | 535 | 475 | −60 |
| `DegreeChipStrip.test.tsx` | 406 | 369 | −37 |
| `atoms.test.ts` | 642 | 619 | −23 |

## Patterns collapsed

**`FretboardNoteLayer.test.tsx`** (biggest win): extracted `renderLayer(notes, opts)` to wrap the repetitive `<svg><FretboardNoteLayer .../></svg>` boilerplate — cuts most tests roughly in half. Shape-primitive tests (`note-active`=circle, `chord-tone-outside-scale`=diamond, `note-blue`=hexagon) folded into one `it.each` that also asserts the other primitives stay absent. `chord-root` and `chord-tone-in-scale` radius tests merged into one `it.each`, same for `filter='chord'` / `filter='non-chord'`.

**`chordOverlayAtoms.test.ts`**:
- Degree-mode read path (4 tests) → one `it.each` parameterized by degree
- Quality override (8 tests) reorganized into shared `V_IN_C_MAJOR` seeds + 4 focused `it.each` blocks (write paths, degree-change clears, etc.)
- Storage migration uses a `mountAtoms` helper to drop the repeated mount/unmount lines
- Voicing string-set options (4 tests) → 2 `it.each` blocks parameterized by chord quality
- `availableInversionsAtom` (3 tests) → one `it.each` by chord quality
- Task 3 regression (2 tests) → one `it.each` by fingering pattern

**`CircleOfFifths.test.tsx`**:
- Scale-aware display (4 mode tests) → one `it.each` by root+scale
- Accidentals (4 tests with useFlats variations) → 2 `it.each` blocks (render-text + rerender)

**`Fretboard.test.tsx`**: 5 nearly-identical "renders without crashing with prop X" tests (chord tones, fret spread, shape polygons, wrapped notes, colorNotes) → one `it.each` table.

**`pathGeometry.test.ts`**: extracted `commandCount(path, cmd)` and `expectClosedPath(d)` helpers. 3 hull-arity tests (1/2/3-point) → one `it.each`; 4 radius-variant tests (CCW triangle, r=0, near-collinear) → one `it.each`; CW vs CCW winding test simplified to loop over both hulls.

**`DegreeChipStrip.test.tsx`**: 4 `visible=true/false` tests → one `it.each` of (state, expected); 2 toggle-enabled/disabled tests → one `it.each`; 2 `headerAction` tests → one parameterized by visibility; 2 `hiddenNotes` tests → one `it.each`.

**`atoms.test.ts`**: 5 `setFingeringPatternAtom` tests that only changed one literal each → one `it.each` table covering all five patterns.

## Verification

- `pnpm run lint` ✅
- `pnpm run build` ✅
- `pnpm run test` ✅ 1789/1789 tests pass

## Combined with #422 and #430

Total LOC removed across this branch family: **~2.4k**, with `useChordConnectorPolylines.test.ts` going from 1,790 → 1,096 in #430, `FretboardNoteLayer.test.tsx` from 449 → 250 here. Tests are still the largest file pool (~20k LOC) — another round could probably get another 1k by cleaning up the remaining 1.4k-LOC `FretboardSVG.test.tsx`, the `chordDomainSplit` / `scheduler` / `FingeringPatternControls` tests, and the smaller files PR #430 dipped into.

## Test plan

- [ ] CI green
- [ ] Coverage report shows no regression on the affected files

https://claude.ai/code/session_01BrK9qpBCeteJz3oCt6XJR3

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrK9qpBCeteJz3oCt6XJR3)_