### PR TITLE
fix(song-controls): tie borrowed Roman numerals to enharmonic preference

### DIFF
--- a/src/components/shared/DegreeGrid.test.tsx
+++ b/src/components/shared/DegreeGrid.test.tsx
@@ -43,7 +43,9 @@ describe("DegreeGrid", () => {
     const onSelectBorrowed = vi.fn();
     render(<DegreeGrid {...baseProps} onSelectBorrowed={onSelectBorrowed} />);
     fireEvent.click(screen.getByRole("button", { name: /^C#|C♯/ }));
-    expect(onSelectBorrowed).toHaveBeenCalledWith("C#", "♭ii");
+    // C major defaults to sharps (useFlats=false), so the numeral spells the
+    // root with a sharp too: ♯i (not ♭ii).
+    expect(onSelectBorrowed).toHaveBeenCalledWith("C#", "♯i");
   });
 
   describe("borrowed numerals across modes", () => {
@@ -60,8 +62,11 @@ describe("DegreeGrid", () => {
       );
       // In A Natural Minor: in-key = A B C D E F G;
       // borrowed offsets {1,4,6,9,11} → A#, C#, D#, F#, G#.
+      // A natural minor resolves to useFlats=false, so chromatic offsets (1, 6)
+      // pick the sharp form (♯i, ♯iv); natural-position offsets (4, 9, 11) have
+      // no accidental and are unchanged.
       const cases: Array<[string, string]> = [
-        ["A#", "♭ii"],
+        ["A#", "♯i"],
         ["C#", "iii"],
         ["D#", "♯iv"],
         ["F#", "vi"],
@@ -89,11 +94,13 @@ describe("DegreeGrid", () => {
       );
       // In D Dorian: in-key = D E F G A B C;
       // borrowed offsets {1,4,6,8,11} → D#, F#, G#, A#, C#.
+      // D Dorian resolves to useFlats=false, so chromatic offsets (1, 6, 8)
+      // pick the sharp form; natural-position offsets (4, 11) are unchanged.
       const expected: Record<string, string> = {
-        "D#": "♭ii",
+        "D#": "♯i",
         "F#": "iii",
         "G#": "♯iv",
-        "A#": "♭vi",
+        "A#": "♯v",
         "C#": "vii",
       };
       for (const [note, numeral] of Object.entries(expected)) {
@@ -127,6 +134,15 @@ describe("DegreeGrid", () => {
       expect(displays).toContain("D♭");
       expect(displays).not.toContain("C♯");
       for (const d of displays) expect(d).not.toMatch(/♯/);
+
+      // Numeral accidentals must follow the same useFlats=true preference —
+      // the C#/D♭ chromatic cell (offset 6 from G) reads ♭v, not ♯iv.
+      const numeralSpans = Array.from(
+        container.querySelectorAll<HTMLElement>(`.${styles.numeral}`),
+      );
+      const numerals = numeralSpans.map((n) => n.textContent ?? "");
+      expect(numerals).toContain("♭v");
+      for (const n of numerals) expect(n).not.toMatch(/♯/);
     });
 
     it("never renders a raw integer numeral as a borrowed label", () => {

--- a/src/components/shared/DegreeGrid.tsx
+++ b/src/components/shared/DegreeGrid.tsx
@@ -31,20 +31,41 @@ interface CellInfo {
 // `getDegreesForScale` instead, which honours mode-specific spelling. Lowercase
 // is used universally as a quality-neutral label (the cell's quality is set
 // independently by the user).
-const BORROWED_NUMERAL_BY_OFFSET: Record<number, string> = {
+//
+// Diatonic-position labels (no accidental) are the same in either spelling.
+const NATURAL_NUMERAL_BY_OFFSET: Record<number, string> = {
   0: "i",
-  1: "♭ii",
   2: "ii",
-  3: "♭iii",
   4: "iii",
   5: "iv",
-  6: "♯iv",
   7: "v",
-  8: "♭vi",
   9: "vi",
-  10: "♭vii",
   11: "vii",
 };
+// Chromatic-offset labels — accidental follows the active enharmonic preference,
+// matching the chord-root spelling (Roman-numeral convention: numeral accidental
+// ≡ root accidental). This keeps the numeral coherent with the note name shown
+// above it, instead of mixing flats (♭ii, ♭iii, ♭vi, ♭vii) with a stray ♯iv.
+const FLAT_BORROWED_BY_OFFSET: Record<number, string> = {
+  1: "♭ii",
+  3: "♭iii",
+  6: "♭v",
+  8: "♭vi",
+  10: "♭vii",
+};
+const SHARP_BORROWED_BY_OFFSET: Record<number, string> = {
+  1: "♯i",
+  3: "♯ii",
+  6: "♯iv",
+  8: "♯v",
+  10: "♯vi",
+};
+
+function getBorrowedNumeral(offset: number, useFlats: boolean): string {
+  if (offset in NATURAL_NUMERAL_BY_OFFSET) return NATURAL_NUMERAL_BY_OFFSET[offset];
+  const chromatic = useFlats ? FLAT_BORROWED_BY_OFFSET : SHARP_BORROWED_BY_OFFSET;
+  return chromatic[offset] ?? "";
+}
 
 export function DegreeGrid({
   scaleName,
@@ -64,7 +85,7 @@ export function DegreeGrid({
       const inKey = diatonic.has(note);
       const numeral = inKey
         ? degreesMap[offset] ?? ""
-        : BORROWED_NUMERAL_BY_OFFSET[offset] ?? "";
+        : getBorrowedNumeral(offset, useFlats);
       return {
         note,
         display: formatAccidental(getNoteDisplay(note, tonicNote, useFlats)),


### PR DESCRIPTION
## Summary

- The Song-tab chord-root grid was labeling chromatic roots with a hardcoded spelling table — `♭ii, ♭iii, ♯iv, ♭vi, ♭vii` — so the numeral accidental was internally inconsistent (sharp at offset 6 next to flats everywhere else) and ignored the user's enharmonic preference. In C major (sharps default) the note name read `C♯` but the numeral spelled it as a flat (`♭ii`).
- Replaced the static table with a `useFlats`-aware helper in [DegreeGrid.tsx](src/components/shared/DegreeGrid.tsx) so the numeral accidental always matches the chord-root spelling — the standard Roman-numeral-analysis convention (Kostka/Payne, Aldwell/Schachter, Laitz): the numeral accidental is whatever is needed to spell the actual root pitch.
- Diatonic labels (`I, ii, iii, IV, V, vi, vii°`) are unchanged.

After the fix:

| Enharmonic preference | Borrowed labels |
|---|---|
| Sharps (e.g. C major, A nat. minor, G major) | `♯i, ♯ii, ♯iv, ♯v, ♯vi` |
| Flats (e.g. F major, accidental override) | `♭ii, ♭iii, ♭v, ♭vi, ♭vii` |

The visible split — sharp `♯iv` next to flat `♭ii` — is gone, and the numeral spelling now flips in lockstep with the note name when the user changes the Accidentals preference.

## Test plan

- [x] `pnpm lint` — clean.
- [x] `pnpm test src/components/shared/DegreeGrid.test.tsx` — 17/17 pass.
- [x] `pnpm test` (full suite) — 1790/1790 pass.
- [x] `pnpm build` — clean.
- [x] Browser smoke (C major, Auto → sharps): grid cells render as `C/I, C♯/♯i, D/ii, D♯/♯ii, E/iii, F/IV, F♯/♯iv, G/V, G♯/♯v, A/vi, A♯/♯vi, B/vii°` — uniformly sharp.
- [x] Browser smoke (Accidentals → ♭ override): cells render as `C/I, D♭/♭ii, D/ii, E♭/♭iii, E/iii, F/IV, G♭/♭v, G/V, A♭/♭vi, A/vi, B♭/♭vii, B/vii°` — uniformly flat, note name and numeral accidentals match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)