### PR TITLE
feat(degree-grid): add roving tabindex keyboard navigation

### DIFF
--- a/src/components/shared/DegreeGrid.test.tsx
+++ b/src/components/shared/DegreeGrid.test.tsx
@@ -116,9 +116,82 @@ describe("DegreeGrid", () => {
       );
       const buttons = screen.getAllByRole("button");
       for (const btn of buttons) {
-        // The numeral span never contains a raw single-digit fallback.
         expect(btn.textContent).not.toMatch(/\b\d{1,2}\b/);
       }
     });
+  });
+
+  describe("keyboard navigation (roving tabindex)", () => {
+    it("starts with only the selected cell as tabIndex=0", () => {
+      render(<DegreeGrid {...baseProps} selectedNote="E" />);
+      const buttons = screen.getAllByRole("button");
+      const tabbable = buttons.filter((b) => b.tabIndex === 0);
+      expect(tabbable).toHaveLength(1);
+      expect(tabbable[0].getAttribute("aria-label")).toMatch(/^E/);
+    });
+
+    it("falls back to the first cell when selectedNote is not in the chromatic set", () => {
+      render(<DegreeGrid {...baseProps} selectedNote="Zz" />);
+      const buttons = screen.getAllByRole("button");
+      expect(buttons[0].tabIndex).toBe(0);
+      expect(buttons.slice(1).every((b) => b.tabIndex === -1)).toBe(true);
+    });
+
+    it("moves focus to the next cell on ArrowRight", () => {
+      render(<DegreeGrid {...baseProps} selectedNote="C" />);
+      const buttons = screen.getAllByRole("button");
+      buttons[0].focus();
+      fireEvent.keyDown(buttons[0], { key: "ArrowRight" });
+      expect(document.activeElement).toBe(buttons[1]);
+      expect(buttons[1].tabIndex).toBe(0);
+      expect(buttons[0].tabIndex).toBe(-1);
+    });
+
+    it("moves focus to the previous cell on ArrowLeft", () => {
+      render(<DegreeGrid {...baseProps} selectedNote="C" />);
+      const buttons = screen.getAllByRole("button");
+      buttons[2].focus();
+      fireEvent.keyDown(buttons[2], { key: "ArrowLeft" });
+      expect(document.activeElement).toBe(buttons[1]);
+      expect(buttons[1].tabIndex).toBe(0);
+    });
+
+    it("wraps focus from last cell to first on ArrowRight", () => {
+      render(<DegreeGrid {...baseProps} />);
+      const buttons = screen.getAllByRole("button");
+      buttons[11].focus();
+      fireEvent.keyDown(buttons[11], { key: "ArrowRight" });
+      expect(document.activeElement).toBe(buttons[0]);
+    });
+
+    it("wraps focus from first cell to last on ArrowLeft", () => {
+      render(<DegreeGrid {...baseProps} />);
+      const buttons = screen.getAllByRole("button");
+      buttons[0].focus();
+      fireEvent.keyDown(buttons[0], { key: "ArrowLeft" });
+      expect(document.activeElement).toBe(buttons[11]);
+    });
+
+    it("jumps to first cell on Home and last cell on End", () => {
+      render(<DegreeGrid {...baseProps} />);
+      const buttons = screen.getAllByRole("button");
+      buttons[5].focus();
+      fireEvent.keyDown(buttons[5], { key: "End" });
+      expect(document.activeElement).toBe(buttons[11]);
+      fireEvent.keyDown(buttons[11], { key: "Home" });
+      expect(document.activeElement).toBe(buttons[0]);
+    });
+
+    it("keeps exactly one tabbable cell at any time", () => {
+      render(<DegreeGrid {...baseProps} />);
+      const buttons = screen.getAllByRole("button");
+      buttons[0].focus();
+      fireEvent.keyDown(buttons[0], { key: "ArrowRight" });
+      fireEvent.keyDown(buttons[1], { key: "ArrowRight" });
+      fireEvent.keyDown(buttons[2], { key: "ArrowRight" });
+      const tabbable = buttons.filter((b) => b.tabIndex === 0);
+      expect(tabbable).toHaveLength(1);
+    });
+
   });
 });

--- a/src/components/shared/DegreeGrid.tsx
+++ b/src/components/shared/DegreeGrid.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useRef, useState, type KeyboardEvent } from "react";
 import {
   NOTES,
   getDiatonicNotes,
@@ -74,11 +74,47 @@ export function DegreeGrid({
     });
   }, [scaleName, tonicNote]);
 
+  const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const selectedIndex = cells.findIndex((c) => c.note === selectedNote);
+  const [focusIndex, setFocusIndex] = useState(
+    selectedIndex >= 0 ? selectedIndex : 0,
+  );
+
+  const moveFocus = (next: number) => {
+    const wrapped = ((next % cells.length) + cells.length) % cells.length;
+    setFocusIndex(wrapped);
+    buttonRefs.current[wrapped]?.focus();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    switch (event.key) {
+      case "ArrowRight":
+        event.preventDefault();
+        moveFocus(index + 1);
+        break;
+      case "ArrowLeft":
+        event.preventDefault();
+        moveFocus(index - 1);
+        break;
+      case "Home":
+        event.preventDefault();
+        moveFocus(0);
+        break;
+      case "End":
+        event.preventDefault();
+        moveFocus(cells.length - 1);
+        break;
+    }
+  };
+
   return (
     <div className={styles.grid} role="group" aria-label="Chord root">
-      {cells.map((cell) => (
+      {cells.map((cell, index) => (
         <button
           key={cell.note}
+          ref={(el) => {
+            buttonRefs.current[index] = el;
+          }}
           type="button"
           className={clsx(
             styles.cell,
@@ -88,6 +124,9 @@ export function DegreeGrid({
           data-in-key={cell.inKey ? "true" : "false"}
           aria-pressed={cell.note === selectedNote}
           aria-label={cell.inKey ? `${cell.display} ${cell.numeral}` : `${cell.numeral} ${cell.display}`}
+          tabIndex={index === focusIndex ? 0 : -1}
+          onKeyDown={(event) => handleKeyDown(event, index)}
+          onFocus={() => setFocusIndex(index)}
           onClick={() =>
             cell.inKey
               ? onSelectInKey(cell.note, cell.numeral)


### PR DESCRIPTION
## Summary

- Implements the WCAG 2.1 roving-tabindex pattern on `DegreeGrid`: only the active cell has `tabIndex=0`; the rest are `-1`, so the widget is a single Tab stop.
- `ArrowLeft` / `ArrowRight` move focus between adjacent cells (wrapping at the ends). `Home` / `End` jump to the first / last cell. `event.preventDefault()` is called on handled keys so the page does not scroll.
- Initial focus index defaults to the currently selected note's column, or column 0 when the selection is outside the chromatic set.

## Test plan

- [x] `pnpm run test -- src/components/shared/DegreeGrid.test.tsx` — 8 new keyboard-nav assertions cover initial tabindex layout, arrow nav, wrap-around, Home/End, and the single-tabbable-cell invariant.
- [x] `pnpm run lint`
- [x] `pnpm run build`


---
_Generated by [Claude Code](https://claude.ai/code/session_0148WiU5cjKBYaeRePaYnUXV)_