### PR TITLE
feat: adopt Tonal.js for music theory (Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ pnpm run preview               # preview build locally
 
 - **State:** Jotai atoms under `src/store/`, domain-split across `scaleAtoms`, `chordOverlayAtoms`, `practiceLensAtoms`, `fingeringAtoms`, `shapeAtoms`, `layoutAtoms`, `audioAtoms`, `uiAtoms`, `actions`. Import directly from the relevant domain module (e.g. `import { rootNoteAtom } from "../store/scaleAtoms"`). Components subscribe directly to the atoms they consume (atomic reactivity — no prop drilling).
 - **Domain (pure):** `src/core/` — `theory.ts`, `theoryCatalog.ts`, `guitar.ts`, `degrees.ts`, `circleOfFifthsUtils.ts`, `constants.ts`. Plus the `src/shapes/` package (`templates`, `helpers`, `polygons`, `threeNPS`, `analytics`).
+- **Music theory:** `@fretflow/core`'s theory functions (`getNoteDisplay`, `getChordNotes`, `getScaleNotes`, `getDiatonicChord`, `getKeySignature`, etc.) are backed by [Tonal.js](https://github.com/tonaljs/tonal) (`@tonaljs/note`, `@tonaljs/chord`, `@tonaljs/scale`, `@tonaljs/key`, `@tonaljs/interval`). Naming translation lives in `packages/core/src/lib/tonal.ts`.
 - **Audio:** `GuitarSynth` singleton in `src/core/audio.ts` (Web Audio API).
 - **Persistence:** `atomWithStorage` with keys prefixed via `src/utils/storage.ts`.
 

--- a/docs/superpowers/plans/2026-05-20-fretflow-phase-1-tonal-foundation.md
+++ b/docs/superpowers/plans/2026-05-20-fretflow-phase-1-tonal-foundation.md
@@ -1,0 +1,1154 @@
+# FretFlow Phase 1 — Tonal.js Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the bespoke music-theory implementation in `@fretflow/core` with Tonal.js-backed implementations, keeping the public API stable so all 73 consumer files in `src/` continue working without modification.
+
+**Architecture:** Swap the engine, not the API. The exported function signatures of `getNoteDisplay`, `getChordNotes`, `getScaleNotes`, `getDiatonicChord`, `getKeySignature`, `getQualityForDegree`, etc. stay byte-identical. Their bodies are rewritten to delegate to `@tonaljs/*` modules through a thin internal adapter layer (`packages/core/src/lib/tonal.ts`). Existing tests serve as the safety net — every migration must keep them green. App-specific names ("Major Triad", "Minor Triad", verbose scale names) are mapped to Tonal's symbol names (`"M"`, `"m"`, etc.) at the adapter boundary; consumers never see Tonal types.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspaces, `@tonaljs/chord`, `@tonaljs/scale`, `@tonaljs/note`, `@tonaljs/interval`, `@tonaljs/key`.
+
+**Spec reference:** [`docs/superpowers/specs/2026-05-20-fretflow-integration-design.md`](../specs/2026-05-20-fretflow-integration-design.md) §9a.
+
+**Out of scope for this plan:** No UI changes. No store-atom changes. No removal of public exports. The Inspector still has four tabs. The chord-overlay mode toggle still exists. Those are Plans 2–8.
+
+---
+
+## File Structure
+
+### Created
+
+- `packages/core/src/lib/tonal.ts` — internal adapter layer. Maps app-specific chord/scale names to Tonal symbols and back. Wraps Tonal calls so the rest of `core/` imports from this single module instead of directly from `@tonaljs/*`. Single responsibility: be the Tonal/FretFlow translation boundary.
+- `packages/core/src/lib/tonal.test.ts` — focused tests for the adapter's name mapping (the only new behavior introduced by this plan).
+
+### Modified
+
+- `packages/core/package.json` — adds 5 `@tonaljs/*` dependencies.
+- `packages/core/src/theory.ts` — function bodies rewritten to use the adapter. Public exports preserved (every `export function` keeps its signature). Backing data structures (`CHORD_DEFINITIONS`, `CHORDS`, `SCALES`, `KEY_SIGNATURES`, `ENHARMONICS`, `NOTES`) progressively dereferenced and ultimately removed when no longer used internally.
+- `packages/core/src/degrees.ts` — `getQualityForDegree` and `remapDegreeForScale` rewritten to use the adapter. `DEGREE_COLORS` and `DegreeId` type unchanged.
+- `packages/core/src/circleOfFifthsUtils.ts` — `getCircleNoteLabels` rewritten to use the adapter.
+- `packages/core/src/theoryCatalog.ts` — left mostly as-is (it holds app-specific scale-family UX data). Verify each function still passes its existing tests.
+- `packages/core/src/index.ts` — no changes; same set of exports.
+- `CLAUDE.md` — one-line addition under "Architecture" noting the Tonal backing.
+
+### Untouched (verify only)
+
+- `packages/core/src/guitar.ts` — string tuning logic. No theory dependencies.
+- `packages/core/src/constants.ts` — animation/UI constants only.
+- `packages/core/src/shapes/**` — fingering-shape geometry. No theory dependencies.
+
+---
+
+## Pre-flight Setup
+
+### Task 0: Baseline — confirm a clean starting state
+
+**Files:** none modified
+
+- [ ] **Step 0.1: Confirm tree is clean**
+
+Run: `git status`
+Expected: working tree clean, on branch `claude/optimistic-rhodes-1d1ad7`.
+
+- [ ] **Step 0.2: Verify the existing test suite passes (the safety net)**
+
+Run: `pnpm run test`
+Expected: all suites pass. Note the count for later comparison.
+
+- [ ] **Step 0.3: Verify the core package builds independently**
+
+Run: `pnpm --filter @fretflow/core run build`
+Expected: exits 0; `packages/core/dist/` populated.
+
+- [ ] **Step 0.4: Capture a baseline bundle size**
+
+Run: `pnpm run build && du -sh dist/`
+Expected: build succeeds; record the byte size for the §13 comparison.
+
+---
+
+## Task 1: Install Tonal dependencies
+
+**Files:**
+- Modify: `packages/core/package.json`
+- Modify: `pnpm-lock.yaml` (auto)
+
+- [ ] **Step 1.1: Add the five Tonal modules as production dependencies**
+
+Run from repo root:
+```bash
+pnpm --filter @fretflow/core add @tonaljs/note@^6 @tonaljs/chord@^6 @tonaljs/scale@^6 @tonaljs/interval@^6 @tonaljs/key@^6
+```
+Expected: pnpm resolves and installs; `packages/core/package.json` now lists them under `dependencies`.
+
+- [ ] **Step 1.2: Verify the existing tests still pass after install**
+
+Run: `pnpm run test`
+Expected: all suites pass; same count as baseline.
+
+- [ ] **Step 1.3: Verify TypeScript compiles**
+
+Run: `pnpm run build:types`
+Expected: exits 0.
+
+- [ ] **Step 1.4: Commit**
+
+```bash
+git add packages/core/package.json pnpm-lock.yaml
+git commit -m "chore(core): add @tonaljs dependencies for theory migration"
+```
+
+---
+
+## Task 2: Create the Tonal adapter module
+
+**Files:**
+- Create: `packages/core/src/lib/tonal.ts`
+- Create: `packages/core/src/lib/tonal.test.ts`
+
+The adapter has two jobs:
+1. Map FretFlow's verbose chord-quality names ("Major Triad") to Tonal's symbol names ("M") and back.
+2. Map FretFlow's verbose scale names ("Natural Minor", "Major Pentatonic") to Tonal's scale names ("minor", "major pentatonic") and back.
+
+This module is purely about naming. Tonal does the music.
+
+- [ ] **Step 2.1: Write the failing tests for chord-name mapping**
+
+Create `packages/core/src/lib/tonal.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { chordQualityToTonal, tonalToChordQuality, scaleNameToTonal, tonalToScaleName } from "./tonal";
+
+describe("chord-name adapter", () => {
+  it("maps Major Triad to M", () => {
+    expect(chordQualityToTonal("Major Triad")).toBe("M");
+  });
+  it("maps Minor Triad to m", () => {
+    expect(chordQualityToTonal("Minor Triad")).toBe("m");
+  });
+  it("maps Dominant 7th to 7", () => {
+    expect(chordQualityToTonal("Dominant 7th")).toBe("7");
+  });
+  it("maps Diminished 7th to dim7", () => {
+    expect(chordQualityToTonal("Diminished 7th")).toBe("dim7");
+  });
+  it("maps Half-Diminished 7th to m7b5", () => {
+    expect(chordQualityToTonal("Half-Diminished 7th")).toBe("m7b5");
+  });
+  it("maps Power Chord (5) to 5", () => {
+    expect(chordQualityToTonal("Power Chord (5)")).toBe("5");
+  });
+  it("returns undefined for unknown quality", () => {
+    expect(chordQualityToTonal("Bogus Chord")).toBeUndefined();
+  });
+  it("round-trips Major Triad", () => {
+    expect(tonalToChordQuality("M")).toBe("Major Triad");
+  });
+  it("round-trips Minor 7th", () => {
+    expect(tonalToChordQuality("m7")).toBe("Minor 7th");
+  });
+});
+
+describe("scale-name adapter", () => {
+  it("maps Major to major", () => {
+    expect(scaleNameToTonal("Major")).toBe("major");
+  });
+  it("maps Natural Minor to minor", () => {
+    expect(scaleNameToTonal("Natural Minor")).toBe("minor");
+  });
+  it("maps Harmonic Minor to harmonic minor", () => {
+    expect(scaleNameToTonal("Harmonic Minor")).toBe("harmonic minor");
+  });
+  it("maps Major Pentatonic to major pentatonic", () => {
+    expect(scaleNameToTonal("Major Pentatonic")).toBe("major pentatonic");
+  });
+  it("maps Dorian to dorian", () => {
+    expect(scaleNameToTonal("Dorian")).toBe("dorian");
+  });
+  it("round-trips Major", () => {
+    expect(tonalToScaleName("major")).toBe("Major");
+  });
+});
+```
+
+- [ ] **Step 2.2: Run the test to confirm it fails**
+
+Run: `pnpm --filter @fretflow/core test src/lib/tonal.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 2.3: Implement the adapter**
+
+Create `packages/core/src/lib/tonal.ts`:
+
+```ts
+/**
+ * Adapter between FretFlow's verbose music-theory names and Tonal's symbol names.
+ *
+ * FretFlow chose verbose names ("Major Triad", "Natural Minor", "Major Pentatonic")
+ * for user-facing clarity; Tonal uses compact symbols ("M", "minor", "major pentatonic").
+ * Every cross-module call into Tonal passes through this file.
+ */
+
+/**
+ * App chord-quality name (e.g., "Major Triad") → Tonal chord symbol suffix
+ * (e.g., "M"). Suffix is what Tonal.Chord.get() consumes after the root.
+ */
+const QUALITY_TO_TONAL: Record<string, string> = {
+  "Major Triad": "M",
+  "Minor Triad": "m",
+  "Diminished Triad": "dim",
+  "Augmented Triad": "aug",
+  "Sus2": "sus2",
+  "Sus4": "sus4",
+  "Major 6th": "6",
+  "Minor 6th": "m6",
+  "Major 7th": "maj7",
+  "Minor 7th": "m7",
+  "Dominant 7th": "7",
+  "Diminished 7th": "dim7",
+  "Half-Diminished 7th": "m7b5",
+  "Minor-Major 7th": "mMaj7",
+  "Power Chord (5)": "5",
+};
+
+const TONAL_TO_QUALITY: Record<string, string> = Object.fromEntries(
+  Object.entries(QUALITY_TO_TONAL).map(([app, tonal]) => [tonal, app]),
+);
+
+const SCALE_TO_TONAL: Record<string, string> = {
+  "Major": "major",
+  "Natural Minor": "minor",
+  "Harmonic Minor": "harmonic minor",
+  "Melodic Minor": "melodic minor",
+  "Major Pentatonic": "major pentatonic",
+  "Minor Pentatonic": "minor pentatonic",
+  "Blues": "blues",
+  "Blues Major": "major blues",
+  "Ionian": "ionian",
+  "Dorian": "dorian",
+  "Phrygian": "phrygian",
+  "Lydian": "lydian",
+  "Mixolydian": "mixolydian",
+  "Aeolian": "aeolian",
+  "Locrian": "locrian",
+};
+
+const TONAL_TO_SCALE: Record<string, string> = Object.fromEntries(
+  Object.entries(SCALE_TO_TONAL).map(([app, tonal]) => [tonal, app]),
+);
+
+export function chordQualityToTonal(quality: string): string | undefined {
+  return QUALITY_TO_TONAL[quality];
+}
+
+export function tonalToChordQuality(symbol: string): string | undefined {
+  return TONAL_TO_QUALITY[symbol];
+}
+
+export function scaleNameToTonal(scaleName: string): string | undefined {
+  return SCALE_TO_TONAL[scaleName];
+}
+
+export function tonalToScaleName(tonalName: string): string | undefined {
+  return TONAL_TO_SCALE[tonalName];
+}
+
+/**
+ * Return the canonical Tonal chord symbol for an (root, app-quality) pair, or
+ * undefined if the quality is not a known FretFlow chord. Example: ("C", "Major Triad") → "CM".
+ */
+export function tonalChordSymbol(root: string, quality: string): string | undefined {
+  const suffix = chordQualityToTonal(quality);
+  return suffix === undefined ? undefined : `${root}${suffix}`;
+}
+```
+
+- [ ] **Step 2.4: Run the test to confirm it passes**
+
+Run: `pnpm --filter @fretflow/core test src/lib/tonal.test.ts`
+Expected: PASS — all 14 tests green.
+
+- [ ] **Step 2.5: Run the full core test suite**
+
+Run: `pnpm --filter @fretflow/core test`
+Expected: all tests pass (the new test plus all existing).
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add packages/core/src/lib/tonal.ts packages/core/src/lib/tonal.test.ts
+git commit -m "feat(core): add Tonal adapter for chord/scale name mapping"
+```
+
+---
+
+## Task 3: Migrate note operations to Tonal
+
+Functions: `getNoteIndex`, `getNoteDisplay`, `getIntervalNotes`, `formatAccidental` (no migration needed — pure string transform), and the related `NOTES`, `ENHARMONICS`, `FLAT_KEYS` constants.
+
+Strategy: keep `NOTES`, `ENHARMONICS`, `FLAT_KEYS` exported as constants (74 consumers depend on them). Their *internal* use inside `theory.ts` shifts to Tonal.
+
+**Files:**
+- Modify: `packages/core/src/theory.ts:398-512` (functions only)
+- Test: `packages/core/src/theory.test.ts` (existing — no changes expected)
+
+- [ ] **Step 3.1: Run the existing tests for a green baseline**
+
+Run: `pnpm --filter @fretflow/core test src/theory.test.ts`
+Expected: all PASS. Record the count.
+
+- [ ] **Step 3.2: Add a Tonal import block at the top of `theory.ts`**
+
+In `packages/core/src/theory.ts`, after the existing imports, add:
+
+```ts
+import * as Note from "@tonaljs/note";
+import * as Interval from "@tonaljs/interval";
+```
+
+Use per-module imports (not the `@tonaljs/tonal` barrel) — Task 1 cherry-picked individual modules to keep the bundle minimal, so the barrel is not installed.
+
+- [ ] **Step 3.3: Replace `getNoteIndex` body**
+
+Replace lines 398-404 with:
+
+```ts
+export function getNoteIndex(noteName: string): number {
+  const chroma = Note.chroma(noteName);
+  return chroma ?? -1;
+}
+```
+
+`Note.chroma` returns 0–11 for valid notes (handling both sharp and flat spellings via `Note.get`), or `undefined` for invalid input. The `?? -1` matches the legacy `indexOf(-1)` contract.
+
+- [ ] **Step 3.4: Run theory.test.ts; expect any `getNoteIndex`-related cases to pass**
+
+Run: `pnpm --filter @fretflow/core test src/theory.test.ts`
+Expected: all PASS. If any fail, the test names will indicate which input the Tonal version handles differently — most likely an edge case like `"Cb"` or `"E#"`. Resolve by widening the fallback (e.g., `Note.chroma(noteName) ?? Note.chroma(Note.simplify(noteName)) ?? -1`) until green.
+
+- [ ] **Step 3.5: Replace `getIntervalNotes` body**
+
+Replace lines 502-512 with:
+
+```ts
+export function getIntervalNotes(
+  rootNote: string,
+  intervals: number[],
+): string[] {
+  if (Note.chroma(rootNote) === undefined) return [];
+  return intervals.map((semitones) => {
+    const transposed = Note.transpose(rootNote, Interval.fromSemitones(semitones));
+    // Tonal returns spellings that respect input enharmonics. For internal use
+    // we want sharps-only chromatic equivalents (preserves the legacy NOTES contract).
+    return Note.enharmonic(transposed).replace(/b/g, "").length === transposed.length
+      ? transposed
+      : Note.simplify(transposed);
+  });
+}
+```
+
+Note: the existing implementation returns sharps-form names. The Tonal replacement must produce the same casing for consumers that compare strings. If `Note.transpose` gives `"Bb"` where the legacy returns `"A#"`, normalize.
+
+Simpler form if `Note.simplify` already canonicalizes:
+
+```ts
+export function getIntervalNotes(
+  rootNote: string,
+  intervals: number[],
+): string[] {
+  if (Note.chroma(rootNote) === undefined) return [];
+  return intervals.map((semitones) => {
+    const t = Note.transpose(rootNote, Interval.fromSemitones(semitones));
+    // Force sharps-form for chromatic semitone-based operations.
+    const simplified = Note.simplify(t);
+    return simplified.includes("b") ? Note.enharmonic(simplified) : simplified;
+  });
+}
+```
+
+- [ ] **Step 3.6: Run the theory test suite; tune until green**
+
+Run: `pnpm --filter @fretflow/core test src/theory.test.ts`
+Expected: all PASS. If a test fails with a wrong enharmonic, fine-tune the `simplify`/`enharmonic` choice in §3.5.
+
+- [ ] **Step 3.7: Replace `getNoteDisplay` body**
+
+The legacy function picks between sharp and flat spelling based on `useFlats` and `FLAT_KEYS`. Tonal's equivalent is `Note.enharmonic`.
+
+Replace lines 406-421 with:
+
+```ts
+export function getNoteDisplay(
+  noteName: string,
+  activeRoot: string,
+  useFlats?: boolean,
+): string {
+  const wantsFlats = useFlats ?? FLAT_KEYS.includes(activeRoot);
+  if (wantsFlats && noteName.includes("#")) {
+    return Note.enharmonic(noteName);
+  }
+  if (!wantsFlats && noteName.includes("b")) {
+    return Note.enharmonic(noteName);
+  }
+  return noteName;
+}
+```
+
+`FLAT_KEYS` is retained as a constant — it's the app's policy decision about which keys prefer flats, not a Tonal concern.
+
+- [ ] **Step 3.8: Run the full theory test suite**
+
+Run: `pnpm --filter @fretflow/core test src/theory.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 3.9: Run the property tests**
+
+Run: `pnpm --filter @fretflow/core test src/theory.property.test.ts`
+Expected: all PASS. Property tests check chromatic round-trips and enharmonic equivalence — these are the most sensitive to engine swaps. If a property fails, the diff narrows down whether the issue is in `getNoteIndex`, `getIntervalNotes`, or `getNoteDisplay`.
+
+- [ ] **Step 3.10: Commit**
+
+```bash
+git add packages/core/src/theory.ts
+git commit -m "refactor(core): migrate note operations to Tonal"
+```
+
+---
+
+## Task 4: Migrate scale-aware note spelling
+
+Function: `getNoteDisplayInScale` (theory.ts:443-500). Picks the correct letter-name spelling for a note based on its scale-degree role (e.g., the 3rd of D Major is `F#`, not `Gb`, regardless of `useFlats`).
+
+Tonal equivalent: `Scale.get(name).notes` returns scale-degree-respecting spellings.
+
+**Files:**
+- Modify: `packages/core/src/theory.ts:432-500`
+
+- [ ] **Step 4.1: Run existing tests for the function as a green baseline**
+
+Run: `pnpm --filter @fretflow/core test src/theory.test.ts -t "getNoteDisplayInScale"`
+Expected: PASS.
+
+- [ ] **Step 4.2: Add Scale import**
+
+In `packages/core/src/theory.ts`:
+
+```ts
+import * as Scale from "@tonaljs/scale";
+```
+
+(Adjust import style to match Task 3's choice — barrel or per-module.)
+
+- [ ] **Step 4.3: Replace `getNoteDisplayInScale` body**
+
+Replace lines 443-500 with:
+
+```ts
+export function getNoteDisplayInScale(
+  noteName: string,
+  rootNote: string,
+  scaleIntervals: number[],
+  useFlats?: boolean,
+): string {
+  if (scaleIntervals.length !== 7) {
+    return getNoteDisplay(noteName, rootNote, useFlats);
+  }
+
+  // Try to find a Tonal scale matching the interval pattern at the given root.
+  // We compare the chromatic intervals (semitones from root) to identify the mode.
+  const rootChroma = Note.chroma(rootNote);
+  const noteChroma = Note.chroma(noteName);
+  if (rootChroma === undefined || noteChroma === undefined) {
+    return getNoteDisplay(noteName, rootNote, useFlats);
+  }
+
+  const interval = (noteChroma - rootChroma + 12) % 12;
+  const degreeIndex = scaleIntervals.indexOf(interval);
+  if (degreeIndex === -1) {
+    return getNoteDisplay(noteName, rootNote, useFlats);
+  }
+
+  // Resolve the spelled root in the desired accidental space.
+  const spelledRoot = getNoteDisplay(rootNote, rootNote, useFlats);
+
+  // Build a degree-letter target using the heptatonic letter cycle.
+  const letterNames = ["C", "D", "E", "F", "G", "A", "B"];
+  const letterPitches: Record<string, number> = { C: 0, D: 2, E: 4, F: 5, G: 7, A: 9, B: 11 };
+  const rootLetter = spelledRoot.charAt(0);
+  const rootLetterIdx = letterNames.indexOf(rootLetter);
+  if (rootLetterIdx === -1) return getNoteDisplay(noteName, rootNote, useFlats);
+
+  const expectedLetter = letterNames[(rootLetterIdx + degreeIndex) % 7];
+  const expectedBasePitch = letterPitches[expectedLetter];
+  const targetPitch = (rootChroma + interval) % 12;
+  const diff = (targetPitch - expectedBasePitch + 12) % 12;
+
+  if (diff === 0) return expectedLetter;
+  if (diff === 1) return expectedLetter + "#";
+  if (diff === 11) return expectedLetter + "b";
+  if (diff === 2) return expectedLetter + "##";
+  if (diff === 10) return expectedLetter + "bb";
+  return getNoteDisplay(noteName, rootNote, useFlats);
+}
+```
+
+This keeps the existing letter-cycle algorithm but uses `Note.chroma` (Tonal) instead of `NOTES.indexOf` + custom enharmonic lookup. The behavior is identical; the dependency on the local `LETTER_NAMES`/`LETTER_PITCHES` constants moves inside the function (so they can be removed from the module scope if not used elsewhere).
+
+- [ ] **Step 4.4: Remove the now-orphaned module-level constants**
+
+If `LETTER_NAMES` and `LETTER_PITCHES` (theory.ts:432-441) are not exported and not used elsewhere, delete them.
+
+Verify they aren't exported (lines 432-441 should be `const`, not `export const`). They aren't — safe to remove.
+
+Search for other internal usage:
+```bash
+grep -n "LETTER_NAMES\|LETTER_PITCHES" packages/core/src/theory.ts
+```
+Expected: only the (now-deleted) declarations and (now-inlined) function references appear. If `theory.ts` is clean, the constants are gone.
+
+- [ ] **Step 4.5: Run the test suite**
+
+Run: `pnpm --filter @fretflow/core test`
+Expected: all PASS.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add packages/core/src/theory.ts
+git commit -m "refactor(core): use Tonal chroma in scale-aware note spelling"
+```
+
+---
+
+## Task 5: Migrate scale operations
+
+Functions: `getScaleNotes`, `getScaleSemitones`, `getDivergentNotes`. They consume the `SCALES` table.
+
+Strategy: keep `SCALES` exported (consumers depend on it), but populate it from Tonal at module-load time so the source of truth is Tonal's catalog.
+
+**Files:**
+- Modify: `packages/core/src/theory.ts:514-576`
+- Modify: `packages/core/src/theoryCatalog.ts` (the `SCALES` export at line 313)
+
+- [ ] **Step 5.1: Run scale-related tests for baseline**
+
+Run: `pnpm --filter @fretflow/core test src/theory.test.ts -t "getScaleNotes|getScaleSemitones|getDivergentNotes"`
+Expected: all PASS.
+
+- [ ] **Step 5.2: Replace `getScaleNotes` body**
+
+In `packages/core/src/theory.ts`, replace lines 514-519 with:
+
+```ts
+import { scaleNameToTonal } from "./lib/tonal";
+
+export function getScaleNotes(rootNote: string, scaleName: string): string[] {
+  const tonalName = scaleNameToTonal(normalizeScaleName(scaleName));
+  if (!tonalName) return [];
+  if (Note.chroma(rootNote) === undefined) return [];
+  const tonalScale = Scale.get(`${rootNote} ${tonalName}`);
+  // Tonal returns spelled notes (with octave info stripped). Normalize to sharps-form
+  // to maintain the legacy contract (consumers do NOTES.indexOf on the result).
+  return tonalScale.notes.map((n) => {
+    const simplified = Note.simplify(n);
+    return simplified.includes("b") ? Note.enharmonic(simplified) : simplified;
+  });
+}
+```
+
+- [ ] **Step 5.3: Replace `getScaleSemitones` body**
+
+Replace lines 528-532 with:
+
+```ts
+export function getScaleSemitones(rootNote: string, scaleName: string): number[] {
+  const tonalName = scaleNameToTonal(normalizeScaleName(scaleName));
+  if (!tonalName) return [];
+  const tonalScale = Scale.get(`${rootNote} ${tonalName}`);
+  return tonalScale.intervals
+    .map((interval) => Interval.semitones(interval))
+    .filter((n): n is number => typeof n === "number");
+}
+```
+
+- [ ] **Step 5.4: Replace `getDivergentNotes` body**
+
+Replace lines 546-576. The legacy function compares a scale's intervals to a reference scale (Major or Natural Minor). Tonal-backed version:
+
+```ts
+export function getDivergentNotes(
+  rootNote: string,
+  scaleName: string,
+): string[] {
+  const resolvedScaleName = normalizeScaleName(scaleName);
+  if (resolvedScaleName.includes("Blues")) return [];
+  if (resolvedScaleName === "Major Pentatonic" || resolvedScaleName === "Minor Pentatonic") return [];
+  if (resolvedScaleName === "Major" || resolvedScaleName === "Natural Minor") return [];
+
+  const semis = getScaleSemitones(rootNote, scaleName);
+  if (semis.length === 0) return [];
+
+  const isMajorQuality = semis.includes(4); // contains major 3rd
+  const refName = isMajorQuality ? "Major" : "Natural Minor";
+  const refSemis = new Set(getScaleSemitones(rootNote, refName));
+
+  return semis
+    .filter((semitone) => !refSemis.has(semitone))
+    .map((semitone) => {
+      const t = Note.transpose(rootNote, Interval.fromSemitones(semitone));
+      const simplified = Note.simplify(t);
+      return simplified.includes("b") ? Note.enharmonic(simplified) : simplified;
+    });
+}
+```
+
+- [ ] **Step 5.5: Run scale tests**
+
+Run: `pnpm --filter @fretflow/core test src/theory.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add packages/core/src/theory.ts
+git commit -m "refactor(core): migrate scale operations to Tonal"
+```
+
+---
+
+## Task 6: Migrate chord operations
+
+Functions: `getChordNotes`. Consumes `CHORDS` (which is derived from `CHORD_DEFINITIONS`).
+
+Strategy: keep `CHORDS` and `CHORD_DEFINITIONS` exported (many internal references). Replace `getChordNotes`'s body to use Tonal. Future plans may delete the table entirely.
+
+**Files:**
+- Modify: `packages/core/src/theory.ts:534-539`
+
+- [ ] **Step 6.1: Baseline**
+
+Run: `pnpm --filter @fretflow/core test src/theory.test.ts -t "getChordNotes"`
+Expected: PASS.
+
+- [ ] **Step 6.2: Add Chord import**
+
+In `packages/core/src/theory.ts`:
+
+```ts
+import * as Chord from "@tonaljs/chord";
+import { chordQualityToTonal, tonalChordSymbol } from "./lib/tonal";
+```
+
+- [ ] **Step 6.3: Replace `getChordNotes` body**
+
+Replace lines 534-539 with:
+
+```ts
+export function getChordNotes(rootNote: string, chordName: string): string[] {
+  if (Note.chroma(rootNote) === undefined) return [];
+  const symbol = tonalChordSymbol(rootNote, chordName);
+  if (!symbol) return [];
+  const tonalChord = Chord.get(symbol);
+  if (tonalChord.empty) return [];
+  // Same sharps-form normalization as getIntervalNotes.
+  return tonalChord.notes.map((n) => {
+    const simplified = Note.simplify(n);
+    return simplified.includes("b") ? Note.enharmonic(simplified) : simplified;
+  });
+}
+```
+
+- [ ] **Step 6.4: Run chord-related tests**
+
+Run: `pnpm --filter @fretflow/core test src/theory.test.ts`
+Expected: all PASS.
+
+If a particular chord (e.g. "Power Chord (5)") fails because Tonal returns fewer/different notes, verify the mapping in `tonal.ts` — the Tonal symbol `"5"` should produce a 2-note chord (root + 5th).
+
+- [ ] **Step 6.5: Run the chord property tests if they exist**
+
+Run: `pnpm --filter @fretflow/core test src/theory.property.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add packages/core/src/theory.ts
+git commit -m "refactor(core): migrate chord-note resolution to Tonal"
+```
+
+---
+
+## Task 7: Migrate diatonic chord generation
+
+Function: `getDiatonicChord` (theory.ts:712-736). The composition: scale + degree → (root, quality). Used heavily by the chord-overlay degree mode and progression resolution.
+
+**Files:**
+- Modify: `packages/core/src/theory.ts:712-736`
+
+- [ ] **Step 7.1: Baseline**
+
+Run: `pnpm --filter @fretflow/core test src/theory.test.ts -t "getDiatonicChord"`
+Expected: PASS.
+
+- [ ] **Step 7.2: Replace `getDiatonicChord` body**
+
+Replace lines 712-736 with:
+
+```ts
+import { getQualityForDegree, getDegreesForScale } from "./degrees";
+
+export function getDiatonicChord(
+  degreeId: string,
+  scaleName: string,
+  tonicNote: string,
+): { root: string; quality: string } | undefined {
+  const degreesMap = getDegreesForScale(scaleName);
+
+  // Find the semitone offset for this degree
+  const semitoneEntry = Object.entries(degreesMap).find(
+    ([, roman]) => roman === degreeId,
+  );
+  if (!semitoneEntry) return undefined;
+  const semitone = Number(semitoneEntry[0]);
+
+  // Compute the absolute root note via Tonal (was: NOTES + indexOf).
+  if (Note.chroma(tonicNote) === undefined) return undefined;
+  const transposed = Note.transpose(tonicNote, Interval.fromSemitones(semitone));
+  const simplified = Note.simplify(transposed);
+  const root = simplified.includes("b") ? Note.enharmonic(simplified) : simplified;
+
+  const quality = getQualityForDegree(degreeId, scaleName);
+  if (quality === undefined) return undefined;
+
+  return { root, quality };
+}
+```
+
+The dependency on `getQualityForDegree` and `getDegreesForScale` (in `degrees.ts`) is unchanged — those are migrated in Task 9.
+
+- [ ] **Step 7.3: Run tests**
+
+Run: `pnpm --filter @fretflow/core test src/theory.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add packages/core/src/theory.ts
+git commit -m "refactor(core): migrate getDiatonicChord to Tonal-based transposition"
+```
+
+---
+
+## Task 8: Migrate key-signature functions
+
+Functions: `getKeySignature`, `getKeySignatureForDisplay`. They use the legacy `KEY_SIGNATURES` lookup table.
+
+Strategy: keep `KEY_SIGNATURES` exported (consumers may rely on it). Replace the functions to use Tonal's `Key.majorKey` / `Key.minorKey`, falling back to the legacy table.
+
+**Files:**
+- Modify: `packages/core/src/theory.ts:599-634`
+
+- [ ] **Step 8.1: Baseline**
+
+Run: `pnpm --filter @fretflow/core test src/theory.test.ts -t "getKeySignature"`
+Expected: PASS.
+
+- [ ] **Step 8.2: Add Key import**
+
+```ts
+import * as Key from "@tonaljs/key";
+```
+
+- [ ] **Step 8.3: Replace `getKeySignature` body**
+
+Replace lines 599-601 with:
+
+```ts
+export function getKeySignature(rootNote: string): number {
+  const tonalKey = Key.majorKey(rootNote);
+  // Tonal returns `alteration` as a positive integer for sharps, negative for flats.
+  if (typeof tonalKey.alteration === "number") return tonalKey.alteration;
+  // Fallback for inputs Tonal does not recognize (rare; preserves legacy behavior).
+  return KEY_SIGNATURES[rootNote] ?? 0;
+}
+```
+
+- [ ] **Step 8.4: Replace `getKeySignatureForDisplay` body**
+
+The legacy function adjusts the signature based on the scale's offset from its parent major key and the user's flat-preference. Tonal does not have a direct equivalent — but it does provide the scale's degree intervals, and we already have `SCALE_TO_PARENT_MAJOR_OFFSET` from `theoryCatalog`.
+
+Replace lines 603-634 with:
+
+```ts
+export function getKeySignatureForDisplay(
+  rootNote: string,
+  scaleName: string,
+  useFlats: boolean,
+): number {
+  const offset = SCALE_TO_PARENT_MAJOR_OFFSET[normalizeScaleName(scaleName)] ?? 0;
+  if (Note.chroma(rootNote) === undefined) return KEY_SIGNATURES[rootNote] ?? 0;
+
+  // The "parent major" is the major key whose tonic is `offset` semitones above the current root.
+  const parentMajorRoot = Note.transpose(rootNote, Interval.fromSemitones(offset));
+  const parentSharp = Note.simplify(parentMajorRoot).includes("b")
+    ? Note.enharmonic(Note.simplify(parentMajorRoot))
+    : Note.simplify(parentMajorRoot);
+
+  const originalIsSharp = rootNote.includes("#");
+
+  if (!originalIsSharp && useFlats) {
+    const flatName = Note.enharmonic(parentSharp);
+    const flatKey = Key.majorKey(flatName);
+    if (typeof flatKey.alteration === "number" && flatKey.alteration < 0) {
+      return flatKey.alteration;
+    }
+  }
+
+  const tonalKey = Key.majorKey(parentSharp);
+  const sig = typeof tonalKey.alteration === "number" ? tonalKey.alteration : (KEY_SIGNATURES[parentSharp] ?? 0);
+
+  if (originalIsSharp && sig < 0) {
+    return 12 + sig;
+  }
+  return sig;
+}
+```
+
+- [ ] **Step 8.5: Run tests**
+
+Run: `pnpm --filter @fretflow/core test src/theory.test.ts`
+Expected: all PASS. Key-signature tests are sensitive to flat/sharp enharmonics — if a case fails, identify the specific `(rootNote, scaleName, useFlats)` triple from the failure and check whether Tonal's `alteration` differs from the legacy table.
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+git add packages/core/src/theory.ts
+git commit -m "refactor(core): migrate key-signature functions to Tonal"
+```
+
+---
+
+## Task 9: Migrate degree-quality resolution
+
+Functions: `getQualityForDegree` (degrees.ts:168-217), `remapDegreeForScale` (degrees.ts:144-167), `getDegreeSequence` (degrees.ts:241-263), `getDegreesForScale` (degrees.ts:264-end).
+
+The legacy implementation hand-codes the diatonic chord qualities per scale (e.g., I = Major Triad in Major, V = Dominant 7th in Harmonic Minor with 7th-chord context). Tonal's `Key.majorKey().chords` gives the same diatonic-chord sequence.
+
+Strategy: keep the existing data structure in `degrees.ts` as the source of truth for now (it's app-specific UX data — Roman-numeral conventions, scale-degree colors). Replace only the *derivation* internals where Tonal helps.
+
+**Files:**
+- Modify: `packages/core/src/degrees.ts:144-end`
+
+- [ ] **Step 9.1: Baseline**
+
+Run: `pnpm --filter @fretflow/core test src/degrees.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 9.2: Read `degrees.ts:144-end` to understand the data structures**
+
+Run: `cat packages/core/src/degrees.ts | tail -140`
+Review the structure — most of the file is data tables mapping (scale, semitone) → degree Roman-numeral, and (scale, degree) → chord quality.
+
+- [ ] **Step 9.3: Audit which functions benefit from Tonal**
+
+Most of `degrees.ts` is *FretFlow-specific* data: the choice of which Roman numerals to display, which qualities to prefer in modes, the color palette. Tonal does not have this opinion.
+
+The one function that benefits: `remapDegreeForScale` (lines 144-167) translates a degree from one scale into another. With Tonal, this becomes a chord-quality intersection check.
+
+For this task, **leave `degrees.ts` largely unchanged**, but add an internal helper that uses Tonal to validate the legacy data structures match.
+
+In `packages/core/src/degrees.ts`, add at the bottom:
+
+```ts
+import * as Key from "@tonaljs/key";
+import { chordQualityToTonal, tonalToChordQuality } from "./lib/tonal";
+
+/**
+ * Validates that the diatonic-chord-quality table for a given scale matches what
+ * Tonal would produce. Used in tests to catch drift; not called in production.
+ *
+ * @internal
+ */
+export function _validateDiatonicQualitiesAgainstTonal(
+  scaleName: string,
+): boolean {
+  // Only validates Major and Natural Minor; modes derived from these use the same
+  // sequence so a Major check is sufficient for Ionian/Dorian/etc.
+  if (scaleName === "Major") {
+    const key = Key.majorKey("C");
+    const expectedTriadQualities = ["M", "m", "m", "M", "M", "m", "dim"];
+    return key.triads.every((triad, i) => triad === expectedTriadQualities[i]);
+  }
+  if (scaleName === "Natural Minor") {
+    const key = Key.minorKey("A");
+    const expectedTriadQualities = ["m", "dim", "M", "m", "m", "M", "M"];
+    return key.natural.triads.every((triad, i) => triad === expectedTriadQualities[i]);
+  }
+  return true;
+}
+```
+
+- [ ] **Step 9.4: Add a passing test for the validator**
+
+In `packages/core/src/degrees.test.ts`, add:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { _validateDiatonicQualitiesAgainstTonal } from "./degrees";
+
+describe("diatonic-quality alignment with Tonal (drift detection)", () => {
+  it("Major diatonic triads match Tonal", () => {
+    expect(_validateDiatonicQualitiesAgainstTonal("Major")).toBe(true);
+  });
+  it("Natural Minor diatonic triads match Tonal", () => {
+    expect(_validateDiatonicQualitiesAgainstTonal("Natural Minor")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 9.5: Run tests**
+
+Run: `pnpm --filter @fretflow/core test src/degrees.test.ts`
+Expected: all PASS — both the new validator tests and the existing tests.
+
+If the new tests fail, that means Tonal's diatonic-chord catalog disagrees with FretFlow's hard-coded data. Inspect the disagreement: in most cases Tonal is right and the legacy data has a transcription error worth fixing. If it's a legitimate FretFlow choice (e.g., always Dominant 7 on V in minor), document it in a code comment inside the validator and skip that comparison.
+
+- [ ] **Step 9.6: Commit**
+
+```bash
+git add packages/core/src/degrees.ts packages/core/src/degrees.test.ts
+git commit -m "feat(core): add Tonal-based drift detection for diatonic qualities"
+```
+
+---
+
+## Task 10: Migrate the circle of fifths label generator
+
+Function: `getCircleNoteLabels` (circleOfFifthsUtils.ts:5-38). Generates display labels for the 12 positions on the Circle of Fifths wheel.
+
+**Files:**
+- Modify: `packages/core/src/circleOfFifthsUtils.ts:1-end`
+
+- [ ] **Step 10.1: Baseline — read the existing implementation**
+
+Run: `cat packages/core/src/circleOfFifthsUtils.ts`
+Note the 12 positions and the rule for picking sharps vs flats per position.
+
+- [ ] **Step 10.2: Check for existing tests**
+
+Run: `ls packages/core/src/ | grep -i circle`
+Expected: no dedicated test file. The function's output is exercised indirectly through component tests in `src/components/CircleOfFifths/*`.
+
+Read the legacy behavior first to pin the expected output:
+
+```bash
+node --input-type=module -e "import('@fretflow/core').then(m => console.log(m.getCircleNoteLabels(false), m.getCircleNoteLabels(true)))"
+```
+Record the two arrays — these become the expected values below. Replace the `<sharps-array>` and `<flats-array>` placeholders with the recorded outputs (e.g., sharps: `["C","G","D","A","E","B","F#","C#","G#","D#","A#","F"]`; flats: `["C","G","D","A","E","B","Gb","Db","Ab","Eb","Bb","F"]`).
+
+Add focused tests in a new `packages/core/src/circleOfFifthsUtils.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { getCircleNoteLabels } from "./circleOfFifthsUtils";
+
+describe("getCircleNoteLabels", () => {
+  it("returns 12 labels in the sharps cycle", () => {
+    expect(getCircleNoteLabels(false)).toEqual(<sharps-array>);
+  });
+  it("returns 12 labels in the flats cycle", () => {
+    expect(getCircleNoteLabels(true)).toEqual(<flats-array>);
+  });
+  it("starts at C and advances by perfect fifths", () => {
+    const labels = getCircleNoteLabels(false);
+    expect(labels[0]).toBe("C");
+    expect(labels[1]).toBe("G");
+    expect(labels[2]).toBe("D");
+  });
+});
+```
+
+Run: `pnpm --filter @fretflow/core test src/circleOfFifthsUtils.test.ts`
+Expected: PASS — the tests pin the legacy output exactly.
+
+- [ ] **Step 10.3: Rewrite the function using Tonal**
+
+Replace `circleOfFifthsUtils.ts` contents with:
+
+```ts
+import * as Note from "@tonaljs/note";
+import * as Interval from "@tonaljs/interval";
+
+/**
+ * Returns the 12 root labels for the Circle of Fifths, starting at C and
+ * advancing by perfect 5ths. Sharps used by default; flats when `useFlats` is true.
+ */
+export function getCircleNoteLabels(useFlats: boolean): string[] {
+  return Array.from({ length: 12 }, (_, i) => {
+    const note = Note.transpose("C", Interval.fromSemitones(7 * i));
+    const simplified = Note.simplify(note);
+    // Convention: sharps form by default; user can opt into flats for keys 7+
+    // (D♭, A♭, E♭, B♭, F, etc.) where flats are the conventional spelling.
+    if (useFlats && simplified.includes("#")) {
+      return Note.enharmonic(simplified);
+    }
+    return simplified;
+  });
+}
+```
+
+- [ ] **Step 10.4: Run the tests**
+
+Run: `pnpm --filter @fretflow/core test src/circleOfFifthsUtils.test.ts`
+Expected: PASS — Tonal must produce the same labels as the legacy implementation pinned in §10.2. If a label differs, the migration has changed user-visible behavior; either adjust the Tonal-backed code to match (preferred — Phase 1 is engine swap, not behavior change) or update the spec to acknowledge the change.
+
+- [ ] **Step 10.5: Run the consuming component tests to confirm no regression**
+
+Run: `pnpm test -- src/components/CircleOfFifths`
+Expected: all PASS.
+
+- [ ] **Step 10.6: Commit**
+
+```bash
+git add packages/core/src/circleOfFifthsUtils.ts packages/core/src/circleOfFifthsUtils.test.ts
+git commit -m "refactor(core): migrate circle of fifths to Tonal"
+```
+
+---
+
+## Task 11: Full-suite verification + bundle measurement
+
+**Files:** none modified (verification only)
+
+- [ ] **Step 11.1: Run the full core test suite**
+
+Run: `pnpm --filter @fretflow/core test`
+Expected: all PASS. Count should equal Step 0.2's baseline plus the new tests from Tasks 2, 9, and 10.
+
+- [ ] **Step 11.2: Run the app test suite**
+
+Run: `pnpm run test`
+Expected: all PASS. None of the 73 `src/` consumer files should need changes — the migrated theory layer kept its public API.
+
+- [ ] **Step 11.3: Run the linter**
+
+Run: `pnpm run lint`
+Expected: exits 0.
+
+- [ ] **Step 11.4: Run the typecheck**
+
+Run: `pnpm run build:types`
+Expected: exits 0.
+
+- [ ] **Step 11.5: Build the app**
+
+Run: `pnpm run build`
+Expected: exits 0; `dist/` populated.
+
+- [ ] **Step 11.6: Measure the bundle**
+
+Run: `du -sh dist/ && find dist -name "*.js" -exec wc -c {} + | sort -n`
+Compare against Step 0.4's baseline. Tonal cherry-picked is roughly +15KB gzipped; the spec expects this and budgets for it.
+
+- [ ] **Step 11.7: Run the e2e smoke test**
+
+Run: `pnpm run test:e2e -- --grep "@smoke" --reporter=line` (or, if no smoke tag exists, the shortest spec: `pnpm run test:e2e -- e2e/app-components.spec.ts`)
+Expected: all PASS. Smoke confirms no runtime regression in the deployed surface.
+
+---
+
+## Task 12: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 12.1: Update the Architecture section**
+
+In `CLAUDE.md`, in the "Architecture > State & Logic" subsection, find the line:
+
+```
+- **Domain (pure):** `src/core/` — `theory.ts`, `theoryCatalog.ts`, `guitar.ts`, `degrees.ts`, `circleOfFifthsUtils.ts`, `constants.ts`. Plus the `src/shapes/` package (...).
+```
+
+Append after it:
+
+```
+- **Music theory:** `@fretflow/core`'s theory functions (`getNoteDisplay`, `getChordNotes`, `getScaleNotes`, `getDiatonicChord`, `getKeySignature`, etc.) are backed by [Tonal.js](https://github.com/tonaljs/tonal) (`@tonaljs/note`, `@tonaljs/chord`, `@tonaljs/scale`, `@tonaljs/key`, `@tonaljs/interval`). Naming translation lives in `packages/core/src/lib/tonal.ts`.
+```
+
+- [ ] **Step 12.2: Run tests to ensure CLAUDE.md doesn't break anything**
+
+Run: `pnpm run test` (CLAUDE.md is not built or tested, but a sanity check is cheap)
+Expected: PASS.
+
+- [ ] **Step 12.3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): note Tonal.js backing of theory layer"
+```
+
+---
+
+## Task 13: Final sanity check before declaring Phase 1 done
+
+**Files:** none modified (verification only)
+
+- [ ] **Step 13.1: Verify all phase-1 commits are present**
+
+Run: `git log --oneline 7042ae84..HEAD`
+Expected: a clean sequence of commits matching the task list above (Tasks 1–12).
+
+- [ ] **Step 13.2: Re-run the full suite as a final check**
+
+Run: `pnpm run lint && pnpm run test && pnpm run build && pnpm run build:types`
+Expected: each exits 0.
+
+- [ ] **Step 13.3: Confirm no breaking changes to public exports**
+
+Run:
+```bash
+git diff 7042ae84..HEAD -- packages/core/src/index.ts
+```
+Expected: empty diff. Phase 1 must not change what `@fretflow/core` exports.
+
+- [ ] **Step 13.4: Confirm phase 1 acceptance**
+
+Acceptance per spec §15:
+- [ ] `@tonaljs/chord`, `@tonaljs/scale`, `@tonaljs/note`, `@tonaljs/interval`, `@tonaljs/key` are dependencies.
+- [ ] The bespoke theory layer has been *shrunk* (function bodies replaced) — full removal is deferred to later plans.
+- [ ] `pnpm run lint`, `pnpm run test`, `pnpm run build`, `npx tsc -b` all pass.
+
+If all four boxes check, Phase 1 is complete and ready for PR.
+
+- [ ] **Step 13.5: Open a PR**
+
+Run:
+```bash
+git push -u origin claude/optimistic-rhodes-1d1ad7
+gh pr create --title "feat: adopt Tonal.js for music theory (Phase 1)" --body "$(cat <<'EOF'
+## Summary
+
+- Adopts `@tonaljs/*` (cherry-picked: note, chord, scale, interval, key) as the music-theory engine in `@fretflow/core`.
+- Replaces function bodies in `theory.ts`, `degrees.ts`, `circleOfFifthsUtils.ts` to delegate to Tonal through a new `packages/core/src/lib/tonal.ts` adapter.
+- Public API of `@fretflow/core` is unchanged — all 73 consumer files in `src/` work without modification.
+- Existing test suites serve as the safety net; all green.
+
+Implements Phase 1 of [docs/superpowers/specs/2026-05-20-fretflow-integration-design.md](docs/superpowers/specs/2026-05-20-fretflow-integration-design.md).
+
+## Test plan
+
+- [ ] `pnpm run lint` passes
+- [ ] `pnpm run test` passes (count matches baseline + new tests)
+- [ ] `pnpm run build` succeeds
+- [ ] `pnpm run test:e2e -- --grep @smoke` (or app-components spec) passes
+- [ ] Bundle size delta < +30KB gzipped
+- [ ] Manual smoke: open dev server, change scale, change chord, verify fretboard renders correctly
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-20-fretflow-integration-design.md
+++ b/docs/superpowers/specs/2026-05-20-fretflow-integration-design.md
@@ -1,0 +1,660 @@
+# FretFlow Integration — Design
+
+**Status:** Brainstorm spec. Produced 2026-05-20 from a deep cross-tab audit of the chord / progression / scale / view domains. Consolidates and supersedes the chord-overlay mode model.
+
+**Date:** 2026-05-20
+
+**Scope:** Integrate the four Inspector tabs (View / Scale / Chord / Progression) into a coherent DAW-first user experience. Eliminate cross-tab couplings that silently override each other. Reduce control density to a level a new user can navigate. Adopt Tonal.js for music theory and Tone.js for audio.
+
+**Non-goals:** No visual restyle (deferred). No new voicing engines. No new fingering patterns. No notation rendering, MIDI export, or AI generation features.
+
+---
+
+## 1. Background — why integration is needed
+
+FretFlow Studio grew feature-by-feature: View, Scale, Chord, then Progression. The four domains were each designed locally; their boundaries leak. Live use surfaces several structural problems the existing controls-overhaul spec did not address:
+
+### 1a. The progression silently owns the chord overlay
+
+`progressionIsActiveChordSource(get)` returns true whenever a resolvable active step exists (`chordOverlayAtoms.ts:201`). Since the default progression has resolvable steps and `activeProgressionStepIndexAtom` always points at one, the progression is *always* the chord source — even when playback is stopped. `effectiveChordOverlayModeAtom` (line 214) consequently always returns `"degree"`, regardless of the user's setting on the Chord-tab Mode toggle.
+
+Consequence: the Source > Mode toggle (`Off / Degree / Manual`) at `ChordOverlayControls.tsx:191` is dead UI. Clicking "Off" or "Manual" appears to do nothing.
+
+### 1b. No way to turn off the chord overlay
+
+The chord overlay can be hidden via `chordOverlayHiddenAtom` from `ChordPracticeBar`, but this state lives in the top-band legend and the Inspector is oblivious to it. The Chord tab's Mode toggle includes an "Off" value that does not actually hide the overlay.
+
+### 1c. Standalone chord vs progression step
+
+Today the chord exists in two places: as a standalone chord (Chord tab in `manual` mode, via `chordRootOverrideAtom` + `chordQualityOverrideAtom`) and as a step in a progression. Two ways to set the chord, with `effective*` atoms patching over the conflict at read time. The Chord-tab `manual` mode is unreachable in practice (§1a).
+
+### 1d. Cross-tab coupling without visible cross-references
+
+- `scope-to-position` (Chord tab) consumes the fingering position from Scale tab. The dependency is invisible.
+- Writing to `chordRootAtom` / `chordTypeAtom` silently flips `chordOverlayModeAtom` to `"manual"` (`chordOverlayAtoms.ts:270`, `:331`). Side-effect not signaled.
+- Setting `chordDegreeAtom` clears `chordQualityOverrideAtom`. Side-effect not signaled.
+- `effectiveColorNotesAtom` combines scale + chord color preferences across tabs.
+
+### 1e. Control overload
+
+The Chord tab today exposes (in `ChordOverlayControls.tsx`): mode toggle, degree select, root select, chord-type grid, lens toggle, voicing type, voicing inversion, string set, connectors switch, chord spread stepper, scope-to-position switch. The Progression tab adds meter, preset, step list, per-step degree, per-step duration, per-step quality, tempo, plus the backing-track style/lead/comp/bass/drums/swing controls. The user reports this is overwhelming even for the app's author.
+
+### 1f. Duplicated controls and stale features
+
+- The top-band summary (`TopBandSummary.tsx`) was added before connectors made chord tones visually obvious. Its information is now duplicated by what's already drawn on the fretboard plus the StatusBar.
+- The Scale-tab "Theory facts" panel restates information visible in the Circle of Fifths wheel.
+- The "Scale relationship" toggle adds a complexity dimension users rarely engage.
+- String-set selection uses one UX in the Chord tab (graphical 6-string picker) and a different UX in the Scale tab string-study modes.
+
+### 1g. Half-baked lens system
+
+Three lenses (`targets`, `guide-tones`, `tension`) exist but their visual differentiation is too subtle to actually help improvise over a progression. They do not consider the upcoming chord — no anticipation, no common-tone preview, no voice-leading cues.
+
+### 1h. Visual: disabled ToggleBar options
+
+`.toggle-btn` in `shared.module.css` lacks any `:disabled` rule. Unavailable voicing options (drop2/triad/inversions/string sets) are rendered with the HTML `disabled` attribute but look identical to enabled options. The user cannot tell which options are unavailable.
+
+---
+
+## 2. Core insight
+
+**The progression is the universal container for "the current chord."**
+
+There is no standalone chord. The Chord tab is the detail view of the active progression step. A "single-chord exploration" is a 1-step progression. A "free-form chord" is a manually-input step.
+
+This collapses the §1a–§1c tension. One source of truth: the active step of the progression. One editor: the Chord tab, which writes back to the active step.
+
+The fretboard is conceptually three independently-visible layers:
+
+```
+┌──────────────────────────────────────┐
+│  Tuning    (instrument — always on)  │
+│  Scale     (key + pattern — toggle)  │
+│  Chord     (active step — toggle)    │
+└──────────────────────────────────────┘
+```
+
+Visibility is orthogonal to source. The chord overlay can be hidden (scale-only view) regardless of whether the progression is playing.
+
+---
+
+## 3. Architecture
+
+### 3a. Inspector reduced to 3 tabs
+
+The Inspector goes from four tabs to three:
+
+| Tab | Job |
+|---|---|
+| **Scale** | Key, scale type, fingering pattern + sub-controls. |
+| **Chord** | The active progression step's chord quality, voicing, lens, region. Writes back to the step. |
+| **Song** | The progression — arrangement, steps, tempo, meter, backing track. Renamed from Progression to reflect its expanded scope. |
+
+The **View tab is removed.** Its current contents migrate as follows:
+
+| Was in View | New home |
+|---|---|
+| Note labels (degree / note / none) | Settings overlay → Display |
+| Accidental display (sharps / flats) | Settings overlay → Display |
+| Fret range | Settings overlay → Display |
+| Theme | Settings overlay → Display (already there) |
+| Degree colors on/off | Settings overlay → Display |
+| Fingering pattern controls | Already moved to Scale tab (per the controls-overhaul spec) |
+
+Settings overlay grows by 4–5 fields; the Inspector shrinks by one tab.
+
+### 3b. Top-band legend (TopBandSummary) removed
+
+The fretboard renders without the inline legend strip. `FretboardLensOverlay.tsx` and `TopBandSummary.tsx` are deleted (together with `DegreeChipStrip.tsx` and `ChordPracticeBar.tsx`, unless they have other consumers — audit before removal). The scale/chord/lens labels that the legend duplicated remain available in the StatusBar.
+
+Per-note "hide this scale chip" toggling — the only feature unique to the legend — is dropped. Hiding individual scale notes is a low-frequency power-user feature; its disappearance is acceptable. If revived later, it lives in Scale tab → More.
+
+### 3c. Layer visibility — one toggle per layer, in its tab
+
+The top-band eye-toggles are removed (§3b). Replacement: one visibility switch at the top of each layer's Inspector tab.
+
+- **Scale tab → top row:** `Scale layer  [ Switch ]`
+- **Chord tab → top row:** `Chord layer  [ Switch ]`
+
+Each writes to its existing atom (`scaleVisibleAtom`, `chordOverlayHiddenAtom`). No other surfaces. The fretboard itself is the readout — if the layer is hidden, you see it's hidden by looking at the fretboard.
+
+Keyboard shortcuts (existing pattern in app): `S` toggles scale visibility, `C` toggles chord visibility. Discoverable via `HelpModal`.
+
+### 3d. Per-tab sub-structure: Music above, Display below
+
+Each layer tab is internally split into two sub-sections (visually labeled, not as separate tabs):
+
+- **Music** — what the layer *is* (theory): scale key/type, chord quality/voicing, progression steps.
+- **Display** — how the layer is *drawn* within itself: lens, region, scope-to-position, connectors, chord spread.
+
+This places per-layer rendering preferences with their layer (not in a generic View tab) while distinguishing music decisions from rendering preferences.
+
+### 3e. Cross-tab dependencies made visible
+
+Wherever a tab consumes another tab's state, an explicit reference is rendered:
+
+- Chord tab → region row: hint reads *"Position comes from Scale → Fingering. Currently: CAGED Shape A."* The "Scale → Fingering" segment is a click-target that routes to Scale tab.
+- Chord tab → top: context header reads *"Editing bar 1 · Am (i) — writes to your progression"*.
+- Song tab → step row: per-step "Edit on Chord ↗" link (currently in screenshot but unbuilt) routes to Chord tab with that step active.
+
+---
+
+## 4. Chord domain redesign
+
+### 4a. Unified chord state
+
+The chord state has three fields, written by either input UI:
+
+```ts
+interface Chord {
+  root: string;                    // canonical note name, e.g., "A"
+  quality: string;                 // e.g., "Minor Triad"
+  cachedDegree: DegreeId | null;   // last-known scale-degree relationship
+}
+```
+
+This replaces the trio (`chordDegreeAtom`, `chordRootOverrideAtom`, `chordQualityOverrideAtom`) and the mode discriminator (`chordOverlayModeAtom`). The chord state lives on the active progression step (`ProgressionStep` gains `cachedDegree`). Editing the Chord tab writes back to the active step.
+
+### 4b. Two input affordances — same state
+
+The Chord-tab Music section exposes two equally-prominent inputs, side by side:
+
+- **Degree input** — Roman-numeral picker constrained to the active scale. Sets `root` from `getDiatonicChord(degree, scale, scaleRoot)` and `cachedDegree`.
+- **Manual input** — Root note picker + quality picker, unconstrained. Sets `root` and `quality` directly; recomputes `cachedDegree` (null if the chord is not in-key).
+
+The user picks the input style per-action. There is no "mode" — both inputs always work, always write the same state.
+
+### 4c. Out-of-scale transpose rule
+
+On scale change (key or scale type), each progression step's chord is updated as follows:
+
+- **`cachedDegree` is non-null** (in-key chord): re-derive `root` via `getDiatonicChord(cachedDegree, newScale, newScaleRoot)`. Quality is preserved unless the new scale's diatonic-default quality differs *and* the user has not set a quality override.
+- **`cachedDegree` is null** (out-of-scale chord): compute the interval from old `scaleRoot` to new `scaleRoot` and transpose `root` by that interval. The chord stays at the same relative pitch.
+
+Implementation uses Tonal.js: `Note.transpose(root, Interval.distance(oldScaleRoot, newScaleRoot))`.
+
+### 4d. Visibility decoupled from input
+
+The Chord-tab visibility switch (§3c) controls `chordOverlayHiddenAtom` and is independent of all input state. Hidden does not mean "no chord" — the active step is still semantically the current chord; it's just not drawn.
+
+### 4e. Mode toggle removed
+
+`ChordOverlayControls.tsx:191` — the `Off / Degree / Manual` ToggleBar — is deleted. Along with:
+
+- `chordOverlayModeAtom`
+- `effectiveChordOverlayModeAtom`
+- `chordOverlayModeStorage`
+- `i18n` strings `controls.mode`, `controls.modeHint`, `controls.off`, `controls.manual` (the `controls.degree` key remains, repurposed for the Degree input label)
+
+### 4f. Silent side-effects removed
+
+- The auto-flip-to-manual on `chordRootAtom`/`chordTypeAtom` write (today `chordOverlayAtoms.ts:270`, `:331`) is unnecessary in the new model — there is no mode — and is removed.
+- The clear-quality-override on `chordDegreeAtom` change becomes explicit: when the user changes a step's degree via the Degree input, the Chord-tab header announces "Quality reset to diatonic default for new degree" briefly.
+
+---
+
+## 5. Lens redesign — Tones and Lead
+
+The current three lenses (`targets`, `guide-tones`, `tension`) are replaced with two:
+
+### 5a. `tones` lens (default; replaces `targets`)
+
+Static visual treatment for the active chord:
+
+- **Base:** Full-CAGED-style coloring — chord notes share the connector color, reading as a single visual unit on the fretboard. This is the treatment the user identified as "what I like about Full CAGED — all notes on that chord are the same color as the connector."
+- **Guide tones (3rd and 7th)** get a stronger emphasis within the chord: brighter fill, slight scale-up, or inner glow ring (visual treatment to be finalized in a follow-up frontend-design pass).
+- Scale notes dim to ambient brightness (`note-scale-only` role).
+
+### 5b. `lead` lens (new; replaces `guide-tones` + `tension`)
+
+Dynamic visual treatment for improvisation. Builds on Tones as the base, then adds progression-aware cues:
+
+- **Common tones with next chord** glow steady — a "hold this" cue. Computed as `Chord.notes(currentChord).intersect(Chord.notes(nextChord))` via Tonal.
+- **Notes that will depart** (in current chord, not in next) get a subtle directional cue — fade or arrow toward their resolution target.
+- **Anticipation window (last beat of current bar):** the next chord's guide tones ghost-in at low opacity, so the user has been looking at where they'll land before they land there.
+- **Beat-strength sub-toggle (optional, default on):** chord tones saturate on beats 1 and 3, dim on 2 and 4 — the "downbeat = target, upbeat = passing" pedagogical pattern.
+
+### 5c. Architecture
+
+New derived atoms in `practiceLensAtoms.ts`:
+
+```ts
+nextChordTonesAtom        // chord tones of the step after activeProgressionStepIndex
+commonTonesWithNextAtom   // intersection of current + next chord notes
+beatPositionAtom          // current beat within the active step (0..duration in beats)
+```
+
+`beatPositionAtom` derives from `progressionStepDeadlineAtom` + `progressionTempoBpmAtom` + the step's duration. It exists regardless of playback state — when paused, it returns the current frozen position.
+
+### 5d. What disappears
+
+- `practiceLens` enum values `guide-tones` and `tension` are removed. (`targets` is renamed to `tones`.)
+- `lensAvailabilityAtom`'s three-entry registry shrinks to two.
+- Lens-related i18n keys for `guide-tones` and `tension` are dropped.
+
+### 5e. What's deferred
+
+The research identified additional candidates (approach-note lens, avoid-note lens, beat-strength as its own lens). These are not in v1. They can be added later as sub-toggles within Lead or as a third lens if usage data justifies it.
+
+---
+
+## 6. Voicing redesign
+
+### 6a. Region — single 4-state control
+
+`chordScopeToPositionAtom` (boolean) and `chordFretSpreadAtom` (0–4) collapse into one user-facing control: a 4-state ToggleBar.
+
+```
+REGION  ⓘ How broadly the chord overlay extends across the fretboard.
+
+[ Position ] [ +2 ] [ +4 ] [ All ]
+```
+
+| Value | Effect | Backing atoms |
+|---|---|---|
+| `Position` | Constrained to the active fingering position; no buffer. | `chordScopeToPositionAtom = true`, `chordFretSpreadAtom = 0` |
+| `+2` | Position plus 2 frets each side. | `chordScopeToPositionAtom = true`, `chordFretSpreadAtom = 2` |
+| `+4` | Position plus 4 frets each side. | `chordScopeToPositionAtom = true`, `chordFretSpreadAtom = 4` |
+| `All` | Whole fretboard, no constraint. | `chordScopeToPositionAtom = false` |
+
+Per-option `title` attributes:
+
+- Position: "Chord shown only within the active fingering position."
+- +2: "Chord shown within the position, plus 2 frets each side."
+- +4: "Chord shown within the position, plus 4 frets each side."
+- All: "Chord shown across the whole fretboard."
+
+When no active position exists (fingering = None or multi-shape CAGED), the three position-relative values disable; the control collapses to `All` automatically and a hint clarifies why: "No active position — region defaults to All." This reuses the existing `activePositionAtom` from the controls-overhaul spec.
+
+Buffer values 1 and 3 are dropped from the UI. The atoms still support them; a Settings-overlay power-user slider may expose finer control in a future spec.
+
+### 6b. String set — simpler and contextual
+
+The graphical 6-string `StringSetPicker` is replaced with a `LabeledSelect` of named options:
+
+```
+STRING SET  ⓘ Which strings to use for this voicing.
+
+[ Top 3 strings (1-2-3)              ▾ ]
+```
+
+Options are computed by `stringSetOptionsAtom` (already exists). Display labels favor named groupings ("Top 3 strings", "Middle 3 strings", "Bottom 3 strings", "Strings 2-3-4", etc.) over numeric IDs. Same UX is used by the Scale-tab string-study modes — one picker pattern across the app.
+
+`StringSetPicker.tsx` is removed; `LabeledSelect` is used in both call sites.
+
+### 6c. Visual base — Full-CAGED style as default
+
+Chord-note coloring matches the voicing connector color by default (the user-preferred treatment). For triads, when multiple voicings overlap on the same notes, the string-set filter (§6b) is the disambiguation tool — picking a string set narrows the displayed voicings to just that set.
+
+This is partially in place for Full-CAGED voicings; the change is to apply the same treatment to all voicing types.
+
+### 6d. ToggleBar disabled styling
+
+`shared.module.css` gains a `.toggle-btn:disabled` rule:
+
+```css
+.toggle-btn:disabled {
+  opacity: var(--disabled-opacity);
+  cursor: not-allowed;
+  color: var(--dc-fg-muted);
+}
+.toggle-btn:disabled:hover {
+  background-color: transparent;
+  border-color: transparent;
+  color: var(--dc-fg-muted);
+}
+```
+
+`opacity: var(--disabled-opacity)` reuses the token defined for `.control-button:disabled` (line 98). Tooltips via the existing `title` prop on `ToggleBarOption` are unchanged.
+
+This applies wherever ToggleBar disables an option: voicing type (caged/drop2/triad), voicing inversion, region (when no active position), lens (if a lens is unavailable).
+
+---
+
+## 7. Scale tab redesign
+
+### 7a. Scale picker — one grouped select
+
+`scaleFamilyAtom` + `scaleNameAtom` are replaced with a single grouped `LabeledSelect`:
+
+```
+SCALE  [ A Minor Pentatonic                  ▾ ]
+       ┌─ Major modes ───────────┐
+       │  Ionian (Major)         │
+       │  Dorian                 │
+       │  ... (7 modes)          │
+       ├─ Pentatonics ───────────┤
+       │  Major Pentatonic       │
+       │  Minor Pentatonic       │
+       ├─ Blues ─────────────────┤
+       │  Blues Scale            │
+       └─ Harmonic / Melodic ────┘
+```
+
+The component already supports `LabeledSelectGroup` (used in Progression presets). The atom `scaleNameAtom` becomes the single source; family is derived for display purposes only.
+
+### 7b. Theory facts panel removed
+
+`ScaleTheoryFacts.tsx` and its CSS are deleted. The Circle of Fifths wheel remains. Anything irreplaceable from Theory facts becomes a tooltip annotation on the wheel; in practice the wheel already covers relative-minor/relative-major relationships and the modal positions.
+
+### 7c. Scale relationship toggle removed
+
+The relationship toggle (parent / relative / parallel) is deleted. The wheel always renders the relative key annotation; modal positions are implied by the scale name itself.
+
+### 7d. String-study modes unified UX
+
+1-String and 2-Strings sub-controls use the same `LabeledSelect` for string-set selection as Chord tab voicing (§6b). Same naming conventions ("Top 3 strings" etc.); the underlying atoms differ per mode but the picker is shared.
+
+### 7e. Fingering pattern controls
+
+Fingering pattern controls (None / CAGED / 3NPS / 1-String / 2-Strings) remain in the Scale tab as established by the existing controls-overhaul spec ([`2026-05-19-controls-overhaul-design.md`](2026-05-19-controls-overhaul-design.md)). This spec does not modify their position, presentation, or per-mode sub-controls.
+
+---
+
+## 8. Song tab (renamed from Progression)
+
+### 8a. Renaming
+
+`Progression` tab → `Song`. The atom names, file names, and store-level identifiers keep their existing `progression*` prefixes for storage compatibility; only user-facing label and the tab `id` change.
+
+### 8b. Structure
+
+```
+┌── Song ────────────────────────┐
+│  Preset · Tempo · Meter        │  always visible — primary controls
+│  Step list                     │  primary editor
+│                                │
+│  ▸ Backing track               │  collapsed by default
+└────────────────────────────────┘
+```
+
+Backing track (style/lead/comp/bass/drums/swing) is wrapped in a collapsible section, default collapsed. The user picks a preset and the backing track adopts that preset's defaults; advanced tweaking is one disclosure click away.
+
+### 8c. Step-list "Edit on Chord ↗"
+
+The screenshot's "Edit on Chord ↗" link (currently unbuilt) is implemented. Per step:
+
+```
+│ 1 │ i  │ A Minor Triad │ 1 bar │ ↗ Edit │
+```
+
+Clicking ↗:
+- Sets `activeProgressionStepIndexAtom` to that step's index.
+- Switches Inspector active tab to `chord`.
+- Optionally scrolls the Chord tab to the Music section.
+
+### 8d. Progression playback blocked-reason surfacing
+
+`progressionPlaybackBlockedReasonAtom` (currently shown only as a `statusNote` in `ProgressionTrack`) is also surfaced in the TransportBar Play button's `title` tooltip. The Play button already disables; the tooltip now explains why.
+
+---
+
+## 9. Library adoption
+
+### 9a. Tonal.js (cherry-picked modules)
+
+Adopted modules:
+
+- `@tonaljs/chord` — chord parsing, voicings, intervals
+- `@tonaljs/scale` — scale construction, modes
+- `@tonaljs/note` — note manipulation, transposition, enharmonics
+- `@tonaljs/interval` — interval distance, transposition
+
+Replaces:
+
+| Today | Replaced by |
+|---|---|
+| `core/theory.ts` chord/scale logic | `@tonaljs/chord`, `@tonaljs/scale` |
+| `core/degrees.ts` | `@tonaljs/chord` (Roman-numeral / degree resolution) |
+| `core/circleOfFifthsUtils.ts` (parts) | `@tonaljs/key` |
+| `getNoteDisplay` + `FLAT_KEYS` enharmonic logic | `@tonaljs/note` (`Note.enharmonic`, `Note.simplify`) |
+| `getDiatonicChord` | `@tonaljs/chord.getChord(quality, root)` + degree resolution |
+
+Files removed or shrunk substantially: `core/theory.ts`, `core/theoryCatalog.ts`, `core/degrees.ts`, `core/circleOfFifthsUtils.ts`.
+
+Constants for chord definitions, scale names, etc. in `core/constants.ts` may stay as a thin app-specific layer mapping Tonal types to FretFlow's display labels.
+
+### 9b. Tone.js
+
+Adopted for audio playback. Replaces:
+
+| Today | Replaced by |
+|---|---|
+| Bespoke step-deadline timer in `progressionAtoms.ts:343-347` | `Tone.Transport` |
+| Manual step advance via `setTimeout` / event loop | `Tone.Sequence` |
+| `core/audio.ts` `GuitarSynth` singleton | `Tone.PolySynth` + `Tone.Sampler` |
+| Backing-track audio scheduling in `src/progressions/audio/*` | `Tone.Pattern` + `Tone.Loop` |
+| Metronome via custom oscillator | `Tone.Transport.scheduleRepeat` |
+
+Significant code reduction in `src/progressions/audio/`. Latency and timing precision improve (Tone uses Web Audio's scheduling clock).
+
+### 9c. What is *not* adopted now
+
+`@tonejs/midi`, `VexFlow`, `abcjs`, `scribbletune`, `@dnd-kit`, `idb-keyval` — deferred until specific features pull them.
+
+### 9d. Bundle impact
+
+- `@tonaljs/*` cherry-picked: ~15–20KB gzipped (vs ~50KB for the full package).
+- `Tone.js`: ~150KB gzipped.
+- Net offset: removing `core/theory.ts`, `core/degrees.ts`, parts of `core/circleOfFifthsUtils.ts`, and chunks of `src/progressions/audio/*` saves on the order of 30–60KB of source (less compressed). Approximate net add: ~120KB gzipped.
+
+---
+
+## 10. File-level impact
+
+### Removed
+
+- `src/components/FretboardLensOverlay/FretboardLensOverlay.tsx`
+- `src/components/FretboardLensOverlay/FretboardLensOverlay.module.css`
+- `src/components/TopBandSummary/TopBandSummary.tsx`
+- `src/components/TopBandSummary/TopBandSummary.module.css`
+- `src/components/DegreeChipStrip/DegreeChipStrip.tsx` (audit other consumers first)
+- `src/components/ChordPracticeBar/ChordPracticeBar.tsx` (audit other consumers first)
+- `src/components/Inspector/ScaleTheoryFacts.tsx`
+- `src/components/Inspector/ViewTab.tsx`
+- `src/components/Inspector/scaleTheoryDerivations.ts`
+- `src/components/Inspector/StringSetPicker.tsx`
+- `src/components/Inspector/StringSetPicker.module.css`
+- `src/core/theory.ts` (replaced by Tonal)
+- `src/core/theoryCatalog.ts` (replaced by Tonal)
+- `src/core/degrees.ts` (replaced by Tonal)
+- `src/core/circleOfFifthsUtils.ts` (most logic moves to `@tonaljs/key`)
+- `src/store/chordOverlayAtoms.ts` — `chordOverlayModeAtom`, `effectiveChordOverlayModeAtom`, `chordOverlayModeStorage`, `chordRootOverrideAtom`, `chordQualityOverrideAtom`, `chordDegreeAtom` (consolidated into the active step)
+
+### Substantially changed
+
+- `src/App.tsx` — remove Top-band rendering, remove View tab from layout.
+- `src/components/Inspector/Inspector.tsx` — three tabs instead of four.
+- `src/components/Inspector/tabs.tsx` — remove `view`; rename `progression` → `song`.
+- `src/components/Inspector/ScaleTab.tsx` — add layer-visibility switch at top; replace family+mode with grouped select; remove theory facts; remove relationship toggle.
+- `src/components/ChordOverlayControls/ChordOverlayControls.tsx` — remove Mode toggle; add layer-visibility switch at top; add context header; unify degree+manual inputs; replace scope/spread with Region ToggleBar; replace StringSetPicker with LabeledSelect.
+- `src/components/ProgressionControls/ProgressionControls.tsx` — rename to SongControls (file rename + import updates); collapse backing track; add Edit-on-Chord links to step rows.
+- `src/components/TransportBar/TransportBar.tsx` — surface `progressionPlaybackBlockedReasonAtom` in the Play button `title`.
+- `src/components/SettingsOverlay/` — add Display section with note labels, accidentals, fret range, degree colors.
+- `src/store/practiceLensAtoms.ts` — collapse three lenses to two (`tones`, `lead`); add `nextChordTonesAtom`, `commonTonesWithNextAtom`, `beatPositionAtom`.
+- `src/store/scaleAtoms.ts` — `scaleFamilyAtom` derived from `scaleNameAtom`, not stored.
+- `src/store/progressionAtoms.ts` — `ProgressionStep` gains `cachedDegree`; on-write hook updates it.
+- `src/progressions/audio/*` — rewritten on Tone.js.
+- `src/core/audio.ts` — replaced with Tone.js synths/samplers.
+- `src/components/shared/shared.module.css` — `.toggle-btn:disabled` rule added.
+
+### New
+
+- `src/store/songStateAtoms.ts` (or similar) — unified atom selectors for the active chord (delegating to the active step).
+- `src/lib/tonalAdapters.ts` — thin app-specific wrappers around Tonal modules for display-label mapping.
+
+### i18n
+
+- Remove keys: `controls.mode`, `controls.modeHint`, `controls.off`, `controls.manual`, `inspector.viewTab`, lens keys for `guide-tones` and `tension`.
+- Add keys: chord-tab visibility-switch label, scale-tab visibility-switch label, Region ToggleBar label + per-option titles + hint, lens labels for `tones` and `lead`, Edit-on-Chord link label, scope-via-Settings labels for migrated View prefs.
+
+---
+
+## 11. State migration
+
+`atomWithStorage` persists state in localStorage with the `k()` prefix. Migration concerns:
+
+### 11a. Chord-mode collapse
+
+Existing values of `chordOverlayMode`:
+
+- `"off"` → set `chordOverlayHiddenAtom = true`. The progression remains the chord source (as it always has been under the hood); only the visual overlay is hidden, matching what `"off"` users were trying to achieve.
+- `"manual"` → discard the persisted `chordRootOverride` and `chordQualityOverride`. The user's manual chord is *not* preserved as a step's quality override, because the progression's existing steps already define the chord sequence. Adding a "scratch" step from the migrated manual chord would alter the user's progression arrangement, which is more surprising than losing the manual chord. A first-load `HelpModal` notice explains: "Manual chord mode has been removed — edit the active progression step directly to customize the chord."
+- `"degree"` → no change; the progression was already the effective source.
+
+The migration is one-shot, run on first load after upgrade, via a `migrate` hook in `chordOverlayModeStorage` (and then the storage entry is removed). The orphaned `chordRootOverride` and `chordQualityOverride` storage entries are deleted in the same pass.
+
+### 11b. Lens collapse
+
+Existing values of `practiceLens`:
+
+- `"targets"` → `"tones"` (renamed; semantics preserved + guide-tone emphasis now built in).
+- `"guide-tones"` → `"tones"` (guide-tone emphasis is now part of Tones, not a separate lens).
+- `"tension"` → `"lead"` (tension/color is folded into Lead's color treatment alongside voice-leading cues).
+
+Note: `"tension"` users will see a different visual treatment under Lead — it adds anticipation and common-tone cues their old lens did not have. A one-time `HelpModal` notice on first load after upgrade explains the lens redesign.
+
+### 11c. Scale family + mode collapse
+
+`scaleFamily` storage entry is removed; `scaleName` is the single source. Existing `scaleName` values continue to deserialize unchanged.
+
+### 11d. Region collapse
+
+`chordScopeToPosition` + `chordFretSpread` continue to back the new control. No storage migration needed; the UI maps existing values to the nearest 4-state value (spread 0→Position, 1-2→+2, 3-4→+4, scope-off→All).
+
+### 11e. View tab → Settings overlay
+
+Existing atoms (`noteLabelStyleAtom`, `useFlatsAtom`, `fretRangeAtom`, `themeAtom`, `degreeColorsEnabledAtom`) are unchanged. Only the rendering location moves.
+
+---
+
+## 12. Testing strategy (TDD — failing test first per task)
+
+### Unit / component tests
+
+- **`chordOverlayAtoms.test.ts`** — remove tests for `chordOverlayMode`, `effective*`, `chordRootOverride`, `chordQualityOverride`. Add tests for unified chord state on the active step; out-of-scale transpose by interval; degree input transposes diatonically; manual input clears `cachedDegree` when chord is out of key.
+- **`practiceLensAtoms.test.ts`** — `lensAvailabilityAtom` returns 2 entries (`tones`, `lead`). Migrations from `targets`/`guide-tones`/`tension` map correctly. `commonTonesWithNextAtom` computes intersection. `beatPositionAtom` derives from step deadline.
+- **`progressionAtoms.test.ts`** — `ProgressionStep` carries `cachedDegree`. Scale change updates step roots diatonically for in-key cached degrees; transposes by interval for null cached degrees.
+- **`ChordOverlayControls.test.tsx`** — no Mode toggle. Visibility switch at top toggles `chordOverlayHiddenAtom`. Degree input writes to active step. Manual input writes to active step + clears cachedDegree if out of key. Region ToggleBar has 4 states. String set is a select.
+- **`ScaleTab.test.tsx`** — scale picker is a grouped select. Theory facts not rendered. Relationship toggle not rendered. Visibility switch at top.
+- **`SongTab.test.tsx`** (renamed) — backing track collapsed by default. Each step has an Edit-on-Chord link routing to Chord tab + activating that step.
+- **`ToggleBar.test.tsx`** — disabled options render with the disabled class and applied opacity; hover does not change appearance.
+- **`Inspector.test.tsx`** — three tabs: Scale, Chord, Song. No View tab.
+- **`useFretboardState.test.tsx`** — visibility atoms gate rendering; Region affects fullChordMatches filter; lens roles include `lead` outputs (common-tone, anticipation).
+
+### Visual regression
+
+- `e2e/app-components.visual.spec.ts` — refresh snapshots for the Chord tab, Scale tab, Song tab (all changed).
+- `e2e/app-layout.visual.spec.ts` — refresh for Inspector tab list (3 tabs), top-band removal.
+- `e2e/app-overlays.visual.spec.ts` — refresh chord-overlay rendering with Full-CAGED-style coloring as default.
+- `e2e/fretboard-svg.visual.spec.ts` — refresh lens variants (Tones / Lead).
+- Refresh both darwin and linux snapshots.
+
+### E2E
+
+- `e2e/chord-overlay.spec.ts` — visibility switch in Chord tab hides overlay; visibility switch in Scale tab hides scale notes; both independent.
+- `e2e/song-edit-flow.spec.ts` — click Edit-on-Chord link in Song tab → Inspector switches to Chord tab → active step matches.
+- `e2e/lens-anticipation.spec.ts` — during last beat of a step, next chord's guide tones render at low opacity.
+
+---
+
+## 13. Phasing
+
+This spec describes a large coordinated change. Implementing it as one PR is impractical. Phased rollout:
+
+| Phase | Contents | Depends on |
+|---|---|---|
+| **1. Foundation** | Tonal.js adoption. Replace `core/theory.ts`, `core/degrees.ts`, `core/circleOfFifthsUtils.ts`. Tests adapted. No UI change. | — |
+| **2. Chord unification** | Active-step-as-source-of-truth. Remove mode toggle, `chordOverlayModeAtom`, override atoms. Add `cachedDegree` to steps. Migration. | Phase 1 |
+| **3. Inspector reshape** | Remove View tab. Move View contents to Settings overlay. Rename Progression → Song. Add per-tab visibility switches. Remove top-band. | Phase 2 |
+| **4. Lens redesign** | Collapse three lenses to Tones + Lead. Add `nextChordTonesAtom`, `commonTonesWithNextAtom`, `beatPositionAtom`. Full-CAGED-style base treatment. | Phase 2 |
+| **5. Voicing simplification** | Region ToggleBar replacing scope+spread. StringSet → LabeledSelect. Disabled ToggleBar styling. | Phase 2 |
+| **6. Scale simplification** | Family+mode grouped select. Remove Theory facts. Remove relationship toggle. | Phase 1 |
+| **7. Audio (Tone.js)** | Replace bespoke audio engine. Beat-aware lens timing precision improves. | Phase 1 |
+| **8. Polish** | Edit-on-Chord links. Playback-blocked tooltip. Cross-tab dependency hints. | Phases 2–7 |
+
+Phases 4 and 7 are independent of each other and can run in parallel. Phases 6 and 1 can begin together.
+
+---
+
+## 14. Cross-cutting notes
+
+- All new user-facing strings go through `useTranslation` (en + es).
+- Persisted atoms use `atomWithStorage` + `k()` key prefix. Defaults set conservatively (visibility on, region `+2`, lens `tones`).
+- Mandatory before each PR: `pnpm run lint`, `pnpm run test`, `pnpm run build`, `npx tsc -b`.
+- Visual regression baselines refresh per phase, darwin + linux.
+- `HelpModal` updated each phase with the relevant new keyboard shortcuts (`S`, `C` for visibility) and conceptual notes (the active chord is always a progression step; lens variants; region).
+- `CLAUDE.md` updated to reflect the new architecture (three tabs, layer model, Tonal/Tone adoption).
+
+---
+
+## 15. Acceptance criteria
+
+### Chord domain
+
+- The Chord tab has no Mode toggle.
+- The chord overlay can be hidden by a visibility switch at the top of the Chord tab.
+- Editing the Chord tab's quality or root writes back to the active progression step.
+- Changing the scale transposes in-scale chords diatonically and out-of-scale chords by the new-scale-root interval.
+- Both Degree and Manual inputs are simultaneously available on the Chord tab; both write to the same state.
+
+### Inspector
+
+- The Inspector has three tabs: Scale, Chord, Song.
+- The View tab is absent.
+- Note labels, accidentals, fret range, theme, and degree-colors controls are in the Settings overlay.
+- Each layer tab has a visibility switch at the top.
+
+### Top band
+
+- The top-band legend strip is not rendered.
+- The fretboard renders without the inline legend; the StatusBar carries the scale/chord/lens text labels.
+
+### Lens
+
+- Two lenses are available: Tones and Lead.
+- Lead's anticipation window ghosts the next chord's guide tones during the last beat of the current step.
+- Existing persisted lens values (`targets`, `guide-tones`, `tension`) migrate to `tones` or `lead` on first load after upgrade.
+
+### Voicing
+
+- The Region control is a 4-state ToggleBar: Position, +2, +4, All.
+- The String Set picker is a `LabeledSelect`, not the graphical 6-string picker.
+- Disabled ToggleBar options render with reduced opacity, `not-allowed` cursor, and no hover effect.
+
+### Scale
+
+- Scale picker is a single grouped `LabeledSelect`.
+- The Theory Facts panel and the Scale Relationship toggle are gone.
+- String-study modes use the same `LabeledSelect` picker pattern as Chord-tab voicing.
+
+### Song (renamed Progression)
+
+- The tab label reads "Song".
+- The Backing Track section is collapsed by default.
+- Each step row has an "Edit on Chord ↗" link that switches to the Chord tab and activates that step.
+- The TransportBar Play button's tooltip surfaces `progressionPlaybackBlockedReasonAtom` when disabled.
+
+### Libraries
+
+- `@tonaljs/chord`, `@tonaljs/scale`, `@tonaljs/note`, `@tonaljs/interval` are dependencies. The bespoke theory layer (`core/theory.ts`, `core/degrees.ts`, `core/circleOfFifthsUtils.ts`) is removed or substantially shrunk.
+- `tone` is a dependency. The bespoke audio scheduling layer is replaced by `Tone.Transport` + `Tone.Sequence`.
+- No other libraries are added.
+
+### Build / quality gates
+
+- `pnpm run lint`, `pnpm run test`, `pnpm run build`, `npx tsc -b` all pass at each phase boundary.
+- Visual regression suites pass (darwin and linux) at each phase boundary.
+
+---
+
+## 16. What this spec deliberately does not address
+
+- **Visual restyle.** Colors, spacing, typography are unchanged except where structurally required (e.g., the chord-note coloring base treatment). A dedicated visual refresh spec follows.
+- **New voicing types.** No additions to `caged`/`drop2`/`triad`.
+- **New fingering patterns.** The five (none/caged/3nps/one-string/two-strings) are unchanged.
+- **Notation rendering.** No staff view, no MIDI export.
+- **Multiple progressions / song library.** Save/load of named songs is out of scope.
+- **AI features.** No suggested progressions, no generated melodies.
+
+These can become future specs once the integration is stable.

--- a/docs/superpowers/specs/2026-05-20-fretflow-phase-1-followups.md
+++ b/docs/superpowers/specs/2026-05-20-fretflow-phase-1-followups.md
@@ -1,0 +1,76 @@
+# FretFlow Phase 1 — Follow-up Observations
+
+**Status:** Reference notes. Produced 2026-05-20 from the final code review of Phase 1 (Tonal.js foundation). Not a spec — captures non-blocking observations to be addressed in Phase 2 cleanup or a small targeted follow-up PR.
+
+**Source:** Final-review subagent on the complete Phase 1 diff, prior to opening PR.
+
+**Phase 1 PR:** to be linked after creation.
+
+---
+
+## Observations
+
+### 1. `getChordNotes` NaN guard inconsistency (Minor — cosmetic)
+
+**Location:** `packages/core/src/theory.ts:522` (approximately).
+
+The Phase 1 migration established a canonical NaN guard pattern for `Note.chroma` (which returns `NaN`, not `undefined`, for invalid input):
+
+```ts
+const chroma = Note.chroma(x);
+if (typeof chroma !== "number" || isNaN(chroma)) return [];
+```
+
+Every migrated function uses this hoisted form except `getChordNotes`, which writes:
+
+```ts
+if (Note.chroma(rootNote) === undefined || Number.isNaN(Note.chroma(rootNote))) return [];
+```
+
+This calls `Note.chroma` twice and mixes the canonical patterns. It works (Tonal returns `NaN`; `NaN === undefined` is false; `Number.isNaN(NaN)` is true), but it's inconsistent with the rest of the file.
+
+**Fix:** Hoist the call once and use the canonical guard. ~3-line change.
+
+### 2. `getDivergentNotes` was not fully migrated to Tonal (Minor — pre-existing gap)
+
+**Location:** `packages/core/src/theory.ts:551, 562` (approximately).
+
+`getDivergentNotes` was rewritten to delegate to `getScaleSemitones` (which is Tonal-backed) but still uses two legacy idioms:
+
+- Line 551 (approx): `NOTES.indexOf(rootNote)` — returns `-1` for flat-spelled roots like `"Bb"`, `"Eb"`, `"Ab"`, causing the function to silently return `[]`.
+- Line 562 (approx): `NOTES[semitone]` — converts absolute semitone indices back to note names via the chromatic array.
+
+This is **not a regression** — the original code had the same `NOTES.indexOf` issue for flat roots. The Phase 1 migration didn't fix it but also didn't worsen it. The UI currently uses sharp/natural roots in most paths, so the gap is rarely reachable.
+
+**Fix:** Replace both legacy idioms with the canonical Tonal patterns (`Note.chroma` guard for input validation; `Note.transpose(rootNote, Interval.fromSemitones(...))` + sharps normalization for output). Likely ~15 lines.
+
+### 3. `getDivergentNotes` lacks flat-root test coverage (Minor)
+
+The existing tests for `getDivergentNotes` exercise only sharp and natural roots (`"D"`, `"F"`, `"G"`, `"C"`, `"A"`). They do not exercise flat roots, which is why the gap in observation #2 stayed silent.
+
+**Fix:** Add at least one test case like `getDivergentNotes("Bb", "Dorian")` and pin the expected output (either after fixing the flat-root bug, or to document current behavior).
+
+---
+
+## Suggested handling
+
+These three observations are coherent — they all concern flat-root handling and pattern consistency in `theory.ts`. Smallest reasonable PR: combine the fix for observation #1 (`getChordNotes` guard) with observations #2 and #3 (`getDivergentNotes` migration + tests) into one targeted cleanup PR titled something like `refactor(core): fix theory.ts NaN guard inconsistency and complete getDivergentNotes migration`.
+
+Alternatively, address them inline during Phase 2 (Chord unification) since that work also touches `theory.ts`.
+
+Both are appropriate; the targeted PR is faster, the inline approach has less churn.
+
+---
+
+## What was *not* observed (passed final review cleanly)
+
+For reference, these aspects of Phase 1 were reviewed and found solid:
+
+- Adapter file `packages/core/src/lib/tonal.ts` — single responsibility, clean.
+- Namespace imports applied uniformly (no deprecated defaults).
+- Sharps-form normalization pattern applied at every Tonal output boundary.
+- Public API of `@fretflow/core` (its `index.ts`) byte-identical to baseline.
+- `KEY_SIGNATURES` and `ENHARMONICS` legitimately retained (still consumed by `src/` and by `resolveAccidentalMode`).
+- Test additions (`tonal.test.ts`, `circleOfFifthsUtils.test.ts`, drift-detection tests in `degrees.test.ts`) pin real expected values.
+- All 1794 tests pass; lint + build + typecheck clean.
+- Bundle add ~52KB gzipped (within the spec's total ~120KB budget for Tonal + Tone combined).

--- a/docs/superpowers/specs/2026-05-20-library-survey-notes.md
+++ b/docs/superpowers/specs/2026-05-20-library-survey-notes.md
@@ -1,0 +1,124 @@
+# Library Survey — Reference Notes
+
+**Status:** Reference document, not a spec. Produced 2026-05-20 alongside the FretFlow Integration Design ([`2026-05-20-fretflow-integration-design.md`](2026-05-20-fretflow-integration-design.md)).
+
+**Date:** 2026-05-20
+
+**Purpose:** Capture the library landscape considered during the integration brainstorm so future feature work can revisit candidates without re-doing the survey. The integration spec commits to **Tonal.js + Tone.js only**; this document records what else was considered and the conditions under which each becomes worth adopting.
+
+---
+
+## 1. Committed in the integration spec
+
+| Library | Why committed | Modules in use |
+|---|---|---|
+| **Tonal.js** | Replaces bespoke theory (`core/theory.ts`, `core/degrees.ts`, parts of `core/circleOfFifthsUtils.ts`). Powers degree resolution, transposition, enharmonics, common-tone computation for the Lead lens. | `@tonaljs/chord`, `@tonaljs/scale`, `@tonaljs/note`, `@tonaljs/interval`, `@tonaljs/key` |
+| **Tone.js** | Replaces bespoke audio scheduling. Powers `Tone.Transport`, `Tone.Sequence`, `Tone.PolySynth`, `Tone.Sampler`, metronome scheduling. Improves timing precision for beat-aware lens. | `tone` (single package) |
+
+Bundle add: ~165KB gzipped (Tonal cherry-picked ~15KB; Tone ~150KB). Net after removing replaced bespoke code: approximately +120KB gzipped.
+
+---
+
+## 2. Deferred — feature-gated
+
+These libraries solve real problems but only earn their bundle weight if a specific feature ships. Re-evaluate when the feature is proposed.
+
+### 2a. MIDI
+
+| Library | What it gives | Pulls in when |
+|---|---|---|
+| **`@tonejs/midi`** | Read / write standard MIDI files. Integrates cleanly with Tone.js since it shares the same author/ecosystem. | "Save progression as MIDI", "Import MIDI progression", "Export practice loop to my DAW" |
+
+Approximate size: ~30KB gzipped.
+
+### 2b. Music notation
+
+| Library | What it gives | Pulls in when | Notes |
+|---|---|---|---|
+| **VexFlow** | Standard music notation renderer (treble/bass clef, key signatures, chord symbols). Mature, large API. | Sheet-music views of chords, scales, or progressions. | ~200KB gzipped. Heavy but standard. |
+| **abcjs** | ABC notation → SVG renderer. Lighter than VexFlow, less expressive. | Quick chord-on-staff visualizations. | ~120KB gzipped. |
+| **OpenSheetMusicDisplay** | MusicXML rendering. Built on VexFlow. | Importing teacher-provided sheet music. | Heaviest of the three. |
+
+Verdict: if notation becomes a feature, **VexFlow** is the default pick unless the use case is constrained to chord diagrams (then abcjs).
+
+### 2c. Algorithmic composition
+
+| Library | What it gives | Pulls in when | Notes |
+|---|---|---|---|
+| **scribbletune** | Pattern-based melody / rhythm generation. Lightweight, deterministic. | "Suggest a melody over this progression", "Generate a bass line" | ~50KB gzipped. |
+| **magenta-music** | ML-based melody / chord continuation. TensorFlow.js dependency. | "AI-generated continuation", "Style-transfer the backing track" | ~500KB+ gzipped (with TF.js). Heavy. |
+
+Verdict: scribbletune is the modest pick; magenta is only worth it if AI-driven generation becomes a top-line feature.
+
+### 2d. UI / interaction
+
+| Library | What it gives | Pulls in when | Notes |
+|---|---|---|---|
+| **`@dnd-kit`** | Drag-and-drop for reordering progression steps (replacing the up/down buttons in `ProgressionControls.tsx`). Modern, accessible, tree-shakeable. | Song tab progression-step editing should feel direct. | ~25KB gzipped. Strong candidate when polishing the Song tab. |
+| **react-dnd** | Older drag-and-drop. Larger API surface. | — | Skip in favor of @dnd-kit. |
+
+`@dnd-kit` is the closest to "adopt during the integration if you want" — the Song-tab UX would improve, and the library is small. The integration spec defers it; if the user changes their mind, it slots into Phase 3 (Inspector reshape) or Phase 8 (Polish) cleanly.
+
+### 2e. Persistence
+
+| Library | What it gives | Pulls in when | Notes |
+|---|---|---|---|
+| **`idb-keyval`** | Async, robust IndexedDB key-value store. ~600 bytes. | "Save named progression", "Export / import song", larger persisted state than localStorage handles cleanly. | Tiny; safe to adopt once persistence needs outgrow localStorage. |
+| **Dexie.js** | Full IndexedDB ORM. | Complex relational persistence (multiple songs, tags, history). | ~40KB gzipped. Overkill until justified. |
+
+### 2f. Sample-based instruments
+
+| Library | What it gives | Pulls in when | Notes |
+|---|---|---|---|
+| **`soundfont-player`** | SoundFont (.sf2) playback in the browser. | If Tone.js's built-in synths sound thin and we want higher-quality sampled instruments. | ~20KB gzipped + sample bytes. Tone.js's `Tone.Sampler` may already cover this. |
+| **`webaudiofont`** | Pre-encoded instrument samples (large library). | Same trigger as soundfont-player. | Generous sample library; bundle impact depends on which instruments are imported. |
+
+Verdict: only adopt if Tone.js audio quality is found insufficient after Phase 7.
+
+---
+
+## 3. Considered and explicitly skipped
+
+These libraries overlap with what's already adopted, or don't add enough value to justify the dependency.
+
+| Library | Why skipped |
+|---|---|
+| **music21j** | Alternative theory library to Tonal. No reason to double up. |
+| **teoria** | Older theory library, less maintained than Tonal. |
+| **howler.js** | General-purpose Web Audio wrapper. Tone.js covers the same ground better for music applications. |
+| **d3 / visx** | Chart/data-viz libraries. FretFlow's SVG rendering is bespoke and fine; no chart-style needs. |
+| **react-dnd** | Older drag-and-drop. `@dnd-kit` is the modern replacement (§2d). |
+| **midijs** | Alternative MIDI handler. `@tonejs/midi` integrates better with the Tone.js audio stack. |
+
+---
+
+## 4. Decision framework — when to revisit
+
+For each candidate, the test is the same:
+
+1. **Is a specific feature pulling for it?** Don't adopt a library to "have it ready." Adopt it when a designed feature needs it.
+2. **Does it replace meaningfully more bespoke code than it adds?** Tonal does (clear win). Tone.js does (clear win). VexFlow would replace zero existing code (pure addition).
+3. **Is the bundle add proportional to the feature value?** Magenta-music's 500KB+ only pays off if AI generation is a top-line feature.
+4. **Is there a maintained alternative we already use?** If yes, default to the one we have unless the alternative offers a distinct advantage.
+
+A library passes the bar when the answer is *yes* to (1), and *yes* to either (2) or (3).
+
+---
+
+## 5. Bundle budget context
+
+For reference when re-evaluating:
+
+- Pre-integration estimated bundle: ~400KB gzipped (rough order-of-magnitude — verify with `pnpm run build` + bundle analyzer).
+- Post-integration estimated: ~520KB gzipped (Tonal + Tone added, theory layer shrunk).
+- Reasonable target ceiling for a guitar practice app: ~800KB gzipped.
+- Headroom remaining post-integration: ~280KB.
+
+VexFlow (200KB) and Magenta (500KB+) are the only candidates large enough that bundle pressure would be a primary consideration. Most others fit comfortably.
+
+---
+
+## 6. Related context
+
+- The integration spec ([`2026-05-20-fretflow-integration-design.md`](2026-05-20-fretflow-integration-design.md) §9) is the source of truth for committed libraries.
+- The voicing engine redesign spec ([`2026-05-18-voicing-engine-redesign-design.md`](2026-05-18-voicing-engine-redesign-design.md)) is the closest existing reference for a pure-engine change without new libraries — useful precedent for measuring "what fraction of an engine rewrite needs library help."

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,5 +25,12 @@
     "fast-check": "^4.8.0",
     "typescript": "~6.0.3",
     "vitest": "^4.1.7"
+  },
+  "dependencies": {
+    "@tonaljs/chord": "^6.1.2",
+    "@tonaljs/interval": "^5.1.0",
+    "@tonaljs/key": "^4.11.2",
+    "@tonaljs/note": "^4.12.1",
+    "@tonaljs/scale": "^4.13.4"
   }
 }

--- a/packages/core/src/circleOfFifthsUtils.test.ts
+++ b/packages/core/src/circleOfFifthsUtils.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { getCircleNoteLabels } from "./circleOfFifthsUtils";
+import { SCALES } from "./theoryCatalog";
+
+const labels = (
+  note: string,
+  root: string,
+  useFlats: boolean,
+  mode: "auto" | "on" | "off",
+) => getCircleNoteLabels(note, root, useFlats, SCALES["Major"], mode);
+
+describe("getCircleNoteLabels", () => {
+  describe("mode = auto (default)", () => {
+    it("sharp note shows flat enharmonic when in foreign key", () => {
+      const r = labels("A#", "C", false, "auto");
+      expect(r.primary).toBe("A♯"); // A♯
+      expect(r.enharmonic).toBe("B♭"); // B♭
+    });
+
+    it("natural note has no enharmonic", () => {
+      const r = labels("C", "C", false, "auto");
+      expect(r.primary).toBe("C");
+      expect(r.enharmonic).toBeNull();
+    });
+
+    it("respelled note (root uses flats) shows original sharp as enharmonic", () => {
+      const r = labels("A#", "A#", true, "auto");
+      expect(r.primary).toBe("B♭"); // B♭
+      expect(r.enharmonic).toBe("A♯"); // A♯
+    });
+
+    it("D# in C major: sharp + enharmonic Eb", () => {
+      const r = labels("D#", "C", false, "auto");
+      expect(r.primary).toBe("D♯"); // D♯
+      expect(r.enharmonic).toBe("E♭"); // E♭
+    });
+
+    it("G in C major: no enharmonic", () => {
+      const r = labels("G", "C", false, "auto");
+      expect(r.primary).toBe("G");
+      expect(r.enharmonic).toBeNull();
+    });
+  });
+
+  describe("mode = on", () => {
+    it("sharp note always shows flat enharmonic", () => {
+      const r = labels("C#", "C", false, "on");
+      expect(r.primary).toBe("C♯"); // C♯
+      expect(r.enharmonic).toBe("D♭"); // D♭
+    });
+
+    it("natural note with no enharmonic shows primary only", () => {
+      const r = labels("C", "C", false, "on");
+      expect(r.primary).toBe("C");
+      expect(r.enharmonic).toBeNull();
+    });
+
+    it("flat-spelled primary shows sharp enharmonic", () => {
+      const r = labels("A#", "A#", true, "on");
+      expect(r.primary).toBe("B♭"); // B♭
+      expect(r.enharmonic).toBe("A♯"); // A♯
+    });
+
+    it("every enharmonic pair shows both spellings", () => {
+      const pairs: [string, string][] = [
+        ["C#", "D♭"],
+        ["D#", "E♭"],
+        ["F#", "G♭"],
+        ["G#", "A♭"],
+        ["A#", "B♭"],
+      ];
+      for (const [note, expectedEnh] of pairs) {
+        expect(labels(note, "C", false, "on").enharmonic).toBe(expectedEnh);
+      }
+    });
+
+    it("all flat-spelled pairs show distinct enharmonics", () => {
+      const flatPairs: [string, string, string][] = [
+        ["C#", "D♭", "C♯"],
+        ["D#", "E♭", "D♯"],
+        ["F#", "G♭", "F♯"],
+        ["G#", "A♭", "G♯"],
+        ["A#", "B♭", "A♯"],
+      ];
+      for (const [note, expectedPrimary, expectedEnh] of flatPairs) {
+        const r = labels(note, note, true, "on");
+        expect(r.primary).toBe(expectedPrimary);
+        expect(r.enharmonic).toBe(expectedEnh);
+        expect(r.primary).not.toBe(r.enharmonic);
+      }
+    });
+  });
+
+  describe("mode = off", () => {
+    it("sharp note shows primary only", () => {
+      const r = labels("A#", "C", false, "off");
+      expect(r.primary).toBe("A♯"); // A♯
+      expect(r.enharmonic).toBeNull();
+    });
+
+    it("respelled note shows respelled primary only", () => {
+      const r = labels("A#", "A#", true, "off");
+      expect(r.primary).toBe("B♭"); // B♭
+      expect(r.enharmonic).toBeNull();
+    });
+
+    it("natural note shows primary only", () => {
+      const r = labels("C", "C", false, "off");
+      expect(r.primary).toBe("C");
+      expect(r.enharmonic).toBeNull();
+    });
+  });
+
+  describe("default mode (auto)", () => {
+    it("uses auto when mode is omitted", () => {
+      const r = getCircleNoteLabels("A#", "C", false, SCALES["Major"]);
+      expect(r.primary).toBe("A♯");
+      expect(r.enharmonic).toBe("B♭");
+    });
+  });
+});

--- a/packages/core/src/circleOfFifthsUtils.ts
+++ b/packages/core/src/circleOfFifthsUtils.ts
@@ -1,4 +1,5 @@
-import { ENHARMONICS, getNoteDisplayInScale, formatAccidental } from "./theory";
+import { getNoteDisplayInScale, formatAccidental } from "./theory";
+import * as Note from "@tonaljs/note";
 
 /** Computes the primary + enharmonic label pair for a Circle of Fifths slice.
  *  Exported for testability. */
@@ -17,9 +18,9 @@ export function getCircleNoteLabels(
 
   if (mode === "on") {
     const primary = formatAccidental(display);
-    // Look up the opposite spelling directly from ENHARMONICS
-    const enh = ENHARMONICS[display];
-    // Guard: if resolution yields the same as primary, suppress duplicate
+    // Use Tonal to resolve the enharmonic spelling
+    const enh = Note.enharmonic(display);
+    // Guard: if resolution yields the same as primary (e.g. naturals), suppress duplicate
     if (!enh || formatAccidental(enh) === primary) {
       return { primary, enharmonic: null };
     }
@@ -31,8 +32,10 @@ export function getCircleNoteLabels(
     return { primary: formatAccidental(display), enharmonic: formatAccidental(note) };
   }
   if (note.includes('#')) {
-    const enh = ENHARMONICS[note] ?? null;
-    return { primary: formatAccidental(note), enharmonic: enh ? formatAccidental(enh) : null };
+    const enh = Note.enharmonic(note);
+    // Guard: if Tonal returns the same note (no true enharmonic), suppress
+    const formatted = enh && enh !== note ? formatAccidental(enh) : null;
+    return { primary: formatAccidental(note), enharmonic: formatted };
   }
   return { primary: formatAccidental(note), enharmonic: null };
 }

--- a/packages/core/src/degrees.test.ts
+++ b/packages/core/src/degrees.test.ts
@@ -6,6 +6,7 @@ import {
   getDegreesForScale,
   getQualityForDegree,
   remapDegreeForScale,
+  _validateDiatonicQualitiesAgainstTonal,
 } from './degrees';
 
 const BASE_DEGREE_COLOR_KEYS = ["I", "II", "III", "IV", "V", "VI", "VII"] as const;
@@ -758,5 +759,14 @@ describe('remapDegreeForScale', () => {
   it('Major → Harmonic Minor: V (semitone 7) → V (semitone 7) — both Major Triad', () => {
     // Harmonic Minor's V is intentionally raised — semitone 7 stays Major.
     expect(remapDegreeForScale('V', 'Major', 'Harmonic Minor')).toBe('V');
+  });
+});
+
+describe("diatonic-quality alignment with Tonal (drift detection)", () => {
+  it("Major diatonic triads match Tonal", () => {
+    expect(_validateDiatonicQualitiesAgainstTonal("Major")).toBe(true);
+  });
+  it("Natural Minor diatonic triads match Tonal", () => {
+    expect(_validateDiatonicQualitiesAgainstTonal("Natural Minor")).toBe(true);
   });
 });

--- a/packages/core/src/degrees.ts
+++ b/packages/core/src/degrees.ts
@@ -1,4 +1,5 @@
 import { SCALES } from "./theoryCatalog";
+import * as Key from "@tonaljs/key";
 
 /**
  * Opaque type alias for Roman-numeral scale degree identifiers.
@@ -274,4 +275,48 @@ export function getDegreesForScale(scaleName: string): Record<number, string> {
 
   if (intervals.includes(4)) return MODE_DEGREES["Major"];
   return MODE_DEGREES["Natural Minor"];
+}
+
+/**
+ * Extracts a quality symbol ("M", "m", "dim", "aug") from a Tonal triad chord
+ * name by stripping the tonic note prefix.
+ *
+ * @internal
+ */
+function extractTriadQuality(chordName: string, tonicNote: string): string {
+  const suffix = chordName.slice(tonicNote.length);
+  if (suffix === "") return "M";
+  if (suffix === "m") return "m";
+  if (suffix === "dim") return "dim";
+  if (suffix === "aug") return "aug";
+  return suffix;
+}
+
+/**
+ * Validates that the diatonic-chord-quality table for a given scale matches what
+ * Tonal would produce. Used in tests to catch drift; not called in production.
+ *
+ * @internal
+ */
+export function _validateDiatonicQualitiesAgainstTonal(
+  scaleName: string,
+): boolean {
+  if (scaleName === "Major") {
+    const key = Key.majorKey("C");
+    const expectedTriadQualities = ["M", "m", "m", "M", "M", "m", "dim"];
+    return key.triads.every(
+      (triad, i) =>
+        extractTriadQuality(triad, key.scale[i]) === expectedTriadQualities[i],
+    );
+  }
+  if (scaleName === "Natural Minor") {
+    const key = Key.minorKey("A");
+    const expectedTriadQualities = ["m", "dim", "M", "m", "m", "M", "M"];
+    return key.natural.triads.every(
+      (triad, i) =>
+        extractTriadQuality(triad, key.natural.scale[i]) ===
+        expectedTriadQualities[i],
+    );
+  }
+  return true;
 }

--- a/packages/core/src/lib/tonal.test.ts
+++ b/packages/core/src/lib/tonal.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { chordQualityToTonal, tonalToChordQuality, scaleNameToTonal, tonalToScaleName } from "./tonal";
+
+describe("chord-name adapter", () => {
+  it("maps Major Triad to M", () => {
+    expect(chordQualityToTonal("Major Triad")).toBe("M");
+  });
+  it("maps Minor Triad to m", () => {
+    expect(chordQualityToTonal("Minor Triad")).toBe("m");
+  });
+  it("maps Dominant 7th to 7", () => {
+    expect(chordQualityToTonal("Dominant 7th")).toBe("7");
+  });
+  it("maps Diminished 7th to dim7", () => {
+    expect(chordQualityToTonal("Diminished 7th")).toBe("dim7");
+  });
+  it("maps Half-Diminished 7th to m7b5", () => {
+    expect(chordQualityToTonal("Half-Diminished 7th")).toBe("m7b5");
+  });
+  it("maps Power Chord (5) to 5", () => {
+    expect(chordQualityToTonal("Power Chord (5)")).toBe("5");
+  });
+  it("returns undefined for unknown quality", () => {
+    expect(chordQualityToTonal("Bogus Chord")).toBeUndefined();
+  });
+  it("round-trips Major Triad", () => {
+    expect(tonalToChordQuality("M")).toBe("Major Triad");
+  });
+  it("round-trips Minor 7th", () => {
+    expect(tonalToChordQuality("m7")).toBe("Minor 7th");
+  });
+});
+
+describe("scale-name adapter", () => {
+  it("maps Major to major", () => {
+    expect(scaleNameToTonal("Major")).toBe("major");
+  });
+  it("maps Natural Minor to minor", () => {
+    expect(scaleNameToTonal("Natural Minor")).toBe("minor");
+  });
+  it("maps Harmonic Minor to harmonic minor", () => {
+    expect(scaleNameToTonal("Harmonic Minor")).toBe("harmonic minor");
+  });
+  it("maps Major Pentatonic to major pentatonic", () => {
+    expect(scaleNameToTonal("Major Pentatonic")).toBe("major pentatonic");
+  });
+  it("maps Dorian to dorian", () => {
+    expect(scaleNameToTonal("Dorian")).toBe("dorian");
+  });
+  it("round-trips Major", () => {
+    expect(tonalToScaleName("major")).toBe("Major");
+  });
+});

--- a/packages/core/src/lib/tonal.ts
+++ b/packages/core/src/lib/tonal.ts
@@ -48,6 +48,23 @@ const SCALE_TO_TONAL: Record<string, string> = {
   "Mixolydian": "mixolydian",
   "Aeolian": "aeolian",
   "Locrian": "locrian",
+  // Harmonic Minor modes
+  "Locrian Natural 6": "locrian 6",
+  "Ionian Augmented": "ionian augmented",
+  "Dorian Sharp 4": "dorian #4",
+  "Phrygian Dominant": "phrygian dominant",
+  "Lydian Sharp 2": "lydian #9",
+  "Altered Diminished": "ultralocrian",
+  // Melodic Minor modes
+  "Dorian Flat 2": "dorian b2",
+  "Lydian Augmented": "lydian augmented",
+  "Lydian Dominant": "lydian dominant",
+  "Mixolydian Flat 6": "mixolydian b6",
+  "Locrian Natural 2": "locrian #2",
+  "Altered": "altered",
+  // Blues variants
+  "Minor Blues": "minor blues",
+  "Major Blues": "major blues",
 };
 
 const TONAL_TO_SCALE: Record<string, string> = Object.fromEntries(

--- a/packages/core/src/lib/tonal.ts
+++ b/packages/core/src/lib/tonal.ts
@@ -40,7 +40,6 @@ const SCALE_TO_TONAL: Record<string, string> = {
   "Major Pentatonic": "major pentatonic",
   "Minor Pentatonic": "minor pentatonic",
   "Blues": "blues",
-  "Blues Major": "major blues",
   "Ionian": "ionian",
   "Dorian": "dorian",
   "Phrygian": "phrygian",

--- a/packages/core/src/lib/tonal.ts
+++ b/packages/core/src/lib/tonal.ts
@@ -1,0 +1,80 @@
+/**
+ * Adapter between FretFlow's verbose music-theory names and Tonal's symbol names.
+ *
+ * FretFlow chose verbose names ("Major Triad", "Natural Minor", "Major Pentatonic")
+ * for user-facing clarity; Tonal uses compact symbols ("M", "minor", "major pentatonic").
+ * Every cross-module call into Tonal passes through this file.
+ */
+
+/**
+ * App chord-quality name (e.g., "Major Triad") → Tonal chord symbol suffix
+ * (e.g., "M"). Suffix is what Tonal.Chord.get() consumes after the root.
+ */
+const QUALITY_TO_TONAL: Record<string, string> = {
+  "Major Triad": "M",
+  "Minor Triad": "m",
+  "Diminished Triad": "dim",
+  "Augmented Triad": "aug",
+  "Sus2": "sus2",
+  "Sus4": "sus4",
+  "Major 6th": "6",
+  "Minor 6th": "m6",
+  "Major 7th": "maj7",
+  "Minor 7th": "m7",
+  "Dominant 7th": "7",
+  "Diminished 7th": "dim7",
+  "Half-Diminished 7th": "m7b5",
+  "Minor-Major 7th": "mMaj7",
+  "Power Chord (5)": "5",
+};
+
+const TONAL_TO_QUALITY: Record<string, string> = Object.fromEntries(
+  Object.entries(QUALITY_TO_TONAL).map(([app, tonal]) => [tonal, app]),
+);
+
+const SCALE_TO_TONAL: Record<string, string> = {
+  "Major": "major",
+  "Natural Minor": "minor",
+  "Harmonic Minor": "harmonic minor",
+  "Melodic Minor": "melodic minor",
+  "Major Pentatonic": "major pentatonic",
+  "Minor Pentatonic": "minor pentatonic",
+  "Blues": "blues",
+  "Blues Major": "major blues",
+  "Ionian": "ionian",
+  "Dorian": "dorian",
+  "Phrygian": "phrygian",
+  "Lydian": "lydian",
+  "Mixolydian": "mixolydian",
+  "Aeolian": "aeolian",
+  "Locrian": "locrian",
+};
+
+const TONAL_TO_SCALE: Record<string, string> = Object.fromEntries(
+  Object.entries(SCALE_TO_TONAL).map(([app, tonal]) => [tonal, app]),
+);
+
+export function chordQualityToTonal(quality: string): string | undefined {
+  return QUALITY_TO_TONAL[quality];
+}
+
+export function tonalToChordQuality(symbol: string): string | undefined {
+  return TONAL_TO_QUALITY[symbol];
+}
+
+export function scaleNameToTonal(scaleName: string): string | undefined {
+  return SCALE_TO_TONAL[scaleName];
+}
+
+export function tonalToScaleName(tonalName: string): string | undefined {
+  return TONAL_TO_SCALE[tonalName];
+}
+
+/**
+ * Return the canonical Tonal chord symbol for an (root, app-quality) pair, or
+ * undefined if the quality is not a known FretFlow chord. Example: ("C", "Major Triad") → "CM".
+ */
+export function tonalChordSymbol(root: string, quality: string): string | undefined {
+  const suffix = chordQualityToTonal(quality);
+  return suffix === undefined ? undefined : `${root}${suffix}`;
+}

--- a/packages/core/src/theory.ts
+++ b/packages/core/src/theory.ts
@@ -6,7 +6,7 @@ import {
 import { getDegreesForScale, getQualityForDegree, type DegreeId } from "./degrees";
 import * as Note from "@tonaljs/note";
 import * as Interval from "@tonaljs/interval";
-import Scale from "@tonaljs/scale";
+import * as Scale from "@tonaljs/scale";
 import { scaleNameToTonal } from "./lib/tonal";
 
 export const NOTES = [

--- a/packages/core/src/theory.ts
+++ b/packages/core/src/theory.ts
@@ -426,73 +426,52 @@ export function formatAccidental(s: string): string {
 }
 
 
-const LETTER_NAMES = ["C", "D", "E", "F", "G", "A", "B"];
-const LETTER_PITCHES: Record<string, number> = {
-  C: 0,
-  D: 2,
-  E: 4,
-  F: 5,
-  G: 7,
-  A: 9,
-  B: 11,
-};
-
 export function getNoteDisplayInScale(
   noteName: string,
   rootNote: string,
   scaleIntervals: number[],
   useFlats?: boolean,
 ): string {
-  // Apply scale-aware spelling for 7-note scales
   if (scaleIntervals.length !== 7) {
     return getNoteDisplay(noteName, rootNote, useFlats);
   }
 
-  // Normalize to sharps for internal lookup
-  const normNote =
-    noteName.includes("b") && ENHARMONICS[noteName]
-      ? ENHARMONICS[noteName]
-      : noteName;
-  const rootNorm =
-    rootNote.includes("b") && ENHARMONICS[rootNote]
-      ? ENHARMONICS[rootNote]
-      : rootNote;
-
-  const rootIdx = NOTES.indexOf(rootNorm);
-  const noteIdx = NOTES.indexOf(normNote);
-  if (rootIdx === -1 || noteIdx === -1)
+  // Use Tonal for chroma calculation; matches the legacy NOTES.indexOf behavior.
+  const rootChroma = Note.chroma(rootNote);
+  const noteChroma = Note.chroma(noteName);
+  if (
+    typeof rootChroma !== "number" || isNaN(rootChroma) ||
+    typeof noteChroma !== "number" || isNaN(noteChroma)
+  ) {
     return getNoteDisplay(noteName, rootNote, useFlats);
+  }
 
-  const interval = (noteIdx - rootIdx + 12) % 12;
-
+  const interval = (noteChroma - rootChroma + 12) % 12;
   const degreeIndex = scaleIntervals.indexOf(interval);
   if (degreeIndex === -1) {
     return getNoteDisplay(noteName, rootNote, useFlats);
   }
 
-  const rootDisplay = getNoteDisplay(rootNote, rootNote, useFlats);
-  const rootLetter = rootDisplay.charAt(0);
-  const rootLetterIdx = LETTER_NAMES.indexOf(rootLetter);
+  const spelledRoot = getNoteDisplay(rootNote, rootNote, useFlats);
+
+  // Heptatonic letter cycle — used only for scale-aware spelling, scoped to this function.
+  const letterNames = ["C", "D", "E", "F", "G", "A", "B"];
+  const letterPitches: Record<string, number> = { C: 0, D: 2, E: 4, F: 5, G: 7, A: 9, B: 11 };
+
+  const rootLetter = spelledRoot.charAt(0);
+  const rootLetterIdx = letterNames.indexOf(rootLetter);
   if (rootLetterIdx === -1) return getNoteDisplay(noteName, rootNote, useFlats);
 
-  const expectedLetter = LETTER_NAMES[(rootLetterIdx + degreeIndex) % 7];
-  const expectedBasePitch = LETTER_PITCHES[expectedLetter];
-  const targetPitch = (rootIdx + interval) % 12;
-
+  const expectedLetter = letterNames[(rootLetterIdx + degreeIndex) % 7];
+  const expectedBasePitch = letterPitches[expectedLetter];
+  const targetPitch = (rootChroma + interval) % 12;
   const diff = (targetPitch - expectedBasePitch + 12) % 12;
 
-  if (diff === 0) {
-    return expectedLetter;
-  } else if (diff === 1) {
-    return expectedLetter + "#";
-  } else if (diff === 11) {
-    return expectedLetter + "b";
-  } else if (diff === 2) {
-    return expectedLetter + "##";
-  } else if (diff === 10) {
-    return expectedLetter + "bb";
-  }
-
+  if (diff === 0) return expectedLetter;
+  if (diff === 1) return expectedLetter + "#";
+  if (diff === 11) return expectedLetter + "b";
+  if (diff === 2) return expectedLetter + "##";
+  if (diff === 10) return expectedLetter + "bb";
   return getNoteDisplay(noteName, rootNote, useFlats);
 }
 

--- a/packages/core/src/theory.ts
+++ b/packages/core/src/theory.ts
@@ -7,7 +7,8 @@ import { getDegreesForScale, getQualityForDegree, type DegreeId } from "./degree
 import * as Note from "@tonaljs/note";
 import * as Interval from "@tonaljs/interval";
 import * as Scale from "@tonaljs/scale";
-import { scaleNameToTonal } from "./lib/tonal";
+import { scaleNameToTonal, tonalChordSymbol } from "./lib/tonal";
+import * as Chord from "@tonaljs/chord";
 
 export const NOTES = [
   "C",
@@ -517,10 +518,16 @@ export function getScaleSemitones(rootNote: string, scaleName: string): number[]
 }
 
 export function getChordNotes(rootNote: string, chordName: string): string[] {
-  const intervals = CHORDS[chordName];
-  if (!intervals) return [];
-  if (getNoteIndex(rootNote) === -1) return [];
-  return getIntervalNotes(rootNote, intervals);
+  if (Note.chroma(rootNote) === undefined || Number.isNaN(Note.chroma(rootNote))) return [];
+  const symbol = tonalChordSymbol(rootNote, chordName);
+  if (!symbol) return [];
+  const tonalChord = Chord.get(symbol);
+  if (tonalChord.empty) return [];
+  // Same sharps-form normalization as getIntervalNotes.
+  return tonalChord.notes.map((n) => {
+    const simplified = Note.simplify(n);
+    return simplified.includes("b") ? Note.enharmonic(simplified) : simplified;
+  });
 }
 
 /**

--- a/packages/core/src/theory.ts
+++ b/packages/core/src/theory.ts
@@ -519,7 +519,8 @@ export function getScaleSemitones(rootNote: string, scaleName: string): number[]
 }
 
 export function getChordNotes(rootNote: string, chordName: string): string[] {
-  if (Note.chroma(rootNote) === undefined || Number.isNaN(Note.chroma(rootNote))) return [];
+  const chroma = Note.chroma(rootNote);
+  if (typeof chroma !== "number" || isNaN(chroma)) return [];
   const symbol = tonalChordSymbol(rootNote, chordName);
   if (!symbol) return [];
   const tonalChord = Chord.get(symbol);

--- a/packages/core/src/theory.ts
+++ b/packages/core/src/theory.ts
@@ -6,6 +6,8 @@ import {
 import { getDegreesForScale, getQualityForDegree, type DegreeId } from "./degrees";
 import * as Note from "@tonaljs/note";
 import * as Interval from "@tonaljs/interval";
+import Scale from "@tonaljs/scale";
+import { scaleNameToTonal } from "./lib/tonal";
 
 export const NOTES = [
   "C",
@@ -489,10 +491,16 @@ export function getIntervalNotes(
 }
 
 export function getScaleNotes(rootNote: string, scaleName: string): string[] {
-  const intervals = SCALES[normalizeScaleName(scaleName)];
-  if (!intervals) return [];
+  const tonalName = scaleNameToTonal(normalizeScaleName(scaleName));
+  if (!tonalName) return [];
   if (getNoteIndex(rootNote) === -1) return [];
-  return getIntervalNotes(rootNote, intervals);
+  const tonalScale = Scale.get(`${rootNote} ${tonalName}`);
+  // Tonal returns spelled notes. Normalize to sharps-form to maintain the
+  // legacy contract (consumers do NOTES.indexOf on the result).
+  return tonalScale.notes.map((n) => {
+    const simplified = Note.simplify(n);
+    return simplified.includes("b") ? Note.enharmonic(simplified) : simplified;
+  });
 }
 
 /**
@@ -525,31 +533,25 @@ export function getDivergentNotes(
   scaleName: string,
 ): string[] {
   const resolvedScaleName = normalizeScaleName(scaleName);
-  const intervals = SCALES[resolvedScaleName];
-  if (!intervals || resolvedScaleName.includes("Blues")) return [];
+  if (resolvedScaleName.includes("Blues")) return [];
+  if (resolvedScaleName === "Major Pentatonic" || resolvedScaleName === "Minor Pentatonic") return [];
+  if (resolvedScaleName === "Major" || resolvedScaleName === "Natural Minor") return [];
 
-  // Pentatonic scales are subsets, not modes — no divergence to show
-  if (
-    resolvedScaleName === "Major Pentatonic" ||
-    resolvedScaleName === "Minor Pentatonic"
-  )
-    return [];
-  // Major and Natural Minor are the references themselves
-  if (resolvedScaleName === "Major" || resolvedScaleName === "Natural Minor")
-    return [];
-
-  const isMajorQuality = intervals.includes(4); // contains major 3rd
-  const refIntervals = isMajorQuality
-    ? SCALES["Major"]
-    : SCALES["Natural Minor"];
+  const semis = getScaleSemitones(rootNote, scaleName);
+  if (semis.length === 0) return [];
 
   const rootIdx = NOTES.indexOf(rootNote);
   if (rootIdx === -1) return [];
 
-  const refSet = new Set(refIntervals);
-  return intervals
-    .filter((interval) => !refSet.has(interval))
-    .map((interval) => NOTES[(rootIdx + interval) % 12]);
+  // Convert absolute NOTES indices to relative semitone intervals from root
+  const relativeIntervals = semis.map((s) => (s - rootIdx + 12) % 12);
+  const isMajorQuality = relativeIntervals.includes(4); // contains major 3rd
+  const refName = isMajorQuality ? "Major" : "Natural Minor";
+  const refSemis = new Set(getScaleSemitones(rootNote, refName));
+
+  return semis
+    .filter((semitone) => !refSemis.has(semitone))
+    .map((semitone) => NOTES[semitone]);
 }
 
 // Key signature accidental counts (+ sharps, - flats)

--- a/packages/core/src/theory.ts
+++ b/packages/core/src/theory.ts
@@ -4,6 +4,8 @@ import {
   SCALE_TO_PARENT_MAJOR_OFFSET,
 } from "./theoryCatalog";
 import { getDegreesForScale, getQualityForDegree, type DegreeId } from "./degrees";
+import * as Note from "@tonaljs/note";
+import * as Interval from "@tonaljs/interval";
 
 export const NOTES = [
   "C",
@@ -396,11 +398,8 @@ export const CIRCLE_OF_FIFTHS = [
 ];
 
 export function getNoteIndex(noteName: string): number {
-  const norm =
-    ENHARMONICS[noteName] && noteName.includes("b")
-      ? ENHARMONICS[noteName]
-      : noteName;
-  return NOTES.indexOf(norm);
+  const chroma = Note.chroma(noteName);
+  return typeof chroma === "number" && !isNaN(chroma) ? chroma : -1;
 }
 
 export function getNoteDisplay(
@@ -408,16 +407,14 @@ export function getNoteDisplay(
   activeRoot: string,
   useFlats?: boolean,
 ): string {
-  const normNote =
-    ENHARMONICS[noteName] && noteName.includes("b")
-      ? ENHARMONICS[noteName]
-      : noteName;
-  const flats = useFlats ?? FLAT_KEYS.includes(activeRoot);
-
-  if (flats && normNote.includes("#")) return ENHARMONICS[normNote] || normNote;
-  if (!flats && normNote.includes("b"))
-    return ENHARMONICS[normNote] || normNote;
-  return normNote;
+  const wantsFlats = useFlats ?? FLAT_KEYS.includes(activeRoot);
+  if (wantsFlats && noteName.includes("#")) {
+    return Note.enharmonic(noteName);
+  }
+  if (!wantsFlats && noteName.includes("b")) {
+    return Note.enharmonic(noteName);
+  }
+  return noteName;
 }
 
 export function formatAccidental(s: string): string {
@@ -503,11 +500,12 @@ export function getIntervalNotes(
   rootNote: string,
   intervals: number[],
 ): string[] {
-  const rootIndex = getNoteIndex(rootNote);
-  if (rootIndex === -1) return [];
-
-  return intervals.map((interval) => {
-    return NOTES[(rootIndex + interval) % 12];
+  if (getNoteIndex(rootNote) === -1) return [];
+  return intervals.map((semitones) => {
+    const t = Note.transpose(rootNote, Interval.fromSemitones(semitones));
+    // Force sharps-form for chromatic semitone-based operations (matches legacy NOTES contract).
+    const simplified = Note.simplify(t);
+    return simplified.includes("b") ? Note.enharmonic(simplified) : simplified;
   });
 }
 

--- a/packages/core/src/theory.ts
+++ b/packages/core/src/theory.ts
@@ -7,6 +7,7 @@ import { getDegreesForScale, getQualityForDegree, type DegreeId } from "./degree
 import * as Note from "@tonaljs/note";
 import * as Interval from "@tonaljs/interval";
 import * as Scale from "@tonaljs/scale";
+import * as Key from "@tonaljs/key";
 import { scaleNameToTonal, tonalChordSymbol } from "./lib/tonal";
 import * as Chord from "@tonaljs/chord";
 
@@ -583,6 +584,10 @@ export const KEY_SIGNATURES: Record<string, number> = {
 };
 
 export function getKeySignature(rootNote: string): number {
+  const tonalKey = Key.majorKey(rootNote);
+  // Tonal returns `alteration` as a positive integer for sharps, negative for flats.
+  if (typeof tonalKey.alteration === "number") return tonalKey.alteration;
+  // Fallback for inputs Tonal does not recognize (rare; preserves legacy behavior).
   return KEY_SIGNATURES[rootNote] ?? 0;
 }
 
@@ -592,27 +597,37 @@ export function getKeySignatureForDisplay(
   useFlats: boolean,
 ): number {
   const offset = SCALE_TO_PARENT_MAJOR_OFFSET[normalizeScaleName(scaleName)] ?? 0;
+  const rootChroma = Note.chroma(rootNote);
+  if (typeof rootChroma !== "number" || isNaN(rootChroma)) {
+    return KEY_SIGNATURES[rootNote] ?? 0;
+  }
 
-  const sharpRoot =
-    rootNote.includes("b") && ENHARMONICS[rootNote]
-      ? ENHARMONICS[rootNote]
-      : rootNote;
-  const rootIdx = NOTES.indexOf(sharpRoot);
-  if (rootIdx === -1) return KEY_SIGNATURES[rootNote] ?? 0;
+  // The "parent major" is the major key whose tonic is `offset` semitones above the current root.
+  const parentMajorRoot = Note.transpose(rootNote, Interval.fromSemitones(offset));
+  const parentSimplified = Note.simplify(parentMajorRoot);
+  const parentSharp = parentSimplified.includes("b") ? Note.enharmonic(parentSimplified) : parentSimplified;
 
-  const parentIdx = (rootIdx + offset) % 12;
-  const parentSharp = NOTES[parentIdx];
-
-  // Preserve user's intended root spelling for sharp-side key signatures
   const originalIsSharp = rootNote.includes("#");
-  if (!originalIsSharp && useFlats && ENHARMONICS[parentSharp]) {
-    const flatName = ENHARMONICS[parentSharp];
-    if (KEY_SIGNATURES[flatName] !== undefined) {
-      return KEY_SIGNATURES[flatName];
+
+  // When root is not sharp-spelled, prefer the flat enharmonic for any parent key that is
+  // naturally on the flat side (alteration < 0). This covers both useFlats=true and the case
+  // where the root itself is flat-spelled (e.g. Ab → parent G# → prefer Ab key sig -4).
+  if (!originalIsSharp) {
+    const flatName = Note.enharmonic(parentSharp);
+    const flatKey = Key.majorKey(flatName);
+    if (typeof flatKey.alteration === "number" && flatKey.alteration < 0) {
+      // Only return the flat sig if: useFlats is true, OR the root itself is flat-spelled
+      // (meaning the user's intent is a flat-side key even when useFlats=false).
+      const rootIsFlat = rootNote.includes("b");
+      if (useFlats || rootIsFlat || flatName === parentMajorRoot) {
+        return flatKey.alteration;
+      }
     }
   }
-  const sig = KEY_SIGNATURES[parentSharp] ?? 0;
-  // Convert flat-equivalent negative signature to enharmonic sharp count
+
+  const tonalKey = Key.majorKey(parentSharp);
+  const sig = typeof tonalKey.alteration === "number" ? tonalKey.alteration : (KEY_SIGNATURES[parentSharp] ?? 0);
+
   if (originalIsSharp && sig < 0) {
     return 12 + sig;
   }

--- a/packages/core/src/theory.ts
+++ b/packages/core/src/theory.ts
@@ -709,10 +709,12 @@ export function getDiatonicChord(
   if (!semitoneEntry) return undefined;
   const semitone = Number(semitoneEntry[0]);
 
-  // Compute the absolute root note (sharps-only via NOTES)
-  const rootIndex = getNoteIndex(tonicNote);
-  if (rootIndex === -1) return undefined;
-  const root = NOTES[(rootIndex + semitone) % 12];
+  // Compute the absolute root note via Tonal transposition.
+  const tonicChroma = Note.chroma(tonicNote);
+  if (typeof tonicChroma !== "number" || isNaN(tonicChroma)) return undefined;
+  const transposed = Note.transpose(tonicNote, Interval.fromSemitones(semitone));
+  const simplified = Note.simplify(transposed);
+  const root = simplified.includes("b") ? Note.enharmonic(simplified) : simplified;
 
   // Resolve chord quality via the degree quality table
   const quality = getQualityForDegree(degreeId, scaleName);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,22 @@ importers:
         version: 0.1.0(vitest@4.1.7)
 
   packages/core:
+    dependencies:
+      '@tonaljs/chord':
+        specifier: ^6.1.2
+        version: 6.1.2
+      '@tonaljs/interval':
+        specifier: ^5.1.0
+        version: 5.1.0
+      '@tonaljs/key':
+        specifier: ^4.11.2
+        version: 4.11.2
+      '@tonaljs/note':
+        specifier: ^4.12.1
+        version: 4.12.1
+      '@tonaljs/scale':
+        specifier: ^4.13.4
+        version: 4.13.4
     devDependencies:
       fast-check:
         specifier: ^4.8.0
@@ -140,7 +156,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.6.0)(@vitest/coverage-v8@4.1.6(vitest@4.1.7))(jsdom@29.1.1)(vite@8.0.13(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
+        version: 4.1.7(@types/node@25.6.0)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.0.13(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
 
 packages:
 
@@ -1082,6 +1098,54 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
+
+  '@tonaljs/chord-detect@4.9.1':
+    resolution: {integrity: sha512-rV/9+R7aZ9cQorQ3jdNMMMh63onosglYZM71Q0n7KKcWMAGrxF66MzxBG82xy+w1QDMJQslB3iHfDHUiS6wRjA==}
+
+  '@tonaljs/chord-type@5.1.1':
+    resolution: {integrity: sha512-ti4WzRYvvjH7to0G3zlJFq7WsjHqmcqbk8Jv98aZSR5YumLdY/ua2yOPPyoPq82n6vfgjZsacnAZ3v8/SodOcw==}
+
+  '@tonaljs/chord@6.1.2':
+    resolution: {integrity: sha512-39crsPVyBJxdGJ1DGl+4diM+6+mZ/ws6crkQMlqX4zTYHMUVfJOQrko4mPF1CD89AFhHJe1zCT9Js+nNp3Gffg==}
+
+  '@tonaljs/collection@4.9.0':
+    resolution: {integrity: sha512-Mk0h7O54nT6PgNVcUYauzxa5KOB23+0AOKudWzRH7JhJIN9vhVIC7PtwZXE+/G051UTbHSFIcN/afkgF4nB/8A==}
+
+  '@tonaljs/interval@5.1.0':
+    resolution: {integrity: sha512-GR9dUjn0j7yhjwjRh8HQxZYXOiVl05WfY3AFyMB9rfg807K4dSJmWfPTULPQXyHJ6NiZOPXcwRs8MxMLDxgdbg==}
+
+  '@tonaljs/key@4.11.2':
+    resolution: {integrity: sha512-fc1y5+NwS4S3amirzYLLB324PxJDO00oIBbLJclAddc46UBeYnu4FNz+1nZboHCXRQ/06/ftuaWD/l7HrAoulw==}
+
+  '@tonaljs/midi@4.10.2':
+    resolution: {integrity: sha512-MPamXhEwPL7L1udLfYMm3Ft8mLYtHr62Zi2w5zYHM2P7YwIvNoiX0+dvAN5is1Wvq4iVRa8AjFHerjOW/SZhGg==}
+
+  '@tonaljs/note@4.12.1':
+    resolution: {integrity: sha512-yh6cnhu21bUb0VuIQWxObSbWBVp2cHIkJj4zZ4qsNOW4jSqn74+wHpSbOTDF8q+2hl6upz7TtBRavtqwPtLUCQ==}
+
+  '@tonaljs/pcset@4.10.1':
+    resolution: {integrity: sha512-CZG1rpKc38yMfpEJsbDTvsTmQqsek9xxcuMgK64Tr6sP1lEiDuZJbQeKVWWRnreBF2FQ1cEGLmfOpvSO+40csA==}
+
+  '@tonaljs/pitch-distance@5.0.5':
+    resolution: {integrity: sha512-dTfjsU0zyrj5YmiFio5prPaD5w7sBmHp4nnmlEg70nHY+SerAH0KiO9HM9usttVgRFUaXl0Gc7OI8YMGfSFmug==}
+
+  '@tonaljs/pitch-interval@6.1.0':
+    resolution: {integrity: sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==}
+
+  '@tonaljs/pitch-note@6.1.0':
+    resolution: {integrity: sha512-A4OSLo8DjM38u73862LnDmL4YInDDRBmg0fojXcvu4cyU3oOlqndyeHOra1OVoH/WW46uNIxNs1wJDZNPWL5KQ==}
+
+  '@tonaljs/pitch@5.0.2':
+    resolution: {integrity: sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==}
+
+  '@tonaljs/roman-numeral@4.9.1':
+    resolution: {integrity: sha512-dJGKBNHdPrNTE97ZDk4t6wpNmgYcpHyLkAvWkRP9I/HsDkeTFFQqNXosYIvspPWrFySlRpeqqFwcqV74MYoOag==}
+
+  '@tonaljs/scale-type@4.9.2':
+    resolution: {integrity: sha512-XDRPySg0X6owJ6AVzVRpS4ZpgleAUQakuq5VtfQ0JitnJKGRYo5Y0w7Fl/wEz/X9aEMk2lxcdF8VGGMIsQFo0g==}
+
+  '@tonaljs/scale@4.13.4':
+    resolution: {integrity: sha512-hyilnmsCmoGQiRhYWKM1QPrqaNH3KGEfrSfxeXcicPnEh12yvrVRm4djKmTVw7Rc/5P4GniPAA51+CS0C5dbLw==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -4197,6 +4261,97 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@tonaljs/chord-detect@4.9.1':
+    dependencies:
+      '@tonaljs/chord-type': 5.1.1
+      '@tonaljs/pcset': 4.10.1
+      '@tonaljs/pitch-note': 6.1.0
+
+  '@tonaljs/chord-type@5.1.1':
+    dependencies:
+      '@tonaljs/pcset': 4.10.1
+
+  '@tonaljs/chord@6.1.2':
+    dependencies:
+      '@tonaljs/chord-detect': 4.9.1
+      '@tonaljs/chord-type': 5.1.1
+      '@tonaljs/collection': 4.9.0
+      '@tonaljs/interval': 5.1.0
+      '@tonaljs/pcset': 4.10.1
+      '@tonaljs/pitch-distance': 5.0.5
+      '@tonaljs/pitch-note': 6.1.0
+      '@tonaljs/scale-type': 4.9.2
+
+  '@tonaljs/collection@4.9.0': {}
+
+  '@tonaljs/interval@5.1.0':
+    dependencies:
+      '@tonaljs/pitch': 5.0.2
+      '@tonaljs/pitch-distance': 5.0.5
+      '@tonaljs/pitch-interval': 6.1.0
+
+  '@tonaljs/key@4.11.2':
+    dependencies:
+      '@tonaljs/note': 4.12.1
+      '@tonaljs/pitch-note': 6.1.0
+      '@tonaljs/roman-numeral': 4.9.1
+
+  '@tonaljs/midi@4.10.2':
+    dependencies:
+      '@tonaljs/pitch-note': 6.1.0
+
+  '@tonaljs/note@4.12.1':
+    dependencies:
+      '@tonaljs/midi': 4.10.2
+      '@tonaljs/pitch': 5.0.2
+      '@tonaljs/pitch-distance': 5.0.5
+      '@tonaljs/pitch-interval': 6.1.0
+      '@tonaljs/pitch-note': 6.1.0
+
+  '@tonaljs/pcset@4.10.1':
+    dependencies:
+      '@tonaljs/collection': 4.9.0
+      '@tonaljs/pitch': 5.0.2
+      '@tonaljs/pitch-distance': 5.0.5
+      '@tonaljs/pitch-interval': 6.1.0
+      '@tonaljs/pitch-note': 6.1.0
+
+  '@tonaljs/pitch-distance@5.0.5':
+    dependencies:
+      '@tonaljs/pitch': 5.0.2
+      '@tonaljs/pitch-interval': 6.1.0
+      '@tonaljs/pitch-note': 6.1.0
+
+  '@tonaljs/pitch-interval@6.1.0':
+    dependencies:
+      '@tonaljs/pitch': 5.0.2
+
+  '@tonaljs/pitch-note@6.1.0':
+    dependencies:
+      '@tonaljs/pitch': 5.0.2
+
+  '@tonaljs/pitch@5.0.2': {}
+
+  '@tonaljs/roman-numeral@4.9.1':
+    dependencies:
+      '@tonaljs/pitch': 5.0.2
+      '@tonaljs/pitch-interval': 6.1.0
+      '@tonaljs/pitch-note': 6.1.0
+
+  '@tonaljs/scale-type@4.9.2':
+    dependencies:
+      '@tonaljs/pcset': 4.10.1
+
+  '@tonaljs/scale@4.13.4':
+    dependencies:
+      '@tonaljs/chord-type': 5.1.1
+      '@tonaljs/collection': 4.9.0
+      '@tonaljs/note': 4.12.1
+      '@tonaljs/pcset': 4.10.1
+      '@tonaljs/pitch-distance': 5.0.5
+      '@tonaljs/pitch-note': 6.1.0
+      '@tonaljs/scale-type': 4.9.2
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -6381,35 +6536,6 @@ snapshots:
       redent: 3.0.0
       vitest: 4.1.7(@types/node@25.6.0)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
 
-  vitest@4.1.7(@types/node@25.6.0)(@vitest/coverage-v8@4.1.6(vitest@4.1.7))(jsdom@29.1.1)(vite@8.0.13(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.0.13(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.7
-      '@vitest/runner': 4.1.7
-      '@vitest/snapshot': 4.1.7
-      '@vitest/spy': 4.1.7
-      '@vitest/utils': 4.1.7
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.13(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.6.0
-      '@vitest/coverage-v8': 4.1.6(vitest@4.1.7)
-      jsdom: 29.1.1
-    transitivePeerDependencies:
-      - msw
-
   vitest@4.1.7(@types/node@25.6.0)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.7
@@ -6431,6 +6557,35 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+      '@vitest/coverage-v8': 4.1.6(vitest@4.1.7)
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.7(@types/node@25.6.0)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.0.13(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.13(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.13(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0


### PR DESCRIPTION
## Summary

Adopts `@tonaljs/*` (cherry-picked: note, chord, scale, interval, key) as the music-theory engine in `@fretflow/core`. Replaces function bodies in `theory.ts`, `degrees.ts`, and `circleOfFifthsUtils.ts` to delegate to Tonal through a new `packages/core/src/lib/tonal.ts` naming adapter. Public API of `@fretflow/core` is unchanged — all 73 consumer files in `src/` work without modification. Existing test suites served as the safety net.

Implements **Phase 1** of [docs/superpowers/specs/2026-05-20-fretflow-integration-design.md](docs/superpowers/specs/2026-05-20-fretflow-integration-design.md). Plan: [docs/superpowers/plans/2026-05-20-fretflow-phase-1-tonal-foundation.md](docs/superpowers/plans/2026-05-20-fretflow-phase-1-tonal-foundation.md).

## What changed

- **Dependencies added** (~52 KB gzipped): `@tonaljs/note`, `@tonaljs/chord`, `@tonaljs/scale`, `@tonaljs/interval`, `@tonaljs/key`.
- **New file:** `packages/core/src/lib/tonal.ts` — translation between FretFlow's verbose names ("Major Triad", "Natural Minor") and Tonal's symbols ("M", "minor").
- **Migrated functions** (signatures unchanged):
  - `getNoteIndex`, `getNoteDisplay`, `getIntervalNotes`, `getNoteDisplayInScale`
  - `getScaleNotes`, `getScaleSemitones`, `getDivergentNotes`
  - `getChordNotes`, `getDiatonicChord`
  - `getKeySignature`, `getKeySignatureForDisplay`
  - `getCircleNoteLabels`
- **New tests** (+31): adapter tests, circle-of-fifths tests pinning current behavior, diatonic-quality drift detection against Tonal.
- **Docs:** `CLAUDE.md` notes the Tonal backing; integration spec + Phase 1 plan + library survey notes + follow-up observations committed under `docs/superpowers/`.

## What's intentionally NOT in this PR

- No UI changes.
- No store-atom changes.
- No removal of public exports (`NOTES`, `ENHARMONICS`, `FLAT_KEYS`, `KEY_SIGNATURES`, `CHORDS`, `CHORD_DEFINITIONS`, etc.) — those are referenced by `src/` consumers and stay exported.
- Chord-overlay mode toggle, Inspector tab structure, lens system — all unchanged. Those are Phases 2–8.

## Quality gates

- ✅ `pnpm run lint` — clean
- ✅ `pnpm run test` — 1794 passing (1763 baseline + 31 new)
- ✅ `pnpm run build` — clean
- ✅ `pnpm run build:types` — clean (no Tonal deprecation warnings)
- ✅ Public API of `@fretflow/core` (`packages/core/src/index.ts`) — byte-identical to base

## Bundle impact

| | Baseline | Phase 1 |
|---|---|---|
| `index-*.js` | 224.87 kB raw / **69.24 kB** gzip | 257.74 kB raw / **78.54 kB** gzip |
| New `vendor-*.js` (Tonal) | — | 123.18 kB raw / **42.86 kB** gzip |

Net add: ~**+52 KB gzipped**. Within the spec's total budget of ~120 KB gzipped for Tonal + Tone combined.

## Follow-ups

Three non-blocking observations from the final review, captured in [`docs/superpowers/specs/2026-05-20-fretflow-phase-1-followups.md`](docs/superpowers/specs/2026-05-20-fretflow-phase-1-followups.md):

1. `getChordNotes` NaN guard is inconsistent with the rest of `theory.ts` (cosmetic).
2. `getDivergentNotes` still uses `NOTES.indexOf(rootNote)` — silently returns `[]` for flat-spelled roots. Pre-existing gap, not a regression.
3. `getDivergentNotes` lacks flat-root test coverage.

Can be addressed as one small follow-up PR or inline during Phase 2 (Chord unification).

## Test plan

- [ ] CI passes (lint + unit + build + types).
- [ ] e2e + visual regression CI is green.
- [ ] Manual smoke (dev server): change key, change scale, change chord, change progression step, switch fingering pattern, confirm fretboard renders correctly in all combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Upgraded core music theory calculations with library integration for more accurate chord, scale, and enharmonic note handling.

* **Tests**
  * Added test coverage for chord/scale naming conversions and diatonic quality validation.

* **Documentation**
  * Added integration planning and library evaluation documentation.

* **Chores**
  * Added music theory library dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->