### PR TITLE
docs(release): require BREAKING CHANGE footer for major bumps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,17 @@ pnpm run preview               # preview build locally
 
 - **Branching:** Trunk-based. `main` = trunk. PRs required.
 - **Commits:** Conventional Commits with scope. `type(scope): message`.
+- **Breaking changes:** The Auto Release workflow uses the Angular preset, which does **not** recognize the `!` shorthand (e.g. `feat!:`). To trigger a major version bump you **must** include a `BREAKING CHANGE:` footer in the commit body:
+
+  ```text
+  feat(scope): short subject
+
+  Optional body.
+
+  BREAKING CHANGE: explanation of what breaks and how to migrate.
+  ```
+
+  When merging a PR via squash, ensure the squash commit body (not just the title) carries the footer — GitHub does not append PR body to the commit by default. Without the footer, breaking PRs will be released as a minor bump.
 - **Releases:** Triggered via GitHub Actions (Auto Release). Never tag manually.
 
 ## Architecture

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fretboard-app",
   "private": true,
-  "version": "1.27.0",
+  "version": "2.0.0",
   "type": "module",
   "main": "./packages/core/dist/index.js",
   "types": "./packages/core/dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fretboard-app",
   "private": true,
-  "version": "2.0.0",
+  "version": "1.27.0",
   "type": "module",
   "main": "./packages/core/dist/index.js",
   "types": "./packages/core/dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Document that Auto Release uses the Angular conventional-commits preset, which does **not** recognize the `!` shorthand for breaking changes.
- Require a `BREAKING CHANGE:` footer in the commit body for any breaking PR going forward.
- Reassert the v2.0 breaking change that was missed by [PR #451](https://github.com/iecg/fretboard-app/pull/451) (`feat(v2.0)!: shell restructure + voicing overhaul + chord input redesign`), which released as 1.27.0 instead of 2.0.0.

## Why

The default preset for `mathieudutour/github-tag-action@v6.2` (used in [auto-release.yml:41](.github/workflows/auto-release.yml#L41)) only honors a `BREAKING CHANGE:` footer — not `feat!:` / `fix!:`. PR #451 used only the `!` notation, so the analyzer scored it as a minor bump and released 1.27.0.

Adding the footer here lets the next Auto Release dispatch from `main` produce a `v2.0.0` tag, retroactively marking the v2.0 line.

## Merge instructions (important)

⚠️ **The `BREAKING CHANGE:` footer must end up in the commit on `main`.** GitHub's squash-merge UI defaults the squash body to the PR description, not commit bodies.

Two safe options:

1. **Squash + paste the footer into the PR description below this line before merging.**
2. **Use "Rebase and merge"** — preserves the original commit body verbatim.

After merging, manually dispatch the **Auto Release** workflow from `main`. It should calculate `v2.0.0`.

## Test plan

- [ ] Tests + lint pass locally (pre-push hooks already ran on push).
- [ ] Verify the squash/rebase commit on `main` contains the `BREAKING CHANGE:` footer.
- [ ] Dispatch Auto Release; confirm the calculated tag is `v2.0.0` (dry-run output in the workflow logs).
- [ ] Confirm the auto-generated bump PR sets `package.json` to `2.0.0`.

---

BREAKING CHANGE: This release marks the v2.0 line. The shell restructure, voicing overhaul, and chord input redesign landed in PR #451 (commit dfbf3277) introduce breaking changes to public layout/voicing/chord-input behavior. The `!` notation in that commit was not picked up by the auto-release Angular preset, so this footer reasserts the breaking change to trigger the correct major version bump on the next Auto Release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development and release process guidelines for conventional commits and version management procedures.

**Note:** This release contains no end-user facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->