### PR TITLE
fix(shared): wrap note-grid to 2×6 on mobile for WCAG touch targets

### DIFF
--- a/src/components/shared/shared.module.css
+++ b/src/components/shared/shared.module.css
@@ -298,6 +298,12 @@
   gap: 0.22rem;
 }
 
+/* Wrap to 2 rows × 6 cells on mobile so each touch target meets the
+   WCAG 2.5.5 44×44 minimum (12 columns at ~390px viewport = ~32px wide). */
+:global(.app-container[data-layout-tier="mobile"]) .note-grid {
+  grid-template-columns: repeat(6, minmax(44px, 1fr));
+}
+
 .note-btn {
   width: 100%;
   min-height: var(--control-height);


### PR DESCRIPTION
## Summary

- `.note-grid` in `src/components/shared/shared.module.css` was a fixed `repeat(12, 1fr)`. At a 390px viewport this collapses each cell to ~32×34px, below the WCAG 2.5.5 44×44 touch-target minimum.
- Add a mobile variant under the existing `:global(.app-container[data-layout-tier="mobile"])` selector pattern (already used a few rules below for `.note-btn` and elsewhere in this file) that switches the grid to `repeat(6, minmax(44px, 1fr))` — 2 rows × 6 cells.

## Notes on the task description

The original request pointed at `src/components/shared/DegreeGrid.module.css` and `docs/superpowers/specs/2026-05-21-v2.0-redesign-design.md`. Neither file exists in the repo. The actual 12-cell note/degree grid lives in `shared.module.css` as `.note-grid` (consumed by `src/components/NoteGrid/NoteGrid.tsx`), so the fix was applied there. The codebase pattern uses `data-layout-tier="mobile"` rather than raw media queries, so this PR follows that convention for consistency with the surrounding rules.

## Test plan

- [x] `pnpm run lint` — passes
- [x] `pnpm run test` — 1825 tests pass
- [x] `pnpm run build` — succeeds
- [ ] `pnpm run test:visual:update` — **not run**: Playwright's chromium download is blocked by this sandbox's network policy. Visual baselines will need to be refreshed via CI or locally before merge (snapshots under `e2e/app-mobile.visual.spec.ts-snapshots/` are the likely diffs).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHyd2kCSNe34BHEt4kRCuB)_