### PR TITLE
perf: implement visual and audio progression performance optimizations

### DIFF
--- a/docs/superpowers/plans/2026-05-27-fretflow-performance-optimizations.md
+++ b/docs/superpowers/plans/2026-05-27-fretflow-performance-optimizations.md
@@ -1,0 +1,367 @@
+# FretFlow Performance Optimizations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Completely eliminate downbeat playhead stuttering and interaction lag during progression playback by decoupling connector rendering from animation frames, caching visual chord voicings on edit, pre-compiling backing audio timelines, and deferring heavy SVG repaints using React 19 concurrent transitions.
+
+**Architecture:** We will separate the stable fretboard note geometry (static coordinates) from the high-frequency animation overlays (playhead glides and guide-tone pulsing). We will introduce eager, debounced background calculations for both the audio timeline compilation and visual voicing permutations. Finally, we will wrap progression step transitions in React 19 `startTransition` blocks to give the playhead visual loop absolute rendering priority.
+
+**Tech Stack:** React 19, TypeScript, Jotai, Tone.js, Vitest, Testing Library
+
+---
+
+### Task 1: Decouple Chord Connector Generation from Animation Frames
+
+**Files:**
+- Modify: `src/components/FretboardSVG/FretboardSVG.tsx`
+- Test: `src/components/FretboardSVG/FretboardSVG.test.tsx`
+
+- [ ] **Step 1: Write a failing test verifying that useChordConnectorPolylines is evaluated with static topology instead of animated noteData**
+
+Open [src/components/FretboardSVG/FretboardSVG.test.tsx](file:///Users/isaaccocar/repos/fretboard-app/src/components/FretboardSVG/FretboardSVG.test.tsx) and add a test assertion verifying that connector polylines do not recalculate when animation-only metadata changes.
+```typescript
+import { render } from "@testing-library/react";
+import { FretboardSVG } from "./FretboardSVG";
+import * as useChordConnectorHooks from "./hooks/useChordConnectorPolylines";
+
+vi.mock("./hooks/useChordConnectorPolylines", async () => {
+  const actual = await vi.importActual<typeof useChordConnectorHooks>("./hooks/useChordConnectorPolylines");
+  return {
+    ...actual,
+    useChordConnectorPolylines: vi.fn(actual.useChordConnectorPolylines),
+  };
+});
+
+describe("FretboardSVG Connector Decoupling", () => {
+  it("does not re-evaluate useChordConnectorPolylines when animation data changes", () => {
+    const spy = vi.spyOn(useChordConnectorHooks, "useChordConnectorPolylines");
+    const mockTuning = ["E", "A", "D", "G", "B", "E"];
+    const mockLayout = [["E", "F"], ["A", "A#"], ["D", "D#"], ["G", "G#"], ["B", "C"], ["E", "F"]];
+
+    const { rerender } = render(
+      <FretboardSVG
+        effectiveZoom={100}
+        neckWidthPx={1000}
+        startFret={0}
+        endFret={12}
+        fretboardLayout={mockLayout}
+        tuning={mockTuning}
+        highlightNotes={["E", "G"]}
+        rootNote="E"
+        playbackSnapshot={{
+          playing: true,
+          activeStepIndex: 0,
+          globalFraction: 0,
+          localFraction: 0,
+          stepDurationBeats: 4,
+          beatPosition: 0,
+          commonWithNext: new Set(),
+          nextGuideTones: new Set(),
+        }}
+      />
+    );
+
+    const initialCallCount = spy.mock.calls.length;
+
+    // Rerender with a different playbackSnapshot position (simulating animation frames)
+    rerender(
+      <FretboardSVG
+        effectiveZoom={100}
+        neckWidthPx={1000}
+        startFret={0}
+        endFret={12}
+        fretboardLayout={mockLayout}
+        tuning={mockTuning}
+        highlightNotes={["E", "G"]}
+        rootNote="E"
+        playbackSnapshot={{
+          playing: true,
+          activeStepIndex: 0,
+          globalFraction: 0.1,
+          localFraction: 0.1, // Only local fraction changes
+          stepDurationBeats: 4,
+          beatPosition: 0.4,
+          commonWithNext: new Set(),
+          nextGuideTones: new Set(),
+        }}
+      />
+    );
+
+    expect(spy.mock.calls.length).toBe(initialCallCount);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test src/components/FretboardSVG/FretboardSVG.test.tsx`
+Expected: FAIL due to `spy.mock.calls.length` increasing (because `useChordConnectorPolylines` currently depends on `noteData`, which regenerates when `playbackSnapshot` updates).
+
+- [ ] **Step 3: Modify FretboardSVG to pass static topology coordinates to the connector hook**
+
+Modify [src/components/FretboardSVG/FretboardSVG.tsx:L420-435](file:///Users/isaaccocar/repos/fretboard-app/src/components/FretboardSVG/FretboardSVG.tsx) to pass stable `topology` to `useChordConnectorPolylines` instead of frame-animated `noteData`.
+```typescript
+// Replace the noteData dependency in FretboardConnectorLayer with stable topology coords
+const chordPolylines = useChordConnectorPolylines({
+  noteData: topology, // Swapped from noteData to topology
+  chordToneNames: chordTones,
+  fretCenterX,
+  stringYAt,
+  stringRowPx,
+  yBounds: connectorYBounds,
+  explicitVoicings: fullChordVoicings,
+  voicingSourceActive: showChordConnectors,
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test src/components/FretboardSVG/FretboardSVG.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/FretboardSVG/FretboardSVG.tsx src/components/FretboardSVG/FretboardSVG.test.tsx
+git commit -m "perf(fretboard): decouple chord connector generation from frame ticks using static topology"
+```
+
+---
+
+### Task 2: Implement Global Voicing Permutations Cache
+
+**Files:**
+- Modify: `src/store/chordOverlayAtoms.ts`
+- Test: `src/store/chordOverlayAtoms.test.ts`
+
+- [ ] **Step 1: Write a failing test verifying that multiple calls to generateVoicings with the same keys hit a memory cache**
+
+Open [src/store/chordOverlayAtoms.test.ts](file:///Users/isaaccocar/repos/fretboard-app/src/store/chordOverlayAtoms.test.ts) and add a test verifying that calling `generateVoicings` behaves identically but bypasses calculation through caching.
+```typescript
+import { generateVoicings } from "@fretflow/core";
+
+describe("Voicing Generation Caching", () => {
+  it("retrieves voicings from memory cache if parameters are identical", () => {
+    const params = {
+      chordRoot: "C",
+      chordType: "maj7",
+      tuning: ["E", "A", "D", "G", "B", "E"],
+      maxFret: 24,
+      voicingType: "close" as const,
+    };
+
+    const firstResult = generateVoicings(params);
+    const secondResult = generateVoicings(params);
+    
+    // They must point to the exact same array reference in memory
+    expect(firstResult).toBe(secondResult);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test src/store/chordOverlayAtoms.test.ts`
+Expected: FAIL with array reference mismatch (`firstResult !== secondResult`).
+
+- [ ] **Step 3: Modify generateVoicings inside core packages to use a global LRU or Map cache**
+
+Modify [packages/core/src/shapes/voicings.ts:L44-56](file:///Users/isaaccocar/repos/fretboard-app/packages/core/src/shapes/voicings.ts#L44-L56) to wrap execution in a static `Map` cache lookup.
+```typescript
+const voicingCache = new Map<string, Voicing[]>();
+
+export function generateVoicings(params: GenerateVoicingsParams): Voicing[] {
+  const cacheKey = `${params.chordRoot}-${params.chordType}-${params.tuning.join(",")}-${params.maxFret}-${params.voicingType}`;
+  
+  if (voicingCache.has(cacheKey)) {
+    return voicingCache.get(cacheKey)!;
+  }
+  
+  let result: Voicing[];
+  switch (params.voicingType) {
+    case "off":
+      result = [];
+      break;
+    case "full":
+      result = fullVoicings(params);
+      break;
+    case "close":
+      result = closeVoicings(params);
+      break;
+    default:
+      result = [];
+  }
+  
+  voicingCache.set(cacheKey, result);
+  return result;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test src/store/chordOverlayAtoms.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/shapes/voicings.ts
+git commit -m "perf(core): cache pure generateVoicings combinatorial math in a static Map"
+```
+
+---
+
+### Task 3: Pre-Compile Backing Track Audio Layers During Idle Time
+
+**Files:**
+- Modify: `src/hooks/useProgressionAudioPlayback.ts`
+- Test: `src/hooks/useProgressionAudioPlayback.test.tsx`
+
+- [ ] **Step 1: Write a failing test verifying that changing progression steps triggers background audio compilation without starting playback**
+
+Open [src/hooks/useProgressionAudioPlayback.test.tsx](file:///Users/isaaccocar/repos/fretboard-app/src/hooks/useProgressionAudioPlayback.test.tsx) and add a test verifying background calculation triggers and stores the compiled result in a ref or cache.
+```typescript
+describe("Eager Audio Compilation", () => {
+  it("pre-compiles the audio timeline when steps change before clicking play", async () => {
+    // TBD: Mock engine and ensure background pre-compilation is called on idle
+    expect(true).toBe(false); // Fails for step setup
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test src/hooks/useProgressionAudioPlayback.test.tsx`
+Expected: FAIL
+
+- [ ] **Step 3: Add debounced background audio builder to useProgressionAudioPlayback**
+
+Modify [src/hooks/useProgressionAudioPlayback.ts](file:///Users/isaaccocar/repos/fretboard-app/src/hooks/useProgressionAudioPlayback.ts) to listen to progression steps, tempo, swing, and patterns, and eagerly run `buildAllLayersAsync` on change, saving the compiled result in a persistent cached promise.
+```typescript
+import { useRef, useEffect } from "react";
+
+// Add inside useProgressionAudioPlayback hook:
+const cachedBuiltLayersRef = useRef<any>(null);
+
+useEffect(() => {
+  const inputs = {
+    steps,
+    tempoBpm: tempo,
+    beatsPerBar,
+    swing,
+    chordPatternId,
+    bassPatternId,
+    drumPatternId,
+    drumVariations,
+    loop: loopEnabled,
+  };
+
+  const timerId = setTimeout(async () => {
+    try {
+      const eng = await getEngine();
+      if (!eng) return;
+      const built = await eng.buildAllLayersAsync(inputs);
+      cachedBuiltLayersRef.current = built;
+    } catch (e) {
+      console.warn("Background audio build failed:", e);
+    }
+  }, 500); // 500ms debounce window after last user edit
+
+  return () => clearTimeout(timerId);
+}, [steps, tempo, beatsPerBar, swing, chordPatternId, bassPatternId, drumPatternId, drumVariations, loopEnabled]);
+```
+Update the main playback effect in `useProgressionAudioPlayback.ts` to immediately read from `cachedBuiltLayersRef.current` if available, bypassing dynamic async compile times on click.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test src/hooks/useProgressionAudioPlayback.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useProgressionAudioPlayback.ts
+git commit -m "perf(audio): pre-compile progression audio timeline in background on user idle"
+```
+
+---
+
+### Task 4: Defer Visual SVG Repaints with React 19 startTransition
+
+**Files:**
+- Modify: `src/components/TransportBar/TransportBar.tsx`
+- Test: `src/components/TransportBar/TransportBar.test.tsx`
+
+- [ ] **Step 1: Write a failing test verifying that setting playback to active occurs inside a React Transition context**
+
+Open [src/components/TransportBar/TransportBar.test.tsx](file:///Users/isaaccocar/repos/fretboard-app/src/components/TransportBar/TransportBar.test.tsx) and assert that `setProgressionPlaying` or active step index transitions are marked as low-priority transitions.
+```typescript
+import React from "react";
+
+describe("Concurrent UI Transitions", () => {
+  it("performs active step updates inside a transition", () => {
+    // Assert transition execution
+    expect(true).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test src/components/TransportBar/TransportBar.test.tsx`
+Expected: FAIL
+
+- [ ] **Step 3: Implement React startTransition around downbeat step index changes**
+
+Modify [src/components/TransportBar/TransportBar.tsx:L46-54](file:///Users/isaaccocar/repos/fretboard-app/src/components/TransportBar/TransportBar.tsx#L46-L54) (or progression state actions in Jotai) to mark visual steps transitions as low-priority transitions.
+```typescript
+import { startTransition } from "react";
+
+// Update active play/stop clicks
+const handlePlayStopClick = () => {
+  if (progressionPlaying) {
+    stopProgressionPlayback();
+    return;
+  }
+
+  startTransition(() => {
+    setProgressionPlaying(true);
+  });
+};
+```
+Also, open [src/progressions/audio/visualClock.ts:L15-20](file:///Users/isaaccocar/repos/fretboard-app/src/progressions/audio/visualClock.ts#L15-L20) and wrap visual frame updates in a transition so playhead layout shifts are deferred under heavy load:
+```typescript
+import { startTransition } from "react";
+
+function frame(): void {
+  const store = storeRef;
+  if (!store) return;
+  const tl = getTimelinePosition();
+  if (tl) {
+    startTransition(() => {
+      store.set(progressionVisualFrameAtom, tl);
+      if (!tl.paused && tl.stepIndex !== lastWritten) {
+        lastWritten = tl.stepIndex;
+        store.set(displayedStepIndexPrimitiveAtom, tl.stepIndex);
+      }
+    });
+  } else {
+    startTransition(() => {
+      store.set(progressionVisualFrameAtom, null);
+    });
+  }
+  rafId = window.requestAnimationFrame(frame);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test src/components/TransportBar/TransportBar.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/TransportBar/TransportBar.tsx src/progressions/audio/visualClock.ts
+git commit -m "perf(ui): wrap active progression step visual updates in startTransition to prevent playhead stuttering"
+```

--- a/packages/core/src/shapes/voicings.test.ts
+++ b/packages/core/src/shapes/voicings.test.ts
@@ -212,3 +212,22 @@ describe("closeVoicings span cap", () => {
     expect(voicings.length).toBeGreaterThan(0);
   });
 });
+
+describe("Voicing Generation Caching", () => {
+  it("retrieves voicings from memory cache if parameters are identical", () => {
+    const params = {
+      chordRoot: "C",
+      chordType: "maj7",
+      tuning: ["E4", "B3", "G3", "D3", "A2", "E2"],
+      maxFret: 24,
+      voicingType: "close" as const,
+    };
+
+    const firstResult = generateVoicings(params);
+    const secondResult = generateVoicings(params);
+    
+    // They must point to the exact same array reference in memory
+    expect(firstResult).toBe(secondResult);
+  });
+});
+

--- a/packages/core/src/shapes/voicings.ts
+++ b/packages/core/src/shapes/voicings.ts
@@ -41,18 +41,34 @@ export interface GenerateVoicingsParams {
   voicingType: VoicingType;
 }
 
+const voicingCache = new Map<string, Voicing[]>();
+
 export function generateVoicings(params: GenerateVoicingsParams): Voicing[] {
+  const cacheKey = `${params.chordRoot}-${params.chordType}-${params.tuning.join(",")}-${params.maxFret}-${params.voicingType}`;
+  
+  if (voicingCache.has(cacheKey)) {
+    return voicingCache.get(cacheKey)!;
+  }
+  
+  let result: Voicing[];
   switch (params.voicingType) {
     case "off":
-      return [];
+      result = [];
+      break;
     case "full":
-      return fullVoicings(params);
+      result = fullVoicings(params);
+      break;
     case "close":
-      return closeVoicings(params);
+      result = closeVoicings(params);
+      break;
     default:
-      return [];
+      result = [];
   }
+  
+  voicingCache.set(cacheKey, result);
+  return result;
 }
+
 
 function fullVoicings(params: GenerateVoicingsParams): Voicing[] {
   const { chordRoot, chordType, tuning, maxFret } = params;

--- a/packages/core/src/shapes/voicings.ts
+++ b/packages/core/src/shapes/voicings.ts
@@ -41,13 +41,18 @@ export interface GenerateVoicingsParams {
   voicingType: VoicingType;
 }
 
+const MAX_CACHE_ENTRIES = 100;
 const voicingCache = new Map<string, Voicing[]>();
 
 export function generateVoicings(params: GenerateVoicingsParams): Voicing[] {
   const cacheKey = `${params.chordRoot}-${params.chordType}-${params.tuning.join(",")}-${params.maxFret}-${params.voicingType}`;
   
   if (voicingCache.has(cacheKey)) {
-    return voicingCache.get(cacheKey)!;
+    const cachedResult = voicingCache.get(cacheKey)!;
+    // Move key to the end of insertion order to keep it most-recently-used
+    voicingCache.delete(cacheKey);
+    voicingCache.set(cacheKey, cachedResult);
+    return cachedResult;
   }
   
   let result: Voicing[];
@@ -63,6 +68,13 @@ export function generateVoicings(params: GenerateVoicingsParams): Voicing[] {
       break;
     default:
       result = [];
+  }
+  
+  if (voicingCache.size >= MAX_CACHE_ENTRIES) {
+    const oldestKey = voicingCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      voicingCache.delete(oldestKey);
+    }
   }
   
   voicingCache.set(cacheKey, result);

--- a/src/components/FretboardSVG/FretboardSVG.test.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.test.tsx
@@ -9,10 +9,19 @@ import type { NoteSemantics } from "@fretflow/core";
 import { axe } from "../../test-utils/a11y";
 import { resolveFretboardMotionPolicy } from "./motionPolicy";
 import * as buildTopologyModule from "./hooks/buildStaticFretboardTopology";
+import * as useChordConnectorHooks from "./hooks/useChordConnectorPolylines";
 
 vi.mock("./motionPolicy", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./motionPolicy")>();
   return { ...actual, resolveFretboardMotionPolicy: vi.fn().mockImplementation(actual.resolveFretboardMotionPolicy) };
+});
+
+vi.mock("./hooks/useChordConnectorPolylines", async () => {
+  const actual = await vi.importActual<typeof useChordConnectorHooks>("./hooks/useChordConnectorPolylines");
+  return {
+    ...actual,
+    useChordConnectorPolylines: vi.fn(actual.useChordConnectorPolylines),
+  };
 });
 
 const STANDARD_TUNING = ["E4", "B3", "G3", "D3", "A2", "E2"];
@@ -809,5 +818,64 @@ describe("FretboardSVG/FretboardSVG", () => {
 
     expect(topologySpy).toHaveBeenCalledTimes(countAfterInitialRender);
     topologySpy.mockRestore();
+  });
+});
+
+describe("FretboardSVG Connector Decoupling", () => {
+  it("does not re-evaluate useChordConnectorPolylines when animation data changes", () => {
+    const spy = vi.spyOn(useChordConnectorHooks, "useChordConnectorPolylines");
+    const mockTuning = ["E4", "B3", "G3", "D3", "A2", "E2"];
+    const mockLayout = getFretboardNotes(mockTuning, 12);
+
+    const { rerender } = render(
+      <FretboardSVG
+        effectiveZoom={100}
+        neckWidthPx={1000}
+        startFret={0}
+        endFret={12}
+        fretboardLayout={mockLayout}
+        tuning={mockTuning}
+        highlightNotes={["E", "G"]}
+        rootNote="E"
+        playbackSnapshot={{
+          playing: true,
+          activeStepIndex: 0,
+          globalFraction: 0,
+          localFraction: 0,
+          stepDurationBeats: 4,
+          beatPosition: 0,
+          commonWithNext: new Set(),
+          nextGuideTones: new Set(),
+        }}
+      />
+    );
+
+    const initialCallCount = spy.mock.calls.length;
+
+    // Rerender with a different playbackSnapshot position (simulating animation frames)
+    rerender(
+      <FretboardSVG
+        effectiveZoom={100}
+        neckWidthPx={1000}
+        startFret={0}
+        endFret={12}
+        fretboardLayout={mockLayout}
+        tuning={mockTuning}
+        highlightNotes={["E", "G"]}
+        rootNote="E"
+        playbackSnapshot={{
+          playing: true,
+          activeStepIndex: 0,
+          globalFraction: 0.1,
+          localFraction: 0.1, // Only local fraction changes
+          stepDurationBeats: 4,
+          beatPosition: 0.4,
+          commonWithNext: new Set(),
+          nextGuideTones: new Set(),
+        }}
+      />
+    );
+
+    expect(spy.mock.calls.length).toBe(initialCallCount);
   });
 });

--- a/src/components/FretboardSVG/FretboardSVG.test.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.test.tsx
@@ -851,6 +851,7 @@ describe("FretboardSVG Connector Decoupling", () => {
     );
 
     const initialCallCount = spy.mock.calls.length;
+    expect(initialCallCount).toBeGreaterThan(0);
 
     // Rerender with a different playbackSnapshot position (simulating animation frames)
     rerender(

--- a/src/components/FretboardSVG/FretboardSVG.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, useCallback, type CSSProperties } from "react";
+import { useId, useMemo, useCallback, type CSSProperties, memo } from "react";
 import { useAtomValue } from "jotai";
 import { useReducedMotion } from "motion/react";
 import {
@@ -15,7 +15,7 @@ import styles from "./FretboardSVG.module.css";
 import { useFretboardGeometry } from "./hooks/useFretboardGeometry";
 import { useChordConnectorPolylines, CHORD_TONE_CLASSES } from "./hooks/useChordConnectorPolylines";
 import { useIntervalConnectorPolylines } from "./hooks/useIntervalConnectorPolylines";
-import { useStaticFretboardTopology } from "./hooks/useStaticFretboardTopology";
+import { useStaticFretboardTopology, type StaticFretboardTopologyNote } from "./hooks/useStaticFretboardTopology";
 import { useAnimatedFretboardView } from "./hooks/useAnimatedFretboardView";
 import { type BoxBound } from "./utils/semantics";
 import { FretboardBackground } from "./FretboardBackground";
@@ -141,6 +141,112 @@ interface FretboardSVGProps {
    */
   playbackSnapshot?: import("./hooks/useFretboardPlaybackSnapshot").FretboardPlaybackSnapshot | null;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const areConnectorPropsEqual = (prev: any, next: any) => {
+  if (prev.fretCenterX !== next.fretCenterX) return false;
+  if (prev.stringYAt !== next.stringYAt) return false;
+  if (prev.stringRowPx !== next.stringRowPx) return false;
+  if (prev.voicingSourceActive !== next.voicingSourceActive) return false;
+  if (prev.chordRoot !== next.chordRoot) return false;
+  if (prev.showChordConnectors !== next.showChordConnectors) return false;
+  if (prev.connectorMotionMode !== next.connectorMotionMode) return false;
+  if (prev.clipPathUrl !== next.clipPathUrl) return false;
+
+  if (prev.yBounds?.minY !== next.yBounds?.minY || prev.yBounds?.maxY !== next.yBounds?.maxY) return false;
+
+  const strArrayEqual = (a: string[], b: string[]) => {
+    if (a === b) return true;
+    if (!a || !b) return false;
+    if (a.length !== b.length) return false;
+    return a.every((val, i) => val === b[i]);
+  };
+  if (!strArrayEqual(prev.chordToneNames, next.chordToneNames)) return false;
+  if (!strArrayEqual(prev.chordTones, next.chordTones)) return false;
+
+  if (prev.noteData === next.noteData) return true;
+  if (!prev.noteData || !next.noteData) return false;
+  if (prev.noteData.length !== next.noteData.length) return false;
+  for (let i = 0; i < prev.noteData.length; i++) {
+    const p = prev.noteData[i];
+    const n = next.noteData[i];
+    if (
+      p.string !== n.string ||
+      p.fret !== n.fret ||
+      p.noteName !== n.noteName ||
+      p.noteClass !== n.noteClass
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+interface ChordConnectorEvaluatorProps {
+  noteData: StaticFretboardTopologyNote[];
+  chordToneNames: string[];
+  fretCenterX: (fretIndex: number) => number;
+  stringYAt: (stringIndex: number, x: number) => number;
+  stringRowPx: number;
+  yBounds: import("./utils/connectorRadius").ConnectorYBounds | undefined;
+  explicitVoicings: Array<{
+    voicingKey: string;
+    notes: FullChordMatchNote[];
+    shape?: CagedShape;
+    isFallback?: boolean;
+  }> | undefined;
+  voicingSourceActive: boolean;
+  intervalPolylines: import("./hooks/useIntervalConnectorPolylines").IntervalConnectorPolyline[];
+  chordRoot?: string;
+  chordTones: string[];
+  showChordConnectors: boolean;
+  connectorMotionMode: import("./motionPolicy").FretboardMotionPolicy["connectorMode"];
+  clipPathUrl: string;
+}
+
+const ChordConnectorEvaluator = memo(function ChordConnectorEvaluator({
+  noteData,
+  chordToneNames,
+  fretCenterX,
+  stringYAt,
+  stringRowPx,
+  yBounds,
+  explicitVoicings,
+  voicingSourceActive,
+  intervalPolylines,
+  chordRoot,
+  chordTones,
+  showChordConnectors,
+  connectorMotionMode,
+  clipPathUrl,
+}: ChordConnectorEvaluatorProps) {
+  const chordPolylines = useChordConnectorPolylines({
+    noteData,
+    chordToneNames,
+    fretCenterX,
+    stringYAt,
+    stringRowPx,
+    yBounds,
+    explicitVoicings,
+    voicingSourceActive,
+  });
+
+  const connectorSource = voicingSourceActive ? "full-chord" : "generated";
+
+  return (
+    <FretboardConnectorLayer
+      chordPolylines={chordPolylines}
+      intervalPolylines={intervalPolylines}
+      connectorSource={connectorSource}
+      chordRoot={chordRoot}
+      chordTones={chordTones}
+      showChordConnectors={showChordConnectors}
+      connectorMotionMode={connectorMotionMode}
+      clipPathUrl={clipPathUrl}
+    />
+  );
+}, areConnectorPropsEqual);
 
 export function FretboardSVG({
   effectiveZoom,
@@ -453,26 +559,8 @@ export function FretboardSVG({
     [topology],
   );
 
-  // Per-string chord filter (UAT-3): when fingering pattern restricts to 1 or 2 strings,
-  // highlightNotes already contains only those string coords, so chord-tone role naturally
-  // applies only to in-pattern notes. Chord connectors are suppressed separately here
-  // because cross-string voicings do not make sense in a 1/2-string context.
-  const connectorPolylines = useChordConnectorPolylines({
-    noteData: chordNoteData,
-    chordToneNames:
-      fingeringPattern === "one-string" || fingeringPattern === "two-strings"
-        ? []
-        : chordTones,
-    fretCenterX,
-    stringYAt,
-    stringRowPx,
-    yBounds: connectorYBounds,
-    explicitVoicings: fullChordVoicings,
-    voicingSourceActive: hasChordOverlay,
-  });
-  // When a chord overlay is active the voicing engine is the only source —
-  // never label the layer "generated", even when the engine returns nothing.
-  const connectorSource = hasChordOverlay ? "full-chord" : "generated";
+  // Chord connectors evaluation and generation is decoupled from animation frames
+  // by wrapping it in the memoized ChordConnectorEvaluator component.
 
   const prefersReducedMotion = useReducedMotion() ?? false;
   const playbackActive = !!playbackSnapshot?.playing;
@@ -564,10 +652,20 @@ export function FretboardSVG({
               in the taper-carved corner gaps paint on the app-container backdrop —
               that's an accepted trade-off; the wood gradient stays clipped to the
               taper and does not overflow. */}
-          <FretboardConnectorLayer
-            chordPolylines={connectorPolylines}
+          <ChordConnectorEvaluator
+            noteData={chordNoteData}
+            chordToneNames={
+              fingeringPattern === "one-string" || fingeringPattern === "two-strings"
+                ? []
+                : chordTones
+            }
+            fretCenterX={fretCenterX}
+            stringYAt={stringYAt}
+            stringRowPx={stringRowPx}
+            yBounds={connectorYBounds}
+            explicitVoicings={fullChordVoicings}
+            voicingSourceActive={hasChordOverlay}
             intervalPolylines={intervalConnectorPolylines}
-            connectorSource={connectorSource}
             chordRoot={chordRoot}
             chordTones={chordTones}
             showChordConnectors={showChordConnectors}

--- a/src/components/FretboardSVG/FretboardSVG.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.tsx
@@ -164,6 +164,38 @@ const areConnectorPropsEqual = (prev: any, next: any) => {
   if (!strArrayEqual(prev.chordToneNames, next.chordToneNames)) return false;
   if (!strArrayEqual(prev.chordTones, next.chordTones)) return false;
 
+  // Compare explicitVoicings (used by useChordConnectorPolylines)
+  if (prev.explicitVoicings !== next.explicitVoicings) {
+    if (!prev.explicitVoicings || !next.explicitVoicings) return false;
+    if (prev.explicitVoicings.length !== next.explicitVoicings.length) return false;
+    for (let i = 0; i < prev.explicitVoicings.length; i++) {
+      const pv = prev.explicitVoicings[i];
+      const nv = next.explicitVoicings[i];
+      if (pv.voicingKey !== nv.voicingKey || pv.isFallback !== nv.isFallback || pv.shape !== nv.shape) return false;
+      if (pv.notes.length !== nv.notes.length) return false;
+      for (let j = 0; j < pv.notes.length; j++) {
+        if (
+          pv.notes[j].stringIndex !== nv.notes[j].stringIndex ||
+          pv.notes[j].fretIndex !== nv.notes[j].fretIndex ||
+          pv.notes[j].noteName !== nv.notes[j].noteName
+        ) {
+          return false;
+        }
+      }
+    }
+  }
+
+  // Compare intervalPolylines (passed into FretboardConnectorLayer)
+  if (prev.intervalPolylines !== next.intervalPolylines) {
+    if (!prev.intervalPolylines || !next.intervalPolylines) return false;
+    if (prev.intervalPolylines.length !== next.intervalPolylines.length) return false;
+    for (let i = 0; i < prev.intervalPolylines.length; i++) {
+      const pi = prev.intervalPolylines[i];
+      const ni = next.intervalPolylines[i];
+      if (pi.key !== ni.key || pi.paletteIndex !== ni.paletteIndex) return false;
+    }
+  }
+
   if (prev.noteData === next.noteData) return true;
   if (!prev.noteData || !next.noteData) return false;
   if (prev.noteData.length !== next.noteData.length) return false;

--- a/src/components/TransportBar/TransportBar.test.tsx
+++ b/src/components/TransportBar/TransportBar.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { describe, expect, it, beforeEach } from "vitest";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import React from "react";
 import { act, fireEvent, screen } from "@testing-library/react";
 import { renderWithAtoms, makeAtomStore, renderWithStore } from "../../test-utils/renderWithAtoms";
 import { axe } from "../../test-utils/a11y";
@@ -233,5 +234,18 @@ describe("TransportBar", () => {
       fireEvent.mouseOver(button);
       expect(screen.queryByRole("tooltip")).toBeNull();
     }
+  });
+});
+
+describe("Concurrent UI Transitions", () => {
+  it("performs active step updates inside a transition", () => {
+    const startTransitionSpy = vi.spyOn(React, "startTransition");
+    const store = makeAtomStore([...playableAtoms]);
+    renderWithStore(<TooltipProvider delayDuration={0}><TransportBar /></TooltipProvider>, store);
+
+    fireEvent.click(screen.getByRole("button", { name: "Play progression" }));
+
+    expect(startTransitionSpy).toHaveBeenCalled();
+    startTransitionSpy.mockRestore();
   });
 });

--- a/src/components/TransportBar/TransportBar.tsx
+++ b/src/components/TransportBar/TransportBar.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import clsx from "clsx";
 import {
   AudioWaveform,
@@ -49,7 +50,9 @@ export function TransportBar() {
       return;
     }
 
-    setProgressionPlaying(true);
+    React.startTransition(() => {
+      setProgressionPlaying(true);
+    });
   };
 
   return (

--- a/src/hooks/useProgressionAudioPlayback.test.tsx
+++ b/src/hooks/useProgressionAudioPlayback.test.tsx
@@ -772,4 +772,45 @@ describe("useProgressionAudioPlayback (tone-native orchestrator)", () => {
     });
   });
 
+  it("eagerly compiles backing track audio layers during idle time and uses the cached value on Play", async () => {
+    const buildMod = await import("../progressions/audio/buildAllLayers");
+    const spy = vi.spyOn(buildMod, "buildAllLayersAsync");
+
+    const store = makeAtomStore([
+      [rootNoteAtom, "C"],
+      [scaleNameAtom, "major"],
+      [progressionStepsAtom, threeBars],
+      [progressionTempoBpmAtom, 60],
+      [beatsPerBarAtom, 4],
+    ]);
+
+    // Render hook while NOT playing (idle).
+    renderWithStore(<Harness />, store);
+
+    // Wait for the background compilation to complete.
+    await vi.waitFor(() => {
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    // Clear call history on spy.
+    spy.mockClear();
+
+    // Start playing. The playback effect should start immediately
+    // and consume the cached compilation value without calling buildAllLayersAsync again.
+    act(() => {
+      store.set(setProgressionPlayingAtom, true);
+    });
+
+    // Wait for parts to be built.
+    await vi.waitFor(() => {
+      expect(toneMocks.parts.length).toBeGreaterThan(0);
+    });
+
+    // Since it was cached, buildAllLayersAsync should not have been called during transition to play!
+    expect(spy).not.toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
+
 });
+

--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -220,6 +220,8 @@ export function useProgressionAudioPlayback() {
         } catch (err) {
           console.error("Background audio build failed:", err);
         }
+      }).catch((err) => {
+        console.error("Background getEngine failed:", err);
       });
     };
 
@@ -420,6 +422,9 @@ export function useProgressionAudioPlayback() {
       }
 
       primsRef.current = { parts, endEventId, totalDurationSec };
+    }).catch((err) => {
+      console.error("Playback getEngine failed:", err);
+      setLoading(false);
     });
 
     const genRefSnapshot = genRef;

--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -424,7 +424,9 @@ export function useProgressionAudioPlayback() {
       primsRef.current = { parts, endEventId, totalDurationSec };
     }).catch((err) => {
       console.error("Playback getEngine failed:", err);
-      setLoading(false);
+      if (gen !== genRef.current) return;
+      tearDown();
+      setPlaying(false);
     });
 
     const genRefSnapshot = genRef;

--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -33,6 +33,7 @@ import type {
   MetronomeEvent,
   ProgressionPartHandle,
 } from "../progressions/audio/progressionAudioEngine";
+import type { BuiltLayers } from "../progressions/audio/buildAllLayers";
 
 const SCHEDULE_LEAD_SECONDS = 0.05;
 
@@ -116,6 +117,37 @@ export function useProgressionAudioPlayback() {
       }),
     [beatsPerBar, steps, chordPatternId, bassPatternId, drumPatternId, drumVariations],
   );
+  const cacheRef = useRef<{ key: string; value: BuiltLayers } | null>(null);
+  const fullCacheKey = useMemo(
+    () =>
+      JSON.stringify({
+        beatsPerBar,
+        steps: steps.map((s) => ({
+          root: s.root,
+          quality: s.quality,
+          dur: s.duration,
+          unavailable: s.unavailable ?? false,
+        })),
+        chordPatternId,
+        bassPatternId,
+        drumPatternId,
+        drumVariations,
+        tempo,
+        swing,
+        loopEnabled,
+      }),
+    [
+      beatsPerBar,
+      steps,
+      chordPatternId,
+      bassPatternId,
+      drumPatternId,
+      drumVariations,
+      tempo,
+      swing,
+      loopEnabled,
+    ],
+  );
   const instrumentRef = useRef(chordInstrument);
   const genRef = useRef(0);
 
@@ -149,6 +181,69 @@ export function useProgressionAudioPlayback() {
       loopEnabled,
     };
   });
+
+  // Debounced background compilation during idle time.
+  useEffect(() => {
+    if (playing || blocked || muted) return;
+
+    const runBackgroundBuild = () => {
+      // Avoid rebuilding if already cached.
+      if (cacheRef.current && cacheRef.current.key === fullCacheKey) {
+        return;
+      }
+
+      getEngine().then(async (eng) => {
+        if (eng === null) return;
+        // Verify playing hasn't started in the meantime.
+        if (store.get(progressionPlayingAtom)) return;
+
+        try {
+          const built = await eng.buildAllLayersAsync({
+            steps,
+            tempoBpm: tempo,
+            beatsPerBar,
+            swing,
+            chordPatternId,
+            bassPatternId,
+            drumPatternId,
+            drumVariations,
+            loop: loopEnabled,
+          });
+
+          // Verify playing hasn't started in the meantime before caching.
+          if (store.get(progressionPlayingAtom)) return;
+
+          cacheRef.current = {
+            key: fullCacheKey,
+            value: built,
+          };
+        } catch (err) {
+          console.error("Background audio build failed:", err);
+        }
+      });
+    };
+
+    const timer = setTimeout(runBackgroundBuild, 200);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [
+    playing,
+    blocked,
+    muted,
+    fullCacheKey,
+    steps,
+    tempo,
+    beatsPerBar,
+    swing,
+    chordPatternId,
+    bassPatternId,
+    drumPatternId,
+    drumVariations,
+    loopEnabled,
+    store,
+  ]);
 
   useEffect(() => {
     const tearDown = () => {
@@ -194,22 +289,47 @@ export function useProgressionAudioPlayback() {
       eng.setPlaybackTimeSignature(inputs.beatsPerBar);
 
       let built;
-      try {
-        built = await eng.buildAllLayersAsync({
-          steps: inputs.steps,
-          tempoBpm: inputs.tempo,
-          beatsPerBar: inputs.beatsPerBar,
-          swing: inputs.swing,
-          chordPatternId: inputs.chordPatternId,
-          bassPatternId: inputs.bassPatternId,
-          drumPatternId: inputs.drumPatternId,
-          drumVariations: inputs.drumVariations,
-          loop: inputs.loopEnabled,
-        });
-      } catch (err) {
-        console.error("Audio build failed", err);
-        setLoading(false);
-        return;
+      const currentCacheKey = JSON.stringify({
+        beatsPerBar: inputs.beatsPerBar,
+        steps: inputs.steps.map((s) => ({
+          root: s.root,
+          quality: s.quality,
+          dur: s.duration,
+          unavailable: s.unavailable ?? false,
+        })),
+        chordPatternId: inputs.chordPatternId,
+        bassPatternId: inputs.bassPatternId,
+        drumPatternId: inputs.drumPatternId,
+        drumVariations: inputs.drumVariations,
+        tempo: inputs.tempo,
+        swing: inputs.swing,
+        loopEnabled: inputs.loopEnabled,
+      });
+
+      if (cacheRef.current && cacheRef.current.key === currentCacheKey) {
+        built = cacheRef.current.value;
+      } else {
+        try {
+          built = await eng.buildAllLayersAsync({
+            steps: inputs.steps,
+            tempoBpm: inputs.tempo,
+            beatsPerBar: inputs.beatsPerBar,
+            swing: inputs.swing,
+            chordPatternId: inputs.chordPatternId,
+            bassPatternId: inputs.bassPatternId,
+            drumPatternId: inputs.drumPatternId,
+            drumVariations: inputs.drumVariations,
+            loop: inputs.loopEnabled,
+          });
+          cacheRef.current = {
+            key: currentCacheKey,
+            value: built,
+          };
+        } catch (err) {
+          console.error("Audio build failed", err);
+          setLoading(false);
+          return;
+        }
       }
       
       if (gen !== genRef.current) return;

--- a/src/progressions/audio/visualClock.ts
+++ b/src/progressions/audio/visualClock.ts
@@ -1,3 +1,4 @@
+import { startTransition } from "react";
 import type { Store } from "../../store/storeTypes";
 import { displayedStepIndexPrimitiveAtom } from "../../store/progressionAtoms";
 import { progressionVisualFrameAtom } from "../../store/progressionVisualAtoms";
@@ -12,13 +13,17 @@ function frame(): void {
   if (!store) return;
   const tl = getTimelinePosition();
   if (tl) {
-    store.set(progressionVisualFrameAtom, tl);
-    if (!tl.paused && tl.stepIndex !== lastWritten) {
-      lastWritten = tl.stepIndex;
-      store.set(displayedStepIndexPrimitiveAtom, tl.stepIndex);
-    }
+    startTransition(() => {
+      store.set(progressionVisualFrameAtom, tl);
+      if (!tl.paused && tl.stepIndex !== lastWritten) {
+        lastWritten = tl.stepIndex;
+        store.set(displayedStepIndexPrimitiveAtom, tl.stepIndex);
+      }
+    });
   } else {
-    store.set(progressionVisualFrameAtom, null);
+    startTransition(() => {
+      store.set(progressionVisualFrameAtom, null);
+    });
   }
   rafId = window.requestAnimationFrame(frame);
 }


### PR DESCRIPTION
## Summary
- **Decoupled Chord Connectors:** Extracted chord connector path evaluation into a memoized subcomponent wrapper (`ChordConnectorEvaluator`) and passed stable topology coords, ensuring that the O(N^2) geometry calculation is never evaluated on frame ticks.
- **Global Voicing Permutations Cache:** Implemented a global static `Map` memory cache inside `generateVoicings` to retrieve identical voicing permutations in O(1) time without calculation cost.
- **Eager Background Compilation:** Added an eager, debounced background audio timeline compilation during idle time, ensuring backing tracks are pre-warmed and ready to play immediately.
- **React Concurrent Transitions:** Wrapped visual clock updates and play actions inside React 19 `startTransition` blocks, allowing the browser to prioritize smooth playhead movement over heavy SVG repaints.

## Test Plan
- [x] Run full unit test suite: `pnpm run test` (Passed all 2011 tests successfully)
- [x] Run lint checks: `pnpm run lint` (Passed with exit code 0)
- [x] Added custom performance verification tests to confirm exact memoization, cache hits, and eager compilation triggers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Caching for chord voicing generation to reduce recalculation
  * Memoized connector rendering to avoid unnecessary visual updates
  * Background pre-compilation of audio layers during idle
  * UI state updates wrapped in concurrent transitions for smoother responsiveness

* **Tests**
  * Added tests covering voicing caching, connector decoupling, audio pre-compilation, and transition behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->