### PR TITLE
chore(release): mark v2.0 line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ pnpm run preview               # preview build locally
   - Any "token: value" paragraph that comes after `BREAKING CHANGE:`.
 
   Keep the body plain text and put `BREAKING CHANGE:` as the last paragraph. If the squash UI appends trailers, use **Rebase and merge** instead to preserve the body verbatim. After merging, dispatch Auto Release and confirm the dry-run prints `Type: major` before the tag step runs.
+
+  When squashing, GitHub fills the squash body from the PR description by default. Confirmed failure mode: PR #463 and PR #465 both squashed with a PR description that contained markdown rules and ended with a `Co-authored-by:` paragraph, and the analyzer scored both as non-breaking. The safe path for any breaking PR is to use **Rebase and merge** so the branch commit body lands on `main` verbatim.
 - **Releases:** Triggered via GitHub Actions (Auto Release). Never tag manually.
 
 ## Architecture


### PR DESCRIPTION
Re-assert the v2.0 breaking change from PR #451 so the next Auto Release dispatch produces v2.0.0. PR #463 and PR #465 both attempted this and both squashed in a way that dropped the footer.

## ⚠️ Use "Rebase and merge"

Do **not** squash this PR. The squash UI replaces the commit body with this PR description (and may append Co-authored-by trailers), which is exactly what dropped the BREAKING CHANGE footer on the previous two attempts.

**Rebase and merge** preserves the branch commit verbatim, which is the only form the conventional-commits parser will accept.

The branch commit body (what must land on main):

    chore(release): mark v2.0 line

    Re-assert the v2.0 breaking change from PR #451 that the Auto Release
    analyzer missed on commits 9596e41, 1570f26, and dfbf3277. Strengthen
    the CLAUDE.md guidance with the confirmed failure mode from PR #463
    and PR #465.

    BREAKING CHANGE: shell restructure, voicing overhaul, and chord input
    redesign from PR #451 change public layout, voicing, and chord-input
    behavior. This commit exists to trigger the v2.0.0 tag that PR #451
    should have produced.

## After merge

Dispatch **Auto Release** from main. The dry-run log must print `Type: major` and `New version is 2.0.0`. If it prints anything else, the footer was dropped again — do not proceed with the tag.