### PR TITLE
fix(degree-grid): honor useFlats prop in note display

### DIFF
--- a/src/components/shared/DegreeGrid.test.tsx
+++ b/src/components/shared/DegreeGrid.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { DegreeGrid } from "./DegreeGrid";
+import styles from "./DegreeGrid.module.css";
 
 describe("DegreeGrid", () => {
   const baseProps = {
@@ -103,6 +104,29 @@ describe("DegreeGrid", () => {
         expect(btn.textContent).toContain(numeral);
         expect(btn.getAttribute("aria-label")).toContain(note.replace("#", "♯"));
       }
+    });
+
+    it("flips spelling to flats when useFlats=true overrides a sharp-default tonic", () => {
+      const { container } = render(
+        <DegreeGrid
+          {...baseProps}
+          scaleName="Major"
+          tonicNote="G"
+          selectedNote="G"
+          useFlats={true}
+        />,
+      );
+      // G major defaults to sharps — without the override, the C♯ chromatic
+      // slot would display "C♯". With useFlats=true it must render as "D♭",
+      // and no note-display span should contain a ♯.
+      const noteSpans = Array.from(
+        container.querySelectorAll<HTMLElement>(`.${styles.note}`),
+      );
+      expect(noteSpans).not.toHaveLength(0);
+      const displays = noteSpans.map((n) => n.textContent ?? "");
+      expect(displays).toContain("D♭");
+      expect(displays).not.toContain("C♯");
+      for (const d of displays) expect(d).not.toMatch(/♯/);
     });
 
     it("never renders a raw integer numeral as a borrowed label", () => {

--- a/src/components/shared/DegreeGrid.tsx
+++ b/src/components/shared/DegreeGrid.tsx
@@ -15,7 +15,6 @@ export interface DegreeGridProps {
   selectedNote: string;
   onSelectInKey: (note: string, degree: string) => void;
   onSelectBorrowed: (note: string, degreeLabel: string) => void;
-   
   useFlats: boolean;
 }
 
@@ -53,6 +52,7 @@ export function DegreeGrid({
   selectedNote,
   onSelectInKey,
   onSelectBorrowed,
+  useFlats,
 }: DegreeGridProps) {
   const cells: CellInfo[] = useMemo(() => {
     const diatonic = getDiatonicNotes(scaleName, tonicNote);
@@ -67,12 +67,12 @@ export function DegreeGrid({
         : BORROWED_NUMERAL_BY_OFFSET[offset] ?? "";
       return {
         note,
-        display: formatAccidental(getNoteDisplay(note, tonicNote)),
+        display: formatAccidental(getNoteDisplay(note, tonicNote, useFlats)),
         inKey,
         numeral,
       };
     });
-  }, [scaleName, tonicNote]);
+  }, [scaleName, tonicNote, useFlats]);
 
   return (
     <div className={styles.grid} role="group" aria-label="Chord root">


### PR DESCRIPTION
## Summary

- `DegreeGrid` declared `useFlats: boolean` on its props and `SongControls` passed it through, but the component body never destructured or forwarded it. `getNoteDisplay(note, tonicNote)` was called without the third argument, so spelling silently fell back to `FLAT_KEYS.includes(tonicNote)` auto-detection.
- Destructure `useFlats` and pass it as the third argument to `getNoteDisplay`. Add it to the `useMemo` dependency array.
- Add a regression test: a sharp-default tonic (G major) with `useFlats={true}` renders `D♭` instead of `C♯`, and no note-display span contains a `♯`.

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run test` (1794 passed)
- [x] New test fails on the old wiring (verified — without the override, the C♯ slot still rendered as `C♯`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01McuSohCEiUuTftpWNe7uqm)_