### PR TITLE
refactor(core): complete getDivergentNotes Tonal migration

### DIFF
--- a/packages/core/src/theory.test.ts
+++ b/packages/core/src/theory.test.ts
@@ -182,6 +182,16 @@ describe("getDivergentNotes", () => {
   it("returns empty for blues scales", () => {
     expect(getDivergentNotes("A", "Minor Blues")).toEqual([]);
   });
+
+  it("returns raised 6th for Bb Dorian (vs Natural Minor) — flat root", () => {
+    // Bb Dorian: Bb C Db Eb F G Ab; Bb Natural Minor: Bb C Db Eb F Gb Ab
+    // Divergent semitone = G (chroma 7) → sharps-form "G"
+    expect(getDivergentNotes("Bb", "Dorian")).toEqual(["G"]);
+  });
+
+  it("returns empty for invalid root", () => {
+    expect(getDivergentNotes("Zz", "Dorian")).toEqual([]);
+  });
 });
 
 describe("getKeySignature", () => {

--- a/packages/core/src/theory.ts
+++ b/packages/core/src/theory.ts
@@ -546,21 +546,28 @@ export function getDivergentNotes(
   if (resolvedScaleName === "Major Pentatonic" || resolvedScaleName === "Minor Pentatonic") return [];
   if (resolvedScaleName === "Major" || resolvedScaleName === "Natural Minor") return [];
 
+  const rootChroma = Note.chroma(rootNote);
+  if (typeof rootChroma !== "number" || isNaN(rootChroma)) return [];
+
   const semis = getScaleSemitones(rootNote, scaleName);
   if (semis.length === 0) return [];
 
-  const rootIdx = NOTES.indexOf(rootNote);
-  if (rootIdx === -1) return [];
-
-  // Convert absolute NOTES indices to relative semitone intervals from root
-  const relativeIntervals = semis.map((s) => (s - rootIdx + 12) % 12);
+  // Convert absolute chroma indices to relative semitone intervals from root
+  const relativeIntervals = semis.map((s) => (s - rootChroma + 12) % 12);
   const isMajorQuality = relativeIntervals.includes(4); // contains major 3rd
   const refName = isMajorQuality ? "Major" : "Natural Minor";
   const refSemis = new Set(getScaleSemitones(rootNote, refName));
 
   return semis
     .filter((semitone) => !refSemis.has(semitone))
-    .map((semitone) => NOTES[semitone]);
+    .map((semitone) => {
+      const t = Note.transpose(
+        rootNote,
+        Interval.fromSemitones((semitone - rootChroma + 12) % 12),
+      );
+      const simplified = Note.simplify(t);
+      return simplified.includes("b") ? Note.enharmonic(simplified) : simplified;
+    });
 }
 
 // Key signature accidental counts (+ sharps, - flats)


### PR DESCRIPTION
## Summary

Phase 1 (Tonal.js migration) follow-up cleanup of `packages/core/src/theory.ts`. Addresses the three observations in [docs/superpowers/specs/2026-05-20-fretflow-phase-1-followups.md](docs/superpowers/specs/2026-05-20-fretflow-phase-1-followups.md):

- **Obs # 1 — `getChordNotes` NaN guard:** verified already canonical (hoisted `Note.chroma` + `typeof !== "number" || isNaN`). No change required.
- **Obs # 2 — `getDivergentNotes` migration:** replaces the two remaining legacy idioms with canonical Tonal patterns:
  - `NOTES.indexOf(rootNote)` → `Note.chroma(rootNote)` (fixes silent `[]` return for flat roots like `Bb`, `Eb`, `Ab`).
  - `NOTES[semitone]` output lookup → `Note.transpose` + `Interval.fromSemitones` + sharps-form normalization (`Note.simplify` + conditional `Note.enharmonic`), matching `getIntervalNotes` / `getChordNotes` / `getScaleNotes`.
  - Sharps-form output contract preserved.
- **Obs # 3 — Flat-root test coverage:** adds `getDivergentNotes("Bb", "Dorian") → ["G"]` and an invalid-root case (`"Zz"` → `[]`).

## Why

The Phase 1 final review flagged these as non-blocking gaps. Combining the three into one targeted PR (per the doc's own recommendation) keeps the churn small and the change coherent — all three concern flat-root handling and Tonal pattern consistency in `theory.ts`.

## Reviewer notes

- Public API of `@fretflow/core` is unchanged for sharp/natural roots — existing tests pass unmodified.
- The previous behavior for flat roots was a silent `[]`; the new behavior returns the correct divergent notes.
- One non-blocking observation from code review: `(semitone - rootChroma + 12) % 12` is computed both into `relativeIntervals` and again in the output `.map`. Left as-is to keep the diff minimal; a future pass could DRY this up alongside a shared `toSharpsForm` helper across the 4 sibling functions.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run test` — 1828/1828 passing
- [x] `pnpm run build` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)