### PR TITLE
refactor(FretboardSVG): extract FretboardConnectorLayer subcomponent

### DIFF
--- a/src/components/FretboardSVG/FretboardConnectorLayer.tsx
+++ b/src/components/FretboardSVG/FretboardConnectorLayer.tsx
@@ -1,0 +1,112 @@
+import { memo } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { ANIMATION_DURATION_FAST, ANIMATION_EASE } from "@fretflow/core";
+import type { ChordConnectorVoicing } from "./hooks/useChordConnectorPolylines";
+import type { IntervalConnectorPolyline } from "./hooks/useIntervalConnectorPolylines";
+import type { FretboardMotionPolicy } from "./motionPolicy";
+import styles from "./FretboardSVG.module.css";
+
+interface FretboardConnectorLayerProps {
+  chordPolylines: ChordConnectorVoicing[];
+  intervalPolylines: IntervalConnectorPolyline[];
+  connectorSource: "full-chord" | "generated";
+  chordRoot?: string;
+  chordTones: string[];
+  showChordConnectors: boolean;
+  connectorMotionMode: FretboardMotionPolicy["connectorMode"];
+  clipPathUrl: string;
+}
+
+const renderChordPath = (
+  v: ChordConnectorVoicing,
+  layer: "halo" | "fill" | "outline",
+) => (
+  <path
+    key={`${layer}-${v.voicingKey}`}
+    className={layer === "halo" ? undefined : styles["chord-connector-path"]}
+    d={layer === "fill" ? v.paths.fill : v.paths.outline}
+    data-layer={layer}
+    data-caged-shape={v.shape}
+    data-palette-index={v.paletteIndex + 1}
+  />
+);
+
+const renderIntervalPath = (
+  l: IntervalConnectorPolyline,
+  layer: "halo" | "fill" | "outline",
+) => (
+  <path
+    key={`iv-${layer}-${l.key}`}
+    d={layer === "fill" ? l.paths.fill : l.paths.outline}
+    data-layer={layer}
+    data-palette-index={l.paletteIndex}
+  />
+);
+
+export const FretboardConnectorLayer = memo(function FretboardConnectorLayer({
+  chordPolylines,
+  intervalPolylines,
+  connectorSource,
+  chordRoot,
+  chordTones,
+  showChordConnectors,
+  connectorMotionMode,
+  clipPathUrl,
+}: FretboardConnectorLayerProps) {
+  const motionKey = `chord-connectors-${connectorSource}-${chordRoot}-${chordTones?.join("-") ?? "none"}`;
+  return (
+    <g
+      className={styles["fretboard-overlays"]}
+      clipPath={clipPathUrl}
+      aria-hidden="true"
+      pointerEvents="none"
+    >
+      <AnimatePresence mode="wait">
+        {showChordConnectors && chordPolylines.length > 0 && (
+          connectorMotionMode === "group" ? (
+            <motion.g
+              key={motionKey}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: ANIMATION_DURATION_FAST, ease: ANIMATION_EASE }}
+              className={styles["chord-connectors"]}
+              data-connector-source={connectorSource}
+              data-motion="group"
+              aria-hidden="true"
+              pointerEvents="none"
+            >
+              {chordPolylines.map((v) => renderChordPath(v, "halo"))}
+              {chordPolylines.map((v) => renderChordPath(v, "fill"))}
+              {chordPolylines.map((v) => renderChordPath(v, "outline"))}
+            </motion.g>
+          ) : (
+            <g
+              key={motionKey}
+              className={styles["chord-connectors"]}
+              data-connector-source={connectorSource}
+              data-motion="none"
+              aria-hidden="true"
+              pointerEvents="none"
+            >
+              {chordPolylines.map((v) => renderChordPath(v, "halo"))}
+              {chordPolylines.map((v) => renderChordPath(v, "fill"))}
+              {chordPolylines.map((v) => renderChordPath(v, "outline"))}
+            </g>
+          )
+        )}
+      </AnimatePresence>
+      {intervalPolylines.length > 0 && (
+        <g
+          className={styles["interval-connectors"]}
+          aria-hidden="true"
+          pointerEvents="none"
+        >
+          {intervalPolylines.map((l) => renderIntervalPath(l, "halo"))}
+          {intervalPolylines.map((l) => renderIntervalPath(l, "fill"))}
+          {intervalPolylines.map((l) => renderIntervalPath(l, "outline"))}
+        </g>
+      )}
+    </g>
+  );
+});

--- a/src/components/FretboardSVG/FretboardSVG.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.tsx
@@ -1,13 +1,11 @@
 import { useId, useMemo, useCallback, memo, type CSSProperties } from "react";
 import { useAtomValue } from "jotai";
