### PR TITLE
feat: improve progression empty states with interactive CTAs

### DIFF
--- a/src/components/ProgressionTrack/ProgressionTrack.module.css
+++ b/src/components/ProgressionTrack/ProgressionTrack.module.css
@@ -414,6 +414,74 @@
   font-size: var(--text-xs);
 }
 
+.emptyStateBlock {
+  --duration-bars: 1;
+  position: absolute;
+  inset-block: 0;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.34rem;
+  padding: 0.18rem 0.38rem 0.18rem 0.32rem;
+  border-radius: 4px;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 180ms ease,
+    background-color 180ms ease,
+    box-shadow 220ms ease,
+    transform 120ms ease;
+
+  border: 1px dotted rgb(193 218 235 / 0.15);
+  background: rgba(255, 255, 255, 0.015);
+  color: var(--track-text-dim);
+}
+
+.emptyStateBlock:hover {
+  background: rgba(255, 255, 255, 0.03);
+  border-color: var(--track-accent-dim);
+  box-shadow: inset 0 0 10px rgb(77 228 255 / 0.03);
+}
+
+.emptyStateBlock:hover .degreeBadge {
+  border-color: var(--track-accent-dim);
+  color: var(--track-accent);
+  background: rgb(77 228 255 / 0.08);
+}
+
+.emptyStateBlock:hover .chordName {
+  color: var(--track-accent);
+}
+
+.emptyStateBlock:active {
+  transform: translateY(0.5px);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+/* =========================================================================
+   Light-mode emptyState overrides
+   ========================================================================= */
+:global([data-theme="modern-light"]) .emptyStateBlock {
+  border-color: rgb(133 124 108 / 0.28);
+  background: rgb(246 242 233 / 0.50);
+  color: rgb(42 37 29 / 0.65);
+}
+
+:global([data-theme="modern-light"]) .emptyStateBlock:hover {
+  background: rgb(246 242 233 / 0.80);
+  border-color: var(--track-accent);
+}
+
+:global([data-theme="modern-light"]) .emptyStateBlock:hover .degreeBadge {
+  border-color: var(--track-accent-dim);
+  color: var(--track-accent);
+  background: rgb(20 112 136 / 0.07);
+}
+
+:global([data-theme="modern-light"]) .emptyStateBlock:hover .chordName {
+  color: var(--track-accent);
+}
+
 /* ----------------------------------------------------------------------------
  * Responsive — tighten on narrow viewports without losing identity.
  *

--- a/src/components/ProgressionTrack/ProgressionTrack.test.tsx
+++ b/src/components/ProgressionTrack/ProgressionTrack.test.tsx
@@ -40,6 +40,18 @@ describe("ProgressionTrack", () => {
     expect(screen.queryByText("Position")).toBeNull();
   });
 
+  it("renders the empty state overlay inside the track when empty", () => {
+    const { container } = renderWithAtoms(<ProgressionTrack />, [
+      [progressionStepsAtom, []],
+      [beatsPerBarAtom, 4],
+    ]);
+
+    expect(screen.getByText("Add a chord")).toBeTruthy();
+    expect(screen.getByText("To start playback")).toBeTruthy();
+    // Verify that the statusNote is NOT rendered below the track (so it doesn't take extra space/shift layout)
+    expect(container.querySelector("[class*='statusNote']")).toBeNull();
+  });
+
   it("renders short chord labels (e.g. C, G7, Am, F) in the visible block text", () => {
     renderWithAtoms(<ProgressionTrack />, [
       [progressionStepsAtom, fourStepProgression],

--- a/src/components/ProgressionTrack/ProgressionTrack.tsx
+++ b/src/components/ProgressionTrack/ProgressionTrack.tsx
@@ -3,6 +3,7 @@ import { useSetAtom, useAtomValue } from "jotai";
 import {
   setProgressionActiveStepIndexAtom,
   activeResolvedProgressionStepAtom,
+  addProgressionStepAtom,
 } from "../../store/progressionAtoms";
 import { useTimelineViewModel } from "./hooks/useTimelineViewModel";
 import styles from "./ProgressionTrack.module.css";
@@ -26,6 +27,7 @@ export function ProgressionTrack() {
 
   const setActiveStep = useSetAtom(setProgressionActiveStepIndexAtom);
   const activeStep = useAtomValue(activeResolvedProgressionStepAtom);
+  const addProgressionStep = useSetAtom(addProgressionStepAtom);
 
   // Stable callback so memoized ProgressionBlock children don't re-render on
   // every parent render of this component.
@@ -95,9 +97,28 @@ export function ProgressionTrack() {
                 aria-hidden="true"
               />
             ) : null}
+            {stepAtoms.length === 0 && (
+              <button
+                type="button"
+                className={styles.emptyStateBlock}
+                style={{
+                  "--duration-bars": "1",
+                  left: "0%",
+                  width: "calc(100% - 3px)",
+                } as CSSProperties}
+                onClick={() => addProgressionStep()}
+                aria-label="Add a chord to start playback"
+              >
+                <span className={styles.degreeBadge}>+</span>
+                <span className={styles.blockText}>
+                  <span className={styles.chordName}>Add a chord</span>
+                  <span className={styles.duration}>To start playback</span>
+                </span>
+              </button>
+            )}
           </div>
         </div>
-        {playbackBlockedReason ? (
+        {playbackBlockedReason && stepAtoms.length > 0 ? (
           <p className={styles.statusNote} role="status">{playbackBlockedReason}</p>
         ) : activeStep?.unavailable ? (
           <p className={styles.statusNote} role="status">{activeStep.unavailableReason}</p>

--- a/src/components/SongControls/SongControls.module.css
+++ b/src/components/SongControls/SongControls.module.css
@@ -346,3 +346,29 @@
   padding-top: 4px;
   padding-bottom: 4px;
 }
+
+.progressionHint {
+  width: 100%;
+  margin: 0.25rem 0 0;
+  font-size: 0.6875rem;
+  line-height: 1.4;
+  color: var(--dc-fg-muted);
+  text-align: center;
+}
+
+.linkButton {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: var(--faceplate-accent);
+  font: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+  cursor: pointer;
+  transition: color 150ms ease;
+}
+
+.linkButton:hover {
+  color: color-mix(in srgb, var(--faceplate-accent) 80%, white);
+}

--- a/src/components/SongControls/SongControls.test.tsx
+++ b/src/components/SongControls/SongControls.test.tsx
@@ -724,4 +724,41 @@ describe("SongControls grid layout", () => {
     expect(within(hint).getByText("Voicing")).toHaveClass("progressionHelpStrong");
     expect(within(hint).getByText("lens")).toHaveClass("progressionHelpStrong");
   });
+
+  it("asks the user to add a chord when the progression is empty", () => {
+    renderWithStore(
+      <SongControls />,
+      makeAtomStore([
+        [rootNoteAtom, "C"],
+        [scaleNameAtom, "major"],
+        [progressionStepsAtom, []],
+        [activeProgressionStepIndexAtom, 0],
+      ]),
+    );
+
+    expect(screen.getByRole("button", { name: "Add a chord" })).toBeInTheDocument();
+    expect(screen.getByText(/to start building your progression/)).toBeInTheDocument();
+    expect(
+      screen.queryByText("Select a chord to edit its degree, duration, and quality."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("asks the user to select a chord when steps exist but none is active", () => {
+    renderWithStore(
+      <SongControls />,
+      makeAtomStore([
+        [rootNoteAtom, "C"],
+        [scaleNameAtom, "major"],
+        [progressionStepsAtom, [
+          { id: "one", degree: "I", duration: { value: 1, unit: "bar" }, qualityOverride: null },
+        ]],
+        [activeProgressionStepIndexAtom, -1], // out of bounds / inactive
+      ]),
+    );
+
+    expect(
+      screen.getByText("Select a chord to edit its degree, duration, and quality."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add a chord" })).not.toBeInTheDocument();
+  });
 });

--- a/src/components/SongControls/SongControls.tsx
+++ b/src/components/SongControls/SongControls.tsx
@@ -467,8 +467,21 @@ export function SongControls() {
               </p>
             </div>
           </div>
+        ) : progressionSteps.length === 0 ? (
+          <p className={styles.progressionHint}>
+            <button
+              type="button"
+              className={styles.linkButton}
+              onClick={() => addProgressionStep()}
+            >
+              Add a chord
+            </button>{" "}
+            to start building your progression.
+          </p>
         ) : (
-          <p className={shared["field-hint"]}>Select a chord to edit its degree, duration, and quality.</p>
+          <p className={styles.progressionHint}>
+            Select a chord to edit its degree, duration, and quality.
+          </p>
         )}
           </Prop>
         </PropGrid>


### PR DESCRIPTION
## Summary
- Refactored progression card empty state to use `styles.progressionHint` and an interactive `Add a chord` link button.
- Refactored progression track empty state into a clickable "ghost block" containing a degree badge with `+` and primary/secondary instruction labels that exactly matches the populated chord block structure.
- Added comprehensive unit tests in `SongControls.test.tsx` and `ProgressionTrack.test.tsx`.

## Test Plan
- [ ] Open the app, delete all progression steps, and verify the empty states of the track and card.
- [ ] Hover over the empty track block to verify the dotted border and degree badge glow cyan/accent.
- [ ] Click "Add a chord" in either the track or the card to verify a new progression step is added successfully.
- [ ] Verify that all unit tests pass with `pnpm test`.