### PR TITLE
perf: remove audio and fretboard startup hotspots

### DIFF
--- a/docs/superpowers/plans/2026-05-22-performance-hotspots.md
+++ b/docs/superpowers/plans/2026-05-22-performance-hotspots.md
@@ -1,0 +1,705 @@
+# Performance Hot Spots Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce startup render delay and playback click latency by removing eager audio startup work, letting the fretboard paint before measurement, and reusing Tone voices instead of constructing them per scheduled hit.
+
+**Architecture:** Keep the current progression, fretboard, and audio-clock model intact. Add one lazy guitar-audio facade for the startup path, remove the fretboard’s visibility gate so measurement becomes post-paint refinement, and introduce reusable Tone voice helpers so scheduler calls stay structurally the same while the expensive constructors leave the click path.
+
+**Tech Stack:** React 19, TypeScript, Jotai, Vitest, Testing Library, Tone.js, Vite
+
+---
+
+## File map
+
+- **Create:** `src/core/lazyGuitarAudio.ts` — lazy boundary around `src/core/audio.ts`; stores mute/error-handler state without forcing Tone into the startup graph.
+- **Create:** `src/core/lazyGuitarAudio.test.ts` — verifies lazy loading, deferred mute propagation, and note-play delegation.
+- **Create:** `src/progressions/audio/instruments/createReusableChordVoice.ts` — shared helper for cached `Tone.PolySynth` chord voices.
+- **Create:** `src/progressions/audio/createReusableVoicePool.ts` — shared pool helper for bass, drums, and metronome one-shot voices.
+- **Modify:** `src/App.tsx` — replace eager `synth` import/usage with lazy-guitar-audio calls.
+- **Modify:** `src/components/Fretboard/Fretboard.tsx` — replace eager `synth` import, remove hidden-until-measured visibility gate, keep resize logic as post-paint refinement.
+- **Modify:** `src/components/Fretboard/Fretboard.test.tsx` — add visibility-before-measurement and lazy note-play wiring assertions.
+- **Modify:** `src/components/Fretboard/Fretboard.performance.test.tsx` — keep derived-prop reuse assertions green after measurement changes.
+- **Modify:** `src/core/audio.test.ts` — keep eager synth contract covered; this remains the direct-runtime test file.
+- **Modify:** `src/progressions/audio/instruments/pianoVoice.ts` — swap per-call `PolySynth` construction for reusable helper.
+- **Modify:** `src/progressions/audio/instruments/organVoice.ts` — same reusable helper path as piano.
+- **Modify:** `src/progressions/audio/bass.ts` — move to pooled reusable `Tone.MonoSynth` instances.
+- **Modify:** `src/progressions/audio/drumKit.ts` — move kick/snare/hat/ride to pooled reusable instances keyed by destination bus.
+- **Modify:** `src/progressions/audio/metronome.ts` — move clicks to pooled reusable `Tone.Synth` instances.
+- **Modify:** `src/progressions/audio/instruments/pianoVoice.test.ts` — assert constructor reuse across successive chord schedules.
+- **Modify:** `src/progressions/audio/instruments/organVoice.test.ts` — same constructor-reuse assertion as piano.
+- **Modify:** `src/progressions/audio/bass.test.ts` — assert pooled `MonoSynth` reuse and retained scheduling contract.
+- **Modify:** `src/progressions/audio/drumKit.test.ts` — assert pooled reuse per lane rather than per-hit constructor churn.
+- **Modify:** `src/progressions/audio/metronome.test.ts` — assert pooled click reuse.
+
+---
+
+### Task 1: Add the lazy guitar-audio boundary
+
+**Files:**
+
+- Create: `src/core/lazyGuitarAudio.ts`
+- Create: `src/core/lazyGuitarAudio.test.ts`
+- Modify: `src/App.tsx`
+- Modify: `src/components/Fretboard/Fretboard.tsx`
+- Test: `src/core/lazyGuitarAudio.test.ts`
+
+- [x] **Step 1: Write the failing lazy-audio facade test**
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const audioModule = vi.hoisted(() => ({
+  synth: {
+    resume: vi.fn(async () => {}),
+    playNote: vi.fn(async () => {}),
+    setMute: vi.fn(),
+    onError: undefined as ((msg: string) => void) | undefined,
+  },
+}));
+
+vi.mock("./audio", () => audioModule);
+
+import {
+  __resetLazyGuitarAudioForTests,
+  playGuitarNote,
+  resumeGuitarAudio,
+  setGuitarAudioErrorHandler,
+  setGuitarMutePreference,
+} from "./lazyGuitarAudio";
+
+describe("lazyGuitarAudio", () => {
+  beforeEach(() => {
+    __resetLazyGuitarAudioForTests();
+    vi.clearAllMocks();
+  });
+
+  it("does not call synth.setMute until the lazy runtime has been loaded", () => {
+    setGuitarMutePreference(true);
+    expect(audioModule.synth.setMute).not.toHaveBeenCalled();
+  });
+
+  it("replays the stored mute preference and error handler on first lazy load", async () => {
+    const onError = vi.fn();
+    setGuitarMutePreference(true);
+    setGuitarAudioErrorHandler(onError);
+
+    await resumeGuitarAudio();
+
+    expect(audioModule.synth.setMute).toHaveBeenCalledWith(true);
+    expect(audioModule.synth.onError).toBe(onError);
+    expect(audioModule.synth.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it("delegates note playback through the lazy runtime", async () => {
+    await playGuitarNote(440);
+    expect(audioModule.synth.playNote).toHaveBeenCalledWith(440);
+  });
+});
+```
+
+- [x] **Step 2: Run the new test to confirm the facade does not exist yet**
+
+Run:
+
+```bash
+pnpm vitest run src/core/lazyGuitarAudio.test.ts
+```
+
+Expected: FAIL with a module-not-found error for `src/core/lazyGuitarAudio.ts`.
+
+- [x] **Step 3: Implement the lazy audio facade**
+
+```ts
+// src/core/lazyGuitarAudio.ts
+type GuitarSynthModule = typeof import("./audio");
+
+let modulePromise: Promise<GuitarSynthModule> | null = null;
+let desiredMute = false;
+let errorHandler: ((message: string) => void) | undefined;
+
+async function loadAudioModule(): Promise<GuitarSynthModule> {
+  if (!modulePromise) {
+    modulePromise = import("./audio").then((mod) => {
+      mod.synth.onError = errorHandler;
+      mod.synth.setMute(desiredMute);
+      return mod;
+    });
+  }
+  return modulePromise;
+}
+
+export function setGuitarMutePreference(mute: boolean): void {
+  desiredMute = mute;
+  void modulePromise?.then((mod) => {
+    mod.synth.setMute(mute);
+  });
+}
+
+export function setGuitarAudioErrorHandler(
+  nextHandler: ((message: string) => void) | undefined,
+): void {
+  errorHandler = nextHandler;
+  void modulePromise?.then((mod) => {
+    mod.synth.onError = nextHandler;
+  });
+}
+
+export async function resumeGuitarAudio(): Promise<void> {
+  const mod = await loadAudioModule();
+  await mod.synth.resume();
+}
+
+export async function playGuitarNote(frequency: number): Promise<void> {
+  const mod = await loadAudioModule();
+  await mod.synth.playNote(frequency);
+}
+
+export function __resetLazyGuitarAudioForTests(): void {
+  modulePromise = null;
+  desiredMute = false;
+  errorHandler = undefined;
+}
+```
+
+- [x] **Step 4: Wire `App.tsx` and `Fretboard.tsx` through the lazy facade**
+
+```ts
+// src/App.tsx
+import {
+  resumeGuitarAudio,
+  setGuitarAudioErrorHandler,
+  setGuitarMutePreference,
+} from "./core/lazyGuitarAudio";
+
+useEffect(() => {
+  setGuitarMutePreference(isMuted);
+}, [isMuted]);
+
+useEffect(() => {
+  setGuitarAudioErrorHandler((msg) => setAudioError(msg));
+  return () => setGuitarAudioErrorHandler(undefined);
+}, [setAudioError]);
+
+useEffect(() => {
+  const handleGesture = () => {
+    void resumeGuitarAudio();
+    window.removeEventListener("click", handleGesture);
+    window.removeEventListener("touchstart", handleGesture);
+  };
+  window.addEventListener("click", handleGesture);
+  window.addEventListener("touchstart", handleGesture);
+  return () => {
+    window.removeEventListener("click", handleGesture);
+    window.removeEventListener("touchstart", handleGesture);
+  };
+}, []);
+```
+
+```ts
+// src/components/Fretboard/Fretboard.tsx
+import { playGuitarNote } from "../../core/lazyGuitarAudio";
+
+const handleFretClick = useCallback(
+  async (stringIndex: number, fretIndex: number, noteName: string) => {
+    if (dragDistance.current > 5) return;
+    const fretNoteWithOctave = getFretNoteWithOctave(
+      tuning[stringIndex],
+      fretIndex,
+    );
+    const frequency = getNoteFrequency(fretNoteWithOctave);
+    await playGuitarNote(frequency);
+    if (onFretClickProp) onFretClickProp(stringIndex, fretIndex, noteName);
+  },
+  [tuning, onFretClickProp],
+);
+```
+
+- [x] **Step 5: Run the lazy-audio test to verify it passes**
+
+Run:
+
+```bash
+pnpm vitest run src/core/lazyGuitarAudio.test.ts src/core/audio.test.ts
+```
+
+Expected: PASS for the new lazy facade tests and existing direct-runtime audio tests.
+
+- [x] **Step 6: Commit Task 1**
+
+```bash
+git add src/core/lazyGuitarAudio.ts src/core/lazyGuitarAudio.test.ts src/App.tsx src/components/Fretboard/Fretboard.tsx
+git commit -m "perf(audio): lazy-load guitar audio"
+```
+
+---
+
+### Task 2: Let the fretboard paint before measurement settles
+
+**Files:**
+
+- Modify: `src/components/Fretboard/Fretboard.tsx`
+- Modify: `src/components/Fretboard/Fretboard.test.tsx`
+- Modify: `src/components/Fretboard/Fretboard.performance.test.tsx`
+- Test: `src/components/Fretboard/Fretboard.test.tsx`
+
+- [x] **Step 1: Write the failing visibility-before-measurement test**
+
+```ts
+it("keeps the fretboard visible before ResizeObserver publishes width", () => {
+  const { container } = render(<Fretboard {...defaultProps} />);
+  const wrapper = container.querySelector('[class*="fretboard-wrapper"]');
+  expect(wrapper).not.toHaveStyle({ visibility: "hidden" });
+});
+```
+
+- [x] **Step 2: Run the fretboard test to capture the current regression**
+
+Run:
+
+```bash
+pnpm vitest run src/components/Fretboard/Fretboard.test.tsx -t "keeps the fretboard visible before ResizeObserver publishes width"
+```
+
+Expected: FAIL because the wrapper currently renders with `visibility: hidden` until `containerWidth` is set.
+
+- [x] **Step 3: Remove the visibility gate and seed width with a paint-safe fallback**
+
+```ts
+// src/components/Fretboard/Fretboard.tsx
+const [containerWidth, setContainerWidth] = useState<number>(() => {
+  if (typeof window === "undefined") return 0;
+  return Math.max(window.innerWidth, 320);
+});
+
+useLayoutEffect(() => {
+  const el = scrollRef.current;
+  if (!el) return;
+  if (el.clientWidth > 0) setContainerWidth(el.clientWidth);
+
+  const ro = new ResizeObserver((entries) => {
+    const width = entries[0]?.contentRect.width ?? 0;
+    if (width > 0) setContainerWidth(width);
+  });
+  ro.observe(el);
+  return () => ro.disconnect();
+}, []);
+
+// Drop the inline visibility gate entirely.
+<div
+  className={clsx(styles["fretboard-wrapper"], styles["hide-scrollbar"])}
+  ref={scrollRef}
+  onPointerDown={handlePointerDown}
+  onPointerMove={handlePointerMove}
+  onPointerUp={handlePointerUp}
+  onPointerLeave={handlePointerUp}
+>
+```
+
+- [x] **Step 4: Keep the existing prop-reuse performance coverage green**
+
+```ts
+// src/components/Fretboard/Fretboard.performance.test.tsx
+it("still reuses expensive derived props when zoom changes after width fallback", () => {
+  const store = createStore();
+
+  render(
+    <Provider store={store}>
+      <Fretboard stringRowPx={40} />
+    </Provider>,
+  );
+
+  const first = received.at(-1)!;
+
+  act(() => {
+    store.set(fretZoomAtom, 150);
+  });
+
+  const second = received.at(-1)!;
+  expect(second.fretboardLayout).toBe(first.fretboardLayout);
+  expect(second.fullChordVoicings).toBe(first.fullChordVoicings);
+});
+```
+
+- [x] **Step 5: Run the fretboard tests to verify the new startup behavior**
+
+Run:
+
+```bash
+pnpm vitest run src/components/Fretboard/Fretboard.test.tsx src/components/Fretboard/Fretboard.performance.test.tsx
+```
+
+Expected: PASS, including the new “visible before measurement” assertion and the existing reuse assertions.
+
+- [x] **Step 6: Commit Task 2**
+
+```bash
+git add src/components/Fretboard/Fretboard.tsx src/components/Fretboard/Fretboard.test.tsx src/components/Fretboard/Fretboard.performance.test.tsx
+git commit -m "perf(fretboard): paint before measurement"
+```
+
+---
+
+### Task 3: Reuse chord voices instead of constructing `PolySynth` per hit
+
+**Files:**
+
+- Create: `src/progressions/audio/instruments/createReusableChordVoice.ts`
+- Modify: `src/progressions/audio/instruments/pianoVoice.ts`
+- Modify: `src/progressions/audio/instruments/organVoice.ts`
+- Modify: `src/progressions/audio/instruments/pianoVoice.test.ts`
+- Modify: `src/progressions/audio/instruments/organVoice.test.ts`
+- Test: `src/progressions/audio/instruments/pianoVoice.test.ts`
+- Test: `src/progressions/audio/instruments/organVoice.test.ts`
+
+- [x] **Step 1: Add the failing constructor-reuse tests**
+
+```ts
+it("reuses one PolySynth across successive piano schedules", () => {
+  pianoVoice.scheduleChord({} as AudioNode, ["C3", "E3", "G3"], 0, {
+    velocity: 0.7,
+  });
+  pianoVoice.scheduleChord({} as AudioNode, ["F3", "A3", "C4"], 1, {
+    velocity: 0.7,
+  });
+
+  expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
+  expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+});
+```
+
+```ts
+it("reuses one PolySynth across successive organ schedules", () => {
+  organVoice.scheduleChord({} as AudioNode, ["C3", "E3", "G3"], 0, {
+    velocity: 0.7,
+  });
+  organVoice.scheduleChord({} as AudioNode, ["D3", "F3", "A3"], 1, {
+    velocity: 0.7,
+  });
+
+  expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
+  expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+});
+```
+
+- [x] **Step 2: Run the instrument tests to confirm they fail under the current per-call constructor pattern**
+
+Run:
+
+```bash
+pnpm vitest run src/progressions/audio/instruments/pianoVoice.test.ts src/progressions/audio/instruments/organVoice.test.ts
+```
+
+Expected: FAIL because each `scheduleChord()` call currently constructs a fresh `Tone.PolySynth`.
+
+- [x] **Step 3: Implement the shared reusable chord-voice helper**
+
+```ts
+// src/progressions/audio/instruments/createReusableChordVoice.ts
+import * as Tone from "tone";
+import type { ChordVoice, ChordVoiceOptions, VoiceHandle } from "./types";
+
+interface ReusableChordVoiceConfig {
+  volume: number;
+  maxPolyphonyFloor: number;
+  oscillator: { type: "custom"; partials: number[] };
+  envelope: { attack: number; decay: number; sustain: number; release: number };
+  durationFor: (options: ChordVoiceOptions) => number;
+}
+
+export function createReusableChordVoice(
+  config: ReusableChordVoiceConfig,
+): ChordVoice {
+  let synth: Tone.PolySynth<Tone.Synth> | null = null;
+  let currentDest: AudioNode | null = null;
+
+  const getSynth = (dest: AudioNode, notes: readonly string[]) => {
+    if (!synth) {
+      synth = new Tone.PolySynth(Tone.Synth, {
+        oscillator: config.oscillator,
+        envelope: config.envelope,
+        volume: config.volume,
+      });
+    }
+    if (currentDest !== dest) {
+      synth.connect(dest);
+      currentDest = dest;
+    }
+    synth.maxPolyphony = Math.max(notes.length, config.maxPolyphonyFloor);
+    return synth;
+  };
+
+  return {
+    scheduleChord(dest, notes, time, options): VoiceHandle {
+      const velocity = Math.max(0, Math.min(1, options.velocity ?? 0.7));
+      if (velocity <= 0 || notes.length === 0) return { cancel: () => {} };
+
+      const activeSynth = getSynth(dest, notes);
+      activeSynth.triggerAttackRelease(
+        notes as string[],
+        config.durationFor(options),
+        time,
+        velocity,
+      );
+
+      let cancelled = false;
+      return {
+        cancel: () => {
+          if (cancelled) return;
+          cancelled = true;
+          activeSynth.releaseAll(Tone.now());
+        },
+      };
+    },
+  };
+}
+```
+
+- [x] **Step 4: Replace piano/organ implementations with the helper**
+
+```ts
+// src/progressions/audio/instruments/pianoVoice.ts
+import { createReusableChordVoice } from "./createReusableChordVoice";
+
+export const pianoVoice = createReusableChordVoice({
+  volume: -6,
+  maxPolyphonyFloor: 6,
+  oscillator: { type: "custom", partials: [1, 0.5, 0.25, 0.12] },
+  envelope: { attack: 0.005, decay: 0.4, sustain: 0.1, release: 1.2 },
+  durationFor: (options) => (options.style === "sustained" ? 1.2 : 0.4),
+});
+```
+
+```ts
+// src/progressions/audio/instruments/organVoice.ts
+import { createReusableChordVoice } from "./createReusableChordVoice";
+
+export const organVoice = createReusableChordVoice({
+  volume: -10,
+  maxPolyphonyFloor: 6,
+  oscillator: { type: "custom", partials: [1, 0.6, 0.4, 0.3, 0.2] },
+  envelope: { attack: 0.02, decay: 0.05, sustain: 0.9, release: 0.6 },
+  durationFor: (options) => (options.style === "staccato" ? 0.2 : 1.5),
+});
+```
+
+- [x] **Step 5: Run the chord-voice tests to verify constructor reuse**
+
+Run:
+
+```bash
+pnpm vitest run src/progressions/audio/instruments/pianoVoice.test.ts src/progressions/audio/instruments/organVoice.test.ts
+```
+
+Expected: PASS, including the new “ctor called once across two schedules” assertions.
+
+- [x] **Step 6: Commit Task 3**
+
+```bash
+git add src/progressions/audio/instruments/createReusableChordVoice.ts src/progressions/audio/instruments/pianoVoice.ts src/progressions/audio/instruments/organVoice.ts src/progressions/audio/instruments/pianoVoice.test.ts src/progressions/audio/instruments/organVoice.test.ts
+git commit -m "perf(audio): reuse chord voices"
+```
+
+---
+
+### Task 4: Pool bass, drums, and metronome voices
+
+**Files:**
+
+- Create: `src/progressions/audio/createReusableVoicePool.ts`
+- Modify: `src/progressions/audio/bass.ts`
+- Modify: `src/progressions/audio/drumKit.ts`
+- Modify: `src/progressions/audio/metronome.ts`
+- Modify: `src/progressions/audio/bass.test.ts`
+- Modify: `src/progressions/audio/drumKit.test.ts`
+- Modify: `src/progressions/audio/metronome.test.ts`
+- Test: `src/progressions/audio/bass.test.ts`
+- Test: `src/progressions/audio/drumKit.test.ts`
+- Test: `src/progressions/audio/metronome.test.ts`
+
+- [x] **Step 1: Add the failing pooled-reuse tests**
+
+```ts
+it("reuses MonoSynth instances across successive bass notes", () => {
+  scheduleBassNote({} as AudioNode, 110, 0, { velocity: 0.9 });
+  scheduleBassNote({} as AudioNode, 146.83, 1, { velocity: 0.9 });
+
+  expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
+  expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+});
+```
+
+```ts
+it("reuses the metronome synth across successive clicks", () => {
+  scheduleClick({} as AudioNode, 0, { accent: true });
+  scheduleClick({} as AudioNode, 1, { accent: false });
+
+  expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
+  expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+});
+```
+
+```ts
+it("reuses metal synth instances for successive hi-hat hits on the same bus", () => {
+  scheduleHiHat({} as AudioNode, 0, {});
+  scheduleHiHat({} as AudioNode, 0.5, {});
+
+  expect(metalSpies.ctorSpy).toHaveBeenCalledTimes(1);
+  expect(metalSpies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+});
+```
+
+- [x] **Step 2: Run the rhythm-voice tests to confirm the current constructor churn**
+
+Run:
+
+```bash
+pnpm vitest run src/progressions/audio/bass.test.ts src/progressions/audio/drumKit.test.ts src/progressions/audio/metronome.test.ts
+```
+
+Expected: FAIL because each schedule helper currently constructs a fresh Tone synth.
+
+- [x] **Step 3: Implement the reusable one-shot pool helper**
+
+```ts
+// src/progressions/audio/createReusableVoicePool.ts
+interface ReusableVoice {
+  connect: (dest: AudioNode) => unknown;
+}
+
+export function createReusableVoicePool<T extends ReusableVoice>(
+  size: number,
+  build: () => T,
+): (dest: AudioNode) => T {
+  const pools = new WeakMap<AudioNode, { voices: T[]; cursor: number }>();
+
+  return (dest: AudioNode) => {
+    let pool = pools.get(dest);
+    if (!pool) {
+      pool = { voices: [], cursor: 0 };
+      pools.set(dest, pool);
+    }
+
+    if (pool.voices.length < size) {
+      const voice = build();
+      voice.connect(dest);
+      pool.voices.push(voice);
+    }
+
+    const next = pool.voices[pool.cursor]!;
+    pool.cursor = (pool.cursor + 1) % pool.voices.length;
+    return next;
+  };
+}
+```
+
+- [x] **Step 4: Refactor bass, metronome, and drums to use the reusable pool**
+
+```ts
+// src/progressions/audio/metronome.ts
+const getClickSynth = createReusableVoicePool(
+  1,
+  () =>
+    new Tone.Synth({
+      oscillator: { type: "sine" },
+      envelope: { attack: 0.001, decay: DECAY, sustain: 0, release: RELEASE },
+    }),
+);
+
+export function scheduleClick(
+  dest: AudioNode,
+  time: number,
+  options: ClickOptions = {},
+): ClickHandle {
+  const velocity = Math.max(0, Math.min(1, options.velocity ?? 0.6));
+  if (velocity <= 0) return { cancel: () => {} };
+
+  const synth = getClickSynth(dest);
+  synth.triggerAttackRelease(
+    options.accent ? ACCENT_FREQ : NORMAL_FREQ,
+    DECAY,
+    time,
+    velocity,
+  );
+
+  return {
+    cancel: () => {
+      synth.triggerRelease?.(Tone.now());
+    },
+  };
+}
+```
+
+- [x] **Step 5: Run the rhythm-voice tests to verify pooled reuse**
+
+Run:
+
+```bash
+pnpm vitest run src/progressions/audio/bass.test.ts src/progressions/audio/drumKit.test.ts src/progressions/audio/metronome.test.ts
+```
+
+Expected: PASS, with the new reuse assertions confirming that the hot path now schedules onto pooled instances.
+
+- [x] **Step 6: Commit Task 4**
+
+```bash
+git add src/progressions/audio/createReusableVoicePool.ts src/progressions/audio/bass.ts src/progressions/audio/drumKit.ts src/progressions/audio/metronome.ts src/progressions/audio/bass.test.ts src/progressions/audio/drumKit.test.ts src/progressions/audio/metronome.test.ts
+git commit -m "perf(audio): pool rhythm voices"
+```
+
+---
+
+### Task 5: Run end-to-end validation for the hot-spot plan
+
+**Files:**
+
+- Test: `src/core/lazyGuitarAudio.test.ts`
+- Test: `src/components/Fretboard/Fretboard.test.tsx`
+- Test: `src/components/Fretboard/Fretboard.performance.test.tsx`
+- Test: `src/progressions/audio/instruments/pianoVoice.test.ts`
+- Test: `src/progressions/audio/instruments/organVoice.test.ts`
+- Test: `src/progressions/audio/bass.test.ts`
+- Test: `src/progressions/audio/drumKit.test.ts`
+- Test: `src/progressions/audio/metronome.test.ts`
+
+- [x] **Step 1: Run the focused performance-related test slice**
+
+Run:
+
+```bash
+pnpm vitest run \
+  src/core/lazyGuitarAudio.test.ts \
+  src/components/Fretboard/Fretboard.test.tsx \
+  src/components/Fretboard/Fretboard.performance.test.tsx \
+  src/progressions/audio/instruments/pianoVoice.test.ts \
+  src/progressions/audio/instruments/organVoice.test.ts \
+  src/progressions/audio/bass.test.ts \
+  src/progressions/audio/drumKit.test.ts \
+  src/progressions/audio/metronome.test.ts
+```
+
+Expected: PASS for the startup-path and voice-reuse coverage added in Tasks 1-4.
+
+- [x] **Step 2: Run the required repo validation commands**
+
+Run:
+
+```bash
+pnpm run lint
+pnpm run test
+pnpm run build
+```
+
+Expected: all three commands PASS.
+
+- [x] **Step 3: Capture the post-change production trace checklist**
+
+```md
+1. Build production assets with `pnpm run build`.
+2. Serve the built app with the existing production Playwright/Vite path.
+3. Record a fresh trace of initial load and the same playback click.
+4. Confirm:
+   - initial paint no longer waits on the fretboard visibility gate,
+   - Tone-backed guitar audio is not in the critical startup graph before audio use,
+   - click-path constructor churn is gone or materially reduced.
+```

--- a/docs/superpowers/specs/2026-05-21-backing-track-tonal-audit.md
+++ b/docs/superpowers/specs/2026-05-21-backing-track-tonal-audit.md
@@ -1,0 +1,183 @@
+# Backing-Track Engine Audit — Tone.js & Tonal.js
+
+**Status:** Research / recommendation pass. No implementation.
+**Date:** 2026-05-21
+**Scope:** `src/progressions/`, `src/core/audio.ts`, `src/core/toneInit.ts`, `src/store/audioAtoms.ts`, `src/store/progressionAtoms.ts`, `src/hooks/useProgressionPlaybackLoop.ts`, `packages/core/src/lib/tonal.ts`, `packages/core/src/theory.ts`.
+
+> **Note on scope:** The original task brief referenced Tonal.js. The user clarified mid-task that the primary intent was to audit **Tone.js** usage (the audio runtime adopted in the recent migrations), with Tonal.js as a secondary lens. This document covers both.
+
+The recent commits `feat(audio): migrate progression scheduler to tone.js`, `feat(audio): adopt Tone.js for GuitarSynth`, and `feat(scale): Scale Simplification` swapped the audio runtime to Tone.js and standardized theory on Tonal.js. The user reports that the backing-track output sounds essentially unchanged. This audit explains why and identifies concrete wins to unlock the value of both libraries.
+
+---
+
+## Section 1 — Data Flow Map
+
+**Entry**: User toggles play → `progressionAtoms.ts:362–373` sets `progressionPlayingStateAtom` via `setProgressionPlayingAtom`, which also stamps `progressionStepDeadlineAtom = Date.now() + progressionStepDurationMs`.
+
+**Audio bus init**: `useProgressionAudioPlayback` calls `ensureProgressionAudio()` (`src/progressions/audio/bus.ts:42–65`), which lazily builds a shared `AudioContext` + master `GainNode` (gain=0.55). `bindToneToProgressionContext()` (`toneBus.ts:20–24`) then calls `Tone.setContext()` so `Tone.now()` and `audio.ctx.currentTime` advance in lockstep — this single binding is the **critical correctness anchor** for the whole engine.
+
+**Chord resolution**: For each active step, `resolveChordVoicing(root, quality)` in `progressionAudio.ts:27–68` maps `(root, quality)` → absolute pitched notes from `CHORD_DEFINITIONS` + `NOTES`. Bass-line notes are resolved separately via `resolveBassLineNotes()` and `resolveBassNoteForRole()` (root / third / fifth / octave / chromatic-approach).
+
+**Scheduler dispatch**: `scheduleProgressionStep()` in `src/progressions/audio/scheduler.ts:110–268` is the central dispatcher. It takes `{ voicing, bassNotes, beatsAvailable, secondsPerBeat, startTime, chordPatternId, bassPatternId, drumPatternId, swing, enable flags }` and walks the pattern catalogs:
+- **Chord/strum** → `getChordPattern(id)` returns `ChordHit[]` (beat, velocity, direction). For each hit, `voice.scheduleChord(bus, voicing, time, …)` on the active chord voice (strum / piano / organ).
+- **Bass** → `getBassPattern(id)` → `scheduleBassNote(bus, freq, time, …)`.
+- **Drums** → `getDrumPattern(id)` returns `{ kicks, snares, hats, openHats, ride }` lanes, each scheduled via the corresponding `scheduleKick / scheduleSnare / scheduleHiHat / scheduleRide` helpers.
+- **Metronome** → `buildMetronomePattern(beatsPerBar)` → `scheduleClick`.
+- **Swing** — applied in beat domain via `swingBeat(beat, swing)` (`scheduler.ts:99–103`) **before** seconds conversion. Off-beats slide forward by `swing * 1/3` beats. Tempo-agnostic.
+
+**Voice scheduling**: Each `schedule*` helper constructs a **fresh** Tone synth, connects it to the passed bus, calls `triggerAttackRelease(note, dur, time, velocity)`, and returns `{ cancel() }`. Disposal is **deferred** via `setTimeout` after an explicit `triggerRelease(Tone.now())` to preserve release tails (pattern repeated identically across all voice files).
+
+**Step advancement**: `useProgressionPlaybackLoop.ts:21–119` uses `getTransport().scheduleOnce(advance, "+remainingSec")` to advance steps on the audio clock; falls back to `window.setTimeout` if Web Audio is unavailable. The visual playhead reads from `timeline.ts` (`getTimelinePosition()`), which polls `audio.ctx.currentTime` — so React UI stays locked to audio.
+
+**One-line summary**: A small beat-grid pattern catalog is iterated in plain JS; each hit instantiates a fresh single-shot Tone synth at an absolute `AudioContext` time, routes to a single master `GainNode`, and disposes itself after release.
+
+---
+
+## Section 2 — Tone.js Audit
+
+### Currently used
+
+| API | Where | Use |
+|-----|-------|-----|
+| `Tone.Synth` | `metronome.ts:35–42`, `organVoice.ts:35–43`, `pianoVoice.ts:35–45` | Metronome clicks, additive partials. |
+| `Tone.PolySynth` | `organVoice.ts:35`, `pianoVoice.ts:35` | Per-chord polyphonic dispatch (max polyphony set per-call). |
+| `Tone.MonoSynth` | `bass.ts:48–60` | Bass note (saw + filter envelope). |
+| `Tone.PluckSynth` | `string.ts:43–48` | Strum voice (Karplus-Strong). |
+| `Tone.MembraneSynth` | `drumKit.ts:85–96` | Kick. |
+| `Tone.NoiseSynth` | `drumKit.ts:115–126` | Snare. |
+| `Tone.MetalSynth` | `drumKit.ts:149–157, 182–190` | Hi-hat, ride. |
+| `Tone.Filter`, `Tone.Volume` | `core/audio.ts:92–102` | GuitarSynth fixed-LP + master volume w/ `rampTo`. |
+| `Tone.gainToDb` | `string.ts:55` | Velocity → dB for PluckSynth. |
+| `Tone.now()` | All voice files | Explicit release time on cancel. |
+| `Tone.Transport.start / scheduleOnce / clear` | `useProgressionPlaybackLoop.ts:3, 65, 85, 94` | **Step boundary** only — not pattern scheduling. |
+| `Tone.setContext / getContext / start` | `toneBus.ts:22`, `toneInit.ts:15, 71` | Bind to shared `AudioContext`; resume on gesture. |
+
+### Not used but should be (with file:line targets and "why no audible change yet")
+
+1. **`Tone.Part` for chord/bass/drum patterns** — `scheduler.ts:110–268`.
+   The scheduler iterates patterns in plain JS and schedules each hit by raw absolute time. `Tone.Part` is designed for this exact shape: `new Tone.Part((time, hit) => voice.scheduleChord(...), hits).start(startTime).stop(startTime + beatsAvailable)`. Eliminates manual `barStart += beatsPerBar` arithmetic, integrates with Transport, simplifies cancellation. *Why the migration didn't change sound: every hit still fires at the same absolute audio time; Part is a structural improvement, not a sonic one.*
+
+2. **Effects chain on master bus** — `toneBus.ts:20–104`.
+   The bus connects voices **directly** to destination. There is no `Tone.Reverb`, `Tone.Chorus`, `Tone.PingPongDelay`, `Tone.Compressor`, `Tone.Limiter`, or `Tone.EQ3` anywhere in the signal path. This is the single largest reason the user perceived no change after the migration: **timbre is identical whether the runtime is raw Web Audio or Tone.js if no effects are inserted**. A 1.5 s `Tone.Reverb` + bus `Tone.Compressor` would be the biggest perceptual unlock with the smallest diff.
+
+3. **`Tone.Sampler` / `Tone.Players` for drums** — `drumKit.ts:77–192`.
+   Drums are 100% synthesized (Membrane / Noise / Metal). For a backing track, drum *samples* drive ~80% of perceived production value. `Tone.Players({ kick, snare, hihat, ride, … })` with a small hosted kit would be a dramatic upgrade. (Trade-off: asset bundle / network.) *Why no audible change yet: nothing about the kit changed in the migration — same synth types as before.*
+
+4. **`Tone.Transport.scheduleRepeat` for metronome** — `scheduler.ts:233–260`.
+   Metronome clicks are enumerated per-beat through the same imperative loop as the rest. A single `scheduleRepeat("4n", cb)` on Transport would be both cheaper and more idiomatic, and would let the metronome run independently of step boundaries (useful for count-in / fill bars).
+
+5. **`Tone.PolySynth` instance reuse + `releaseAll`** — `organVoice.ts`, `pianoVoice.ts`.
+   Each chord hit **constructs a new PolySynth and disposes it after release**. This is expensive (allocates voices, builds filter graphs) and is the most likely source of any audible artifacts at fast tempos. Cache one PolySynth per voice type, set `maxPolyphony` at init, and reuse — `releaseAll(Tone.now())` on stop. Same approach for `MonoSynth` bass.
+
+6. **Humanization via per-hit jitter** — `scheduler.ts` and pattern data in `patterns.ts:315–429`.
+   No timing or velocity jitter on hits. A `±5 ms` timing nudge and `±0.05` velocity wobble (cheap to add at scheduling time, even without new Tone APIs) would shake off the "drum machine" feel. Tone helpers: `Tone.Time`, `Tone.Frequency` for unit conversion if needed.
+
+7. **`Tone.Channel` / sub-buses for per-instrument mix** — `toneBus.ts`.
+   Everything routes to one master `GainNode`. Per-instrument `Tone.Channel` (with `volume`, `pan`, `solo`, `mute`) would enable a mix UI and per-genre balance presets in `genres.ts` without rewiring scheduling.
+
+8. **`Tone.Draw` for visual sync** — `useProgressionPlaybackLoop.ts`.
+   Visual position is polled from `audio.ctx.currentTime`. `Tone.Draw.schedule(fn, time)` runs callbacks aligned to the audio clock via `requestAnimationFrame` — a cleaner path for animating chord changes in lockstep with audio. Low priority; current polling works.
+
+9. **`Tone.Meter`** — `toneBus.ts`. Useful for a future level/clip indicator. Low priority.
+
+---
+
+## Section 3 — Tonal.js Audit
+
+### Currently used
+
+| API | Where | Use |
+|-----|-------|-----|
+| `@tonaljs/note` | `packages/core/src/lib/tonal.ts`, `theory.ts` | `Note.transpose`, `Note.simplify`, `Note.enharmonic`, `Note.chroma`. |
+| `@tonaljs/interval` | `lib/tonal.ts`, `theory.ts` | `Interval.distance`, `Interval.fromSemitones`. |
+| `@tonaljs/scale` | `theory.ts:482` | `Scale.get` inside `getScaleNotes`. |
+| `@tonaljs/chord` | `theory.ts:509` | `Chord.get` inside `getChordNotes`. |
+| `@tonaljs/key` | `theory.ts:578`, `degrees.ts` | `Key.majorKey / minorKey` for signatures + degree resolution. |
+
+Inside the **backing-track path**, Tonal is reached only via `getDiatonicChord()` (`progressionGeneration.ts:40`) — i.e., one symbol → triad notes. Everything downstream (voicing, bass-note role, beat dispatch) is hand-rolled.
+
+### Not used but should be (with file:line targets)
+
+1. **`Tonal.RomanNumeral`** — `progressionDomain.ts` (Roman-numeral parsing) and `degrees.ts`.
+   Roman numerals are parsed with hand-rolled regex + lookup. `RomanNumeral.get("V7")` returns `{ chordType, root, …}` and consolidates degree+quality+inversion handling. Direct replacement.
+
+2. **`Tonal.Progression.fromRomanNumerals / toRomanNumerals`** — `progressionGeneration.ts:40–98`.
+   Generate progressions from `["I", "vi", "ii", "V"]` in any key for free. Currently templates store absolute chord data and have to be re-rooted manually.
+
+3. **`Tonal.Key.chords / Key.secondaryDominants`** — `progressionGeneration.ts`.
+   The cadential/cycle template catalog hand-encodes diatonic pools. `Key.majorKey("C").chords` returns the full diatonic 7-chord list, and `.secondaryDominants` returns V/ii, V/iii, etc. — unlocks "suggest a secondary dominant here" features for free.
+
+4. **`Tonal.Mode`** — `theory.ts`, scale catalog.
+   Modes are listed as standalone scales. `Mode.notes(modeName, tonic)` + `Mode.triads` would let the backing-track engine pick mode-appropriate chord pools (e.g. Dorian → i, IV, v, ♭VII).
+
+5. **`Tonal.Chord.extended / Chord.detect`** — `progressionAudio.ts:27–68`.
+   `Chord.get("CM").notes` is the only path used. `Chord.extended("CM")` yields 7ths/9ths/11ths/13ths automatically — a richer voicing source for jazz genres. `Chord.detect(notes)` would let the UI label inversions (`C/E`).
+
+6. **`Tonal.Range / Tonal.Note.transpose` for register-aware bass** — `progressionAudio.ts` `resolveBassNoteForRole`.
+   Bass octave is currently hard-coded. `Range.numeric(["E1","E3"])` + nearest-pitch lookup would keep bass in a coherent register across keys (right now low-key bass can drop below the open low E).
+
+7. **Voice-leading (community: `tonal-voice-leading`)** — `progressionAudio.ts`, `scheduler.ts:154–188`.
+   Each chord re-stacks from a fixed root octave, ignoring the previous chord. A nearest-inversion picker (manually implementable on top of `Tonal.Note.midi` distance, no extra dep needed) would minimize aggregate semitone motion between adjacent voicings. This is the single biggest *Tonal-side* perceptual win — and the user almost certainly notices it on chord changes.
+
+---
+
+## Section 4 — Top 5 Wins (Impact ÷ Effort)
+
+Ranked for a v2.1+ plan. Each notes file:line, expected user-perceptible delta, and the reason the recent migration didn't deliver it.
+
+### 1. Master-bus effects chain (Reverb + Compressor + Limiter) — **biggest unlock**
+- **File**: `src/progressions/audio/toneBus.ts:20–104`.
+- **Change**: `bus → Tone.Compressor → Tone.Reverb (decay 1.5s, wet 0.18) → Tone.Limiter → destination`.
+- **Effort**: ~30 lines, no scheduling changes.
+- **Why migration alone didn't help**: Tone.js was adopted *as a 1:1 replacement for raw Web Audio voices*. No effects nodes were inserted into the signal path, so the spectrum reaching the speakers is identical to pre-migration.
+
+### 2. Voice-leading / nearest-inversion picker for chord voicings
+- **Files**: `src/progressions/progressionAudio.ts:27–68` (resolve), `src/progressions/audio/scheduler.ts:154–188` (dispatch).
+- **Change**: Track the previous chord's voicing; when resolving the next, evaluate all inversions and pick the one minimizing total semitone distance (Tonal `Note.midi`).
+- **Effort**: One small module + state thread-through.
+- **Why migration alone didn't help**: Voicings still come from `CHORD_DEFINITIONS` stacked from a fixed `rootOctave` — the migration didn't change voicing logic.
+
+### 3. Cache & reuse PolySynth / MonoSynth instances; stop allocating per-hit
+- **Files**: `src/progressions/audio/instruments/pianoVoice.ts`, `organVoice.ts`, `src/progressions/audio/bass.ts`.
+- **Change**: One PolySynth per chord-voice type, set `maxPolyphony` at init, `triggerAttackRelease` per hit, `releaseAll` on cancel. Drop deferred `dispose` + `setTimeout` cleanup pattern.
+- **Effort**: Localized refactor of each voice file.
+- **Why migration alone didn't help**: The migration ported the **per-hit construct-and-dispose** pattern from the old Web Audio code instead of moving to Tone's reuse model. Likely cause of any tempo-dependent CPU spikes / clicks.
+
+### 4. Real drum samples via `Tone.Players`
+- **Files**: `src/progressions/audio/drumKit.ts` (all `schedule*`).
+- **Change**: Bundle or host a compact kit (kick/snare/hat/open-hat/ride), load via `Tone.Players`, velocity → `playbackRate` + `volume`.
+- **Effort**: Asset pipeline + ~80 LOC.
+- **Why migration alone didn't help**: Migration kept `MembraneSynth / NoiseSynth / MetalSynth` — same synthesized timbres as the pre-Tone era.
+
+### 5. `Tone.Part` for chord/bass/drum patterns + `scheduleRepeat` for metronome
+- **File**: `src/progressions/audio/scheduler.ts:110–268`.
+- **Change**: Replace the imperative pattern loops with one `Tone.Part` per lane started at `startTime` and stopped at `startTime + beatsAvailable`. Run metronome as a long-lived `Transport.scheduleRepeat("4n", …)`.
+- **Effort**: Medium — touches the scheduler core but reduces code overall.
+- **Why migration alone didn't help**: Strictly a structural / maintenance win; sonically identical at first.
+
+**Honorable mentions** (lower in the ranking but cheap):
+- Per-hit velocity & timing humanization (`scheduler.ts`).
+- Per-instrument `Tone.Channel` sub-buses, exposing pan/volume for a future mix UI (`toneBus.ts`).
+- Consolidate Roman-numeral parsing on `Tonal.RomanNumeral` (`progressionDomain.ts`, `degrees.ts`).
+
+---
+
+## Section 5 — Notes & Caveats
+
+- **Why the Tone migration was "silent"**: It was a runtime swap, not a sound-design change. Tone.js doesn't make audio sound better automatically — its leverage is in (a) higher-level scheduling (Part / Sequence / Transport), and (b) the rich effects library. Items (a) and (b) were left untouched in the migration. The current code uses Tone as "raw oscillators with envelopes," which is identical in output to the prior Web Audio implementation.
+- **Why the Tonal adoption was "silent"**: Only `Chord.get / Scale.get / Key.majorKey` are reached. Tonal's structural APIs — `RomanNumeral`, `Progression`, `Mode`, `Key.chords` — replace hand-rolled code without changing what the user hears. They unlock *features* (mode-aware suggestions, secondary dominants, automatic re-rooting of templates), not sound.
+- **The audio-clock binding via `Tone.setContext` (`toneBus.ts:22`) is correct and load-bearing** — don't refactor it casually.
+- **Deferred `setTimeout` disposal** is a workaround for per-hit synth construction. Recommendation #3 removes the need.
+- **Swing implementation is solid**. Beat-domain swing is tempo-agnostic; keep it.
+- **Voice-leading is the most musically impactful Tonal-side win**; effects chain is the most musically impactful Tone-side win. Recommend doing both before any drum-sample work, since each is much cheaper.
+
+---
+
+## Suggested v2.1 sequencing
+
+1. **Effects chain on master bus** (1 PR, low risk, high perceptual delta).
+2. **PolySynth/MonoSynth reuse** (refactor; eliminates one cluster of latent bugs).
+3. **Voice-leading inversion picker** (new module; user-audible on every chord change).
+4. **Tone.Part scheduler rewrite** (medium-risk core refactor; structural).
+5. **Drum samples via `Tone.Players`** (asset work; biggest single perceptual jump but most logistics).
+6. **Tonal `RomanNumeral / Key.chords / Progression` consolidation** (theory-side cleanup; enables modal & secondary-dominant features).

--- a/docs/superpowers/specs/2026-05-22-performance-improvement-design.md
+++ b/docs/superpowers/specs/2026-05-22-performance-improvement-design.md
@@ -1,0 +1,267 @@
+# Performance Improvement Plan — Design
+
+**Status:** Brainstorm spec. Produced 2026-05-22 from a trace-led audit of startup, fretboard render, and progression audio scheduling.
+
+**Date:** 2026-05-22
+
+**Scope:** Improve production-first performance for `http://localhost:5173/fretboard-app/` while still benefiting local dev responsiveness. Focus on the current LCP render delay and the click-path INP hotspot without changing the musical model or visible fretboard behavior.
+
+**Non-goals:** No sound-design expansion, no new drum samples, no `Tone.Part` scheduler rewrite in this pass, no route-level app restructuring, and no unrelated fretboard refactors.
+
+---
+
+## 1. Background
+
+The provided trace shows two distinct classes of work:
+
+1. **Startup / LCP**
+   - LCP is `709 ms`, with only `7 ms` in TTFB and `702 ms` in render delay.
+   - The startup path is therefore dominated by main-thread work, not network latency.
+
+2. **Interaction / INP**
+   - The longest interaction is a `click` at `329 ms`.
+   - `293 ms` of that is processing time, not input delay.
+   - The hottest stack is React passive-effect flush work that reaches the progression audio scheduler and Tone.js constructors.
+
+The code audit maps those findings to concrete sources:
+
+- `src/App.tsx` imports `synth` from `src/core/audio.ts` at module scope.
+- `src/components/Fretboard/Fretboard.tsx` also imports the same eager synth path.
+- `src/core/audio.ts` imports `tone` at module scope and constructs Tone nodes on demand behind a singleton API.
+- `src/components/Fretboard/Fretboard.tsx` hides the fretboard until a layout read / `ResizeObserver` pass sets `containerWidth`.
+- `src/hooks/useProgressionAudioPlayback.ts` rebuilds active segments in a React effect when playback state changes.
+- `src/progressions/audio/scheduler.ts` schedules many individual hits per step.
+- `src/progressions/audio/instruments/pianoVoice.ts`, `organVoice.ts`, `src/progressions/audio/bass.ts`, `src/progressions/audio/drumKit.ts`, and `src/progressions/audio/metronome.ts` allocate fresh Tone synth graphs per scheduled hit.
+
+The existing `docs/superpowers/specs/2026-05-21-backing-track-tonal-audit.md` already identified per-hit Tone allocation as a structural issue. This design turns that audit into a performance-first implementation direction.
+
+---
+
+## 2. Core insight
+
+The app has **two independent hot paths** and they should be treated separately:
+
+1. **The startup path is paying for audio and measurement work too early.**
+   The initial render should not have to import the guitar synth runtime or wait for fretboard measurement before the main visual content becomes visible.
+
+2. **The click path is paying for construction instead of scheduling.**
+   Playback interactions should mostly enqueue work onto already-live audio primitives. They should not allocate `PolySynth`, `MonoSynth`, `MetalSynth`, `Synth`, filters, oscillators, and disposal timers inside the same effect flush that responds to the user's click.
+
+The chosen approach is therefore **phase the hot spots**:
+
+- first move work off the critical startup path,
+- then reuse audio voices without rewriting the full scheduler model,
+- and preserve the existing progression, swing, and rendering semantics while doing so.
+
+---
+
+## 3. Chosen approach
+
+Three approaches were considered:
+
+- **A — Phase the hot spots (chosen).**
+  Address startup, first paint, and click-path allocation directly while keeping the current progression and pattern architecture intact.
+- **B — Audio-engine refactor first.**
+  Rewrite scheduling around longer-lived Tone constructs such as `Tone.Part` and broader Transport ownership. Rejected for this pass because it is higher risk and not required to remove the traced bottleneck.
+- **C — Render-and-bundle first.**
+  Focus on LCP only and leave most playback behavior unchanged. Rejected because it would leave the measured click-path stall mostly intact.
+
+Approach A is the right balance for the user’s stated goal: **both production and dev should improve, but production is the priority**.
+
+---
+
+## 4. Workstream 1 — Startup path / LCP
+
+### Goal
+
+Make the first meaningful paint independent of the audio runtime and avoid gating fretboard visibility on the initial measurement pass.
+
+### Design
+
+#### 4a. Remove eager audio imports from the startup graph
+
+- `src/App.tsx` and `src/components/Fretboard/Fretboard.tsx` should stop importing the audio singleton directly at module scope.
+- The guitar-synth path should move behind a lazy audio facade that is only loaded when the user performs an audio-relevant action:
+  - first fret click,
+  - first mute/unmute interaction that truly needs audio,
+  - first explicit resume/play action.
+
+This aligns `src/core/audio.ts` with the existing lazy pattern already present in `src/progressions/audio/bus.ts`.
+
+#### 4b. Keep autoplay correctness
+
+- `src/core/toneInit.ts` and the existing first-gesture resume behavior remain conceptually intact.
+- Lazy loading must not fire Tone startup outside a valid user gesture.
+- The change is about **when the code is loaded**, not about weakening the autoplay protections.
+
+#### 4c. Stop hiding the fretboard until measurement completes
+
+`src/components/Fretboard/Fretboard.tsx` currently renders the scroll container with:
+
+- `containerWidth === null ? "hidden" : "visible"`,
+- immediate `clientWidth` reads in `useLayoutEffect`,
+- follow-up `ResizeObserver` logic.
+
+That means a layout read decides whether the main fretboard can appear at all. The redesign is:
+
+- render immediately with a stable fallback width/zoom assumption,
+- allow the first paint to occur,
+- refine width, overflow, and cursor behavior after paint,
+- keep `ResizeObserver` for steady-state resizing.
+
+The fretboard can still settle into its measured layout, but initial visibility is no longer blocked on that settlement.
+
+### Expected effect
+
+- Better production LCP and perceived first paint.
+- Less main-thread work on the critical render path.
+- Smaller chance of forced reflow around initial fretboard reveal.
+
+---
+
+## 5. Workstream 2 — Click-path / INP
+
+### Goal
+
+Turn playback interactions back into scheduling work instead of allocation work.
+
+### Design
+
+#### 5a. Keep the current scheduler contract
+
+`src/progressions/audio/scheduler.ts` remains the central dispatcher for:
+
+- chord hits,
+- bass hits,
+- drum lanes,
+- metronome clicks,
+- swing application in beat space.
+
+This pass does **not** rewrite the progression model or the pattern catalog. It preserves the existing timing semantics and audible behavior.
+
+#### 5b. Replace per-hit voice construction with reusable voices or small pools
+
+The current hot path constructs fresh Tone nodes per hit in:
+
+- `src/progressions/audio/instruments/pianoVoice.ts`
+- `src/progressions/audio/instruments/organVoice.ts`
+- `src/progressions/audio/bass.ts`
+- `src/progressions/audio/drumKit.ts`
+- `src/progressions/audio/metronome.ts`
+
+The redesign is:
+
+- chord voices use one reusable `PolySynth` or a tiny stable pool,
+- bass uses a reusable mono/pool strategy that still handles overlapping releases,
+- drums and metronome use lane-specific reusable instances or small pools sized for overlap,
+- cancellation shifts away from “dispose a just-created synth later” toward “release or recycle an already-owned voice.”
+
+This keeps the public scheduling surface stable while removing the expensive constructors from the interaction path.
+
+#### 5c. Keep the shared audio clock binding intact
+
+`src/progressions/audio/toneBus.ts` correctly binds Tone to the shared progression `AudioContext`. That behavior is load-bearing and must remain unchanged.
+
+### Expected effect
+
+- Material INP improvement on play/toggle interactions.
+- Less GC pressure from bursty Tone allocation.
+- Fewer long passive-effect flushes in React when playback state changes.
+
+---
+
+## 6. Workstream 3 — Render-path guardrails
+
+### Goal
+
+Improve performance without changing the app’s musical or visual contract.
+
+### Guardrails
+
+- Preserve current progression timing and audio-clock ownership.
+- Preserve current pattern IDs, swing behavior, and progression step semantics.
+- Preserve current fretboard layout behavior after the initial paint settles.
+- Avoid unrelated refactors inside `FretboardSVG.tsx` unless a change is directly required for the first-render plan.
+
+### Notes
+
+The trace came from localhost dev mode, so React StrictMode and dev-tooling overhead likely inflate the raw timings. That does **not** invalidate the root causes:
+
+- eager audio imports still hurt production startup,
+- per-hit Tone allocation still hurts production interactions.
+
+This plan therefore treats dev-mode noise as measurement noise, not as the target architecture.
+
+---
+
+## 7. Phasing
+
+This work should be implemented in three shippable phases.
+
+### Phase 1 — Startup path
+
+- Introduce the lazy audio facade for the guitar synth path.
+- Remove eager startup imports from `App.tsx` and `Fretboard.tsx`.
+- Change `Fretboard.tsx` so initial visibility does not depend on `containerWidth` being measured.
+
+**Primary win:** LCP / startup render delay.
+
+### Phase 2 — Voice reuse
+
+- Refactor piano, organ, bass, drums, and metronome helpers to reuse stable Tone resources.
+- Preserve the `schedule*` API surface so `scheduler.ts` changes remain minimal.
+
+**Primary win:** INP / click-path processing time.
+
+### Phase 3 — Follow-up hardening
+
+- Trim any leftover layout thrash in fretboard overflow/cursor logic.
+- Add focused regression tests and confirm the startup and interaction traces improved.
+- Reassess whether a larger scheduler rewrite is still needed after the cheaper wins land.
+
+**Primary win:** stability and evidence.
+
+---
+
+## 8. Testing and verification
+
+Use the repo’s existing test/build shape:
+
+- `pnpm run lint`
+- `pnpm run test`
+- `pnpm run build`
+
+Add or update focused tests where coverage is thin:
+
+- lazy audio facade behavior,
+- first-interaction audio resume behavior,
+- reusable voice lifecycle / cancellation,
+- fretboard initial render behavior when width is not yet measured.
+
+Performance verification should include:
+
+- production bundle inspection,
+- a fresh production-oriented trace,
+- confirmation that playback clicks no longer spend most of their time constructing Tone synth graphs.
+
+---
+
+## 9. Acceptance criteria
+
+- Tone-backed guitar audio is no longer part of the critical startup graph unless the user actually engages audio.
+- The fretboard can paint on initial load without waiting for the first measurement pass to flip visibility.
+- Playback-related clicks no longer allocate fresh Tone synth graphs per scheduled hit on the hot path.
+- Existing playback timing, swing, and progression behavior remain intact.
+- `pnpm run lint`, `pnpm run test`, and `pnpm run build` pass after implementation.
+
+---
+
+## 10. Out of scope for this pass
+
+These remain valid future work, but are intentionally not part of this design:
+
+- `Tone.Part` / Transport lane rewrite of the full scheduler,
+- drum samples via `Tone.Players`,
+- effects-chain/sound-design upgrades,
+- large `FretboardSVG.tsx` render-graph simplification,
+- broader route/component chunking beyond the audio path.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -191,7 +191,7 @@ describe("App", () => {
     it("keeps the global gesture listeners installed when resume fails", async () => {
       mockResumeGuitarAudio
         .mockRejectedValueOnce(new Error("resume failed"))
-        .mockResolvedValueOnce(true);
+        .mockResolvedValueOnce(undefined);
 
       render(<App />);
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -9,7 +9,10 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import App from "./App";
-import { setGuitarMutePreference } from "./core/lazyGuitarAudio";
+import {
+  resumeGuitarAudio,
+  setGuitarMutePreference,
+} from "./core/lazyGuitarAudio";
 import { get3NPSCoordinates, STANDARD_TUNING } from "@fretflow/core";
 import { k } from "./test-utils/storage";
 
@@ -60,6 +63,8 @@ vi.mock("./core/lazyGuitarAudio", () => ({
   playGuitarNote: vi.fn(),
 }));
 
+const mockResumeGuitarAudio = vi.mocked(resumeGuitarAudio);
+
 const setViewport = (width: number, height: number) => {
   Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: width });
   Object.defineProperty(window, "innerHeight", { writable: true, configurable: true, value: height });
@@ -76,6 +81,7 @@ describe("App", () => {
     localStorage.clear();
     vi.clearAllMocks();
     setViewport(1920, 1200);
+    mockResumeGuitarAudio.mockResolvedValue(false);
   });
   afterEach(() => localStorage.clear());
 
@@ -166,6 +172,44 @@ describe("App", () => {
       await waitFor(() => {
         expect(document.documentElement.getAttribute("data-theme")).toBe("modern-light");
       });
+    });
+
+    it("keeps the global gesture listeners installed until resume succeeds on a loaded runtime", async () => {
+      mockResumeGuitarAudio.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+      render(<App />);
+
+      fireEvent.click(window);
+      expect(mockResumeGuitarAudio).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(window);
+      await waitFor(() => {
+        expect(mockResumeGuitarAudio).toHaveBeenCalledTimes(2);
+      });
+
+      fireEvent.click(window);
+      expect(mockResumeGuitarAudio).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps the global gesture listeners installed when resume fails", async () => {
+      mockResumeGuitarAudio
+        .mockRejectedValueOnce(new Error("resume failed"))
+        .mockResolvedValueOnce(true);
+
+      render(<App />);
+
+      fireEvent.click(window);
+      await waitFor(() => {
+        expect(mockResumeGuitarAudio).toHaveBeenCalledTimes(1);
+      });
+
+      fireEvent.click(window);
+      await waitFor(() => {
+        expect(mockResumeGuitarAudio).toHaveBeenCalledTimes(2);
+      });
+
+      fireEvent.click(window);
+      expect(mockResumeGuitarAudio).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import App from "./App";
-import { synth } from "./core/audio";
+import { setGuitarMutePreference } from "./core/lazyGuitarAudio";
 import { get3NPSCoordinates, STANDARD_TUNING } from "@fretflow/core";
 import { k } from "./test-utils/storage";
 
@@ -53,13 +53,11 @@ vi.mock("./components/CircleOfFifths/CircleOfFifths", async () => {
   };
 });
 
-vi.mock("./core/audio", () => ({
-  synth: {
-    setMute: vi.fn(),
-    init: vi.fn(),
-    playNote: vi.fn(),
-    resume: vi.fn(),
-  },
+vi.mock("./core/lazyGuitarAudio", () => ({
+  setGuitarMutePreference: vi.fn(),
+  setGuitarAudioErrorHandler: vi.fn(),
+  resumeGuitarAudio: vi.fn(),
+  playGuitarNote: vi.fn(),
 }));
 
 const setViewport = (width: number, height: number) => {
@@ -98,7 +96,7 @@ describe("App", () => {
     it("seeds isMuted in storage and forwards initial mute state to synth", () => {
       localStorage.setItem(k("isMuted"), "true");
       render(<App />);
-      expect(synth.setMute).toHaveBeenCalledWith(true);
+      expect(setGuitarMutePreference).toHaveBeenCalledWith(true);
       expect(localStorage.getItem(k("isMuted"))).toBe("true");
     });
   });
@@ -155,7 +153,7 @@ describe("App", () => {
       fireEvent.click(muteBtn);
       await waitFor(() => {
         expect(localStorage.getItem(k("isMuted"))).toBe("true");
-        expect(synth.setMute).toHaveBeenCalled();
+        expect(setGuitarMutePreference).toHaveBeenCalled();
       });
     });
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -81,7 +81,6 @@ describe("App", () => {
     localStorage.clear();
     vi.clearAllMocks();
     setViewport(1920, 1200);
-    mockResumeGuitarAudio.mockResolvedValue(false);
   });
   afterEach(() => localStorage.clear());
 
@@ -174,21 +173,19 @@ describe("App", () => {
       });
     });
 
-    it("keeps the global gesture listeners installed until resume succeeds on a loaded runtime", async () => {
-      mockResumeGuitarAudio.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    it("keeps the global gesture listeners installed until resume succeeds", async () => {
+      mockResumeGuitarAudio.mockResolvedValue();
 
       render(<App />);
 
       fireEvent.click(window);
-      expect(mockResumeGuitarAudio).toHaveBeenCalledTimes(1);
-
-      fireEvent.click(window);
       await waitFor(() => {
-        expect(mockResumeGuitarAudio).toHaveBeenCalledTimes(2);
+        expect(mockResumeGuitarAudio).toHaveBeenCalledTimes(1);
       });
 
+      // After first success, listeners should be removed.
       fireEvent.click(window);
-      expect(mockResumeGuitarAudio).toHaveBeenCalledTimes(2);
+      expect(mockResumeGuitarAudio).toHaveBeenCalledTimes(1);
     });
 
     it("keeps the global gesture listeners installed when resume fails", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,11 @@ import { useSetAtom, useAtomValue, useAtom, createStore, Provider } from "jotai"
 import { AnimatePresence, motion } from "motion/react";
 import { Fretboard } from "./components/Fretboard/Fretboard";
 import { HelpCircle, Moon, Settings2, Sun, Volume2, VolumeX } from "lucide-react";
-import { synth } from "./core/audio";
+import {
+  resumeGuitarAudio,
+  setGuitarAudioErrorHandler,
+  setGuitarMutePreference,
+} from "./core/lazyGuitarAudio";
 import { isMutedAtom, toggleMuteAtom, audioErrorAtom } from "./store/audioAtoms";
 import { chordRootAtom, chordTypeAtom, chordOverlayHiddenAtom } from "./store/chordOverlayAtoms";
 import { rootNoteAtom, scaleNameAtom } from "./store/scaleAtoms";
@@ -59,20 +63,20 @@ function AppContent() {
   }, [theme]);
 
   useEffect(() => {
-    synth.setMute(isMuted);
+    setGuitarMutePreference(isMuted);
   }, [isMuted]);
 
   useEffect(() => {
-    synth.onError = (msg) => setAudioError(msg);
+    setGuitarAudioErrorHandler((msg) => setAudioError(msg));
     return () => {
-      synth.onError = undefined;
+      setGuitarAudioErrorHandler(undefined);
     };
   }, [setAudioError]);
 
   // Safari/iOS robustness: resume AudioContext on first interaction
   useEffect(() => {
     const handleGesture = () => {
-      void synth.resume();
+      void resumeGuitarAudio();
       window.removeEventListener("click", handleGesture);
       window.removeEventListener("touchstart", handleGesture);
     };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,10 +82,8 @@ function AppContent() {
 
     const handleGesture = () => {
       void Promise.resolve(resumeGuitarAudio())
-        .then((didResume) => {
-          if (didResume) {
-            removeGestureListeners();
-          }
+        .then(() => {
+          removeGestureListeners();
         })
         .catch(() => {
           // Keep listeners installed so the next gesture can retry resume.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,16 +75,26 @@ function AppContent() {
 
   // Safari/iOS robustness: resume AudioContext on first interaction
   useEffect(() => {
-    const handleGesture = () => {
-      void resumeGuitarAudio();
+    const removeGestureListeners = () => {
       window.removeEventListener("click", handleGesture);
       window.removeEventListener("touchstart", handleGesture);
+    };
+
+    const handleGesture = () => {
+      void Promise.resolve(resumeGuitarAudio())
+        .then((didResume) => {
+          if (didResume) {
+            removeGestureListeners();
+          }
+        })
+        .catch(() => {
+          // Keep listeners installed so the next gesture can retry resume.
+        });
     };
     window.addEventListener("click", handleGesture);
     window.addEventListener("touchstart", handleGesture);
     return () => {
-      window.removeEventListener("click", handleGesture);
-      window.removeEventListener("touchstart", handleGesture);
+      removeGestureListeners();
     };
   }, []);
 

--- a/src/components/Fretboard/Fretboard.performance.test.tsx
+++ b/src/components/Fretboard/Fretboard.performance.test.tsx
@@ -74,4 +74,24 @@ describe("Fretboard performance wiring", () => {
     expect(second.fullChordPositionKeys).toBe(first.fullChordPositionKeys);
     expect(second.fullChordVoicings).toBe(first.fullChordVoicings);
   });
+
+  it("still reuses expensive derived props when zoom changes after width fallback", () => {
+    const store = createStore();
+
+    render(
+      <Provider store={store}>
+        <Fretboard stringRowPx={40} />
+      </Provider>,
+    );
+
+    const first = received.at(-1)!;
+
+    act(() => {
+      store.set(fretZoomAtom, 150);
+    });
+
+    const second = received.at(-1)!;
+    expect(second.fretboardLayout).toBe(first.fretboardLayout);
+    expect(second.fullChordVoicings).toBe(first.fullChordVoicings);
+  });
 });

--- a/src/components/Fretboard/Fretboard.test.tsx
+++ b/src/components/Fretboard/Fretboard.test.tsx
@@ -73,6 +73,12 @@ describe("Fretboard/Fretboard", () => {
       expect(container.firstChild).toBeTruthy();
     });
 
+    it("keeps the fretboard visible before ResizeObserver publishes width", () => {
+      const { container } = render(<Fretboard {...defaultProps} />);
+      const wrapper = container.querySelector('[class*="fretboard-wrapper"]');
+      expect(wrapper).not.toHaveStyle({ visibility: "hidden" });
+    });
+
     it("renders all 6 strings for standard tuning", () => {
       const { container } = render(<Fretboard {...defaultProps} />);
       // Fretboard has 6 rows for standard tuning

--- a/src/components/Fretboard/Fretboard.tsx
+++ b/src/components/Fretboard/Fretboard.tsx
@@ -7,7 +7,7 @@ import {
   getFretNoteWithOctave,
   getNoteFrequency,
 } from "@fretflow/core";
-import { synth } from "../../core/audio";
+import { playGuitarNote } from "../../core/lazyGuitarAudio";
 import { fretZoomAtom } from "../../store/layoutAtoms";
 import type { AutoCenterTarget } from "../../store/shapeAtoms";
 import { FretboardSVG } from "../FretboardSVG/FretboardSVG";
@@ -259,7 +259,7 @@ export function Fretboard(props: FretboardProps) {
     pendingTarget.current = null;
   }, [updateCursor]);
 
-  const handleFretClick = useCallback((
+  const handleFretClick = useCallback(async (
     stringIndex: number,
     fretIndex: number,
     noteName: string,
@@ -270,7 +270,7 @@ export function Fretboard(props: FretboardProps) {
       fretIndex,
     );
     const frequency = getNoteFrequency(fretNoteWithOctave);
-    synth.playNote(frequency);
+    await playGuitarNote(frequency);
     if (onFretClickProp) onFretClickProp(stringIndex, fretIndex, noteName);
   }, [tuning, onFretClickProp]);
 

--- a/src/components/Fretboard/Fretboard.tsx
+++ b/src/components/Fretboard/Fretboard.tsx
@@ -135,15 +135,18 @@ export function Fretboard(props: FretboardProps) {
     [state.fullChordMatches],
   );
 
-  const [containerWidth, setContainerWidth] = useState<number | null>(null);
+  const [containerWidth, setContainerWidth] = useState<number>(() => {
+    if (typeof window === "undefined") return 0;
+    return Math.max(window.innerWidth, 320);
+  });
   const totalColumns = endFret - startFret;
   const noteBubblePx = Math.round(stringRowPx * NOTE_BUBBLE_RATIO);
   const MIN_FRET_WIDTH = Math.max(MIN_FRET_WIDTH_BASE, noteBubblePx + MIN_FRET_WIDTH_OVERFLOW_BUFFER);
   
   const autoFitZoom = Math.max(
     MIN_FRET_WIDTH,
-    containerWidth !== null && containerWidth > 0 && totalColumns > 0 
-      ? containerWidth / totalColumns 
+    containerWidth > 0 && totalColumns > 0
+      ? containerWidth / totalColumns
       : 40,
   );
   const desktopZoom =
@@ -162,11 +165,10 @@ export function Fretboard(props: FretboardProps) {
   useLayoutEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
-    setContainerWidth(el.clientWidth);
+    if (el.clientWidth > 0) setContainerWidth(el.clientWidth);
     const ro = new ResizeObserver((entries) => {
-      if (entries.length === 0) return;
-      const entry = entries[0];
-      if (entry) setContainerWidth(entry.contentRect.width);
+      const width = entries[0]?.contentRect.width ?? 0;
+      if (width > 0) setContainerWidth(width);
     });
     ro.observe(el);
     return () => ro.disconnect();
@@ -174,7 +176,7 @@ export function Fretboard(props: FretboardProps) {
 
   useEffect(() => {
     const el = scrollRef.current;
-    if (!el || containerWidth === null) return;
+    if (!el) return;
     const id = requestAnimationFrame(() => {
       setHasOverflow(el.scrollWidth > el.clientWidth + 1);
     });
@@ -292,9 +294,6 @@ export function Fretboard(props: FretboardProps) {
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         onPointerLeave={handlePointerUp}
-        style={{
-          visibility: containerWidth === null ? "hidden" : "visible",
-        }}
       >
         <FretboardSVG
           effectiveZoom={effectiveZoom}

--- a/src/components/SettingsOverlay/SettingsOverlay.test.tsx
+++ b/src/components/SettingsOverlay/SettingsOverlay.test.tsx
@@ -5,7 +5,7 @@ import { Provider, createStore } from "jotai";
 import { axe } from "../../test-utils/a11y";
 import { renderWithAtoms } from "../../test-utils/renderWithAtoms";
 import SettingsOverlay from "./SettingsOverlay";
-import { synth } from "../../core/audio";
+import { setGuitarMutePreference } from "../../core/lazyGuitarAudio";
 import { fretZoomAtom } from "../../store/layoutAtoms";
 import { settingsOverlayOpenAtom, themeAtom } from "../../store/uiAtoms";
 import styles from "./SettingsOverlay.module.css";
@@ -46,13 +46,12 @@ vi.mock("motion/react", async () => {
   };
 });
 
-// Mock the audio synth singleton — we only care that setMute is called on reset.
-vi.mock("../../core/audio", () => ({
-  synth: {
-    setMute: vi.fn(),
-    init: vi.fn(),
-    playNote: vi.fn(),
-  },
+// Mock the audio lazy facade — we only care that setMute is called on reset.
+vi.mock("../../core/lazyGuitarAudio", () => ({
+  setGuitarMutePreference: vi.fn(),
+  resumeGuitarAudio: vi.fn(),
+  playGuitarNote: vi.fn(),
+  setGuitarAudioErrorHandler: vi.fn(),
 }));
 
 function renderOverlay(store: ReturnType<typeof createStore>) {
@@ -243,7 +242,7 @@ describe("SettingsOverlay/SettingsOverlay", () => {
     // Zoom back to default (100) and overlay closed.
     expect(store.get(fretZoomAtom)).toBe(100);
     expect(store.get(settingsOverlayOpenAtom)).toBe(false);
-    expect(synth.setMute).toHaveBeenCalledWith(false);
+    expect(setGuitarMutePreference).toHaveBeenCalledWith(false);
   });
 
   it("reset confirmation auto-cancels after 3 seconds", () => {

--- a/src/components/SettingsOverlay/useResetConfirmation.ts
+++ b/src/components/SettingsOverlay/useResetConfirmation.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useSetAtom } from "jotai";
 import { resetAtom } from "../../store/actions";
-import { synth } from "../../core/audio";
+import { setGuitarMutePreference } from "../../core/lazyGuitarAudio";
 
 export function useResetConfirmation(onConfirm: () => void) {
   const [resetConfirming, setResetConfirming] = useState(false);
@@ -10,7 +10,7 @@ export function useResetConfirmation(onConfirm: () => void) {
   const handleResetClick = () => {
     if (resetConfirming) {
       dispatchReset();
-      synth.setMute(false);
+      setGuitarMutePreference(false);
       onConfirm();
     } else {
       setResetConfirming(true);

--- a/src/core/lazyGuitarAudio.test.ts
+++ b/src/core/lazyGuitarAudio.test.ts
@@ -56,8 +56,38 @@ describe("lazyGuitarAudio", () => {
     expect(audioModule.synth.resume).not.toHaveBeenCalled();
   });
 
+  it("uses a fast path for resume after preload resolves", async () => {
+    setGuitarMutePreference(true);
+
+    await waitFor(() => {
+      expect(audioModule.synth.setMute).toHaveBeenCalledWith(true);
+    });
+
+    audioModule.synth.resume.mockClear();
+
+    const resumePromise = resumeGuitarAudio();
+
+    expect(audioModule.synth.resume).toHaveBeenCalledTimes(1);
+    await resumePromise;
+  });
+
   it("delegates note playback through the lazy runtime", async () => {
     await playGuitarNote(440);
     expect(audioModule.synth.playNote).toHaveBeenCalledWith(440);
+  });
+
+  it("uses a fast path for playback after preload resolves", async () => {
+    setGuitarMutePreference(true);
+
+    await waitFor(() => {
+      expect(audioModule.synth.setMute).toHaveBeenCalledWith(true);
+    });
+
+    audioModule.synth.playNote.mockClear();
+
+    const playPromise = playGuitarNote(440);
+
+    expect(audioModule.synth.playNote).toHaveBeenCalledWith(440);
+    await playPromise;
   });
 });

--- a/src/core/lazyGuitarAudio.test.ts
+++ b/src/core/lazyGuitarAudio.test.ts
@@ -14,6 +14,7 @@ vi.mock("./audio", () => audioModule);
 
 import {
   __resetLazyGuitarAudioForTests,
+  isGuitarAudioLoaded,
   playGuitarNote,
   resumeGuitarAudio,
   setGuitarAudioErrorHandler,
@@ -32,14 +33,17 @@ describe("lazyGuitarAudio", () => {
     expect(audioModule.synth.setMute).not.toHaveBeenCalled();
   });
 
-  it("replays the stored mute preference and error handler on first lazy load", async () => {
+  it("replays the stored mute preference and error handler once preload completes", async () => {
     const onError = vi.fn();
     setGuitarMutePreference(true);
     setGuitarAudioErrorHandler(onError);
 
+    await waitFor(() => {
+      expect(audioModule.synth.setMute).toHaveBeenCalledWith(true);
+    });
+
     await resumeGuitarAudio();
 
-    expect(audioModule.synth.setMute).toHaveBeenCalledWith(true);
     expect(audioModule.synth.onError).toBe(onError);
     expect(audioModule.synth.resume).toHaveBeenCalledTimes(1);
   });
@@ -72,9 +76,43 @@ describe("lazyGuitarAudio", () => {
     await resumePromise;
   });
 
-  it("delegates note playback through the lazy runtime", async () => {
-    await playGuitarNote(440);
-    expect(audioModule.synth.playNote).toHaveBeenCalledWith(440);
+  it("preloads and returns on a cold-path resume until the runtime is loaded", async () => {
+    const testControls = lazyGuitarAudio as typeof lazyGuitarAudio & {
+      __setLazyGuitarAudioModuleLoaderForTests?: (
+        loader: () => Promise<typeof audioModule>,
+      ) => void;
+    };
+    const setModuleLoader = testControls.__setLazyGuitarAudioModuleLoaderForTests;
+
+    expect(setModuleLoader).toBeTypeOf("function");
+
+    let resolveModule: ((value: typeof audioModule) => void) | undefined;
+    const loader = vi.fn(
+      () =>
+        new Promise<typeof audioModule>((resolve) => {
+          resolveModule = resolve;
+        }),
+    );
+
+    setModuleLoader!(loader);
+
+    let settled = false;
+    void resumeGuitarAudio().then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+
+    expect(settled).toBe(true);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(isGuitarAudioLoaded()).toBe(false);
+    expect(audioModule.synth.resume).not.toHaveBeenCalled();
+
+    resolveModule?.(audioModule);
+
+    await waitFor(() => {
+      expect(isGuitarAudioLoaded()).toBe(true);
+    });
   });
 
   it("uses a fast path for playback after preload resolves", async () => {
@@ -90,6 +128,46 @@ describe("lazyGuitarAudio", () => {
 
     expect(audioModule.synth.playNote).toHaveBeenCalledWith(440);
     await playPromise;
+  });
+
+  it("preloads and returns on cold-path playback until the runtime is loaded", async () => {
+    const testControls = lazyGuitarAudio as typeof lazyGuitarAudio & {
+      __setLazyGuitarAudioModuleLoaderForTests?: (
+        loader: () => Promise<typeof audioModule>,
+      ) => void;
+    };
+    const setModuleLoader = testControls.__setLazyGuitarAudioModuleLoaderForTests;
+
+    expect(setModuleLoader).toBeTypeOf("function");
+
+    let resolveModule: ((value: typeof audioModule) => void) | undefined;
+    const loader = vi.fn(
+      () =>
+        new Promise<typeof audioModule>((resolve) => {
+          resolveModule = resolve;
+        }),
+    );
+
+    setModuleLoader!(loader);
+
+    let settled = false;
+    void playGuitarNote(440).then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+
+    expect(settled).toBe(true);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(audioModule.synth.playNote).not.toHaveBeenCalled();
+
+    resolveModule?.(audioModule);
+    await waitFor(() => {
+      expect(isGuitarAudioLoaded()).toBe(true);
+    });
+
+    await playGuitarNote(440);
+    expect(audioModule.synth.playNote).toHaveBeenCalledWith(440);
   });
 
   it("suppresses preload failures during preference registration", async () => {
@@ -119,7 +197,7 @@ describe("lazyGuitarAudio", () => {
     expect(audioModule.synth.setMute).not.toHaveBeenCalled();
   });
 
-  it("retries loading the lazy audio module after an import failure", async () => {
+  it("retries loading the lazy audio module after a cold-path import failure", async () => {
     const testControls = lazyGuitarAudio as typeof lazyGuitarAudio & {
       __setLazyGuitarAudioModuleLoaderForTests?: (
         loader: () => Promise<typeof audioModule>,
@@ -137,10 +215,13 @@ describe("lazyGuitarAudio", () => {
 
     setModuleLoader!(loader);
 
-    await expect(playGuitarNote(440)).rejects.toThrow(loadError);
+    await expect(playGuitarNote(440)).resolves.toBeUndefined();
+    await Promise.resolve();
+    await Promise.resolve();
     await expect(playGuitarNote(440)).resolves.toBeUndefined();
 
     expect(loader).toHaveBeenCalledTimes(2);
+    await playGuitarNote(440);
     expect(audioModule.synth.playNote).toHaveBeenCalledWith(440);
   });
 });

--- a/src/core/lazyGuitarAudio.test.ts
+++ b/src/core/lazyGuitarAudio.test.ts
@@ -19,6 +19,7 @@ import {
   setGuitarAudioErrorHandler,
   setGuitarMutePreference,
 } from "./lazyGuitarAudio";
+import * as lazyGuitarAudio from "./lazyGuitarAudio";
 
 describe("lazyGuitarAudio", () => {
   beforeEach(() => {
@@ -89,5 +90,30 @@ describe("lazyGuitarAudio", () => {
 
     expect(audioModule.synth.playNote).toHaveBeenCalledWith(440);
     await playPromise;
+  });
+
+  it("retries loading the lazy audio module after an import failure", async () => {
+    const testControls = lazyGuitarAudio as typeof lazyGuitarAudio & {
+      __setLazyGuitarAudioModuleLoaderForTests?: (
+        loader: () => Promise<typeof audioModule>,
+      ) => void;
+    };
+    const setModuleLoader = testControls.__setLazyGuitarAudioModuleLoaderForTests;
+
+    expect(setModuleLoader).toBeTypeOf("function");
+
+    const loadError = new Error("chunk load failed");
+    const loader = vi
+      .fn<() => Promise<typeof audioModule>>()
+      .mockRejectedValueOnce(loadError)
+      .mockResolvedValueOnce(audioModule);
+
+    setModuleLoader!(loader);
+
+    await expect(playGuitarNote(440)).rejects.toThrow(loadError);
+    await expect(playGuitarNote(440)).resolves.toBeUndefined();
+
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect(audioModule.synth.playNote).toHaveBeenCalledWith(440);
   });
 });

--- a/src/core/lazyGuitarAudio.test.ts
+++ b/src/core/lazyGuitarAudio.test.ts
@@ -1,4 +1,3 @@
-import { waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const audioModule = vi.hoisted(() => ({
@@ -14,13 +13,11 @@ vi.mock("./audio", () => audioModule);
 
 import {
   __resetLazyGuitarAudioForTests,
-  isGuitarAudioLoaded,
   playGuitarNote,
   resumeGuitarAudio,
   setGuitarAudioErrorHandler,
   setGuitarMutePreference,
 } from "./lazyGuitarAudio";
-import * as lazyGuitarAudio from "./lazyGuitarAudio";
 
 describe("lazyGuitarAudio", () => {
   beforeEach(() => {
@@ -33,194 +30,19 @@ describe("lazyGuitarAudio", () => {
     expect(audioModule.synth.setMute).not.toHaveBeenCalled();
   });
 
-  it("replays the stored mute preference and error handler once preload completes", async () => {
+  it("replays the stored mute preference and error handler on first lazy load", async () => {
     const onError = vi.fn();
     setGuitarMutePreference(true);
     setGuitarAudioErrorHandler(onError);
-
-    await waitFor(() => {
-      expect(audioModule.synth.setMute).toHaveBeenCalledWith(true);
-    });
 
     await resumeGuitarAudio();
 
+    expect(audioModule.synth.setMute).toHaveBeenCalledWith(true);
     expect(audioModule.synth.onError).toBe(onError);
     expect(audioModule.synth.resume).toHaveBeenCalledTimes(1);
   });
 
-  it("preloads the lazy runtime when audio preferences are registered", async () => {
-    const onError = vi.fn();
-
-    setGuitarMutePreference(true);
-    setGuitarAudioErrorHandler(onError);
-
-    await waitFor(() => {
-      expect(audioModule.synth.setMute).toHaveBeenCalledWith(true);
-    });
-    expect(audioModule.synth.onError).toBe(onError);
-    expect(audioModule.synth.resume).not.toHaveBeenCalled();
-  });
-
-  it("uses a fast path for resume after preload resolves", async () => {
-    setGuitarMutePreference(true);
-
-    await waitFor(() => {
-      expect(audioModule.synth.setMute).toHaveBeenCalledWith(true);
-    });
-
-    audioModule.synth.resume.mockClear();
-
-    const resumePromise = resumeGuitarAudio();
-
-    expect(audioModule.synth.resume).toHaveBeenCalledTimes(1);
-    await resumePromise;
-  });
-
-  it("preloads and returns on a cold-path resume until the runtime is loaded", async () => {
-    const testControls = lazyGuitarAudio as typeof lazyGuitarAudio & {
-      __setLazyGuitarAudioModuleLoaderForTests?: (
-        loader: () => Promise<typeof audioModule>,
-      ) => void;
-    };
-    const setModuleLoader = testControls.__setLazyGuitarAudioModuleLoaderForTests;
-
-    expect(setModuleLoader).toBeTypeOf("function");
-
-    let resolveModule: ((value: typeof audioModule) => void) | undefined;
-    const loader = vi.fn(
-      () =>
-        new Promise<typeof audioModule>((resolve) => {
-          resolveModule = resolve;
-        }),
-    );
-
-    setModuleLoader!(loader);
-
-    let settled = false;
-    void resumeGuitarAudio().then(() => {
-      settled = true;
-    });
-
-    await Promise.resolve();
-
-    expect(settled).toBe(true);
-    expect(loader).toHaveBeenCalledTimes(1);
-    expect(isGuitarAudioLoaded()).toBe(false);
-    expect(audioModule.synth.resume).not.toHaveBeenCalled();
-
-    resolveModule?.(audioModule);
-
-    await waitFor(() => {
-      expect(isGuitarAudioLoaded()).toBe(true);
-    });
-  });
-
-  it("uses a fast path for playback after preload resolves", async () => {
-    setGuitarMutePreference(true);
-
-    await waitFor(() => {
-      expect(audioModule.synth.setMute).toHaveBeenCalledWith(true);
-    });
-
-    audioModule.synth.playNote.mockClear();
-
-    const playPromise = playGuitarNote(440);
-
-    expect(audioModule.synth.playNote).toHaveBeenCalledWith(440);
-    await playPromise;
-  });
-
-  it("preloads and returns on cold-path playback until the runtime is loaded", async () => {
-    const testControls = lazyGuitarAudio as typeof lazyGuitarAudio & {
-      __setLazyGuitarAudioModuleLoaderForTests?: (
-        loader: () => Promise<typeof audioModule>,
-      ) => void;
-    };
-    const setModuleLoader = testControls.__setLazyGuitarAudioModuleLoaderForTests;
-
-    expect(setModuleLoader).toBeTypeOf("function");
-
-    let resolveModule: ((value: typeof audioModule) => void) | undefined;
-    const loader = vi.fn(
-      () =>
-        new Promise<typeof audioModule>((resolve) => {
-          resolveModule = resolve;
-        }),
-    );
-
-    setModuleLoader!(loader);
-
-    let settled = false;
-    void playGuitarNote(440).then(() => {
-      settled = true;
-    });
-
-    await Promise.resolve();
-
-    expect(settled).toBe(true);
-    expect(loader).toHaveBeenCalledTimes(1);
-    expect(audioModule.synth.playNote).not.toHaveBeenCalled();
-
-    resolveModule?.(audioModule);
-    await waitFor(() => {
-      expect(isGuitarAudioLoaded()).toBe(true);
-    });
-
-    await playGuitarNote(440);
-    expect(audioModule.synth.playNote).toHaveBeenCalledWith(440);
-  });
-
-  it("suppresses preload failures during preference registration", async () => {
-    const testControls = lazyGuitarAudio as typeof lazyGuitarAudio & {
-      __setLazyGuitarAudioModuleLoaderForTests?: (
-        loader: () => Promise<typeof audioModule>,
-      ) => void;
-    };
-    const setModuleLoader = testControls.__setLazyGuitarAudioModuleLoaderForTests;
-
-    expect(setModuleLoader).toBeTypeOf("function");
-
-    const loadError = new Error("chunk load failed");
-    const loader = vi
-      .fn<() => Promise<typeof audioModule>>()
-      .mockRejectedValueOnce(loadError)
-      .mockResolvedValueOnce(audioModule);
-
-    setModuleLoader!(loader);
-
-    setGuitarMutePreference(true);
-    setGuitarAudioErrorHandler(() => {});
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(loader).toHaveBeenCalledTimes(1);
-    expect(audioModule.synth.setMute).not.toHaveBeenCalled();
-  });
-
-  it("retries loading the lazy audio module after a cold-path import failure", async () => {
-    const testControls = lazyGuitarAudio as typeof lazyGuitarAudio & {
-      __setLazyGuitarAudioModuleLoaderForTests?: (
-        loader: () => Promise<typeof audioModule>,
-      ) => void;
-    };
-    const setModuleLoader = testControls.__setLazyGuitarAudioModuleLoaderForTests;
-
-    expect(setModuleLoader).toBeTypeOf("function");
-
-    const loadError = new Error("chunk load failed");
-    const loader = vi
-      .fn<() => Promise<typeof audioModule>>()
-      .mockRejectedValueOnce(loadError)
-      .mockResolvedValueOnce(audioModule);
-
-    setModuleLoader!(loader);
-
-    await expect(playGuitarNote(440)).resolves.toBeUndefined();
-    await Promise.resolve();
-    await Promise.resolve();
-    await expect(playGuitarNote(440)).resolves.toBeUndefined();
-
-    expect(loader).toHaveBeenCalledTimes(2);
+  it("delegates note playback through the lazy runtime", async () => {
     await playGuitarNote(440);
     expect(audioModule.synth.playNote).toHaveBeenCalledWith(440);
   });

--- a/src/core/lazyGuitarAudio.test.ts
+++ b/src/core/lazyGuitarAudio.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const audioModule = vi.hoisted(() => ({
+  synth: {
+    resume: vi.fn(async () => {}),
+    playNote: vi.fn(async () => {}),
+    setMute: vi.fn(),
+    onError: undefined as ((msg: string) => void) | undefined,
+  },
+}));
+
+vi.mock("./audio", () => audioModule);
+
+import {
+  __resetLazyGuitarAudioForTests,
+  playGuitarNote,
+  resumeGuitarAudio,
+  setGuitarAudioErrorHandler,
+  setGuitarMutePreference,
+} from "./lazyGuitarAudio";
+
+describe("lazyGuitarAudio", () => {
+  beforeEach(() => {
+    __resetLazyGuitarAudioForTests();
+    vi.clearAllMocks();
+  });
+
+  it("does not call synth.setMute until the lazy runtime has been loaded", () => {
+    setGuitarMutePreference(true);
+    expect(audioModule.synth.setMute).not.toHaveBeenCalled();
+  });
+
+  it("replays the stored mute preference and error handler on first lazy load", async () => {
+    const onError = vi.fn();
+    setGuitarMutePreference(true);
+    setGuitarAudioErrorHandler(onError);
+
+    await resumeGuitarAudio();
+
+    expect(audioModule.synth.setMute).toHaveBeenCalledWith(true);
+    expect(audioModule.synth.onError).toBe(onError);
+    expect(audioModule.synth.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it("delegates note playback through the lazy runtime", async () => {
+    await playGuitarNote(440);
+    expect(audioModule.synth.playNote).toHaveBeenCalledWith(440);
+  });
+});

--- a/src/core/lazyGuitarAudio.test.ts
+++ b/src/core/lazyGuitarAudio.test.ts
@@ -1,3 +1,4 @@
+import { waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const audioModule = vi.hoisted(() => ({
@@ -40,6 +41,19 @@ describe("lazyGuitarAudio", () => {
     expect(audioModule.synth.setMute).toHaveBeenCalledWith(true);
     expect(audioModule.synth.onError).toBe(onError);
     expect(audioModule.synth.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it("preloads the lazy runtime when audio preferences are registered", async () => {
+    const onError = vi.fn();
+
+    setGuitarMutePreference(true);
+    setGuitarAudioErrorHandler(onError);
+
+    await waitFor(() => {
+      expect(audioModule.synth.setMute).toHaveBeenCalledWith(true);
+    });
+    expect(audioModule.synth.onError).toBe(onError);
+    expect(audioModule.synth.resume).not.toHaveBeenCalled();
   });
 
   it("delegates note playback through the lazy runtime", async () => {

--- a/src/core/lazyGuitarAudio.test.ts
+++ b/src/core/lazyGuitarAudio.test.ts
@@ -92,6 +92,33 @@ describe("lazyGuitarAudio", () => {
     await playPromise;
   });
 
+  it("suppresses preload failures during preference registration", async () => {
+    const testControls = lazyGuitarAudio as typeof lazyGuitarAudio & {
+      __setLazyGuitarAudioModuleLoaderForTests?: (
+        loader: () => Promise<typeof audioModule>,
+      ) => void;
+    };
+    const setModuleLoader = testControls.__setLazyGuitarAudioModuleLoaderForTests;
+
+    expect(setModuleLoader).toBeTypeOf("function");
+
+    const loadError = new Error("chunk load failed");
+    const loader = vi
+      .fn<() => Promise<typeof audioModule>>()
+      .mockRejectedValueOnce(loadError)
+      .mockResolvedValueOnce(audioModule);
+
+    setModuleLoader!(loader);
+
+    setGuitarMutePreference(true);
+    setGuitarAudioErrorHandler(() => {});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(audioModule.synth.setMute).not.toHaveBeenCalled();
+  });
+
   it("retries loading the lazy audio module after an import failure", async () => {
     const testControls = lazyGuitarAudio as typeof lazyGuitarAudio & {
       __setLazyGuitarAudioModuleLoaderForTests?: (

--- a/src/core/lazyGuitarAudio.ts
+++ b/src/core/lazyGuitarAudio.ts
@@ -1,0 +1,48 @@
+type GuitarSynthModule = typeof import("./audio");
+
+let modulePromise: Promise<GuitarSynthModule> | null = null;
+let desiredMute = false;
+let errorHandler: ((message: string) => void) | undefined;
+
+async function loadAudioModule(): Promise<GuitarSynthModule> {
+  if (!modulePromise) {
+    modulePromise = import("./audio").then((mod) => {
+      mod.synth.onError = errorHandler;
+      mod.synth.setMute(desiredMute);
+      return mod;
+    });
+  }
+  return modulePromise;
+}
+
+export function setGuitarMutePreference(mute: boolean): void {
+  desiredMute = mute;
+  void modulePromise?.then((mod) => {
+    mod.synth.setMute(mute);
+  });
+}
+
+export function setGuitarAudioErrorHandler(
+  nextHandler: ((message: string) => void) | undefined,
+): void {
+  errorHandler = nextHandler;
+  void modulePromise?.then((mod) => {
+    mod.synth.onError = nextHandler;
+  });
+}
+
+export async function resumeGuitarAudio(): Promise<void> {
+  const mod = await loadAudioModule();
+  await mod.synth.resume();
+}
+
+export async function playGuitarNote(frequency: number): Promise<void> {
+  const mod = await loadAudioModule();
+  await mod.synth.playNote(frequency);
+}
+
+export function __resetLazyGuitarAudioForTests(): void {
+  modulePromise = null;
+  desiredMute = false;
+  errorHandler = undefined;
+}

--- a/src/core/lazyGuitarAudio.ts
+++ b/src/core/lazyGuitarAudio.ts
@@ -1,12 +1,18 @@
 type GuitarSynthModule = typeof import("./audio");
 
 let modulePromise: Promise<GuitarSynthModule> | null = null;
+let loadedModule: GuitarSynthModule | null = null;
 let desiredMute = false;
 let errorHandler: ((message: string) => void) | undefined;
 
 async function loadAudioModule(): Promise<GuitarSynthModule> {
+  if (loadedModule) {
+    return loadedModule;
+  }
+
   if (!modulePromise) {
     modulePromise = import("./audio").then((mod) => {
+      loadedModule = mod;
       mod.synth.onError = errorHandler;
       mod.synth.setMute(desiredMute);
       return mod;
@@ -38,17 +44,28 @@ export function setGuitarAudioErrorHandler(
 }
 
 export async function resumeGuitarAudio(): Promise<void> {
+  if (loadedModule) {
+    await loadedModule.synth.resume();
+    return;
+  }
+
   const mod = await loadAudioModule();
   await mod.synth.resume();
 }
 
 export async function playGuitarNote(frequency: number): Promise<void> {
+  if (loadedModule) {
+    await loadedModule.synth.playNote(frequency);
+    return;
+  }
+
   const mod = await loadAudioModule();
   await mod.synth.playNote(frequency);
 }
 
 export function __resetLazyGuitarAudioForTests(): void {
   modulePromise = null;
+  loadedModule = null;
   desiredMute = false;
   errorHandler = undefined;
 }

--- a/src/core/lazyGuitarAudio.ts
+++ b/src/core/lazyGuitarAudio.ts
@@ -1,9 +1,12 @@
 type GuitarSynthModule = typeof import("./audio");
 
+const defaultModuleLoader = () => import("./audio");
+
 let modulePromise: Promise<GuitarSynthModule> | null = null;
 let loadedModule: GuitarSynthModule | null = null;
 let desiredMute = false;
 let errorHandler: ((message: string) => void) | undefined;
+let moduleLoader: () => Promise<GuitarSynthModule> = defaultModuleLoader;
 
 async function loadAudioModule(): Promise<GuitarSynthModule> {
   if (loadedModule) {
@@ -11,12 +14,19 @@ async function loadAudioModule(): Promise<GuitarSynthModule> {
   }
 
   if (!modulePromise) {
-    modulePromise = import("./audio").then((mod) => {
-      loadedModule = mod;
-      mod.synth.onError = errorHandler;
-      mod.synth.setMute(desiredMute);
-      return mod;
-    });
+    modulePromise = Promise.resolve()
+      .then(() => moduleLoader())
+      .then((mod) => {
+        loadedModule = mod;
+        mod.synth.onError = errorHandler;
+        mod.synth.setMute(desiredMute);
+        return mod;
+      })
+      .catch((error: unknown) => {
+        modulePromise = null;
+        loadedModule = null;
+        throw error;
+      });
   }
   return modulePromise;
 }
@@ -68,4 +78,13 @@ export function __resetLazyGuitarAudioForTests(): void {
   loadedModule = null;
   desiredMute = false;
   errorHandler = undefined;
+  moduleLoader = defaultModuleLoader;
+}
+
+export function __setLazyGuitarAudioModuleLoaderForTests(
+  nextLoader: () => Promise<GuitarSynthModule>,
+): void {
+  modulePromise = null;
+  loadedModule = null;
+  moduleLoader = nextLoader;
 }

--- a/src/core/lazyGuitarAudio.ts
+++ b/src/core/lazyGuitarAudio.ts
@@ -63,14 +63,18 @@ export function setGuitarAudioErrorHandler(
     });
 }
 
-export async function resumeGuitarAudio(): Promise<void> {
+export function isGuitarAudioLoaded(): boolean {
+  return loadedModule !== null;
+}
+
+export async function resumeGuitarAudio(): Promise<boolean> {
   if (loadedModule) {
     await loadedModule.synth.resume();
-    return;
+    return true;
   }
 
-  const mod = await loadAudioModule();
-  await mod.synth.resume();
+  preloadAudioModule();
+  return false;
 }
 
 export async function playGuitarNote(frequency: number): Promise<void> {
@@ -79,8 +83,7 @@ export async function playGuitarNote(frequency: number): Promise<void> {
     return;
   }
 
-  const mod = await loadAudioModule();
-  await mod.synth.playNote(frequency);
+  preloadAudioModule();
 }
 
 export function __resetLazyGuitarAudioForTests(): void {

--- a/src/core/lazyGuitarAudio.ts
+++ b/src/core/lazyGuitarAudio.ts
@@ -15,8 +15,13 @@ async function loadAudioModule(): Promise<GuitarSynthModule> {
   return modulePromise;
 }
 
+function preloadAudioModule(): void {
+  void loadAudioModule();
+}
+
 export function setGuitarMutePreference(mute: boolean): void {
   desiredMute = mute;
+  preloadAudioModule();
   void modulePromise?.then((mod) => {
     mod.synth.setMute(mute);
   });
@@ -26,6 +31,7 @@ export function setGuitarAudioErrorHandler(
   nextHandler: ((message: string) => void) | undefined,
 ): void {
   errorHandler = nextHandler;
+  preloadAudioModule();
   void modulePromise?.then((mod) => {
     mod.synth.onError = nextHandler;
   });

--- a/src/core/lazyGuitarAudio.ts
+++ b/src/core/lazyGuitarAudio.ts
@@ -32,15 +32,21 @@ async function loadAudioModule(): Promise<GuitarSynthModule> {
 }
 
 function preloadAudioModule(): void {
-  void loadAudioModule();
+  void loadAudioModule().catch(() => {
+    // Swallow preload failures; explicit resume/play calls can retry.
+  });
 }
 
 export function setGuitarMutePreference(mute: boolean): void {
   desiredMute = mute;
   preloadAudioModule();
-  void modulePromise?.then((mod) => {
-    mod.synth.setMute(mute);
-  });
+  void modulePromise
+    ?.then((mod) => {
+      mod.synth.setMute(mute);
+    })
+    .catch(() => {
+      // Swallow preload failures; explicit resume/play calls can retry.
+    });
 }
 
 export function setGuitarAudioErrorHandler(
@@ -48,9 +54,13 @@ export function setGuitarAudioErrorHandler(
 ): void {
   errorHandler = nextHandler;
   preloadAudioModule();
-  void modulePromise?.then((mod) => {
-    mod.synth.onError = nextHandler;
-  });
+  void modulePromise
+    ?.then((mod) => {
+      mod.synth.onError = nextHandler;
+    })
+    .catch(() => {
+      // Swallow preload failures; explicit resume/play calls can retry.
+    });
 }
 
 export async function resumeGuitarAudio(): Promise<void> {

--- a/src/core/lazyGuitarAudio.ts
+++ b/src/core/lazyGuitarAudio.ts
@@ -1,103 +1,48 @@
 type GuitarSynthModule = typeof import("./audio");
 
-const defaultModuleLoader = () => import("./audio");
-
 let modulePromise: Promise<GuitarSynthModule> | null = null;
-let loadedModule: GuitarSynthModule | null = null;
 let desiredMute = false;
 let errorHandler: ((message: string) => void) | undefined;
-let moduleLoader: () => Promise<GuitarSynthModule> = defaultModuleLoader;
 
 async function loadAudioModule(): Promise<GuitarSynthModule> {
-  if (loadedModule) {
-    return loadedModule;
-  }
-
   if (!modulePromise) {
-    modulePromise = Promise.resolve()
-      .then(() => moduleLoader())
-      .then((mod) => {
-        loadedModule = mod;
-        mod.synth.onError = errorHandler;
-        mod.synth.setMute(desiredMute);
-        return mod;
-      })
-      .catch((error: unknown) => {
-        modulePromise = null;
-        loadedModule = null;
-        throw error;
-      });
+    modulePromise = import("./audio").then((mod) => {
+      mod.synth.onError = errorHandler;
+      mod.synth.setMute(desiredMute);
+      return mod;
+    });
   }
   return modulePromise;
 }
 
-function preloadAudioModule(): void {
-  void loadAudioModule().catch(() => {
-    // Swallow preload failures; explicit resume/play calls can retry.
-  });
-}
-
 export function setGuitarMutePreference(mute: boolean): void {
   desiredMute = mute;
-  preloadAudioModule();
-  void modulePromise
-    ?.then((mod) => {
-      mod.synth.setMute(mute);
-    })
-    .catch(() => {
-      // Swallow preload failures; explicit resume/play calls can retry.
-    });
+  void modulePromise?.then((mod) => {
+    mod.synth.setMute(mute);
+  });
 }
 
 export function setGuitarAudioErrorHandler(
   nextHandler: ((message: string) => void) | undefined,
 ): void {
   errorHandler = nextHandler;
-  preloadAudioModule();
-  void modulePromise
-    ?.then((mod) => {
-      mod.synth.onError = nextHandler;
-    })
-    .catch(() => {
-      // Swallow preload failures; explicit resume/play calls can retry.
-    });
+  void modulePromise?.then((mod) => {
+    mod.synth.onError = nextHandler;
+  });
 }
 
-export function isGuitarAudioLoaded(): boolean {
-  return loadedModule !== null;
-}
-
-export async function resumeGuitarAudio(): Promise<boolean> {
-  if (loadedModule) {
-    await loadedModule.synth.resume();
-    return true;
-  }
-
-  preloadAudioModule();
-  return false;
+export async function resumeGuitarAudio(): Promise<void> {
+  const mod = await loadAudioModule();
+  await mod.synth.resume();
 }
 
 export async function playGuitarNote(frequency: number): Promise<void> {
-  if (loadedModule) {
-    await loadedModule.synth.playNote(frequency);
-    return;
-  }
-
-  preloadAudioModule();
+  const mod = await loadAudioModule();
+  await mod.synth.playNote(frequency);
 }
 
 export function __resetLazyGuitarAudioForTests(): void {
   modulePromise = null;
-  loadedModule = null;
   desiredMute = false;
   errorHandler = undefined;
-  moduleLoader = defaultModuleLoader;
-}
-
-export function __setLazyGuitarAudioModuleLoaderForTests(
-  nextLoader: () => Promise<GuitarSynthModule>,
-): void {
-  modulePromise = null;
-  loadedModule = null;
-  moduleLoader = nextLoader;
 }

--- a/src/integration.test.tsx
+++ b/src/integration.test.tsx
@@ -2,19 +2,20 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import App from "./App";
+import { playGuitarNote } from "./core/lazyGuitarAudio";
 import { k } from "./test-utils/storage";
 // Pre-import lazy-loaded components so React.lazy() resolves from the module
 // cache synchronously, allowing Suspense to mount them without async delay.
 import "./components/Inspector/Inspector";
 
-const mockSynth = vi.hoisted(() => ({
-  playNote: vi.fn(),
-  setMute: vi.fn(),
-  init: vi.fn(),
-  resume: vi.fn(),
+const lazyAudio = vi.hoisted(() => ({
+  playGuitarNote: vi.fn(),
+  setGuitarMutePreference: vi.fn(),
+  setGuitarAudioErrorHandler: vi.fn(),
+  resumeGuitarAudio: vi.fn(),
 }));
 
-vi.mock("./core/audio", () => ({ synth: mockSynth }));
+vi.mock("./core/lazyGuitarAudio", () => lazyAudio);
 
 // Cross-cutting integration tests that App.test.tsx cannot prove because it
 // mocks the Fretboard. Persistence round-trips for individual atoms are
@@ -28,7 +29,7 @@ describe("Integration: real-component user workflows", () => {
   });
   afterEach(() => localStorage.clear());
 
-  it("clicking a real fretboard note button invokes synth.playNote", async () => {
+  it("clicking a real fretboard note button invokes lazy audio playback", async () => {
     localStorage.setItem(k("isMuted"), "false");
     render(<App />);
 
@@ -39,8 +40,8 @@ describe("Integration: real-component user workflows", () => {
     expect(noteButtons.length).toBeGreaterThan(0);
 
     fireEvent.click(noteButtons[0]);
-    expect(mockSynth.playNote).toHaveBeenCalledTimes(1);
-    expect(mockSynth.playNote).toHaveBeenCalledWith(expect.any(Number));
+    expect(playGuitarNote).toHaveBeenCalledTimes(1);
+    expect(playGuitarNote).toHaveBeenCalledWith(expect.any(Number));
   });
 
   it("changing accidental mode in Settings re-renders the scale label without persisting", async () => {

--- a/src/progressions/audio/bass.test.ts
+++ b/src/progressions/audio/bass.test.ts
@@ -14,20 +14,22 @@ vi.mock("tone", async () => {
   const s = await synth;
   return {
     MonoSynth: s.spies.ctorSpy,
-    now: () => 0,
+    now: () => s.now(),
   };
 });
 
-import { scheduleBassNote } from "./bass";
-
 describe("scheduleBassNote — Tone backend", () => {
   let spies: Awaited<typeof synth>["spies"];
+  let tone: Awaited<typeof synth>;
+  let scheduleBassNote: typeof import("./bass").scheduleBassNote;
 
   beforeEach(async () => {
-    const s = await synth;
-    spies = s.spies;
+    tone = await synth;
+    spies = tone.spies;
     vi.useFakeTimers();
-    s.reset();
+    tone.reset();
+    vi.resetModules();
+    ({ scheduleBassNote } = await import("./bass"));
   });
 
   afterEach(() => {
@@ -57,6 +59,38 @@ describe("scheduleBassNote — Tone backend", () => {
     expect(velocity).toBeCloseTo(0.8, 2);
   });
 
+  it("reuses one MonoSynth for non-overlapping notes on the same destination", () => {
+    const dest = {} as AudioNode;
+    scheduleBassNote(dest, 110, 0, { velocity: 0.8 });
+    tone.setNow(1.2);
+    scheduleBassNote(dest, 146.83, 1.3, { velocity: 0.75 });
+
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
+    expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+  });
+
+  it("allocates separate MonoSynths for future notes scheduled in one pass", () => {
+    const dest = {} as AudioNode;
+    scheduleBassNote(dest, 110, 2, { velocity: 0.8 });
+    scheduleBassNote(dest, 146.83, 3, { velocity: 0.75 });
+
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(2);
+    expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps different destinations on different leased synths", () => {
+    const firstDest = {} as AudioNode;
+    const secondDest = {} as AudioNode;
+
+    scheduleBassNote(firstDest, 110, 0, { velocity: 0.8 });
+    tone.setNow(1.2);
+    scheduleBassNote(secondDest, 146.83, 1.3, { velocity: 0.75 });
+
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(2);
+    expect(tone.instances[0]?.connect).toHaveBeenCalledWith(firstDest);
+    expect(tone.instances[1]?.connect).toHaveBeenCalledWith(secondDest);
+  });
+
   it("skips zero-velocity notes (no synth constructed)", () => {
     scheduleBassNote(
       {} as AudioNode,
@@ -81,6 +115,19 @@ describe("scheduleBassNote — Tone backend", () => {
     expect(spies.dispose).not.toHaveBeenCalled();
     vi.advanceTimersByTime(60); // matches the dispose-deferral window in production
     expect(spies.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel() prevents a future-scheduled note from ever being attacked", async () => {
+    const handle = scheduleBassNote({} as AudioNode, 110, 2, { velocity: 0.8 });
+
+    expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(1);
+    expect(spies.playbackAttackRelease).not.toHaveBeenCalled();
+
+    handle.cancel();
+    await vi.advanceTimersByTimeAsync(2_500);
+    tone.setNow(2.5);
+
+    expect(spies.playbackAttackRelease).not.toHaveBeenCalled();
   });
 
   it("cancel() is idempotent — repeated calls schedule release/dispose only once", () => {

--- a/src/progressions/audio/bass.ts
+++ b/src/progressions/audio/bass.ts
@@ -6,15 +6,18 @@
  * manual BiquadFilter.
  */
 import * as Tone from "tone";
+import { createReusableVoicePool } from "./createReusableVoicePool";
 
 const ATTACK = 0.005;
 const DECAY = 0.4;
 const RELEASE = 0.25;
 const FILTER_CUTOFF_HZ = 1200;
 const FILTER_Q = 2;
+const RELEASE_TAIL_SEC = RELEASE;
 // Match the metronome's cancel-tail dispose-deferral window. Slightly longer
 // than the metronome because the bass envelope's release is ~250 ms.
 const DISPOSE_TAIL_MS = 50;
+const DISPOSE_TAIL_SEC = DISPOSE_TAIL_MS / 1000;
 
 export interface BassNoteOptions {
   velocity?: number;
@@ -25,6 +28,23 @@ export interface BassNoteOptions {
 export interface BassVoiceHandle {
   cancel: () => void;
 }
+
+const bassVoicePool = createReusableVoicePool({
+  createVoice: () =>
+    new Tone.MonoSynth({
+      oscillator: { type: "sawtooth" },
+      envelope: { attack: ATTACK, decay: DECAY, sustain: 0, release: RELEASE },
+      filter: { Q: FILTER_Q, type: "lowpass" },
+      filterEnvelope: {
+        attack: ATTACK,
+        decay: DECAY,
+        sustain: 0,
+        release: RELEASE,
+        baseFrequency: FILTER_CUTOFF_HZ,
+        octaves: 0,
+      },
+    }),
+});
 
 /**
  * Schedule a single bass note. Returns a handle that can be cancelled on
@@ -44,46 +64,50 @@ export function scheduleBassNote(
     return { cancel: () => {} };
   }
   const noteLen = Math.max(0.05, Math.min(2, options.durationSec ?? DECAY + RELEASE));
-
-  const synth = new Tone.MonoSynth({
-    oscillator: { type: "sawtooth" },
-    envelope: { attack: ATTACK, decay: DECAY, sustain: 0, release: RELEASE },
-    filter: { Q: FILTER_Q, type: "lowpass" },
-    filterEnvelope: {
-      attack: ATTACK,
-      decay: DECAY,
-      sustain: 0,
-      release: RELEASE,
-      baseFrequency: FILTER_CUTOFF_HZ,
-      octaves: 0,
-    },
-  });
+  const now = Tone.now();
+  const playbackStartTime = Math.max(now, time);
+  const lease = bassVoicePool.lease(dest, now);
+  let busyUntil = playbackStartTime + noteLen + RELEASE_TAIL_SEC;
+  lease.setBusyUntil(busyUntil);
   // Route through the progression bus so silenceProgressionBus() mutes the
   // bass along with the rest of the backing track.
-  synth.connect(dest);
-  synth.triggerAttackRelease(frequency, noteLen, time, velocity);
+  lease.voice.triggerAttackRelease(frequency, noteLen, time, velocity);
 
   let cancelled = false;
   return {
     cancel: () => {
       if (cancelled) return;
       cancelled = true;
+      if (!lease.isCurrent()) return;
+
+      const cancelTime = Tone.now();
+      if (cancelTime < time) {
+        lease.dispose();
+        return;
+      }
+
+      if (cancelTime >= busyUntil) {
+        return;
+      }
+
+      busyUntil = cancelTime + DISPOSE_TAIL_SEC;
+      lease.setBusyUntil(busyUntil);
       // Same release-tail pattern as metronome.ts: close the envelope
       // explicitly, then defer dispose so the tail doesn't get truncated.
       // Calling synth.dispose() while the voice is mid-decay would cut the
       // tail abruptly and produce an audible click.
       try {
-        synth.triggerRelease(Tone.now());
+        lease.voice.triggerRelease(cancelTime);
         setTimeout(() => {
           try {
-            synth.dispose();
+            lease.dispose();
           } catch {
             /* already disposed */
           }
         }, DISPOSE_TAIL_MS);
       } catch {
         try {
-          synth.dispose();
+          lease.dispose();
         } catch {
           /* already disposed */
         }

--- a/src/progressions/audio/createReusableVoicePool.ts
+++ b/src/progressions/audio/createReusableVoicePool.ts
@@ -1,0 +1,73 @@
+interface PoolableVoice {
+  connect(dest: AudioNode): unknown;
+  dispose(): void;
+}
+
+interface PooledVoiceEntry<TVoice extends PoolableVoice> {
+  voice: TVoice;
+  busyUntil: number;
+  leaseGeneration: number;
+}
+
+export interface ReusableVoiceLease<TVoice extends PoolableVoice> {
+  voice: TVoice;
+  generation: number;
+  setBusyUntil: (busyUntil: number) => void;
+  isCurrent: () => boolean;
+  dispose: () => void;
+}
+
+export function createReusableVoicePool<TVoice extends PoolableVoice>(config: {
+  createVoice: () => TVoice;
+}) {
+  const voicePool = new WeakMap<AudioNode, PooledVoiceEntry<TVoice>[]>();
+
+  const removeEntry = (dest: AudioNode, entry: PooledVoiceEntry<TVoice>) => {
+    const entries = voicePool.get(dest);
+    if (!entries) return;
+
+    const nextEntries = entries.filter((candidate) => candidate !== entry);
+    if (nextEntries.length === 0) {
+      voicePool.delete(dest);
+      return;
+    }
+
+    voicePool.set(dest, nextEntries);
+  };
+
+  const createEntry = (dest: AudioNode) => {
+    const voice = config.createVoice();
+    voice.connect(dest);
+    return { voice, busyUntil: 0, leaseGeneration: 0 };
+  };
+
+  return {
+    lease(dest: AudioNode, now: number): ReusableVoiceLease<TVoice> {
+      const entries = voicePool.get(dest) ?? [];
+      const entry =
+        entries.find((candidate) => candidate.busyUntil <= now) ?? createEntry(dest);
+
+      if (!entries.includes(entry)) {
+        voicePool.set(dest, [...entries, entry]);
+      }
+
+      entry.leaseGeneration += 1;
+      const generation = entry.leaseGeneration;
+
+      return {
+        voice: entry.voice,
+        generation,
+        setBusyUntil: (busyUntil) => {
+          entry.busyUntil = busyUntil;
+        },
+        isCurrent: () => entry.leaseGeneration === generation,
+        dispose: () => {
+          if (entry.leaseGeneration !== generation) return;
+          removeEntry(dest, entry);
+          entry.busyUntil = 0;
+          entry.voice.dispose();
+        },
+      };
+    },
+  };
+}

--- a/src/progressions/audio/drumKit.test.ts
+++ b/src/progressions/audio/drumKit.test.ts
@@ -21,6 +21,7 @@ const metal = vi.hoisted(async () => {
   const { createToneSynthSpies } = await import("../../test-utils/toneMocks");
   return createToneSynthSpies();
 });
+const clock = vi.hoisted(() => ({ now: 0 }));
 
 vi.mock("tone", async () => {
   const m = await membrane;
@@ -30,33 +31,36 @@ vi.mock("tone", async () => {
     MembraneSynth: m.spies.ctorSpy,
     NoiseSynth: n.spies.ctorSpy,
     MetalSynth: mt.spies.ctorSpy,
-    now: () => 0,
+    now: () => clock.now,
   };
 });
-
-import {
-  scheduleKick,
-  scheduleSnare,
-  scheduleHiHat,
-  scheduleRide,
-} from "./drumKit";
 
 describe("drumKit — Tone backend", () => {
   let membraneSpies: Awaited<typeof membrane>["spies"];
   let noiseSpies: Awaited<typeof noise>["spies"];
   let metalSpies: Awaited<typeof metal>["spies"];
+  let membraneTone: Awaited<typeof membrane>;
+  let scheduleKick: typeof import("./drumKit").scheduleKick;
+  let scheduleSnare: typeof import("./drumKit").scheduleSnare;
+  let scheduleHiHat: typeof import("./drumKit").scheduleHiHat;
+  let scheduleRide: typeof import("./drumKit").scheduleRide;
 
   beforeEach(async () => {
     const m = await membrane;
     const n = await noise;
     const mt = await metal;
+    membraneTone = m;
     membraneSpies = m.spies;
     noiseSpies = n.spies;
     metalSpies = mt.spies;
     vi.useFakeTimers();
+    clock.now = 0;
     m.reset();
     n.reset();
     mt.reset();
+    vi.resetModules();
+    ({ scheduleKick, scheduleSnare, scheduleHiHat, scheduleRide } =
+      await import("./drumKit"));
   });
 
   afterEach(() => {
@@ -88,6 +92,38 @@ describe("drumKit — Tone backend", () => {
       expect(velocity).toBeCloseTo(0.8, 2);
     });
 
+    it("reuses one MembraneSynth for non-overlapping hits on the same destination", () => {
+      const dest = {} as AudioNode;
+      scheduleKick(dest, 0, { velocity: 0.8 });
+      clock.now = 1.2;
+      scheduleKick(dest, 1.3, { velocity: 0.75 });
+
+      expect(membraneSpies.ctorSpy).toHaveBeenCalledTimes(1);
+      expect(membraneSpies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+    });
+
+    it("allocates separate MembraneSynths for future hits scheduled in one pass", () => {
+      const dest = {} as AudioNode;
+      scheduleKick(dest, 2, { velocity: 0.8 });
+      scheduleKick(dest, 2.6, { velocity: 0.75 });
+
+      expect(membraneSpies.ctorSpy).toHaveBeenCalledTimes(2);
+      expect(membraneSpies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps different destinations on different leased synths", () => {
+      const firstDest = {} as AudioNode;
+      const secondDest = {} as AudioNode;
+
+      scheduleKick(firstDest, 0, { velocity: 0.8 });
+      clock.now = 1.2;
+      scheduleKick(secondDest, 1.3, { velocity: 0.75 });
+
+      expect(membraneSpies.ctorSpy).toHaveBeenCalledTimes(2);
+      expect(membraneTone.instances[0]?.connect).toHaveBeenCalledWith(firstDest);
+      expect(membraneTone.instances[1]?.connect).toHaveBeenCalledWith(secondDest);
+    });
+
     it("skips zero-velocity hits (no MembraneSynth constructed)", () => {
       scheduleKick(
         {} as AudioNode,
@@ -107,6 +143,19 @@ describe("drumKit — Tone backend", () => {
       expect(membraneSpies.dispose).not.toHaveBeenCalled();
       vi.advanceTimersByTime(700); // > KICK_DISPOSE_MS (600)
       expect(membraneSpies.dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancel() prevents a future-scheduled kick from ever being attacked", async () => {
+      const handle = scheduleKick({} as AudioNode, 2, { velocity: 0.8 });
+
+      expect(membraneSpies.triggerAttackRelease).toHaveBeenCalledTimes(1);
+      expect(membraneSpies.playbackAttackRelease).not.toHaveBeenCalled();
+
+      handle.cancel();
+      await vi.advanceTimersByTimeAsync(2_500);
+      clock.now = 2.5;
+
+      expect(membraneSpies.playbackAttackRelease).not.toHaveBeenCalled();
     });
 
     it("cancel() is idempotent — repeated calls dispose only once", () => {
@@ -146,6 +195,16 @@ describe("drumKit — Tone backend", () => {
       expect(args[0]).toBeCloseTo(0.18, 3);
       expect(args[1]).toBeCloseTo(3.25, 3);
       expect(args[2]).toBeCloseTo(0.7, 2);
+    });
+
+    it("reuses one NoiseSynth for non-overlapping hits on the same destination", () => {
+      const dest = {} as AudioNode;
+      scheduleSnare(dest, 0, { velocity: 0.8 });
+      clock.now = 0.6;
+      scheduleSnare(dest, 0.7, { velocity: 0.75 });
+
+      expect(noiseSpies.ctorSpy).toHaveBeenCalledTimes(1);
+      expect(noiseSpies.triggerAttackRelease).toHaveBeenCalledTimes(2);
     });
 
     it("skips zero-velocity hits (no NoiseSynth constructed)", () => {
@@ -203,6 +262,16 @@ describe("drumKit — Tone backend", () => {
       expect(duration).toBeCloseTo(0.05, 3);
       expect(time).toBeCloseTo(1.75, 3);
       expect(velocity).toBeCloseTo(0.4, 2);
+    });
+
+    it("reuses one MetalSynth for non-overlapping closed-hat hits on the same destination", () => {
+      const dest = {} as AudioNode;
+      scheduleHiHat(dest, 0, { velocity: 0.4 });
+      clock.now = 0.3;
+      scheduleHiHat(dest, 0.35, { velocity: 0.5 });
+
+      expect(metalSpies.ctorSpy).toHaveBeenCalledTimes(1);
+      expect(metalSpies.triggerAttackRelease).toHaveBeenCalledTimes(2);
     });
 
     it("skips zero-velocity hits (no MetalSynth constructed)", () => {
@@ -275,6 +344,16 @@ describe("drumKit — Tone backend", () => {
       expect(duration).toBeCloseTo(1.0, 3);
       expect(time).toBeCloseTo(4.0, 3);
       expect(velocity).toBeCloseTo(0.6, 2);
+    });
+
+    it("reuses one MetalSynth for non-overlapping ride hits on the same destination", () => {
+      const dest = {} as AudioNode;
+      scheduleRide(dest, 0, { velocity: 0.6 });
+      clock.now = 1.6;
+      scheduleRide(dest, 1.7, { velocity: 0.5 });
+
+      expect(metalSpies.ctorSpy).toHaveBeenCalledTimes(1);
+      expect(metalSpies.triggerAttackRelease).toHaveBeenCalledTimes(2);
     });
 
     it("skips zero-velocity hits (no MetalSynth constructed)", () => {

--- a/src/progressions/audio/drumKit.ts
+++ b/src/progressions/audio/drumKit.ts
@@ -13,6 +13,8 @@
  * `bass.ts`, and `string.ts` after the Phase 7B migration.
  */
 import * as Tone from "tone";
+import type { ReusableVoiceLease } from "./createReusableVoicePool";
+import { createReusableVoicePool } from "./createReusableVoicePool";
 
 const HIT_VELOCITY_DEFAULT = 1;
 
@@ -38,17 +40,12 @@ export interface DrumVoiceHandle {
   cancel: () => void;
 }
 
-interface DisposableSynth {
-  dispose: () => void;
-}
-
-/**
- * Build a one-shot voice handle whose `cancel()` defers `synth.dispose()` by
- * `tailMs` so the voice's release tail isn't cut off. Repeated `cancel()`
- * calls are idempotent — only the first schedules the timer.
- */
 function deferredDisposeHandle(
-  synth: DisposableSynth,
+  lease: ReusableVoiceLease<
+    Tone.MembraneSynth | Tone.NoiseSynth | Tone.MetalSynth
+  >,
+  time: number,
+  busyUntil: number,
   tailMs: number,
 ): DrumVoiceHandle {
   let cancelled = false;
@@ -56,9 +53,22 @@ function deferredDisposeHandle(
     cancel: () => {
       if (cancelled) return;
       cancelled = true;
+      if (!lease.isCurrent()) return;
+
+      const cancelTime = Tone.now();
+      if (cancelTime < time) {
+        lease.dispose();
+        return;
+      }
+
+      if (cancelTime >= busyUntil) {
+        return;
+      }
+
+      lease.setBusyUntil(cancelTime + tailMs / 1000);
       setTimeout(() => {
         try {
-          synth.dispose();
+          lease.dispose();
         } catch {
           /* already disposed */
         }
@@ -68,6 +78,63 @@ function deferredDisposeHandle(
 }
 
 const NOOP_HANDLE: DrumVoiceHandle = { cancel: () => {} };
+const kickVoicePool = createReusableVoicePool<Tone.MembraneSynth>({
+  createVoice: () =>
+    new Tone.MembraneSynth({
+      pitchDecay: 0.04,
+      octaves: 6,
+      oscillator: { type: "sine" },
+      envelope: {
+        attack: 0.001,
+        decay: 0.35,
+        sustain: 0,
+        release: 0.1,
+        attackCurve: "exponential",
+      },
+    }),
+});
+const snareVoicePool = createReusableVoicePool<Tone.NoiseSynth>({
+  createVoice: () =>
+    new Tone.NoiseSynth({
+      noise: { type: "white" },
+      envelope: {
+        attack: 0.001,
+        decay: 0.18,
+        sustain: 0,
+        release: 0.05,
+      },
+    }),
+});
+const closedHatVoicePool = createReusableVoicePool<Tone.MetalSynth>({
+  createVoice: () =>
+    new Tone.MetalSynth({
+      envelope: { attack: 0.001, decay: 0.05, release: 0.02 },
+      harmonicity: 5.1,
+      modulationIndex: 32,
+      resonance: 4000,
+      octaves: 1.5,
+    }),
+});
+const openHatVoicePool = createReusableVoicePool<Tone.MetalSynth>({
+  createVoice: () =>
+    new Tone.MetalSynth({
+      envelope: { attack: 0.001, decay: 0.35, release: 0.02 },
+      harmonicity: 5.1,
+      modulationIndex: 32,
+      resonance: 4000,
+      octaves: 1.5,
+    }),
+});
+const rideVoicePool = createReusableVoicePool<Tone.MetalSynth>({
+  createVoice: () =>
+    new Tone.MetalSynth({
+      envelope: { attack: 0.001, decay: 1.0, release: 0.3 },
+      harmonicity: 3.1,
+      modulationIndex: 22,
+      resonance: 2400,
+      octaves: 1.0,
+    }),
+});
 
 /**
  * Schedule a kick drum hit at `time`. `Tone.MembraneSynth` provides the
@@ -81,22 +148,13 @@ export function scheduleKick(
 ): DrumVoiceHandle {
   const velocity = clampVelocity(options.velocity);
   if (velocity <= 0) return NOOP_HANDLE;
-
-  const synth = new Tone.MembraneSynth({
-    pitchDecay: 0.04,
-    octaves: 6,
-    oscillator: { type: "sine" },
-    envelope: {
-      attack: 0.001,
-      decay: 0.35,
-      sustain: 0,
-      release: 0.1,
-      attackCurve: "exponential",
-    },
-  });
-  synth.connect(dest);
-  synth.triggerAttackRelease("C1", 0.5, time, velocity);
-  return deferredDisposeHandle(synth, KICK_DISPOSE_MS);
+  const now = Tone.now();
+  const playbackStartTime = Math.max(now, time);
+  const lease = kickVoicePool.lease(dest, now);
+  const busyUntil = playbackStartTime + 0.6;
+  lease.setBusyUntil(busyUntil);
+  lease.voice.triggerAttackRelease("C1", 0.5, time, velocity);
+  return deferredDisposeHandle(lease, time, busyUntil, KICK_DISPOSE_MS);
 }
 
 /**
@@ -111,20 +169,14 @@ export function scheduleSnare(
 ): DrumVoiceHandle {
   const velocity = clampVelocity(options.velocity);
   if (velocity <= 0) return NOOP_HANDLE;
-
-  const synth = new Tone.NoiseSynth({
-    noise: { type: "white" },
-    envelope: {
-      attack: 0.001,
-      decay: 0.18,
-      sustain: 0,
-      release: 0.05,
-    },
-  });
-  synth.connect(dest);
+  const now = Tone.now();
+  const playbackStartTime = Math.max(now, time);
+  const lease = snareVoicePool.lease(dest, now);
+  const busyUntil = playbackStartTime + 0.23;
+  lease.setBusyUntil(busyUntil);
   // NoiseSynth has no pitch — signature is (duration, time, velocity).
-  synth.triggerAttackRelease(0.18, time, velocity);
-  return deferredDisposeHandle(synth, SNARE_DISPOSE_MS);
+  lease.voice.triggerAttackRelease(0.18, time, velocity);
+  return deferredDisposeHandle(lease, time, busyUntil, SNARE_DISPOSE_MS);
 }
 
 export interface HiHatOptions extends DrumHitOptions {
@@ -145,18 +197,19 @@ export function scheduleHiHat(
   const velocity = clampVelocity(options.velocity);
   if (velocity <= 0) return NOOP_HANDLE;
   const decay = options.open ? 0.35 : 0.05;
-
-  const synth = new Tone.MetalSynth({
-    envelope: { attack: 0.001, decay, release: 0.02 },
-    harmonicity: 5.1,
-    modulationIndex: 32,
-    resonance: 4000,
-    octaves: 1.5,
-  });
-  synth.connect(dest);
-  synth.triggerAttackRelease("C6", decay, time, velocity);
+  const now = Tone.now();
+  const playbackStartTime = Math.max(now, time);
+  const lease = (options.open ? openHatVoicePool : closedHatVoicePool).lease(
+    dest,
+    now,
+  );
+  const busyUntil = playbackStartTime + decay + 0.02;
+  lease.setBusyUntil(busyUntil);
+  lease.voice.triggerAttackRelease("C6", decay, time, velocity);
   return deferredDisposeHandle(
-    synth,
+    lease,
+    time,
+    busyUntil,
     options.open ? HAT_OPEN_DISPOSE_MS : HAT_CLOSED_DISPOSE_MS,
   );
 }
@@ -178,15 +231,11 @@ export function scheduleRide(
 ): DrumVoiceHandle {
   const velocity = clampVelocity(options.velocity);
   if (velocity <= 0) return NOOP_HANDLE;
-
-  const synth = new Tone.MetalSynth({
-    envelope: { attack: 0.001, decay: 1.0, release: 0.3 },
-    harmonicity: 3.1,
-    modulationIndex: 22,
-    resonance: 2400,
-    octaves: 1.0,
-  });
-  synth.connect(dest);
-  synth.triggerAttackRelease("D6", 1.0, time, velocity);
-  return deferredDisposeHandle(synth, RIDE_DISPOSE_MS);
+  const now = Tone.now();
+  const playbackStartTime = Math.max(now, time);
+  const lease = rideVoicePool.lease(dest, now);
+  const busyUntil = playbackStartTime + 1.3;
+  lease.setBusyUntil(busyUntil);
+  lease.voice.triggerAttackRelease("D6", 1.0, time, velocity);
+  return deferredDisposeHandle(lease, time, busyUntil, RIDE_DISPOSE_MS);
 }

--- a/src/progressions/audio/instruments/createReusableChordVoice.ts
+++ b/src/progressions/audio/instruments/createReusableChordVoice.ts
@@ -10,7 +10,6 @@ interface ReusableChordVoiceConfig {
 }
 
 const DEFAULT_SHARED_MAX_POLYPHONY = 32;
-
 export function createReusableChordVoice(
   config: ReusableChordVoiceConfig,
 ): ChordVoice {
@@ -47,19 +46,38 @@ export function createReusableChordVoice(
 
       const scheduledNotes = [...notes];
       const activeSynth = getSynth(dest, scheduledNotes);
-      activeSynth.triggerAttackRelease(
-        scheduledNotes,
-        config.durationFor(options),
-        time,
-        velocity,
-      );
+      const duration = config.durationFor(options);
+      const now = Tone.now();
+      const delayMs = Math.max(0, (time - now) * 1000);
 
       let cancelled = false;
+      let attackQueued = false;
+      let futureAttackTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const queueAttack = () => {
+        if (cancelled) return;
+        attackQueued = true;
+        futureAttackTimer = null;
+        activeSynth.triggerAttackRelease(scheduledNotes, duration, time, velocity);
+      };
+
+      if (delayMs === 0) {
+        queueAttack();
+      } else {
+        futureAttackTimer = setTimeout(queueAttack, delayMs);
+      }
+
       return {
         cancel: () => {
           if (cancelled) return;
           cancelled = true;
-          activeSynth.triggerRelease(scheduledNotes, Tone.now());
+          if (futureAttackTimer) {
+            clearTimeout(futureAttackTimer);
+            futureAttackTimer = null;
+          }
+          if (attackQueued) {
+            activeSynth.triggerRelease(scheduledNotes, Tone.now());
+          }
         },
       };
     },

--- a/src/progressions/audio/instruments/createReusableChordVoice.ts
+++ b/src/progressions/audio/instruments/createReusableChordVoice.ts
@@ -55,12 +55,10 @@ export function createReusableChordVoice(
   const acquireEntry = (
     dest: AudioNode,
     notes: readonly string[],
-    playbackStartTime: number,
+    now: number,
   ): PooledSynthEntry => {
     const entries = synthPool.get(dest) ?? [];
-    const reusableEntry = entries.find(
-      (entry) => entry.busyUntil <= playbackStartTime,
-    );
+    const reusableEntry = entries.find((entry) => entry.busyUntil <= now);
     if (reusableEntry) {
       reusableEntry.synth.maxPolyphony = Math.max(
         notes.length,
@@ -84,7 +82,7 @@ export function createReusableChordVoice(
       const scheduledNotes = [...notes];
       const durationSec = config.durationFor(options);
       const playbackStartTime = Math.max(now, time);
-      const entry = acquireEntry(dest, scheduledNotes, playbackStartTime);
+      const entry = acquireEntry(dest, scheduledNotes, now);
       const leaseGeneration = entry.leaseGeneration + 1;
       entry.leaseGeneration = leaseGeneration;
       entry.busyUntil = playbackStartTime + durationSec + config.releaseTailSec;

--- a/src/progressions/audio/instruments/createReusableChordVoice.ts
+++ b/src/progressions/audio/instruments/createReusableChordVoice.ts
@@ -55,10 +55,12 @@ export function createReusableChordVoice(
   const acquireEntry = (
     dest: AudioNode,
     notes: readonly string[],
-    now: number,
+    playbackStartTime: number,
   ): PooledSynthEntry => {
     const entries = synthPool.get(dest) ?? [];
-    const reusableEntry = entries.find((entry) => entry.busyUntil <= now);
+    const reusableEntry = entries.find(
+      (entry) => entry.busyUntil <= playbackStartTime,
+    );
     if (reusableEntry) {
       reusableEntry.synth.maxPolyphony = Math.max(
         notes.length,
@@ -81,10 +83,11 @@ export function createReusableChordVoice(
       const now = Tone.now();
       const scheduledNotes = [...notes];
       const durationSec = config.durationFor(options);
-      const entry = acquireEntry(dest, scheduledNotes, now);
+      const playbackStartTime = Math.max(now, time);
+      const entry = acquireEntry(dest, scheduledNotes, playbackStartTime);
       const leaseGeneration = entry.leaseGeneration + 1;
       entry.leaseGeneration = leaseGeneration;
-      entry.busyUntil = time + durationSec + config.releaseTailSec;
+      entry.busyUntil = playbackStartTime + durationSec + config.releaseTailSec;
       entry.synth.triggerAttackRelease(
         scheduledNotes,
         durationSec,

--- a/src/progressions/audio/instruments/createReusableChordVoice.ts
+++ b/src/progressions/audio/instruments/createReusableChordVoice.ts
@@ -45,9 +45,10 @@ export function createReusableChordVoice(
       const velocity = Math.max(0, Math.min(1, options.velocity ?? 0.7));
       if (velocity <= 0 || notes.length === 0) return { cancel: () => {} };
 
-      const activeSynth = getSynth(dest, notes);
+      const scheduledNotes = [...notes];
+      const activeSynth = getSynth(dest, scheduledNotes);
       activeSynth.triggerAttackRelease(
-        notes as string[],
+        scheduledNotes,
         config.durationFor(options),
         time,
         velocity,
@@ -58,7 +59,7 @@ export function createReusableChordVoice(
         cancel: () => {
           if (cancelled) return;
           cancelled = true;
-          activeSynth.releaseAll(Tone.now());
+          activeSynth.triggerRelease(scheduledNotes, Tone.now());
         },
       };
     },

--- a/src/progressions/audio/instruments/createReusableChordVoice.ts
+++ b/src/progressions/audio/instruments/createReusableChordVoice.ts
@@ -6,37 +6,70 @@ interface ReusableChordVoiceConfig {
   maxPolyphonyFloor: number;
   oscillator: { type: "custom"; partials: number[] };
   envelope: { attack: number; decay: number; sustain: number; release: number };
+  releaseTailSec: number;
   durationFor: (options: ChordVoiceOptions) => number;
 }
 
+interface PooledSynthEntry {
+  synth: Tone.PolySynth<Tone.Synth>;
+  busyUntil: number;
+}
+
 const DEFAULT_SHARED_MAX_POLYPHONY = 32;
+
 export function createReusableChordVoice(
   config: ReusableChordVoiceConfig,
 ): ChordVoice {
-  let synth: Tone.PolySynth<Tone.Synth> | null = null;
-  let currentDest: AudioNode | null = null;
+  const synthPool = new WeakMap<AudioNode, PooledSynthEntry[]>();
 
-  const getSynth = (dest: AudioNode, notes: readonly string[]) => {
-    if (!synth) {
-      synth = new Tone.PolySynth(Tone.Synth, {
-        oscillator: config.oscillator,
-        envelope: config.envelope,
-        volume: config.volume,
-      });
+  const removeEntry = (dest: AudioNode, entry: PooledSynthEntry) => {
+    const entries = synthPool.get(dest);
+    if (!entries) return;
+    const nextEntries = entries.filter((candidate) => candidate !== entry);
+    if (nextEntries.length === 0) {
+      synthPool.delete(dest);
+      return;
     }
-    if (currentDest !== dest) {
-      if (currentDest) {
-        synth.disconnect();
-      }
-      synth.connect(dest);
-      currentDest = dest;
-    }
+    synthPool.set(dest, nextEntries);
+  };
+
+  const createEntry = (
+    dest: AudioNode,
+    notes: readonly string[],
+  ): PooledSynthEntry => {
+    const synth = new Tone.PolySynth(Tone.Synth, {
+      oscillator: config.oscillator,
+      envelope: config.envelope,
+      volume: config.volume,
+    });
     synth.maxPolyphony = Math.max(
       notes.length,
       config.maxPolyphonyFloor,
       DEFAULT_SHARED_MAX_POLYPHONY,
     );
-    return synth;
+    synth.connect(dest);
+    return { synth, busyUntil: 0 };
+  };
+
+  const acquireEntry = (
+    dest: AudioNode,
+    notes: readonly string[],
+    now: number,
+  ): PooledSynthEntry => {
+    const entries = synthPool.get(dest) ?? [];
+    const reusableEntry = entries.find((entry) => entry.busyUntil <= now);
+    if (reusableEntry) {
+      reusableEntry.synth.maxPolyphony = Math.max(
+        notes.length,
+        config.maxPolyphonyFloor,
+        DEFAULT_SHARED_MAX_POLYPHONY,
+      );
+      return reusableEntry;
+    }
+
+    const createdEntry = createEntry(dest, notes);
+    synthPool.set(dest, [...entries, createdEntry]);
+    return createdEntry;
   };
 
   return {
@@ -44,40 +77,39 @@ export function createReusableChordVoice(
       const velocity = Math.max(0, Math.min(1, options.velocity ?? 0.7));
       if (velocity <= 0 || notes.length === 0) return { cancel: () => {} };
 
-      const scheduledNotes = [...notes];
-      const activeSynth = getSynth(dest, scheduledNotes);
-      const duration = config.durationFor(options);
       const now = Tone.now();
-      const delayMs = Math.max(0, (time - now) * 1000);
+      const scheduledNotes = [...notes];
+      const durationSec = config.durationFor(options);
+      const entry = acquireEntry(dest, scheduledNotes, now);
+      entry.busyUntil = time + durationSec + config.releaseTailSec;
+      entry.synth.triggerAttackRelease(
+        scheduledNotes,
+        durationSec,
+        time,
+        velocity,
+      );
 
       let cancelled = false;
-      let attackQueued = false;
-      let futureAttackTimer: ReturnType<typeof setTimeout> | null = null;
-
-      const queueAttack = () => {
-        if (cancelled) return;
-        attackQueued = true;
-        futureAttackTimer = null;
-        activeSynth.triggerAttackRelease(scheduledNotes, duration, time, velocity);
-      };
-
-      if (delayMs === 0) {
-        queueAttack();
-      } else {
-        futureAttackTimer = setTimeout(queueAttack, delayMs);
-      }
 
       return {
         cancel: () => {
           if (cancelled) return;
           cancelled = true;
-          if (futureAttackTimer) {
-            clearTimeout(futureAttackTimer);
-            futureAttackTimer = null;
+
+          const cancelTime = Tone.now();
+          if (cancelTime < time) {
+            removeEntry(dest, entry);
+            entry.busyUntil = 0;
+            entry.synth.dispose();
+            return;
           }
-          if (attackQueued) {
-            activeSynth.triggerRelease(scheduledNotes, Tone.now());
+
+          if (cancelTime >= entry.busyUntil) {
+            return;
           }
+
+          entry.busyUntil = cancelTime + config.releaseTailSec;
+          entry.synth.releaseAll(cancelTime);
         },
       };
     },

--- a/src/progressions/audio/instruments/createReusableChordVoice.ts
+++ b/src/progressions/audio/instruments/createReusableChordVoice.ts
@@ -13,6 +13,7 @@ interface ReusableChordVoiceConfig {
 interface PooledSynthEntry {
   synth: Tone.PolySynth<Tone.Synth>;
   busyUntil: number;
+  leaseGeneration: number;
 }
 
 const DEFAULT_SHARED_MAX_POLYPHONY = 32;
@@ -48,7 +49,7 @@ export function createReusableChordVoice(
       DEFAULT_SHARED_MAX_POLYPHONY,
     );
     synth.connect(dest);
-    return { synth, busyUntil: 0 };
+    return { synth, busyUntil: 0, leaseGeneration: 0 };
   };
 
   const acquireEntry = (
@@ -81,6 +82,8 @@ export function createReusableChordVoice(
       const scheduledNotes = [...notes];
       const durationSec = config.durationFor(options);
       const entry = acquireEntry(dest, scheduledNotes, now);
+      const leaseGeneration = entry.leaseGeneration + 1;
+      entry.leaseGeneration = leaseGeneration;
       entry.busyUntil = time + durationSec + config.releaseTailSec;
       entry.synth.triggerAttackRelease(
         scheduledNotes,
@@ -95,6 +98,9 @@ export function createReusableChordVoice(
         cancel: () => {
           if (cancelled) return;
           cancelled = true;
+          if (entry.leaseGeneration !== leaseGeneration) {
+            return;
+          }
 
           const cancelTime = Tone.now();
           if (cancelTime < time) {

--- a/src/progressions/audio/instruments/createReusableChordVoice.ts
+++ b/src/progressions/audio/instruments/createReusableChordVoice.ts
@@ -26,6 +26,9 @@ export function createReusableChordVoice(
       });
     }
     if (currentDest !== dest) {
+      if (currentDest) {
+        synth.disconnect();
+      }
       synth.connect(dest);
       currentDest = dest;
     }

--- a/src/progressions/audio/instruments/createReusableChordVoice.ts
+++ b/src/progressions/audio/instruments/createReusableChordVoice.ts
@@ -1,0 +1,63 @@
+import * as Tone from "tone";
+import type { ChordVoice, ChordVoiceOptions, VoiceHandle } from "./types";
+
+interface ReusableChordVoiceConfig {
+  volume: number;
+  maxPolyphonyFloor: number;
+  oscillator: { type: "custom"; partials: number[] };
+  envelope: { attack: number; decay: number; sustain: number; release: number };
+  durationFor: (options: ChordVoiceOptions) => number;
+}
+
+const DEFAULT_SHARED_MAX_POLYPHONY = 32;
+
+export function createReusableChordVoice(
+  config: ReusableChordVoiceConfig,
+): ChordVoice {
+  let synth: Tone.PolySynth<Tone.Synth> | null = null;
+  let currentDest: AudioNode | null = null;
+
+  const getSynth = (dest: AudioNode, notes: readonly string[]) => {
+    if (!synth) {
+      synth = new Tone.PolySynth(Tone.Synth, {
+        oscillator: config.oscillator,
+        envelope: config.envelope,
+        volume: config.volume,
+      });
+    }
+    if (currentDest !== dest) {
+      synth.connect(dest);
+      currentDest = dest;
+    }
+    synth.maxPolyphony = Math.max(
+      notes.length,
+      config.maxPolyphonyFloor,
+      DEFAULT_SHARED_MAX_POLYPHONY,
+    );
+    return synth;
+  };
+
+  return {
+    scheduleChord(dest, notes, time, options): VoiceHandle {
+      const velocity = Math.max(0, Math.min(1, options.velocity ?? 0.7));
+      if (velocity <= 0 || notes.length === 0) return { cancel: () => {} };
+
+      const activeSynth = getSynth(dest, notes);
+      activeSynth.triggerAttackRelease(
+        notes as string[],
+        config.durationFor(options),
+        time,
+        velocity,
+      );
+
+      let cancelled = false;
+      return {
+        cancel: () => {
+          if (cancelled) return;
+          cancelled = true;
+          activeSynth.releaseAll(Tone.now());
+        },
+      };
+    },
+  };
+}

--- a/src/progressions/audio/instruments/organVoice.test.ts
+++ b/src/progressions/audio/instruments/organVoice.test.ts
@@ -15,16 +15,19 @@ vi.mock("tone", async () => {
   };
 });
 
-import { organVoice } from "./organVoice";
+import type { ChordVoice } from "./types";
 
 describe("organVoice — Tone.PolySynth backend", () => {
   let spies: Awaited<typeof tone>["spies"];
+  let organVoice: ChordVoice;
 
   beforeEach(async () => {
     const t = await tone;
     spies = t.spies;
     vi.useFakeTimers();
     t.reset();
+    vi.resetModules();
+    ({ organVoice } = await import("./organVoice"));
   });
 
   afterEach(() => {
@@ -65,6 +68,19 @@ describe("organVoice — Tone.PolySynth backend", () => {
     expect(duration).toBeCloseTo(1.5, 3); // sustained (default)
     expect(time).toBeCloseTo(4.0, 3);
     expect(velocity).toBeCloseTo(0.5, 2);
+  });
+
+  it("reuses one PolySynth across successive organ schedules", () => {
+    organVoice.scheduleChord({} as AudioNode, ["C3", "E3", "G3"], 0, {
+      velocity: 0.7,
+    });
+    organVoice.scheduleChord({} as AudioNode, ["D3", "F3", "A3"], 1, {
+      velocity: 0.7,
+    });
+
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
+    expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+    expect(spies.ctorSpy.mock.results[0]?.value.maxPolyphony).toBe(32);
   });
 
   it("uses the staccato duration when options.style === 'staccato'", () => {
@@ -111,7 +127,7 @@ describe("organVoice — Tone.PolySynth backend", () => {
     expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
   });
 
-  it("cancel() releases all voices then defers dispose past the release tail", () => {
+  it("cancel() releases all voices immediately", () => {
     const handle = organVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
@@ -121,11 +137,9 @@ describe("organVoice — Tone.PolySynth backend", () => {
     handle.cancel();
     expect(spies.releaseAll).toHaveBeenCalledTimes(1);
     expect(spies.dispose).not.toHaveBeenCalled();
-    vi.advanceTimersByTime(800); // > DISPOSE_TAIL_MS (700)
-    expect(spies.dispose).toHaveBeenCalledTimes(1);
   });
 
-  it("cancel() is idempotent — repeated calls schedule release/dispose only once", () => {
+  it("cancel() is idempotent — repeated calls release only once", () => {
     const handle = organVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
@@ -135,8 +149,7 @@ describe("organVoice — Tone.PolySynth backend", () => {
     handle.cancel();
     handle.cancel();
     handle.cancel();
-    vi.advanceTimersByTime(800);
     expect(spies.releaseAll).toHaveBeenCalledTimes(1);
-    expect(spies.dispose).toHaveBeenCalledTimes(1);
+    expect(spies.dispose).not.toHaveBeenCalled();
   });
 });

--- a/src/progressions/audio/instruments/organVoice.test.ts
+++ b/src/progressions/audio/instruments/organVoice.test.ts
@@ -142,7 +142,7 @@ describe("organVoice — Tone.PolySynth backend", () => {
     expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
   });
 
-  it("cancel() releases all voices immediately", () => {
+  it("cancel() releases only that handle's notes immediately", () => {
     const handle = organVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
@@ -150,7 +150,37 @@ describe("organVoice — Tone.PolySynth backend", () => {
       { velocity: 0.7 },
     );
     handle.cancel();
-    expect(spies.releaseAll).toHaveBeenCalledTimes(1);
+    expect(spies.triggerRelease).toHaveBeenCalledTimes(1);
+    expect(spies.triggerRelease).toHaveBeenCalledWith(["C3", "E3", "G3"], 0);
+    expect(spies.releaseAll).not.toHaveBeenCalled();
+    expect(spies.dispose).not.toHaveBeenCalled();
+  });
+
+  it("cancel() keeps shared synth handles isolated", () => {
+    const firstHandle = organVoice.scheduleChord(
+      {} as AudioNode,
+      ["C3", "E3", "G3"],
+      0,
+      { velocity: 0.7 },
+    );
+    const secondHandle = organVoice.scheduleChord(
+      {} as AudioNode,
+      ["D3", "F3", "A3"],
+      0.5,
+      { velocity: 0.7 },
+    );
+
+    firstHandle.cancel();
+
+    expect(spies.triggerRelease).toHaveBeenCalledTimes(1);
+    expect(spies.triggerRelease).toHaveBeenCalledWith(["C3", "E3", "G3"], 0);
+    expect(spies.releaseAll).not.toHaveBeenCalled();
+
+    secondHandle.cancel();
+
+    expect(spies.triggerRelease).toHaveBeenCalledTimes(2);
+    expect(spies.triggerRelease).toHaveBeenNthCalledWith(2, ["D3", "F3", "A3"], 0);
+    expect(spies.releaseAll).not.toHaveBeenCalled();
     expect(spies.dispose).not.toHaveBeenCalled();
   });
 
@@ -164,7 +194,9 @@ describe("organVoice — Tone.PolySynth backend", () => {
     handle.cancel();
     handle.cancel();
     handle.cancel();
-    expect(spies.releaseAll).toHaveBeenCalledTimes(1);
+    expect(spies.triggerRelease).toHaveBeenCalledTimes(1);
+    expect(spies.triggerRelease).toHaveBeenCalledWith(["C3", "E3", "G3"], 0);
+    expect(spies.releaseAll).not.toHaveBeenCalled();
     expect(spies.dispose).not.toHaveBeenCalled();
   });
 });

--- a/src/progressions/audio/instruments/organVoice.test.ts
+++ b/src/progressions/audio/instruments/organVoice.test.ts
@@ -54,13 +54,15 @@ describe("organVoice — Tone.PolySynth backend", () => {
     expect(opts.volume).toBe(-10);
   });
 
-  it("triggers the full voicing once with the requested time + velocity (sustained default)", () => {
+  it("triggers the full voicing once with the requested time + velocity (sustained default)", async () => {
     organVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
       4.0,
       { velocity: 0.5 },
     );
+    expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(4_500);
     expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(1);
     const [chord, duration, time, velocity] =
       spies.triggerAttackRelease.mock.calls[0]!;
@@ -74,7 +76,7 @@ describe("organVoice — Tone.PolySynth backend", () => {
     organVoice.scheduleChord({} as AudioNode, ["C3", "E3", "G3"], 0, {
       velocity: 0.7,
     });
-    organVoice.scheduleChord({} as AudioNode, ["D3", "F3", "A3"], 1, {
+    organVoice.scheduleChord({} as AudioNode, ["D3", "F3", "A3"], 0, {
       velocity: 0.7,
     });
 
@@ -88,7 +90,7 @@ describe("organVoice — Tone.PolySynth backend", () => {
     const secondDest = {} as AudioNode;
 
     organVoice.scheduleChord(firstDest, ["C3", "E3", "G3"], 0, { velocity: 0.7 });
-    organVoice.scheduleChord(secondDest, ["D3", "F3", "A3"], 1, { velocity: 0.7 });
+    organVoice.scheduleChord(secondDest, ["D3", "F3", "A3"], 0, { velocity: 0.7 });
 
     expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
     expect(spies.connect).toHaveBeenCalledTimes(2);
@@ -166,7 +168,7 @@ describe("organVoice — Tone.PolySynth backend", () => {
     const secondHandle = organVoice.scheduleChord(
       {} as AudioNode,
       ["D3", "F3", "A3"],
-      0.5,
+      0,
       { velocity: 0.7 },
     );
 
@@ -182,6 +184,22 @@ describe("organVoice — Tone.PolySynth backend", () => {
     expect(spies.triggerRelease).toHaveBeenNthCalledWith(2, ["D3", "F3", "A3"], 0);
     expect(spies.releaseAll).not.toHaveBeenCalled();
     expect(spies.dispose).not.toHaveBeenCalled();
+  });
+
+  it("cancel() prevents a future-scheduled chord from ever being attacked", async () => {
+    const handle = organVoice.scheduleChord(
+      {} as AudioNode,
+      ["C3", "E3", "G3"],
+      2,
+      { velocity: 0.7 },
+    );
+
+    handle.cancel();
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
+    expect(spies.triggerRelease).not.toHaveBeenCalled();
+    expect(spies.releaseAll).not.toHaveBeenCalled();
   });
 
   it("cancel() is idempotent — repeated calls release only once", () => {

--- a/src/progressions/audio/instruments/organVoice.test.ts
+++ b/src/progressions/audio/instruments/organVoice.test.ts
@@ -11,7 +11,7 @@ vi.mock("tone", async () => {
   return {
     PolySynth: t.spies.ctorSpy,
     Synth: function ToneSynthSentinel() {},
-    now: () => 0,
+    now: () => t.now(),
   };
 });
 
@@ -55,28 +55,34 @@ describe("organVoice — Tone.PolySynth backend", () => {
   });
 
   it("triggers the full voicing once with the requested time + velocity (sustained default)", async () => {
+    const t = await tone;
     organVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
       4.0,
       { velocity: 0.5 },
     );
-    expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(4_500);
     expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(1);
+    expect(spies.playbackAttackRelease).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(4_500);
+    t.setNow(4.5);
+    expect(spies.playbackAttackRelease).toHaveBeenCalledTimes(1);
     const [chord, duration, time, velocity] =
-      spies.triggerAttackRelease.mock.calls[0]!;
+      spies.playbackAttackRelease.mock.calls[0]!;
     expect(chord).toEqual(["C3", "E3", "G3"]);
     expect(duration).toBeCloseTo(1.5, 3); // sustained (default)
     expect(time).toBeCloseTo(4.0, 3);
     expect(velocity).toBeCloseTo(0.5, 2);
   });
 
-  it("reuses one PolySynth across successive organ schedules", () => {
-    organVoice.scheduleChord({} as AudioNode, ["C3", "E3", "G3"], 0, {
+  it("reuses one PolySynth for non-overlapping organ schedules on the same destination", async () => {
+    const t = await tone;
+    const dest = {} as AudioNode;
+    organVoice.scheduleChord(dest, ["C3", "E3", "G3"], 0, {
       velocity: 0.7,
     });
-    organVoice.scheduleChord({} as AudioNode, ["D3", "F3", "A3"], 0, {
+    t.setNow(2.2);
+    organVoice.scheduleChord(dest, ["D3", "F3", "A3"], 2.3, {
       velocity: 0.7,
     });
 
@@ -85,19 +91,23 @@ describe("organVoice — Tone.PolySynth backend", () => {
     expect(spies.ctorSpy.mock.results[0]?.value.maxPolyphony).toBe(32);
   });
 
-  it("disconnects the old destination before reconnecting the shared synth", () => {
+  it("keeps different destinations on different leased synths", async () => {
+    const t = await tone;
     const firstDest = {} as AudioNode;
     const secondDest = {} as AudioNode;
 
     organVoice.scheduleChord(firstDest, ["C3", "E3", "G3"], 0, { velocity: 0.7 });
-    organVoice.scheduleChord(secondDest, ["D3", "F3", "A3"], 0, { velocity: 0.7 });
+    t.setNow(2.2);
+    organVoice.scheduleChord(secondDest, ["D3", "F3", "A3"], 2.3, {
+      velocity: 0.7,
+    });
 
-    expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(2);
     expect(spies.connect).toHaveBeenCalledTimes(2);
-    expect(spies.disconnect).toHaveBeenCalledTimes(1);
-    expect(spies.disconnect.mock.invocationCallOrder[0]).toBeLessThan(
-      spies.connect.mock.invocationCallOrder[1]!,
-    );
+    expect(spies.disconnect).not.toHaveBeenCalled();
+    const [firstInstance, secondInstance] = t.instances;
+    expect(firstInstance?.connect).toHaveBeenCalledWith(firstDest);
+    expect(secondInstance?.connect).toHaveBeenCalledWith(secondDest);
   });
 
   it("uses the staccato duration when options.style === 'staccato'", () => {
@@ -144,49 +154,70 @@ describe("organVoice — Tone.PolySynth backend", () => {
     expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
   });
 
-  it("cancel() releases only that handle's notes immediately", () => {
+  it("cancel() releases only that leased synth after playback has started", async () => {
+    const t = await tone;
     const handle = organVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
       0,
       { velocity: 0.7 },
     );
+    await vi.advanceTimersByTimeAsync(1);
+    t.setNow(0.001);
     handle.cancel();
-    expect(spies.triggerRelease).toHaveBeenCalledTimes(1);
-    expect(spies.triggerRelease).toHaveBeenCalledWith(["C3", "E3", "G3"], 0);
-    expect(spies.releaseAll).not.toHaveBeenCalled();
+    expect(spies.releaseAll).toHaveBeenCalledTimes(1);
+    expect(spies.releaseAll).toHaveBeenCalledWith(0.001);
+    expect(spies.triggerRelease).not.toHaveBeenCalled();
     expect(spies.dispose).not.toHaveBeenCalled();
   });
 
-  it("cancel() keeps shared synth handles isolated", () => {
+  it("cancel() leaves another leased synth untouched", async () => {
+    const t = await tone;
+    const dest = {} as AudioNode;
     const firstHandle = organVoice.scheduleChord(
-      {} as AudioNode,
+      dest,
       ["C3", "E3", "G3"],
       0,
       { velocity: 0.7 },
     );
     const secondHandle = organVoice.scheduleChord(
-      {} as AudioNode,
+      dest,
       ["D3", "F3", "A3"],
       0,
       { velocity: 0.7 },
     );
 
+    await vi.advanceTimersByTimeAsync(1);
+    t.setNow(0.001);
     firstHandle.cancel();
 
-    expect(spies.triggerRelease).toHaveBeenCalledTimes(1);
-    expect(spies.triggerRelease).toHaveBeenCalledWith(["C3", "E3", "G3"], 0);
-    expect(spies.releaseAll).not.toHaveBeenCalled();
+    const [firstInstance, secondInstance] = (await tone).instances;
+    expect(firstInstance?.releaseAll).toHaveBeenCalledTimes(1);
+    expect(secondInstance?.releaseAll).not.toHaveBeenCalled();
 
     secondHandle.cancel();
 
-    expect(spies.triggerRelease).toHaveBeenCalledTimes(2);
-    expect(spies.triggerRelease).toHaveBeenNthCalledWith(2, ["D3", "F3", "A3"], 0);
-    expect(spies.releaseAll).not.toHaveBeenCalled();
+    expect(firstInstance?.releaseAll).toHaveBeenCalledTimes(1);
+    expect(secondInstance?.releaseAll).toHaveBeenCalledTimes(1);
     expect(spies.dispose).not.toHaveBeenCalled();
   });
 
+  it("late cancel after the busy window does not block same-destination reuse", async () => {
+    const t = await tone;
+    const dest = {} as AudioNode;
+    const handle = organVoice.scheduleChord(dest, ["C3", "E3", "G3"], 0, {
+      velocity: 0.7,
+    });
+
+    t.setNow(2.2);
+    handle.cancel();
+    organVoice.scheduleChord(dest, ["D3", "F3", "A3"], 2.3, { velocity: 0.7 });
+
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("cancel() prevents a future-scheduled chord from ever being attacked", async () => {
+    const t = await tone;
     const handle = organVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
@@ -194,27 +225,33 @@ describe("organVoice — Tone.PolySynth backend", () => {
       { velocity: 0.7 },
     );
 
+    expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(1);
+    expect(spies.playbackAttackRelease).not.toHaveBeenCalled();
     handle.cancel();
     await vi.advanceTimersByTimeAsync(2_500);
+    t.setNow(2.5);
 
-    expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
+    expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(1);
+    expect(spies.playbackAttackRelease).not.toHaveBeenCalled();
     expect(spies.triggerRelease).not.toHaveBeenCalled();
     expect(spies.releaseAll).not.toHaveBeenCalled();
+    expect(spies.dispose).toHaveBeenCalledTimes(1);
   });
 
-  it("cancel() is idempotent — repeated calls release only once", () => {
+  it("cancel() is idempotent — repeated calls release only once", async () => {
+    const t = await tone;
     const handle = organVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
       0,
       { velocity: 0.7 },
     );
+    await vi.advanceTimersByTimeAsync(1);
+    t.setNow(0.001);
     handle.cancel();
     handle.cancel();
     handle.cancel();
-    expect(spies.triggerRelease).toHaveBeenCalledTimes(1);
-    expect(spies.triggerRelease).toHaveBeenCalledWith(["C3", "E3", "G3"], 0);
-    expect(spies.releaseAll).not.toHaveBeenCalled();
+    expect(spies.releaseAll).toHaveBeenCalledTimes(1);
     expect(spies.dispose).not.toHaveBeenCalled();
   });
 });

--- a/src/progressions/audio/instruments/organVoice.test.ts
+++ b/src/progressions/audio/instruments/organVoice.test.ts
@@ -83,6 +83,21 @@ describe("organVoice — Tone.PolySynth backend", () => {
     expect(spies.ctorSpy.mock.results[0]?.value.maxPolyphony).toBe(32);
   });
 
+  it("disconnects the old destination before reconnecting the shared synth", () => {
+    const firstDest = {} as AudioNode;
+    const secondDest = {} as AudioNode;
+
+    organVoice.scheduleChord(firstDest, ["C3", "E3", "G3"], 0, { velocity: 0.7 });
+    organVoice.scheduleChord(secondDest, ["D3", "F3", "A3"], 1, { velocity: 0.7 });
+
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
+    expect(spies.connect).toHaveBeenCalledTimes(2);
+    expect(spies.disconnect).toHaveBeenCalledTimes(1);
+    expect(spies.disconnect.mock.invocationCallOrder[0]).toBeLessThan(
+      spies.connect.mock.invocationCallOrder[1]!,
+    );
+  });
+
   it("uses the staccato duration when options.style === 'staccato'", () => {
     organVoice.scheduleChord(
       {} as AudioNode,

--- a/src/progressions/audio/instruments/organVoice.ts
+++ b/src/progressions/audio/instruments/organVoice.ts
@@ -1,85 +1,9 @@
-/**
- * Organ chord voice for the progression backing track. A Tone.PolySynth of
- * Tone.Synth voices with a sine oscillator + drawbar-style partials gives
- * the held, breathy character of a tonewheel organ. The envelope sustains
- * high (0.9) so the chord holds at full level until release — by default
- * notes ring for 1.5s; `style: "staccato"` cuts that to 0.2s for short hits.
- *
- * Replaces the prior raw-Web-Audio drawbar additive synthesis with a Tone-
- * native voice so silenceProgressionBus()/Transport scheduling stay coherent
- * with the rest of the backing track (bass, metronome, strum, piano).
- */
-import * as Tone from "tone";
-import type { ChordVoice, ChordVoiceOptions, VoiceHandle } from "./types";
+import { createReusableChordVoice } from "./createReusableChordVoice";
 
-// Release tail is 0.6s; defer dispose past that so the natural decay isn't
-// truncated when a chord change cancels a still-ringing voice.
-const DISPOSE_TAIL_MS = 700;
-const STACCATO_DURATION = 0.2;
-const SUSTAINED_DURATION = 1.5;
-
-export const organVoice: ChordVoice = {
-  scheduleChord(
-    dest: AudioNode,
-    notes: readonly string[],
-    time: number,
-    options: ChordVoiceOptions,
-  ): VoiceHandle {
-    const velocity = Math.max(0, Math.min(1, options.velocity ?? 0.7));
-    // Skip silent or empty chords entirely. Constructing a PolySynth for an
-    // inaudible hit would allocate voices we'd have to clean up for no gain.
-    if (velocity <= 0 || notes.length === 0) {
-      return { cancel: () => {} };
-    }
-
-    const synth = new Tone.PolySynth(Tone.Synth, {
-      // Sine-flavoured drawbar partials. Tone requires `type: "custom"`
-      // whenever a partials array is supplied; the gently-decaying amplitudes
-      // here approximate a Hammond drawbar registration of the lower harmonics.
-      oscillator: {
-        type: "custom",
-        partials: [1, 0.6, 0.4, 0.3, 0.2],
-      },
-      envelope: { attack: 0.02, decay: 0.05, sustain: 0.9, release: 0.6 },
-      volume: -10,
-    });
-    // Allow at least the full voicing simultaneously. Default polyphony (32)
-    // is plenty, but we clamp the floor to the voicing width in case Tone
-    // ever lowers the default.
-    synth.maxPolyphony = Math.max(notes.length, 6);
-    synth.connect(dest);
-
-    // Organs default to sustained — the short style only fires when the
-    // caller explicitly opts in with `style: "staccato"`.
-    const duration =
-      options.style === "staccato" ? STACCATO_DURATION : SUSTAINED_DURATION;
-    synth.triggerAttackRelease(notes as string[], duration, time, velocity);
-
-    let cancelled = false;
-    return {
-      cancel: () => {
-        if (cancelled) return;
-        cancelled = true;
-        // releaseAll triggers the envelope's release on every currently-
-        // playing voice. We defer dispose so the 0.6s release tail isn't
-        // chopped off mid-decay (which would produce an audible click).
-        try {
-          synth.releaseAll(Tone.now());
-          setTimeout(() => {
-            try {
-              synth.dispose();
-            } catch {
-              /* already disposed */
-            }
-          }, DISPOSE_TAIL_MS);
-        } catch {
-          try {
-            synth.dispose();
-          } catch {
-            /* already disposed */
-          }
-        }
-      },
-    };
-  },
-};
+export const organVoice = createReusableChordVoice({
+  volume: -10,
+  maxPolyphonyFloor: 6,
+  oscillator: { type: "custom", partials: [1, 0.6, 0.4, 0.3, 0.2] },
+  envelope: { attack: 0.02, decay: 0.05, sustain: 0.9, release: 0.6 },
+  durationFor: (options) => (options.style === "staccato" ? 0.2 : 1.5),
+});

--- a/src/progressions/audio/instruments/organVoice.ts
+++ b/src/progressions/audio/instruments/organVoice.ts
@@ -5,5 +5,6 @@ export const organVoice = createReusableChordVoice({
   maxPolyphonyFloor: 6,
   oscillator: { type: "custom", partials: [1, 0.6, 0.4, 0.3, 0.2] },
   envelope: { attack: 0.02, decay: 0.05, sustain: 0.9, release: 0.6 },
+  releaseTailSec: 0.6,
   durationFor: (options) => (options.style === "staccato" ? 0.2 : 1.5),
 });

--- a/src/progressions/audio/instruments/pianoVoice.test.ts
+++ b/src/progressions/audio/instruments/pianoVoice.test.ts
@@ -237,6 +237,33 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("cancel() becomes a no-op after that pooled synth lease is reassigned", async () => {
+    const t = await tone;
+    const dest = {} as AudioNode;
+    const firstHandle = pianoVoice.scheduleChord(dest, ["C3", "E3", "G3"], 0, {
+      velocity: 0.7,
+      style: "staccato",
+    });
+
+    t.setNow(2);
+    const secondHandle = pianoVoice.scheduleChord(dest, ["F3", "A3", "C4"], 2.1, {
+      velocity: 0.7,
+      style: "staccato",
+    });
+
+    await vi.advanceTimersByTimeAsync(2_200);
+    t.setNow(2.2);
+    firstHandle.cancel();
+
+    const [sharedInstance] = t.instances;
+    expect(sharedInstance?.releaseAll).not.toHaveBeenCalled();
+
+    secondHandle.cancel();
+
+    expect(sharedInstance?.releaseAll).toHaveBeenCalledTimes(1);
+    expect(sharedInstance?.releaseAll).toHaveBeenCalledWith(2.2);
+  });
+
   it("cancel() prevents a future-scheduled chord from ever being attacked", async () => {
     const t = await tone;
     const handle = pianoVoice.scheduleChord(

--- a/src/progressions/audio/instruments/pianoVoice.test.ts
+++ b/src/progressions/audio/instruments/pianoVoice.test.ts
@@ -15,7 +15,7 @@ vi.mock("tone", async () => {
   return {
     PolySynth: t.spies.ctorSpy,
     Synth: function ToneSynthSentinel() {},
-    now: () => 0,
+    now: () => t.now(),
   };
 });
 
@@ -60,29 +60,43 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
   });
 
   it("triggers the full voicing once with the requested time + velocity (staccato default)", async () => {
+    const t = await tone;
     pianoVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
       2.5,
       { velocity: 0.6 },
     );
-    expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(3_000);
     expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(1);
-    const [chord, duration, time, velocity] =
+    expect(spies.playbackAttackRelease).not.toHaveBeenCalled();
+    const [scheduledChord, scheduledDuration, scheduledTime, scheduledVelocity] =
       spies.triggerAttackRelease.mock.calls[0]!;
+    expect(scheduledChord).toEqual(["C3", "E3", "G3"]);
+    expect(scheduledDuration).toBeCloseTo(0.4, 3);
+    expect(scheduledTime).toBeCloseTo(2.5, 3);
+    expect(scheduledVelocity).toBeCloseTo(0.6, 2);
+    await vi.advanceTimersByTimeAsync(3_000);
+    t.setNow(3);
+    expect(spies.playbackAttackRelease).toHaveBeenCalledTimes(1);
+    const [chord, duration, time, velocity] =
+      spies.playbackAttackRelease.mock.calls[0]!;
     expect(chord).toEqual(["C3", "E3", "G3"]);
     expect(duration).toBeCloseTo(0.4, 3); // staccato (default)
     expect(time).toBeCloseTo(2.5, 3);
     expect(velocity).toBeCloseTo(0.6, 2);
   });
 
-  it("reuses one PolySynth across successive piano schedules", () => {
-    pianoVoice.scheduleChord({} as AudioNode, ["C3", "E3", "G3"], 0, {
+  it("reuses one PolySynth for non-overlapping piano schedules on the same destination", async () => {
+    const t = await tone;
+    const dest = {} as AudioNode;
+    pianoVoice.scheduleChord(dest, ["C3", "E3", "G3"], 0, {
       velocity: 0.7,
+      style: "staccato",
     });
-    pianoVoice.scheduleChord({} as AudioNode, ["F3", "A3", "C4"], 0, {
+    t.setNow(2);
+    pianoVoice.scheduleChord(dest, ["F3", "A3", "C4"], 2.1, {
       velocity: 0.7,
+      style: "staccato",
     });
 
     expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
@@ -90,19 +104,27 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     expect(spies.ctorSpy.mock.results[0]?.value.maxPolyphony).toBe(32);
   });
 
-  it("disconnects the old destination before reconnecting the shared synth", () => {
+  it("keeps different destinations on different leased synths", async () => {
+    const t = await tone;
     const firstDest = {} as AudioNode;
     const secondDest = {} as AudioNode;
 
-    pianoVoice.scheduleChord(firstDest, ["C3", "E3", "G3"], 0, { velocity: 0.7 });
-    pianoVoice.scheduleChord(secondDest, ["F3", "A3", "C4"], 0, { velocity: 0.7 });
+    pianoVoice.scheduleChord(firstDest, ["C3", "E3", "G3"], 0, {
+      velocity: 0.7,
+      style: "staccato",
+    });
+    t.setNow(2);
+    pianoVoice.scheduleChord(secondDest, ["F3", "A3", "C4"], 2.1, {
+      velocity: 0.7,
+      style: "staccato",
+    });
 
-    expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(2);
     expect(spies.connect).toHaveBeenCalledTimes(2);
-    expect(spies.disconnect).toHaveBeenCalledTimes(1);
-    expect(spies.disconnect.mock.invocationCallOrder[0]).toBeLessThan(
-      spies.connect.mock.invocationCallOrder[1]!,
-    );
+    expect(spies.disconnect).not.toHaveBeenCalled();
+    const [firstInstance, secondInstance] = t.instances;
+    expect(firstInstance?.connect).toHaveBeenCalledWith(firstDest);
+    expect(secondInstance?.connect).toHaveBeenCalledWith(secondDest);
   });
 
   it("uses the sustained duration when options.style === 'sustained'", () => {
@@ -149,49 +171,74 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
   });
 
-  it("cancel() releases only that handle's notes immediately", () => {
+  it("cancel() releases only that leased synth after playback has started", async () => {
+    const t = await tone;
     const handle = pianoVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
       0,
       { velocity: 0.7 },
     );
+    await vi.advanceTimersByTimeAsync(1);
+    t.setNow(0.001);
     handle.cancel();
-    expect(spies.triggerRelease).toHaveBeenCalledTimes(1);
-    expect(spies.triggerRelease).toHaveBeenCalledWith(["C3", "E3", "G3"], 0);
-    expect(spies.releaseAll).not.toHaveBeenCalled();
+    expect(spies.releaseAll).toHaveBeenCalledTimes(1);
+    expect(spies.releaseAll).toHaveBeenCalledWith(0.001);
+    expect(spies.triggerRelease).not.toHaveBeenCalled();
     expect(spies.dispose).not.toHaveBeenCalled();
   });
 
-  it("cancel() keeps shared synth handles isolated", () => {
+  it("cancel() leaves another leased synth untouched", async () => {
+    const t = await tone;
+    const dest = {} as AudioNode;
     const firstHandle = pianoVoice.scheduleChord(
-      {} as AudioNode,
+      dest,
       ["C3", "E3", "G3"],
       0,
       { velocity: 0.7 },
     );
     const secondHandle = pianoVoice.scheduleChord(
-      {} as AudioNode,
+      dest,
       ["F3", "A3", "C4"],
       0,
       { velocity: 0.7 },
     );
 
+    await vi.advanceTimersByTimeAsync(1);
+    t.setNow(0.001);
     firstHandle.cancel();
 
-    expect(spies.triggerRelease).toHaveBeenCalledTimes(1);
-    expect(spies.triggerRelease).toHaveBeenCalledWith(["C3", "E3", "G3"], 0);
-    expect(spies.releaseAll).not.toHaveBeenCalled();
+    const [firstInstance, secondInstance] = (await tone).instances;
+    expect(firstInstance?.releaseAll).toHaveBeenCalledTimes(1);
+    expect(secondInstance?.releaseAll).not.toHaveBeenCalled();
 
     secondHandle.cancel();
 
-    expect(spies.triggerRelease).toHaveBeenCalledTimes(2);
-    expect(spies.triggerRelease).toHaveBeenNthCalledWith(2, ["F3", "A3", "C4"], 0);
-    expect(spies.releaseAll).not.toHaveBeenCalled();
+    expect(firstInstance?.releaseAll).toHaveBeenCalledTimes(1);
+    expect(secondInstance?.releaseAll).toHaveBeenCalledTimes(1);
     expect(spies.dispose).not.toHaveBeenCalled();
   });
 
+  it("late cancel after the busy window does not block same-destination reuse", async () => {
+    const t = await tone;
+    const dest = {} as AudioNode;
+    const handle = pianoVoice.scheduleChord(dest, ["C3", "E3", "G3"], 0, {
+      velocity: 0.7,
+      style: "staccato",
+    });
+
+    t.setNow(2);
+    handle.cancel();
+    pianoVoice.scheduleChord(dest, ["F3", "A3", "C4"], 2.1, {
+      velocity: 0.7,
+      style: "staccato",
+    });
+
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("cancel() prevents a future-scheduled chord from ever being attacked", async () => {
+    const t = await tone;
     const handle = pianoVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
@@ -199,27 +246,33 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
       { velocity: 0.7 },
     );
 
+    expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(1);
+    expect(spies.playbackAttackRelease).not.toHaveBeenCalled();
     handle.cancel();
     await vi.advanceTimersByTimeAsync(2_500);
+    t.setNow(2.5);
 
-    expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
+    expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(1);
+    expect(spies.playbackAttackRelease).not.toHaveBeenCalled();
     expect(spies.triggerRelease).not.toHaveBeenCalled();
     expect(spies.releaseAll).not.toHaveBeenCalled();
+    expect(spies.dispose).toHaveBeenCalledTimes(1);
   });
 
-  it("cancel() is idempotent — repeated calls release only once", () => {
+  it("cancel() is idempotent — repeated calls release only once", async () => {
+    const t = await tone;
     const handle = pianoVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
       0,
       { velocity: 0.7 },
     );
+    await vi.advanceTimersByTimeAsync(1);
+    t.setNow(0.001);
     handle.cancel();
     handle.cancel();
     handle.cancel();
-    expect(spies.triggerRelease).toHaveBeenCalledTimes(1);
-    expect(spies.triggerRelease).toHaveBeenCalledWith(["C3", "E3", "G3"], 0);
-    expect(spies.releaseAll).not.toHaveBeenCalled();
+    expect(spies.releaseAll).toHaveBeenCalledTimes(1);
     expect(spies.dispose).not.toHaveBeenCalled();
   });
 });

--- a/src/progressions/audio/instruments/pianoVoice.test.ts
+++ b/src/progressions/audio/instruments/pianoVoice.test.ts
@@ -104,6 +104,26 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     expect(spies.ctorSpy.mock.results[0]?.value.maxPolyphony).toBe(32);
   });
 
+  it("reuses an existing pooled PolySynth for a later future hit in the same scheduling pass", () => {
+    const dest = {} as AudioNode;
+
+    pianoVoice.scheduleChord(dest, ["C3", "E3", "G3"], 4, {
+      velocity: 0.7,
+      style: "staccato",
+    });
+    pianoVoice.scheduleChord(dest, ["E3", "G3", "B3"], 4.5, {
+      velocity: 0.7,
+      style: "staccato",
+    });
+    pianoVoice.scheduleChord(dest, ["G3", "B3", "D4"], 5.7, {
+      velocity: 0.7,
+      style: "staccato",
+    });
+
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(2);
+    expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(3);
+  });
+
   it("keeps different destinations on different leased synths", async () => {
     const t = await tone;
     const firstDest = {} as AudioNode;

--- a/src/progressions/audio/instruments/pianoVoice.test.ts
+++ b/src/progressions/audio/instruments/pianoVoice.test.ts
@@ -59,13 +59,15 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     expect(opts.volume).toBe(-6);
   });
 
-  it("triggers the full voicing once with the requested time + velocity (staccato default)", () => {
+  it("triggers the full voicing once with the requested time + velocity (staccato default)", async () => {
     pianoVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
       2.5,
       { velocity: 0.6 },
     );
+    expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(3_000);
     expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(1);
     const [chord, duration, time, velocity] =
       spies.triggerAttackRelease.mock.calls[0]!;
@@ -79,7 +81,7 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     pianoVoice.scheduleChord({} as AudioNode, ["C3", "E3", "G3"], 0, {
       velocity: 0.7,
     });
-    pianoVoice.scheduleChord({} as AudioNode, ["F3", "A3", "C4"], 1, {
+    pianoVoice.scheduleChord({} as AudioNode, ["F3", "A3", "C4"], 0, {
       velocity: 0.7,
     });
 
@@ -93,7 +95,7 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     const secondDest = {} as AudioNode;
 
     pianoVoice.scheduleChord(firstDest, ["C3", "E3", "G3"], 0, { velocity: 0.7 });
-    pianoVoice.scheduleChord(secondDest, ["F3", "A3", "C4"], 1, { velocity: 0.7 });
+    pianoVoice.scheduleChord(secondDest, ["F3", "A3", "C4"], 0, { velocity: 0.7 });
 
     expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
     expect(spies.connect).toHaveBeenCalledTimes(2);
@@ -171,7 +173,7 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     const secondHandle = pianoVoice.scheduleChord(
       {} as AudioNode,
       ["F3", "A3", "C4"],
-      0.5,
+      0,
       { velocity: 0.7 },
     );
 
@@ -187,6 +189,22 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     expect(spies.triggerRelease).toHaveBeenNthCalledWith(2, ["F3", "A3", "C4"], 0);
     expect(spies.releaseAll).not.toHaveBeenCalled();
     expect(spies.dispose).not.toHaveBeenCalled();
+  });
+
+  it("cancel() prevents a future-scheduled chord from ever being attacked", async () => {
+    const handle = pianoVoice.scheduleChord(
+      {} as AudioNode,
+      ["C3", "E3", "G3"],
+      2,
+      { velocity: 0.7 },
+    );
+
+    handle.cancel();
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
+    expect(spies.triggerRelease).not.toHaveBeenCalled();
+    expect(spies.releaseAll).not.toHaveBeenCalled();
   });
 
   it("cancel() is idempotent — repeated calls release only once", () => {

--- a/src/progressions/audio/instruments/pianoVoice.test.ts
+++ b/src/progressions/audio/instruments/pianoVoice.test.ts
@@ -19,16 +19,19 @@ vi.mock("tone", async () => {
   };
 });
 
-import { pianoVoice } from "./pianoVoice";
+import type { ChordVoice } from "./types";
 
 describe("pianoVoice — Tone.PolySynth backend", () => {
   let spies: Awaited<typeof tone>["spies"];
+  let pianoVoice: ChordVoice;
 
   beforeEach(async () => {
     const t = await tone;
     spies = t.spies;
     vi.useFakeTimers();
     t.reset();
+    vi.resetModules();
+    ({ pianoVoice } = await import("./pianoVoice"));
   });
 
   afterEach(() => {
@@ -70,6 +73,19 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     expect(duration).toBeCloseTo(0.4, 3); // staccato (default)
     expect(time).toBeCloseTo(2.5, 3);
     expect(velocity).toBeCloseTo(0.6, 2);
+  });
+
+  it("reuses one PolySynth across successive piano schedules", () => {
+    pianoVoice.scheduleChord({} as AudioNode, ["C3", "E3", "G3"], 0, {
+      velocity: 0.7,
+    });
+    pianoVoice.scheduleChord({} as AudioNode, ["F3", "A3", "C4"], 1, {
+      velocity: 0.7,
+    });
+
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
+    expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+    expect(spies.ctorSpy.mock.results[0]?.value.maxPolyphony).toBe(32);
   });
 
   it("uses the sustained duration when options.style === 'sustained'", () => {
@@ -116,7 +132,7 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
   });
 
-  it("cancel() releases all voices then defers dispose past the release tail", () => {
+  it("cancel() releases all voices immediately", () => {
     const handle = pianoVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
@@ -125,13 +141,10 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     );
     handle.cancel();
     expect(spies.releaseAll).toHaveBeenCalledTimes(1);
-    // Dispose is deferred so the 1.2s release tail isn't truncated.
     expect(spies.dispose).not.toHaveBeenCalled();
-    vi.advanceTimersByTime(1400); // > DISPOSE_TAIL_MS (1300)
-    expect(spies.dispose).toHaveBeenCalledTimes(1);
   });
 
-  it("cancel() is idempotent — repeated calls schedule release/dispose only once", () => {
+  it("cancel() is idempotent — repeated calls release only once", () => {
     const handle = pianoVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
@@ -141,8 +154,7 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     handle.cancel();
     handle.cancel();
     handle.cancel();
-    vi.advanceTimersByTime(1400);
     expect(spies.releaseAll).toHaveBeenCalledTimes(1);
-    expect(spies.dispose).toHaveBeenCalledTimes(1);
+    expect(spies.dispose).not.toHaveBeenCalled();
   });
 });

--- a/src/progressions/audio/instruments/pianoVoice.test.ts
+++ b/src/progressions/audio/instruments/pianoVoice.test.ts
@@ -104,7 +104,7 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     expect(spies.ctorSpy.mock.results[0]?.value.maxPolyphony).toBe(32);
   });
 
-  it("reuses an existing pooled PolySynth for a later future hit in the same scheduling pass", () => {
+  it("allocates separate PolySynths for future hits scheduled in one pass", () => {
     const dest = {} as AudioNode;
 
     pianoVoice.scheduleChord(dest, ["C3", "E3", "G3"], 4, {
@@ -120,7 +120,7 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
       style: "staccato",
     });
 
-    expect(spies.ctorSpy).toHaveBeenCalledTimes(2);
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(3);
     expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(3);
   });
 

--- a/src/progressions/audio/instruments/pianoVoice.test.ts
+++ b/src/progressions/audio/instruments/pianoVoice.test.ts
@@ -147,7 +147,7 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
   });
 
-  it("cancel() releases all voices immediately", () => {
+  it("cancel() releases only that handle's notes immediately", () => {
     const handle = pianoVoice.scheduleChord(
       {} as AudioNode,
       ["C3", "E3", "G3"],
@@ -155,7 +155,37 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
       { velocity: 0.7 },
     );
     handle.cancel();
-    expect(spies.releaseAll).toHaveBeenCalledTimes(1);
+    expect(spies.triggerRelease).toHaveBeenCalledTimes(1);
+    expect(spies.triggerRelease).toHaveBeenCalledWith(["C3", "E3", "G3"], 0);
+    expect(spies.releaseAll).not.toHaveBeenCalled();
+    expect(spies.dispose).not.toHaveBeenCalled();
+  });
+
+  it("cancel() keeps shared synth handles isolated", () => {
+    const firstHandle = pianoVoice.scheduleChord(
+      {} as AudioNode,
+      ["C3", "E3", "G3"],
+      0,
+      { velocity: 0.7 },
+    );
+    const secondHandle = pianoVoice.scheduleChord(
+      {} as AudioNode,
+      ["F3", "A3", "C4"],
+      0.5,
+      { velocity: 0.7 },
+    );
+
+    firstHandle.cancel();
+
+    expect(spies.triggerRelease).toHaveBeenCalledTimes(1);
+    expect(spies.triggerRelease).toHaveBeenCalledWith(["C3", "E3", "G3"], 0);
+    expect(spies.releaseAll).not.toHaveBeenCalled();
+
+    secondHandle.cancel();
+
+    expect(spies.triggerRelease).toHaveBeenCalledTimes(2);
+    expect(spies.triggerRelease).toHaveBeenNthCalledWith(2, ["F3", "A3", "C4"], 0);
+    expect(spies.releaseAll).not.toHaveBeenCalled();
     expect(spies.dispose).not.toHaveBeenCalled();
   });
 
@@ -169,7 +199,9 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     handle.cancel();
     handle.cancel();
     handle.cancel();
-    expect(spies.releaseAll).toHaveBeenCalledTimes(1);
+    expect(spies.triggerRelease).toHaveBeenCalledTimes(1);
+    expect(spies.triggerRelease).toHaveBeenCalledWith(["C3", "E3", "G3"], 0);
+    expect(spies.releaseAll).not.toHaveBeenCalled();
     expect(spies.dispose).not.toHaveBeenCalled();
   });
 });

--- a/src/progressions/audio/instruments/pianoVoice.test.ts
+++ b/src/progressions/audio/instruments/pianoVoice.test.ts
@@ -88,6 +88,21 @@ describe("pianoVoice — Tone.PolySynth backend", () => {
     expect(spies.ctorSpy.mock.results[0]?.value.maxPolyphony).toBe(32);
   });
 
+  it("disconnects the old destination before reconnecting the shared synth", () => {
+    const firstDest = {} as AudioNode;
+    const secondDest = {} as AudioNode;
+
+    pianoVoice.scheduleChord(firstDest, ["C3", "E3", "G3"], 0, { velocity: 0.7 });
+    pianoVoice.scheduleChord(secondDest, ["F3", "A3", "C4"], 1, { velocity: 0.7 });
+
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
+    expect(spies.connect).toHaveBeenCalledTimes(2);
+    expect(spies.disconnect).toHaveBeenCalledTimes(1);
+    expect(spies.disconnect.mock.invocationCallOrder[0]).toBeLessThan(
+      spies.connect.mock.invocationCallOrder[1]!,
+    );
+  });
+
   it("uses the sustained duration when options.style === 'sustained'", () => {
     pianoVoice.scheduleChord(
       {} as AudioNode,

--- a/src/progressions/audio/instruments/pianoVoice.ts
+++ b/src/progressions/audio/instruments/pianoVoice.ts
@@ -1,84 +1,9 @@
-/**
- * Piano chord voice for the progression backing track. A Tone.PolySynth of
- * Tone.Synth voices with a triangle oscillator + harmonic partials gives a
- * percussive plucked-piano character. The amplitude envelope decays quickly
- * (sustain 0.1) so default playback is staccato; `style: "sustained"` simply
- * holds the gate open longer (1.2s vs 0.4s) before triggering release.
- *
- * Replaces the prior raw-Web-Audio FM synthesis with a Tone-native voice so
- * silenceProgressionBus()/Transport scheduling stay coherent with the rest of
- * the backing track (bass, metronome, strum).
- */
-import * as Tone from "tone";
-import type { ChordVoice, ChordVoiceOptions, VoiceHandle } from "./types";
+import { createReusableChordVoice } from "./createReusableChordVoice";
 
-// Release tail is 1.2s; defer dispose past that so the natural decay isn't
-// truncated when a chord change cancels a still-ringing voice.
-const DISPOSE_TAIL_MS = 1300;
-const STACCATO_DURATION = 0.4;
-const SUSTAINED_DURATION = 1.2;
-
-export const pianoVoice: ChordVoice = {
-  scheduleChord(
-    dest: AudioNode,
-    notes: readonly string[],
-    time: number,
-    options: ChordVoiceOptions,
-  ): VoiceHandle {
-    const velocity = Math.max(0, Math.min(1, options.velocity ?? 0.7));
-    // Skip silent or empty chords entirely. Constructing a PolySynth for an
-    // inaudible hit would allocate voices we'd have to clean up for no gain.
-    if (velocity <= 0 || notes.length === 0) {
-      return { cancel: () => {} };
-    }
-
-    const synth = new Tone.PolySynth(Tone.Synth, {
-      // Triangle-flavoured partials. Tone requires `type: "custom"` whenever
-      // a partials array is supplied; the descending amplitudes here give a
-      // bright, slightly-percussive piano-ish timbre on top of the
-      // amplitude-envelope decay.
-      oscillator: {
-        type: "custom",
-        partials: [1, 0.5, 0.25, 0.12],
-      },
-      envelope: { attack: 0.005, decay: 0.4, sustain: 0.1, release: 1.2 },
-      volume: -6,
-    });
-    // Allow at least the full voicing simultaneously. Default polyphony (32)
-    // is plenty, but we clamp the floor to the voicing width in case Tone
-    // ever lowers the default.
-    synth.maxPolyphony = Math.max(notes.length, 6);
-    synth.connect(dest);
-
-    const duration =
-      options.style === "sustained" ? SUSTAINED_DURATION : STACCATO_DURATION;
-    synth.triggerAttackRelease(notes as string[], duration, time, velocity);
-
-    let cancelled = false;
-    return {
-      cancel: () => {
-        if (cancelled) return;
-        cancelled = true;
-        // releaseAll triggers the envelope's release on every currently-
-        // playing voice. We defer dispose so the 1.2s release tail isn't
-        // chopped off mid-decay (which would produce an audible click).
-        try {
-          synth.releaseAll(Tone.now());
-          setTimeout(() => {
-            try {
-              synth.dispose();
-            } catch {
-              /* already disposed */
-            }
-          }, DISPOSE_TAIL_MS);
-        } catch {
-          try {
-            synth.dispose();
-          } catch {
-            /* already disposed */
-          }
-        }
-      },
-    };
-  },
-};
+export const pianoVoice = createReusableChordVoice({
+  volume: -6,
+  maxPolyphonyFloor: 6,
+  oscillator: { type: "custom", partials: [1, 0.5, 0.25, 0.12] },
+  envelope: { attack: 0.005, decay: 0.4, sustain: 0.1, release: 1.2 },
+  durationFor: (options) => (options.style === "sustained" ? 1.2 : 0.4),
+});

--- a/src/progressions/audio/instruments/pianoVoice.ts
+++ b/src/progressions/audio/instruments/pianoVoice.ts
@@ -5,5 +5,6 @@ export const pianoVoice = createReusableChordVoice({
   maxPolyphonyFloor: 6,
   oscillator: { type: "custom", partials: [1, 0.5, 0.25, 0.12] },
   envelope: { attack: 0.005, decay: 0.4, sustain: 0.1, release: 1.2 },
+  releaseTailSec: 1.2,
   durationFor: (options) => (options.style === "sustained" ? 1.2 : 0.4),
 });

--- a/src/progressions/audio/metronome.test.ts
+++ b/src/progressions/audio/metronome.test.ts
@@ -14,21 +14,23 @@ vi.mock("tone", async () => {
   const s = await synth;
   return {
     Synth: s.spies.ctorSpy,
-    now: () => 0,
+    now: () => s.now(),
     gainToDb: (g: number) => 20 * Math.log10(Math.max(1e-6, g)),
   };
 });
 
-import { scheduleClick } from "./metronome";
-
 describe("scheduleClick — Tone backend", () => {
   let spies: Awaited<typeof synth>["spies"];
+  let tone: Awaited<typeof synth>;
+  let scheduleClick: typeof import("./metronome").scheduleClick;
 
   beforeEach(async () => {
-    const s = await synth;
-    spies = s.spies;
+    tone = await synth;
+    spies = tone.spies;
     vi.useFakeTimers();
-    s.reset();
+    tone.reset();
+    vi.resetModules();
+    ({ scheduleClick } = await import("./metronome"));
   });
 
   afterEach(() => {
@@ -51,6 +53,38 @@ describe("scheduleClick — Tone backend", () => {
     expect(spies.triggerAttackRelease.mock.calls[0]![0]).toBeCloseTo(900, 0);
   });
 
+  it("reuses one Synth for non-overlapping clicks on the same destination", () => {
+    const dest = {} as AudioNode;
+    scheduleClick(dest, 0, { accent: true, velocity: 0.8 });
+    tone.setNow(0.2);
+    scheduleClick(dest, 0.25, { accent: false, velocity: 0.7 });
+
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(1);
+    expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+  });
+
+  it("allocates separate Synths for future clicks scheduled in one pass", () => {
+    const dest = {} as AudioNode;
+    scheduleClick(dest, 2, { accent: true, velocity: 0.8 });
+    scheduleClick(dest, 2.5, { accent: false, velocity: 0.7 });
+
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(2);
+    expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps different destinations on different leased synths", () => {
+    const firstDest = {} as AudioNode;
+    const secondDest = {} as AudioNode;
+
+    scheduleClick(firstDest, 0, { accent: true, velocity: 0.8 });
+    tone.setNow(0.2);
+    scheduleClick(secondDest, 0.25, { accent: false, velocity: 0.7 });
+
+    expect(spies.ctorSpy).toHaveBeenCalledTimes(2);
+    expect(tone.instances[0]?.connect).toHaveBeenCalledWith(firstDest);
+    expect(tone.instances[1]?.connect).toHaveBeenCalledWith(secondDest);
+  });
+
   it("skips scheduling when velocity is zero", () => {
     scheduleClick({} as AudioNode, 0, { velocity: 0 });
     expect(spies.triggerAttackRelease).not.toHaveBeenCalled();
@@ -65,6 +99,19 @@ describe("scheduleClick — Tone backend", () => {
     expect(spies.dispose).not.toHaveBeenCalled();
     vi.advanceTimersByTime(25);
     expect(spies.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel() prevents a future-scheduled click from ever being attacked", async () => {
+    const handle = scheduleClick({} as AudioNode, 2, { accent: true, velocity: 0.8 });
+
+    expect(spies.triggerAttackRelease).toHaveBeenCalledTimes(1);
+    expect(spies.playbackAttackRelease).not.toHaveBeenCalled();
+
+    handle.cancel();
+    await vi.advanceTimersByTimeAsync(2_500);
+    tone.setNow(2.5);
+
+    expect(spies.playbackAttackRelease).not.toHaveBeenCalled();
   });
 
   it("cancel() is idempotent — repeated calls schedule release/dispose only once", () => {

--- a/src/progressions/audio/metronome.ts
+++ b/src/progressions/audio/metronome.ts
@@ -9,10 +9,15 @@
  * synth's output to it so pausing the bus also cuts the click.
  */
 import * as Tone from "tone";
+import { createReusableVoicePool } from "./createReusableVoicePool";
 
 const ACCENT_FREQ = 1500;
 const NORMAL_FREQ = 900;
 const DECAY = 0.04;
+const RELEASE = 0.01;
+const RELEASE_TAIL_SEC = RELEASE;
+const DISPOSE_TAIL_MS = 20;
+const DISPOSE_TAIL_SEC = DISPOSE_TAIL_MS / 1000;
 
 export interface ClickOptions {
   accent?: boolean;
@@ -23,6 +28,14 @@ export interface ClickHandle {
   cancel: () => void;
 }
 
+const clickVoicePool = createReusableVoicePool({
+  createVoice: () =>
+    new Tone.Synth({
+      oscillator: { type: "sine" },
+      envelope: { attack: 0.001, decay: DECAY, sustain: 0, release: RELEASE },
+    }),
+});
+
 export function scheduleClick(
   dest: AudioNode,
   time: number,
@@ -32,14 +45,14 @@ export function scheduleClick(
   if (velocity <= 0) return { cancel: () => {} };
 
   const frequency = options.accent ? ACCENT_FREQ : NORMAL_FREQ;
-  const synth = new Tone.Synth({
-    oscillator: { type: "sine" },
-    envelope: { attack: 0.001, decay: DECAY, sustain: 0, release: 0.01 },
-  });
+  const now = Tone.now();
+  const playbackStartTime = Math.max(now, time);
+  const lease = clickVoicePool.lease(dest, now);
+  let busyUntil = playbackStartTime + DECAY + RELEASE_TAIL_SEC;
+  lease.setBusyUntil(busyUntil);
   // Route through the existing progression bus so silenceProgressionBus()
   // mutes the metronome along with the rest of the backing track.
-  synth.connect(dest);
-  synth.triggerAttackRelease(frequency, DECAY, time, velocity);
+  lease.voice.triggerAttackRelease(frequency, DECAY, time, velocity);
 
   // Tone's voice manager will release the synth on its own, but the
   // scheduler's `cancelAll()` contract requires immediate teardown for
@@ -55,21 +68,35 @@ export function scheduleClick(
     cancel: () => {
       if (cancelled) return;
       cancelled = true;
+      if (!lease.isCurrent()) return;
+
+      const cancelTime = Tone.now();
+      if (cancelTime < time) {
+        lease.dispose();
+        return;
+      }
+
+      if (cancelTime >= busyUntil) {
+        return;
+      }
+
+      busyUntil = cancelTime + DISPOSE_TAIL_SEC;
+      lease.setBusyUntil(busyUntil);
       try {
         // Close the envelope explicitly so the tail isn't truncated mid-decay.
-        synth.triggerRelease(Tone.now());
+        lease.voice.triggerRelease(cancelTime);
         // Give the release ~10 ms to settle, then free the resources.
         setTimeout(() => {
           try {
-            synth.dispose();
+            lease.dispose();
           } catch {
             /* already disposed */
           }
-        }, 20);
+        }, DISPOSE_TAIL_MS);
       } catch {
         // If triggerRelease throws (already disposed?) fall through to dispose.
         try {
-          synth.dispose();
+          lease.dispose();
         } catch {
           /* already disposed */
         }

--- a/src/test-utils/toneMocks.ts
+++ b/src/test-utils/toneMocks.ts
@@ -12,12 +12,25 @@ import { vi } from "vitest";
 export interface ToneSynthSpies {
   ctorSpy: Mock;
   triggerAttackRelease: Mock;
+  playbackAttackRelease: Mock;
   triggerRelease: Mock;
   triggerAttack: Mock;
   releaseAll: Mock;
   connect: Mock;
   disconnect: Mock;
   dispose: Mock;
+}
+
+export interface ToneSynthInstanceSpies {
+  triggerAttackRelease: Mock;
+  triggerRelease: Mock;
+  triggerAttack: Mock;
+  releaseAll: Mock;
+  connect: Mock;
+  disconnect: Mock;
+  dispose: Mock;
+  volume: { value: number };
+  maxPolyphony: number;
 }
 
 /**
@@ -27,11 +40,17 @@ export interface ToneSynthSpies {
  */
 export function createToneSynthSpies(): {
   spies: ToneSynthSpies;
+  instances: ToneSynthInstanceSpies[];
+  now: () => number;
+  setNow: (value: number) => void;
   reset: () => void;
 } {
+  const instances: ToneSynthInstanceSpies[] = [];
+  let currentNow = 0;
   const spies: ToneSynthSpies = {
     ctorSpy: vi.fn(),
     triggerAttackRelease: vi.fn(),
+    playbackAttackRelease: vi.fn(),
     triggerRelease: vi.fn(),
     triggerAttack: vi.fn(),
     releaseAll: vi.fn(),
@@ -41,24 +60,72 @@ export function createToneSynthSpies(): {
   };
   const install = () => {
     spies.ctorSpy.mockImplementation(function () {
-      return {
-        triggerAttackRelease: spies.triggerAttackRelease,
-        triggerRelease: spies.triggerRelease,
-        triggerAttack: spies.triggerAttack,
-        releaseAll: spies.releaseAll,
-        connect: spies.connect,
-        disconnect: spies.disconnect,
-        dispose: spies.dispose,
+      let disposed = false;
+      const playbackTimers = new Set<ReturnType<typeof setTimeout>>();
+      const instance: ToneSynthInstanceSpies = {
+        triggerAttackRelease: vi.fn((...args: unknown[]) => {
+          spies.triggerAttackRelease(...args);
+          const playbackTime =
+            typeof args[2] === "number" ? Math.max(currentNow, args[2]) : currentNow;
+          const delayMs = Math.max(0, (playbackTime - currentNow) * 1000);
+          const playbackTimer = setTimeout(() => {
+            playbackTimers.delete(playbackTimer);
+            if (!disposed) {
+              spies.playbackAttackRelease(...args);
+            }
+          }, delayMs);
+          playbackTimers.add(playbackTimer);
+          return instance;
+        }),
+        triggerRelease: vi.fn((...args: unknown[]) => {
+          spies.triggerRelease(...args);
+          return instance;
+        }),
+        triggerAttack: vi.fn((...args: unknown[]) => {
+          spies.triggerAttack(...args);
+          return instance;
+        }),
+        releaseAll: vi.fn((...args: unknown[]) => {
+          spies.releaseAll(...args);
+          return instance;
+        }),
+        connect: vi.fn((...args: unknown[]) => {
+          spies.connect(...args);
+          return instance;
+        }),
+        disconnect: vi.fn((...args: unknown[]) => {
+          spies.disconnect(...args);
+          return instance;
+        }),
+        dispose: vi.fn((...args: unknown[]) => {
+          disposed = true;
+          for (const playbackTimer of playbackTimers) {
+            clearTimeout(playbackTimer);
+          }
+          playbackTimers.clear();
+          spies.dispose(...args);
+        }),
         volume: { value: 0 },
+        maxPolyphony: 0,
       };
+      instances.push(instance);
+      return instance;
     });
   };
   install();
   return {
     spies,
+    instances,
+    now: () => currentNow,
+    setNow: (value: number) => {
+      currentNow = value;
+    },
     reset: () => {
+      currentNow = 0;
+      instances.length = 0;
       spies.ctorSpy.mockReset();
       spies.triggerAttackRelease.mockReset();
+      spies.playbackAttackRelease.mockReset();
       spies.triggerRelease.mockReset();
       spies.triggerAttack.mockReset();
       spies.releaseAll.mockReset();

--- a/src/test-utils/toneMocks.ts
+++ b/src/test-utils/toneMocks.ts
@@ -16,6 +16,7 @@ export interface ToneSynthSpies {
   triggerAttack: Mock;
   releaseAll: Mock;
   connect: Mock;
+  disconnect: Mock;
   dispose: Mock;
 }
 
@@ -35,6 +36,7 @@ export function createToneSynthSpies(): {
     triggerAttack: vi.fn(),
     releaseAll: vi.fn(),
     connect: vi.fn().mockReturnThis(),
+    disconnect: vi.fn().mockReturnThis(),
     dispose: vi.fn(),
   };
   const install = () => {
@@ -45,6 +47,7 @@ export function createToneSynthSpies(): {
         triggerAttack: spies.triggerAttack,
         releaseAll: spies.releaseAll,
         connect: spies.connect,
+        disconnect: spies.disconnect,
         dispose: spies.dispose,
         volume: { value: 0 },
       };
@@ -60,6 +63,7 @@ export function createToneSynthSpies(): {
       spies.triggerAttack.mockReset();
       spies.releaseAll.mockReset();
       spies.connect.mockReset().mockReturnThis();
+      spies.disconnect.mockReset().mockReturnThis();
       spies.dispose.mockReset();
       install();
     },


### PR DESCRIPTION
## Summary
- **Lazy Guitar Audio**: Defer Tone.js initialization until interaction via a new facade in `src/core/lazyGuitarAudio.ts`.
- **Fretboard Immediate Paint**: Remove visibility gate in `Fretboard.tsx`; seed width from `window.innerWidth` so the neck paints before ResizeObserver fires.
- **Voice Pooling & Reuse**: Introduce `createReusableVoicePool.ts` and `createReusableChordVoice.ts` to cache Tone synths across schedules, eliminating constructor churn in the playback click path.

## Test Plan
- [x] `pnpm run test` (1859/1859 passing)
- [x] Verified constructor reuse with new unit tests in `pianoVoice.test.ts`, `bass.test.ts`, etc.
- [x] Verified lazy load and error replay in `lazyGuitarAudio.test.ts`.
- [x] Successful production build via `pnpm run build`.