### PR TITLE
feat(progression): sync backing track to preset; hide "Custom" options

### DIFF
--- a/src/components/ProgressionControls/BackingTrackControls.tsx
+++ b/src/components/ProgressionControls/BackingTrackControls.tsx
@@ -41,7 +41,11 @@ export function BackingTrackControls() {
           value={progressionGenreStyle}
           options={[
             ...GENRE_STYLES.map((g) => ({ value: g.id, label: g.label })),
-            { value: "custom", label: "Custom" },
+            // Show "Custom" only when it's the current value — the option is
+            // not user-selectable; it just reflects manually edited settings.
+            ...(progressionGenreStyle === "custom"
+              ? [{ value: "custom", label: "Custom" }]
+              : []),
           ]}
           onChange={applyGenreStyle}
         />

--- a/src/components/ProgressionControls/ProgressionControls.tsx
+++ b/src/components/ProgressionControls/ProgressionControls.tsx
@@ -73,15 +73,11 @@ export function ProgressionControls() {
     .filter((g) => g.presets.length > 0);
   const suggestedPresets = generateCommonProgressions(scaleName, rootNote);
   const presetGroups: LabeledSelectGroup[] = [
-    {
-      options: [
-        {
-          value: CUSTOM_PRESET_ID,
-          label: "Custom",
-          disabled: currentProgressionPresetId !== CUSTOM_PRESET_ID,
-        },
-      ],
-    },
+    // Show "Custom" only when it's the current value — the option is not
+    // user-selectable; it just reflects an edited (non-preset) progression.
+    ...(currentProgressionPresetId === CUSTOM_PRESET_ID
+      ? [{ options: [{ value: CUSTOM_PRESET_ID, label: "Custom" }] }]
+      : []),
     ...groupedPresets.map((group) => ({
       groupLabel: group.label,
       options: group.presets.map((preset) => ({

--- a/src/store/progressionAtoms.ts
+++ b/src/store/progressionAtoms.ts
@@ -21,6 +21,7 @@ import {
   remapProgressionStepsForScale,
   resolveProgressionStep,
   totalProgressionBars,
+  type ProgressionPresetCategory,
   type ProgressionStep,
   type ProgressionStepDuration,
 } from "../progressions/progressionDomain";
@@ -346,6 +347,18 @@ export const setProgressionPlayingAtom = atom(null, (get, set, playing: boolean)
   );
 });
 
+// Maps a preset category to the genre style whose backing-track defaults best
+// fit the progression. Loading a preset reapplies the matching genre so the
+// backing track (instrument, patterns, swing) follows the preset.
+const PRESET_CATEGORY_GENRE: Record<ProgressionPresetCategory, string> = {
+  "pop-rock": "rock",
+  blues: "blues",
+  jazz: "jazz",
+  folk: "pop",
+  modal: "rock",
+  minor: "ballad",
+};
+
 export const loadProgressionPresetAtom = atom(null, (get, set, presetId: string) => {
   const preset = PROGRESSION_PRESETS.find((entry) => entry.id === presetId);
   if (!preset) return;
@@ -353,6 +366,8 @@ export const loadProgressionPresetAtom = atom(null, (get, set, presetId: string)
   set(activeProgressionStepIndexAtom, 0);
   set(progressionPlayingStateAtom, false);
   set(progressionStepDeadlineAtom, null);
+  const genreId = PRESET_CATEGORY_GENRE[preset.category];
+  if (genreId) set(applyGenreStyleAtom, genreId);
 });
 
 export const loadProgressionStepsAtom = atom(


### PR DESCRIPTION
## Summary
- Loading a progression preset now also applies a matching genre style, so the backing track (chord instrument, chord/bass/drum patterns, swing) follows the preset instead of being left on whatever was previously selected. Category → genre mapping: `pop-rock → rock`, `blues → blues`, `jazz → jazz`, `folk → pop`, `modal → rock`, `minor → ballad`.
- The "Custom" entry in the Genre and Preset dropdowns is hidden unless it is the current value. Previously these were rendered but disabled — purely informational noise the user couldn't act on.

## Why
The Preset picker controlled progression steps only; the Backing Track group was independent state. Picking "Jazz turnaround" on top of a rock backing track gave a mismatched-feel demo. Tying the genre to the preset's category produces a coherent result on every preset change. The "Custom" options clutter the dropdowns since they can never be picked manually — they just reflect derived state.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run test` (1763 passing)
- [x] `pnpm run build`
- [ ] Manual: load presets across categories and verify backing track instrument/patterns/swing change to match
- [ ] Manual: edit a backing-track field and confirm Genre dropdown shows "Custom" only when the state is custom
- [ ] Manual: edit a chord step and confirm Preset dropdown shows "Custom" only when the state is custom

🤖 Generated with [Claude Code](https://claude.com/claude-code)