### PR TITLE
docs(audio): correct reverb-return routing comment (pre-compressor via reverbReturn)

### DIFF
--- a/src/progressions/audio/sound/buildSignalGraph.ts
+++ b/src/progressions/audio/sound/buildSignalGraph.ts
@@ -109,10 +109,12 @@ function buildReverb(
  * nodes for each instrument family plus a disposer.
  *
  * Routing per channel:
- *   nativeInput(Gain) → [EQ3 → saturation]? → Channel(volume+pan) → masterGlue
- *                                                   └─(reverbSend)→ reverbBus → masterGlue
+ *   nativeInput(Gain) → [EQ3 → saturation]? → Channel(volume+pan) → Compressor
+ *                                                   └─(reverbSend Gain)→ reverbBus
  * masterGlue: Compressor → Limiter → destination
- * reverbBus:  Reverb → (into masterGlue input, post-compressor pre-limiter)
+ * reverbBus:  reverbSend(Gain) → Reverb(wet=1) → reverbReturn(Gain) → Compressor
+ *             input. The wet return enters PRE-compressor, so the room tail is
+ *             glued by the same compressor as the dry channels.
  *
  * INVARIANT: `ctx` MUST be the same AudioContext that Tone is bound to. The app
  * binds Tone to the progression AudioContext via `Tone.setContext(audio.ctx)`


### PR DESCRIPTION
Updates the signal graph documentation to accurately reflect the audio routing architecture.

- Clarifies that the reverb return signal is routed pre-compressor
- Ensures the room tail is properly processed by the master compressor alongside dry channels
- Corrects inaccuracies regarding the reverb bus configuration in the routing documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal audio system documentation for improved clarity on signal routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iecg/fretboard-app/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->