-import { motion, AnimatePresence, useReducedMotion } from "motion/react";
+import { useReducedMotion } from "motion/react";
 import {
   getNoteDisplay,
   getScaleSemitones,
   type PracticeLens,
   type NoteSemantics,
-  ANIMATION_DURATION_FAST,
-  ANIMATION_EASE,
 } from "@fretflow/core";
 import { fingeringPatternAtom } from "../../store/fingeringAtoms";
 import { intervalPairsAtom } from "../../store/shapeAtoms";
@@ -24,6 +22,7 @@ import { FretboardDefs } from "./FretboardDefs";
 import { FretboardShapeLayer } from "./FretboardShapeLayer";
 import { FretboardNoteLayer } from "./FretboardNoteLayer";
 import { FretboardHitTargetLayer } from "./FretboardHitTargetLayer";
+import { FretboardConnectorLayer } from "./FretboardConnectorLayer";
 import { FretNumbersRow } from "./FretNumbersRow";
 import { resolveFretboardMotionPolicy } from "./motionPolicy";
 import type { CagedShape, FullChordMatchNote, ShapePolygon } from "@fretflow/core";
@@ -536,141 +535,16 @@ export const FretboardSVG = memo(function FretboardSVG({
               in the taper-carved corner gaps paint on the app-container backdrop —
               that's an accepted trade-off; the wood gradient stays clipped to the
               taper and does not overflow. */}
-          <g
-            className={styles["fretboard-overlays"]}
-            clipPath={svgDefUrl("fretboard-svg-box")}
-            aria-hidden="true"
-            pointerEvents="none"
-          >
-            <AnimatePresence mode="wait">
-              {showChordConnectors && connectorPolylines.length > 0 && (
-                motionPolicy.connectorMode === "group" ? (
-                  <motion.g
-                    key={`chord-connectors-${connectorSource}-${chordRoot}-${chordTones?.join("-") ?? "none"}`}
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    transition={{ duration: ANIMATION_DURATION_FAST, ease: ANIMATION_EASE }}
-                    className={styles["chord-connectors"]}
-                    data-connector-source={connectorSource}
-                    data-motion="group"
-                    aria-hidden="true"
-                    pointerEvents="none"
-                  >
-                    {/* Halo pass: wide semi-transparent white stroke for background contrast */}
-                    {connectorPolylines.map((voicing) => (
-                      <path
-                        key={`halo-${voicing.voicingKey}`}
-                        d={voicing.paths.outline}
-                        data-layer="halo"
-                        data-caged-shape={voicing.shape}
-                        data-palette-index={voicing.paletteIndex + 1}
-                      />
-                    ))}
-                    {/* Fill pass: all voicings rendered first (below outlines) */}
-                    {connectorPolylines.map((voicing) => (
-                      <path
-                        key={`fill-${voicing.voicingKey}`}
-                        className={styles["chord-connector-path"]}
-                        d={voicing.paths.fill}
-                        data-layer="fill"
-                        data-caged-shape={voicing.shape}
-                        data-palette-index={voicing.paletteIndex + 1}
-                      />
-                    ))}
-                    {/* Outline pass: all voicings rendered on top */}
-                    {connectorPolylines.map((voicing) => (
-                      <path
-                        key={`outline-${voicing.voicingKey}`}
-                        className={styles["chord-connector-path"]}
-                        d={voicing.paths.outline}
-                        data-layer="outline"
-                        data-caged-shape={voicing.shape}
-                        data-palette-index={voicing.paletteIndex + 1}
-                      />
-                    ))}
-                  </motion.g>
-                ) : (
-                  <g
-                    key={`chord-connectors-${connectorSource}-${chordRoot}-${chordTones?.join("-") ?? "none"}`}
-                    className={styles["chord-connectors"]}
-                    data-connector-source={connectorSource}
-                    data-motion="none"
-                    aria-hidden="true"
-                    pointerEvents="none"
-                  >
-                    {connectorPolylines.map((voicing) => (
-                      <path
-                        key={`halo-${voicing.voicingKey}`}
-                        d={voicing.paths.outline}
-                        data-layer="halo"
-                        data-caged-shape={voicing.shape}
-                        data-palette-index={voicing.paletteIndex + 1}
-                      />
-                    ))}
-                    {connectorPolylines.map((voicing) => (
-                      <path
-                        key={`fill-${voicing.voicingKey}`}
-                        className={styles["chord-connector-path"]}
-                        d={voicing.paths.fill}
-                        data-layer="fill"
-                        data-caged-shape={voicing.shape}
-                        data-palette-index={voicing.paletteIndex + 1}
-                      />
-                    ))}
-                    {connectorPolylines.map((voicing) => (
-                      <path
-                        key={`outline-${voicing.voicingKey}`}
-                        className={styles["chord-connector-path"]}
-                        d={voicing.paths.outline}
-                        data-layer="outline"
-                        data-caged-shape={voicing.shape}
-                        data-palette-index={voicing.paletteIndex + 1}
-                      />
-                    ))}
-                  </g>
-                )
-              )}
-            </AnimatePresence>
-            {/* Interval connectors — capsule/blob shape matching chord-connector visual style.
-                Per-pair color driven by lower-note scale-degree via --chord-connector-color-N.
-                Two render passes (fill + outline) mirror chord-connector convention. */}
-            {intervalConnectorPolylines.length > 0 && (
-              <g
-                className={styles["interval-connectors"]}
-                aria-hidden="true"
-                pointerEvents="none"
-              >
-                {/* Halo pass */}
-                {intervalConnectorPolylines.map((line) => (
-                  <path
-                    key={`iv-halo-${line.key}`}
-                    d={line.paths.outline}
-                    data-layer="halo"
-                    data-palette-index={line.paletteIndex}
-                  />
-                ))}
-                {/* Fill pass */}
-                {intervalConnectorPolylines.map((line) => (
-                  <path
-                    key={`iv-fill-${line.key}`}
-                    d={line.paths.fill}
-                    data-layer="fill"
-                    data-palette-index={line.paletteIndex}
-                  />
-                ))}
-                {/* Outline pass */}
-                {intervalConnectorPolylines.map((line) => (
-                  <path
-                    key={`iv-outline-${line.key}`}
-                    d={line.paths.outline}
-                    data-layer="outline"
-                    data-palette-index={line.paletteIndex}
-                  />
-                ))}
-              </g>
-            )}
-          </g>
+          <FretboardConnectorLayer
+            chordPolylines={connectorPolylines}
+            intervalPolylines={intervalConnectorPolylines}
+            connectorSource={connectorSource}
+            chordRoot={chordRoot}
+            chordTones={chordTones}
+            showChordConnectors={showChordConnectors}
+            connectorMotionMode={motionPolicy.connectorMode}
+            clipPathUrl={svgDefUrl("fretboard-svg-box")}
+          />
 
           {/* Chord notes (or all notes when no overlay) render LAST — on top of connectors. */}
           <g clipPath={svgDefUrl("fretboard-taper")}>


### PR DESCRIPTION
## Summary

- Extract chord + interval connector rendering (~135 lines of JSX) from `FretboardSVG.tsx` into a new `FretboardConnectorLayer` subcomponent.
- Collapse six near-identical halo/fill/outline map passes into two `renderChordPath` / `renderIntervalPath` helpers called three times each.
- Parent shrinks from **712 → 586 lines** (−126). New file is 112 lines. Net repo delta: ~−14 LOC — the real win is parent readability and convention alignment.

## Why

`FretboardSVG.tsx` was still 712 lines after prior extractions (Defs, Background, NoteLayer, HitTargetLayer, ShapeLayer, FretNumbersRow). The chord/interval connector JSX block was the largest remaining self-contained chunk, with three-pass loops duplicated across the chord (motion.g vs g branches) and interval groups. Moving it into a data-driven subcomponent matches the established convention (NoteLayer / ShapeLayer / HitTargetLayer all take pre-computed data and render).

## Notes

- Hook calls (`useChordConnectorPolylines`, `useIntervalConnectorPolylines`, `chordNoteData` filter, `connectorSource` derivation) stay in the parent — they couple to parent-owned geometry. The new component is pure render.
- DOM output is preserved: class names (`.chord-connectors`, `.chord-connector-path`, `.interval-connectors`, `.fretboard-overlays`), `data-connector-source`, `data-layer`, `data-caged-shape`, `data-palette-index`, the `AnimatePresence` boundary, and the motion key string are all unchanged.
- The `motion.g` vs plain `g` branches are kept separate (no polymorphic `Wrapper`) because framer-motion's `MotionProps` types don't spread cleanly onto intrinsic SVG elements, and collapsing them would risk losing the `key` identity that drives AnimatePresence enter/exit.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run test` — 1763/1763 pass
- [x] `pnpm run build` — clean
- [ ] Visual regression suite in CI

https://claude.ai/code/session_01BrK9qpBCeteJz3oCt6XJR3

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrK9qpBCeteJz3oCt6XJR3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dedicated connector layer component for fretboard visualization with support for animated chord connectors and interval display.

* **Refactor**
  * Consolidated fretboard connector rendering logic into a dedicated component, improving code organization and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->