### PR TITLE
fix(react): stop "large number of updates inside startTransition" warning

### DIFF
--- a/src/components/FretboardSVG/hooks/useFretboardPlaybackSnapshot.ts
+++ b/src/components/FretboardSVG/hooks/useFretboardPlaybackSnapshot.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useDeferredValue, useMemo } from "react";
 import { useAtomValue } from "jotai";
 import { progressionPlayingAtom } from "../../../store/progressionAtoms";
 import { activeStepDurationBeatsAtom } from "../../../store/practiceLensAtoms";
@@ -16,7 +16,11 @@ export function useFretboardPlaybackSnapshot(
   enabled: boolean,
 ): FretboardPlaybackSnapshot | null {
   const playing = useAtomValue(progressionPlayingAtom);
-  const frame = useAtomValue(progressionVisualFrameAtom);
+  // The frame atom is written synchronously every rAF tick by the visual clock.
+  // Defer it here (React-provided hook) so the expensive per-frame fretboard
+  // playhead render is deprioritized under load and can drop frames gracefully,
+  // without wrapping the external-store write in startTransition.
+  const frame = useDeferredValue(useAtomValue(progressionVisualFrameAtom));
   const stepDurationBeats = useAtomValue(activeStepDurationBeatsAtom);
 
   return useMemo(() => {

--- a/src/components/SongControls/SongControls.tsx
+++ b/src/components/SongControls/SongControls.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useMemo } from "react";
+import { useMemo } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { ArrowDown, ArrowUp, Copy, Plus, Trash2, Info } from "lucide-react";
 import clsx from "clsx";
@@ -85,16 +85,16 @@ export function SongControls() {
     preferFlats,
   } = useScaleState();
 
+  // Discrete user selections write Jotai atoms directly. Wrapping these in
+  // startTransition tagged every atom subscriber's rerender to the transition
+  // and tripped React's ">10 fibers inside startTransition" subscription
+  // warning for no real benefit (a single click commits fine synchronously).
   const handleRootNote = (note: string) => {
-    startTransition(() => {
-      setRootNote(note);
-    });
+    setRootNote(note);
   };
 
   const handleScaleName = (name: string) => {
-    startTransition(() => {
-      setScaleName(name);
-    });
+    setScaleName(name);
   };
 
   const scaleGroups: LabeledSelectGroup[] = useMemo(
@@ -181,10 +181,10 @@ export function SongControls() {
     if (id === CUSTOM_PRESET_ID) return;
     const suggested = suggestedPresets.find((p) => p.id === id);
     if (suggested) {
-      startTransition(() => loadProgressionSteps(suggested.steps));
+      loadProgressionSteps(suggested.steps);
       return;
     }
-    startTransition(() => loadProgressionPreset(id));
+    loadProgressionPreset(id);
   };
   return (
     <div className={styles.sections}>

--- a/src/components/TransportBar/TransportBar.test.tsx
+++ b/src/components/TransportBar/TransportBar.test.tsx
@@ -238,14 +238,21 @@ describe("TransportBar", () => {
 });
 
 describe("Concurrent UI Transitions", () => {
-  it("performs active step updates inside a transition", () => {
+  // Regression guard: the play click must NOT wrap the Jotai setter in
+  // React.startTransition. Doing so tagged every progression-atom subscriber's
+  // rerender to the transition and tripped React's ">10 fibers inside
+  // startTransition" subscription warning. The state change commits directly.
+  it("starts playback without wrapping the write in startTransition", () => {
     const startTransitionSpy = vi.spyOn(React, "startTransition");
     const store = makeAtomStore([...playableAtoms]);
     renderWithStore(<TooltipProvider delayDuration={0}><TransportBar /></TooltipProvider>, store);
 
-    fireEvent.click(screen.getByRole("button", { name: "Play progression" }));
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Play progression" }));
+    });
 
-    expect(startTransitionSpy).toHaveBeenCalled();
+    expect(startTransitionSpy).not.toHaveBeenCalled();
+    expect(store.get(progressionPlayingAtom)).toBe(true);
     startTransitionSpy.mockRestore();
   });
 });

--- a/src/components/TransportBar/TransportBar.tsx
+++ b/src/components/TransportBar/TransportBar.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import clsx from "clsx";
 import {
   AudioWaveform,
@@ -50,9 +49,10 @@ export function TransportBar() {
       return;
     }
 
-    React.startTransition(() => {
-      setProgressionPlaying(true);
-    });
+    // Direct synchronous write. Wrapping this Jotai setter in startTransition
+    // tagged every progression-atom subscriber's rerender to the transition and
+    // tripped React's ">10 fibers inside startTransition" subscription warning.
+    setProgressionPlaying(true);
   };
 
   return (

--- a/src/progressions/audio/visualClock.ts
+++ b/src/progressions/audio/visualClock.ts
@@ -1,4 +1,3 @@
-import { startTransition } from "react";
 import type { Store } from "../../store/storeTypes";
 import { displayedStepIndexPrimitiveAtom } from "../../store/progressionAtoms";
 import { progressionVisualFrameAtom } from "../../store/progressionVisualAtoms";
@@ -12,18 +11,20 @@ function frame(): void {
   const store = storeRef;
   if (!store) return;
   const tl = getTimelinePosition();
+  // Write the frame atom synchronously. This is a per-frame external (rAF)
+  // source, so wrapping it in React's startTransition just tags every
+  // subscriber's rerender to the transition and trips React's
+  // ">10 fibers updated inside startTransition" subscription warning. Deferral
+  // of the expensive playhead render is instead handled at the consumer via
+  // useDeferredValue (see useFretboardPlaybackSnapshot).
   if (tl) {
-    startTransition(() => {
-      store.set(progressionVisualFrameAtom, tl);
-      if (!tl.paused && tl.stepIndex !== lastWritten) {
-        lastWritten = tl.stepIndex;
-        store.set(displayedStepIndexPrimitiveAtom, tl.stepIndex);
-      }
-    });
+    store.set(progressionVisualFrameAtom, tl);
+    if (!tl.paused && tl.stepIndex !== lastWritten) {
+      lastWritten = tl.stepIndex;
+      store.set(displayedStepIndexPrimitiveAtom, tl.stepIndex);
+    }
   } else {
-    startTransition(() => {
-      store.set(progressionVisualFrameAtom, null);
-    });
+    store.set(progressionVisualFrameAtom, null);
   }
   rafId = window.requestAnimationFrame(frame);
 }


### PR DESCRIPTION
## What

Removes every `startTransition` wrapper around Jotai atom writes and replaces the one place that genuinely needed deferral with `useDeferredValue`.

## Why

React fires `Detected a large number of updates inside startTransition. If this is due to a subscription please re-write it to use React provided hooks.` when a single transition updates **more than 10 distinct fibers** (`react-dom` `_updatedFibers.size > 10`).

Jotai v2's `useAtomValue` subscribes via `store.sub(atom, () => rerender())`. When a Jotai setter runs *inside* `startTransition`, the store synchronously fires every subscriber's `rerender()`, and all those fiber updates get tagged to the transition. The fretboard alone has 80+ note-button subscribers, so any whole-board mutation (e.g. loading a progression preset) blows past the threshold. This is exactly the "due to a subscription" case the warning names.

## Changes

- **SongControls.tsx** — dropped `startTransition` from `handleRootNote`, `handleScaleName`, and both `handlePresetChange` branches (the originally reported `SongControls.tsx:187`). Discrete user selections commit synchronously.
- **TransportBar.tsx** — dropped `React.startTransition` around `setProgressionPlaying` (and the now-unused `React` import).
- **visualClock.ts** — removed the per-frame `startTransition`; the rAF clock writes the frame atom directly.
- **useFretboardPlaybackSnapshot.ts** — wrapped the per-frame frame value in `useDeferredValue`. This preserves the smooth-playback deferral added in #468 using the React-provided hook the warning recommends, with no external-store tearing risk.
- **TransportBar.test.tsx** — the prior test asserted the old `startTransition` behavior; repurposed it as a regression guard that the play click updates state **without** wrapping in `startTransition`.

## Verification

- `pnpm lint` ✅ · `pnpm test` ✅ (2026 passed) · `pnpm build` ✅
- Browser preview: ran playback (visualClock at 60fps × 80+ fretboard subscribers, ~3s) and changed the progression preset (the reported path) — **zero warnings, zero errors** in the console.
- `grep` confirms zero `startTransition`/`useTransition` calls and imports remain in `src/` and `packages/` (only explanatory comments and the test's regression-guard spy reference the name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized playback state handling to improve responsiveness and defer expensive rendering operations during progression playback.
  * Refined progression control synchronization to provide more direct state management and eliminate system warnings.
  * Updated audio timeline writing to streamline state updates.

* **Tests**
  * Updated transport control tests to verify correct state update behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->