### PR TITLE
chore(release): mark v2.0 line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,13 @@ pnpm run preview               # preview build locally
   ```
 
   When merging a PR via squash, ensure the squash commit body (not just the title) carries the footer — GitHub does not append PR body to the commit by default. Without the footer, breaking PRs will be released as a minor bump.
+
+  **Footer placement matters.** `conventional-commits-parser` only promotes `BREAKING CHANGE:` to a breaking-change note when it lives in the **footer section** — the final paragraph block of the commit. Things that displace it out of the footer block (and silently demote the release to a minor bump):
+  - Markdown horizontal rules (`---`, `---------`) in the body.
+  - A trailing `Co-authored-by:` / `Signed-off-by:` / "Generated with Claude Code" paragraph after the `BREAKING CHANGE:` line.
+  - Any "token: value" paragraph that comes after `BREAKING CHANGE:`.
+
+  Keep the body plain text and put `BREAKING CHANGE:` as the last paragraph. If the squash UI appends trailers, use **Rebase and merge** instead to preserve the body verbatim. After merging, dispatch Auto Release and confirm the dry-run prints `Type: major` before the tag step runs.
 - **Releases:** Triggered via GitHub Actions (Auto Release). Never tag manually.
 
 ## Architecture


### PR DESCRIPTION
## Summary

Re-assert the v2.0 breaking change from [#451](https://github.com/iecg/fretboard-app/pull/451) so the next **Auto Release** dispatch produces `v2.0.0`. The previous attempt in [#463](https://github.com/iecg/fretboard-app/pull/463) included a `BREAKING CHANGE:` footer in the commit body, but the analyzer logged `The commit should not trigger a release` and calculated `v1.27.1` anyway.

## Root cause

`conventional-commits-parser` only promotes `BREAKING CHANGE:` to a breaking note when it sits in the **footer section** — the final paragraph block of the commit. In the squash commit for #463, the footer was displaced by:

- Markdown horizontal rules (`---`, `---------`) earlier in the body.
- A trailing `Co-authored-by:` paragraph after the `BREAKING CHANGE:` line.

The parser treated the `Co-authored-by:` paragraph as the footer block, so the breaking note was silently dropped and the release scored as `none` for that commit.

## What this PR does

1. Adds guidance in [CLAUDE.md](CLAUDE.md) about footer placement (no markdown rules, no trailers after `BREAKING CHANGE:`).
2. Carries a clean `BREAKING CHANGE:` footer as the **last paragraph** of the commit body so the analyzer actually emits the major bump.

## Merge instructions

The squash commit on `main` must keep `BREAKING CHANGE:` as the final paragraph.

**Recommended:** Use **Rebase and merge** — preserves the commit body verbatim.

If squashing instead, the squash UI body below must end with the footer and nothing else (no `Co-authored-by:`, no Claude Code marker, no `---`):

```text
chore(release): mark v2.0 line

Re-assert the breaking change from PR #451 that the Auto Release
analyzer missed on commits 9596e41 and dfbf3277. Strengthen the
CLAUDE.md guidance so future breaking PRs put the footer in the
position the parser actually reads.

BREAKING CHANGE: shell restructure, voicing overhaul, and chord input
redesign from PR #451 change public layout, voicing, and chord-input
behavior. This commit exists to trigger the v2.0.0 tag that PR #451
should have produced.
```

After merging, dispatch **Auto Release** from `main` and confirm the dry-run log prints `New version is 2.0.0` before the tag step runs.

## Test plan

- [ ] Tests + lint pass locally (pre-push hooks ran).
- [ ] Squash/rebase commit on `main` ends with the `BREAKING CHANGE:` paragraph.
- [ ] Auto Release dry-run shows `Type: major` and `New version is 2.0.0`.
- [ ] Auto-generated bump PR sets `package.json` to `2.0.0`.