### PR TITLE
feat(progressions): funk chicken-scratch rework + genre tempo auto-apply

### DIFF
--- a/docs/superpowers/plans/2026-05-31-funk-chicken-scratch-rework.md
+++ b/docs/superpowers/plans/2026-05-31-funk-chicken-scratch-rework.md
@@ -1,0 +1,772 @@
+# Funk Chicken-Scratch Rework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework the funk genre into an authentic James Brown chicken-scratch groove — sparse, on-the-one, with a tight muted single-coil guitar — and fix the dead `suggestedTempo` config so genre selection applies tempo.
+
+**Architecture:** One additive engine change (per-stroke note length threaded through the strum voice via an articulation enum, mirroring the existing bass-articulation pattern), plus funk-only data: a new short/bright guitar patch, a new sparse comp pattern, retuned funk bass/drums, and a tempo auto-apply in the genre-apply atom. Every new interface field is optional and defaults to today's behavior, so no other genre's sound changes (except the intended cross-genre tempo auto-apply).
+
+**Tech Stack:** TypeScript, Vitest, Tone.js (Web Audio), Jotai.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-funk-chicken-scratch-rework-design.md`
+
+---
+
+## Conventions for this plan
+
+- Run a single test file: `pnpm vitest run <path>`. Run one test by name: `pnpm vitest run <path> -t "<name>"`.
+- Commit after each task with a Conventional Commit (`type(scope): subject`).
+- Final gate before any PR: `pnpm run lint && pnpm run test && pnpm run build`.
+- Audio timbre/feel is verified by ear in the final task — unit tests assert data + wiring only.
+
+## Key existing facts the tasks rely on
+
+- `ChordHit` (`patterns.ts:31-37`) has `beat`, `velocity`, `style?`, `direction?`. We ADD `articulation?`.
+- `ChordStrumEvent` (`buildAllLayers.ts:32-37`) has `voicing`, `velocity`, `style?`, `direction?`. We ADD `durationSec?`. (Note: the `durationSec?` at `buildAllLayers.ts:42` is on `BassEvent`, a different interface.)
+- The chord-strum loop pushes events at `buildAllLayers.ts:212-220` (`style: hit.style, direction: hit.direction`). The bass loop already maps articulation→duration at `:247` via `articulationToDurationSec` (`:89-101`).
+- `ChordVoiceOptions` (`instruments/types.ts:7-12`) has `velocity`, `style?`, `direction?`. We ADD `durationSec?`.
+- `strumVoice.ts:15` calls `pluckString(dest, freq, time, { velocity, spec })`. `pluckString` (`string.ts:40-65`) reads `noteDuration = spec?.noteDurationSec ?? DEFAULT_NOTE_DURATION` (1.8). `PluckStringOptions` is `{ velocity?, spec? }` (`string.ts:14`).
+- `useProgressionAudioPlayback.ts:395-396` calls `voice.scheduleChord(..., { velocity, style, direction })`.
+- `CHORD_PATTERNS` and `CHORD_PATCHES` live in `patterns.ts` and `sound/instrumentPatches.ts`. `CHORD_PATCHES` strum entries: `chord-nylon-strum`, `chord-steel-strum`.
+- Funk genre: `genres.ts` `id: "funk"` entry. Funk mix preset: `genreMixPresets.ts` `genre: "funk"` (chord patch currently `chord-steel-strum`).
+- `applyGenreStyleAtom` (`store/progressionAtoms.ts`) sets instrument/patterns/drumVariations/swing but NOT `progressionTempoBpmAtom`. The tempo atom is `progressionTempoBpmAtom` (`progressionAtoms.ts:120`).
+- The chord-patterns catalog count test is in `patterns.test.ts` (`describe("pattern catalog")`, asserts `CHORD_PATTERNS` length). Adding a pattern requires bumping it.
+
+---
+
+## Task 1: Add `articulation` to ChordHit + the strum-duration mapper
+
+**Files:**
+- Modify: `src/progressions/audio/patterns.ts` (`ChordHit` interface ~31-37)
+- Modify: `src/progressions/audio/buildAllLayers.ts` (add `articulationToStrumDurationSec` near `articulationToDurationSec` ~89-101)
+- Test: `src/progressions/audio/buildAllLayers.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/progressions/audio/buildAllLayers.test.ts`:
+
+```ts
+import { articulationToStrumDurationSec } from "./buildAllLayers";
+
+describe("articulationToStrumDurationSec", () => {
+  it("chokes a muted scratch stroke to a short fixed length", () => {
+    expect(articulationToStrumDurationSec("muted", 1.8)).toBeCloseTo(0.06, 5);
+  });
+  it("lets an accent ring for the full patch note duration", () => {
+    expect(articulationToStrumDurationSec("accent", 1.8)).toBeCloseTo(1.8, 5);
+  });
+  it("defaults (undefined) to the patch note duration — no behavior change", () => {
+    expect(articulationToStrumDurationSec(undefined, 0.42)).toBeCloseTo(0.42, 5);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run src/progressions/audio/buildAllLayers.test.ts -t "articulationToStrumDurationSec"`
+Expected: FAIL — `articulationToStrumDurationSec` is not exported.
+
+- [ ] **Step 3: Add the `ChordArticulation` type + `articulation` field**
+
+In `src/progressions/audio/patterns.ts`, add the type near the other strum types (after the `StrumDirection` type ~line 14) :
+
+```ts
+export type ChordArticulation = "muted" | "accent";
+```
+
+Extend the `ChordHit` interface (~31-37) to:
+
+```ts
+interface ChordHit {
+  beat: number;
+  velocity: number;
+  style?: "staccato" | "sustained";
+  /** Strum direction; up-strokes reverse the voicing order. Defaults to down. */
+  direction?: StrumDirection;
+  /** Note-length intent for the strum voice. "muted" chokes the stroke short
+   *  (chicken-scratch), "accent"/omitted rings for the patch's note duration. */
+  articulation?: ChordArticulation;
+}
+```
+
+- [ ] **Step 4: Add the mapper to `buildAllLayers.ts`**
+
+In `src/progressions/audio/buildAllLayers.ts`, extend the import from `./patterns` to include the new type, and add the function right after `articulationToDurationSec` (after line ~101):
+
+```ts
+/**
+ * Translate a chord hit's articulation into a strum note length in seconds.
+ * "muted" chokes the stroke to a short fixed length (the chicken-scratch);
+ * "accent" or omitted rings for the patch's natural note duration.
+ */
+export function articulationToStrumDurationSec(
+  articulation: ChordArticulation | undefined,
+  patchNoteDurationSec: number,
+): number {
+  return articulation === "muted" ? 0.06 : patchNoteDurationSec;
+}
+```
+
+Add `ChordArticulation` to the existing `import { ... } from "./patterns"` block (alongside `BassArticulation`).
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm vitest run src/progressions/audio/buildAllLayers.test.ts -t "articulationToStrumDurationSec"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/progressions/audio/patterns.ts src/progressions/audio/buildAllLayers.ts src/progressions/audio/buildAllLayers.test.ts
+git commit -m "feat(progressions): add chord articulation type + strum-duration mapper"
+```
+
+---
+
+## Task 2: Thread `durationSec` through the strum voice to pluckString
+
+**Files:**
+- Modify: `src/progressions/audio/string.ts` (`PluckStringOptions` ~14, `pluckString` ~50)
+- Modify: `src/progressions/audio/instruments/types.ts` (`ChordVoiceOptions` ~7-12)
+- Modify: `src/progressions/audio/instruments/strumVoice.ts` (`pluckString` call ~15)
+- Test: `src/progressions/audio/instruments/strumVoice.test.ts`, `src/progressions/audio/string.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/progressions/audio/instruments/strumVoice.test.ts` (inside the `describe("strumVoice", ...)` block):
+
+```ts
+it("forwards durationSec to pluckString when provided", () => {
+  strumVoice.scheduleChord(
+    {} as AudioNode,
+    ["C3", "E3", "G3"],
+    0,
+    { velocity: 0.8, durationSec: 0.06 },
+  );
+  // pluckString(dest, freq, time, options) — options is arg[3].
+  for (const call of pluckStringSpy.mock.calls) {
+    expect((call[3] as { durationSec?: number }).durationSec).toBe(0.06);
+  }
+});
+
+it("omits durationSec when not provided (defaults preserved)", () => {
+  strumVoice.scheduleChord({} as AudioNode, ["C3"], 0, { velocity: 0.8 });
+  expect((pluckStringSpy.mock.calls[0]![3] as { durationSec?: number }).durationSec).toBeUndefined();
+});
+```
+
+Append to `src/progressions/audio/string.test.ts` (inside `describe("pluckString — Tone.Synth backend", ...)`):
+
+```ts
+it("overrides the patch note duration with durationSec when provided", async () => {
+  const t = await tone;
+  pluckString({} as AudioNode, 220, 0, { velocity: 0.8, durationSec: 0.06 });
+  const [, duration] = t.spies.triggerAttackRelease.mock.calls[0]!;
+  expect(duration).toBeCloseTo(0.06, 3);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm vitest run src/progressions/audio/instruments/strumVoice.test.ts src/progressions/audio/string.test.ts -t "durationSec"`
+Expected: FAIL — `durationSec` is neither accepted nor forwarded.
+
+- [ ] **Step 3: Add `durationSec` to `PluckStringOptions` and honor it**
+
+In `src/progressions/audio/string.ts`, change line 14:
+
+```ts
+export interface PluckStringOptions { velocity?: number; spec?: StrumSpec; durationSec?: number; }
+```
+
+Change the `noteDuration` line (~50) to prefer the override:
+
+```ts
+  const noteDuration = options.durationSec ?? spec?.noteDurationSec ?? DEFAULT_NOTE_DURATION;
+```
+
+- [ ] **Step 4: Add `durationSec` to `ChordVoiceOptions`**
+
+In `src/progressions/audio/instruments/types.ts`, extend `ChordVoiceOptions` (~7-12):
+
+```ts
+export interface ChordVoiceOptions {
+  velocity: number;
+  style?: "staccato" | "sustained";
+  /** Strum direction; up-strokes reverse the voicing order. Defaults to down. */
+  direction?: "up" | "down";
+  /** Per-stroke note length override (seconds). Used by the strum voice for
+   *  muted chicken-scratch strokes; ignored by piano/organ voices. */
+  durationSec?: number;
+}
+```
+
+- [ ] **Step 5: Forward it in the strum voice**
+
+In `src/progressions/audio/instruments/strumVoice.ts`, change the `pluckString` call (line 15) to pass `durationSec`:
+
+```ts
+        return pluckString(dest, freq, time + i * STRUM_LAG_SECONDS, { velocity: options.velocity, spec, durationSec: options.durationSec });
+```
+
+(The piano and organ voices do not read `durationSec`, so they are unaffected — no change needed there.)
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pnpm vitest run src/progressions/audio/instruments/strumVoice.test.ts src/progressions/audio/string.test.ts`
+Expected: PASS (new tests + all existing strum/string tests still green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/progressions/audio/string.ts src/progressions/audio/instruments/types.ts src/progressions/audio/instruments/strumVoice.ts src/progressions/audio/instruments/strumVoice.test.ts src/progressions/audio/string.test.ts
+git commit -m "feat(progressions): thread per-stroke durationSec through the strum voice"
+```
+
+---
+
+## Task 3: Emit `durationSec` on chord strum events + forward in playback
+
+**Files:**
+- Modify: `src/progressions/audio/buildAllLayers.ts` (`ChordStrumEvent` ~32-37, chord loop ~203-221)
+- Modify: `src/hooks/useProgressionAudioPlayback.ts` (scheduleChord call ~395-396)
+- Test: `src/progressions/audio/buildAllLayers.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+First, confirm the test file's existing layer-build helper. Add to `src/progressions/audio/buildAllLayers.test.ts` a test that a muted chord hit yields a short `durationSec` on the emitted strum event. Use the existing build helper pattern in that file (it builds layers from steps + pattern ids). Since chord patterns are referenced by id, this test lands meaningfully only after Task 4 adds `funk-scratch`; for THIS task, assert the mapping wiring directly via a focused build using the `funk-scratch` pattern is NOT yet possible — instead assert the field is populated for an existing pattern that has no articulation (so it equals the patch note duration) and is `0.06` for a muted hit by constructing through the public `buildAllLayersAsync`.
+
+To keep this task self-contained, test the emission logic against the `pop-8ths` pattern (no articulation → durationSec equals the strum patch note duration). Add:
+
+```ts
+import { buildAllLayersAsync } from "./buildAllLayers";
+
+describe("chord strum durationSec emission", () => {
+  const baseStep = {
+    id: "s1", degree: "I", root: "C", quality: "M",
+    duration: { value: 1, unit: "bar" as const },
+    qualityOverride: null, manualRoot: null, unavailable: false,
+  };
+
+  it("emits a durationSec on every chord strum event", async () => {
+    const layers = await buildAllLayersAsync({
+      steps: [baseStep],
+      tempoBpm: 120, beatsPerBar: 4, swing: 0,
+      chordPatternId: "pop-8ths", bassPatternId: "root-fifth",
+      drumPatternId: "pop", drumVariations: [], loop: false,
+    });
+    expect(layers.chordStrums.length).toBeGreaterThan(0);
+    for (const s of layers.chordStrums) {
+      expect(typeof s.value.durationSec).toBe("number");
+    }
+  });
+});
+```
+
+(If the `ResolvedProgressionStep` shape in the helper differs, match the existing helper in the file — the key assertion is that `value.durationSec` is a number on each strum event.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run src/progressions/audio/buildAllLayers.test.ts -t "chord strum durationSec emission"`
+Expected: FAIL — `durationSec` is `undefined` on strum events (field not emitted).
+
+- [ ] **Step 3: Add `durationSec` to `ChordStrumEvent`**
+
+In `src/progressions/audio/buildAllLayers.ts`, extend the interface (~32-37):
+
+```ts
+export interface ChordStrumEvent {
+  voicing: readonly string[];
+  velocity: number;
+  style?: StrumStyle;
+  direction?: StrumDirection;
+  durationSec?: number;
+}
+```
+
+- [ ] **Step 4: Populate it in the chord loop**
+
+The chord loop needs the active strum patch's note duration to map "accent"/undefined to. The pure `buildAllLayersAsync` does not know the patch, so use a sensible constant default equal to the strum default (`1.8`) — the muted choke (`0.06`) is what matters musically, and accent/undefined falls back to the patch's own `noteDurationSec` inside `pluckString` anyway when we pass `undefined`. Therefore: emit `0.06` for muted, and `undefined` for accent/omitted (so `pluckString` uses the patch duration).
+
+Replace the `articulationToStrumDurationSec` import-and-use approach with this minimal emission. In the chord-strum push (`buildAllLayers.ts:212-220`), change to:
+
+```ts
+          chordStrums.push({
+            time: hitTime,
+            value: {
+              voicing,
+              velocity,
+              style: hit.style,
+              direction: hit.direction,
+              durationSec: hit.articulation === "muted" ? 0.06 : undefined,
+            },
+          });
+```
+
+(This keeps the muted choke deterministic and lets accent/omitted strokes ring at the patch's own note duration via the `pluckString` fallback. The `articulationToStrumDurationSec` helper from Task 1 documents the intent and is unit-tested; the inline emission uses the same `0.06` choke.)
+
+Update the Task 3 test's expectation accordingly: for `pop-8ths` (no articulation) `durationSec` is `undefined`, so change the assertion to:
+
+```ts
+    for (const s of layers.chordStrums) {
+      expect(s.value.durationSec).toBeUndefined(); // pop-8ths has no muted hits
+    }
+```
+
+- [ ] **Step 5: Forward `durationSec` in playback**
+
+In `src/hooks/useProgressionAudioPlayback.ts`, change the scheduleChord options (lines 395-396):
+
+```ts
+          voice.scheduleChord(audio.layers.chord, value.voicing, audioTime, {
+            velocity: value.velocity, style: value.style, direction: value.direction, durationSec: value.durationSec,
+          });
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `pnpm vitest run src/progressions/audio/buildAllLayers.test.ts -t "chord strum durationSec emission"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/progressions/audio/buildAllLayers.ts src/hooks/useProgressionAudioPlayback.ts src/progressions/audio/buildAllLayers.test.ts
+git commit -m "feat(progressions): emit + forward chord strum durationSec for muted strokes"
+```
+
+---
+
+## Task 4: Add the `chord-funk-scratch` guitar patch
+
+**Files:**
+- Modify: `src/progressions/audio/sound/instrumentPatches.ts` (`CHORD_PATCHES`)
+- Test: `src/progressions/audio/sound/instrumentPatches.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/progressions/audio/sound/instrumentPatches.test.ts`:
+
+```ts
+it("provides a short-decay funk scratch guitar patch", () => {
+  const patch = getChordPatch("chord-funk-scratch")!;
+  expect(patch).toBeDefined();
+  expect(patch.family).toBe("strum");
+  // Must be short so it can scratch, not bloom like the acoustic steel strum (1.8s).
+  expect(patch.strum!.noteDurationSec).toBeLessThanOrEqual(0.3);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run src/progressions/audio/sound/instrumentPatches.test.ts -t "funk scratch guitar"`
+Expected: FAIL — `chord-funk-scratch` does not exist.
+
+- [ ] **Step 3: Add the patch**
+
+In `src/progressions/audio/sound/instrumentPatches.ts`, add to `CHORD_PATCHES` after the `chord-steel-strum` entry:
+
+```ts
+  {
+    id: "chord-funk-scratch", label: "Funk Scratch", family: "strum",
+    strum: {
+      // Bright single-coil chicken-scratch: upper-harmonic-weighted partials so
+      // muted scratches cut on small speakers, and a short note/release so even
+      // voiced stabs stay tight instead of ringing like the acoustic strum.
+      oscillator: { type: "custom", partials: [1, 0.9, 0.7, 0.5, 0.35, 0.25, 0.15] },
+      envelope: { attack: 0.004, decay: 0.18, sustain: 0.0, release: 0.08 },
+      noteDurationSec: 0.18, releaseTailSec: 0.4,
+    },
+    insert: { eq3: { low: -2, mid: 1, high: 3 } },
+  },
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm vitest run src/progressions/audio/sound/instrumentPatches.test.ts -t "funk scratch guitar"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/progressions/audio/sound/instrumentPatches.ts src/progressions/audio/sound/instrumentPatches.test.ts
+git commit -m "feat(progressions): add chord-funk-scratch single-coil guitar patch"
+```
+
+---
+
+## Task 5: Add the `funk-scratch` sparse on-the-one comp pattern
+
+**Files:**
+- Modify: `src/progressions/audio/patterns.ts` (`CHORD_PATTERNS`)
+- Test: `src/progressions/audio/patterns.test.ts` (new describe + bump catalog count)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/progressions/audio/patterns.test.ts`:
+
+```ts
+describe("funk-scratch chord comp", () => {
+  const funk = getChordPattern("funk-scratch")!;
+
+  it("exists and accents the one hardest", () => {
+    expect(funk).toBeDefined();
+    const byBeat = new Map(funk.hits.map((h) => [h.beat, h.velocity]));
+    const one = byBeat.get(0)!;
+    for (const h of funk.hits) {
+      if (h.beat !== 0) expect(h.velocity).toBeLessThan(one);
+    }
+  });
+
+  it("marks the one as an accent and the rest as muted scratches", () => {
+    const byBeat = new Map(funk.hits.map((h) => [h.beat, h]));
+    expect(byBeat.get(0)!.articulation).toBe("accent");
+    const muted = funk.hits.filter((h) => h.articulation === "muted");
+    expect(muted.length).toBeGreaterThanOrEqual(funk.hits.length - 1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run src/progressions/audio/patterns.test.ts -t "funk-scratch chord comp"`
+Expected: FAIL — `funk-scratch` does not exist.
+
+- [ ] **Step 3: Add the pattern**
+
+In `src/progressions/audio/patterns.ts`, add to `CHORD_PATTERNS` after the `funk-16th` entry:
+
+```ts
+  {
+    id: "funk-scratch",
+    label: "Funk Scratch",
+    // James Brown chicken-scratch: a hard accented chord stab on the one, then
+    // muted scratch ghosts with deliberate space. The "muted" hits choke short
+    // via the strum voice; the accent rings the patch's (already short) length.
+    hits: [
+      { beat: 0, velocity: 0.95, direction: "down", articulation: "accent" },
+      { beat: 0.5, velocity: 0.28, direction: "up", articulation: "muted" },
+      { beat: 0.75, velocity: 0.3, direction: "up", articulation: "muted" },
+      { beat: 1.5, velocity: 0.4, direction: "up", articulation: "muted" },
+      { beat: 2.5, velocity: 0.28, direction: "up", articulation: "muted" },
+      { beat: 2.75, velocity: 0.3, direction: "up", articulation: "muted" },
+      { beat: 3.5, velocity: 0.35, direction: "up", articulation: "muted" },
+    ],
+  },
+```
+
+- [ ] **Step 4: Bump the chord-pattern catalog count**
+
+The `describe("pattern catalog")` block in `patterns.test.ts` asserts the chord-pattern count. Find the line asserting `CHORD_PATTERNS` length (currently `expect(CHORD_PATTERNS).toHaveLength(8)`) and bump it to `9`, and update the test name string from `"has 8 chord patterns with unique IDs"` to `"has 9 chord patterns with unique IDs"`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm vitest run src/progressions/audio/patterns.test.ts`
+Expected: PASS (new block + bumped catalog count + all existing pattern tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/progressions/audio/patterns.ts src/progressions/audio/patterns.test.ts
+git commit -m "feat(progressions): add sparse on-the-one funk-scratch chord comp"
+```
+
+---
+
+## Task 6: Retune funk bass + drums toward "the one"
+
+**Files:**
+- Modify: `src/progressions/audio/patterns.ts` (`funk-syncopated` bass, `funk` drums)
+- Test: `src/progressions/audio/patterns.test.ts`
+
+- [ ] **Step 1: Write the failing/guard test**
+
+Add to `src/progressions/audio/patterns.test.ts`:
+
+```ts
+describe("funk groove locks on the one", () => {
+  it("funk-syncopated bass anchors beat 1 as the velocity-1 hit", () => {
+    const bass = getBassPattern("funk-syncopated")!;
+    const one = bass.hits.find((h) => h.beat === 0)!;
+    expect(one.velocity).toBe(1);
+    expect(one.note).toBe("root");
+  });
+
+  it("funk drums put the hardest kick on the one", () => {
+    const funk = getDrumPattern("funk")!;
+    const kickOne = funk.kicks.find((h) => h.beat === 0)!;
+    expect(kickOne.velocity).toBe(1);
+    for (const k of funk.kicks) {
+      if (k.beat !== 0) expect(k.velocity).toBeLessThanOrEqual(kickOne.velocity);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify current state**
+
+Run: `pnpm vitest run src/progressions/audio/patterns.test.ts -t "funk groove locks on the one"`
+Expected: PASS already for the existing patterns (beat-0 bass is velocity 1 / root; beat-0 kick is velocity 1). This test is a REGRESSION GUARD that must keep passing through the retune. If it fails now, the retune in Step 3 must preserve these invariants.
+
+- [ ] **Step 3: Retune the funk bass + drums (keep the guarded invariants)**
+
+In `src/progressions/audio/patterns.ts`, retune `funk-syncopated` to tighten around the one — anchor beat 1, trim one mid-bar hit for more space:
+
+```ts
+  {
+    id: "funk-syncopated",
+    label: "Funk Syncopated",
+    hits: [
+      { beat: 0, velocity: 1, note: "root", articulation: "staccato" },
+      { beat: 0.75, velocity: 0.4, note: "root", articulation: "staccato" },
+      { beat: 1.5, velocity: 0.8, note: "octave", articulation: "staccato" },
+      { beat: 2.5, velocity: 0.55, note: "fifth", articulation: "staccato" },
+      { beat: 3.5, velocity: 0.7, note: "flat-seventh", articulation: "staccato" },
+    ],
+  },
+```
+
+Retune the `funk` drums for a harder, simpler locked groove — keep beat-0 kick at velocity 1 and the backbeat snares full:
+
+```ts
+  {
+    id: "funk",
+    label: "Funk",
+    kicks: [
+      { beat: 0, velocity: 1 },
+      { beat: 0.75, velocity: 0.55 },
+      { beat: 2.5, velocity: 0.8 },
+    ],
+    snares: [
+      { beat: 1, velocity: 1 },
+      { beat: 1.5, velocity: 0.2 },
+      { beat: 2.25, velocity: 0.18 },
+      { beat: 3, velocity: 1 },
+      { beat: 3.5, velocity: 0.15 },
+    ],
+    hats: [
+      { beat: 0, velocity: 0.55 },
+      { beat: 0.25, velocity: 0.3 },
+      { beat: 0.5, velocity: 0.4 },
+      { beat: 0.75, velocity: 0.3 },
+      { beat: 1, velocity: 0.5 },
+      { beat: 1.25, velocity: 0.3 },
+      { beat: 1.5, velocity: 0.4 },
+      { beat: 1.75, velocity: 0.3 },
+      { beat: 2, velocity: 0.5 },
+      { beat: 2.25, velocity: 0.3 },
+      { beat: 2.5, velocity: 0.4 },
+      { beat: 2.75, velocity: 0.3 },
+      { beat: 3, velocity: 0.5 },
+      { beat: 3.25, velocity: 0.3 },
+      { beat: 3.5, velocity: 0.4 },
+      { beat: 3.75, velocity: 0.3 },
+    ],
+  },
+```
+
+Note: the existing `funk drum ghost snares` test asserts the snare beat grid `[0.75, 1, 1.5, 2.25, 3, 3.5]` and that backbeats (1 & 3) are velocity 1 with ≥3 ghosts ≤0.2. The retune above drops the `0.75` ghost, changing the grid to `[1, 1.5, 2.25, 3, 3.5]`. Update that existing test's grid assertion to `[1, 1.5, 2.25, 3, 3.5]` and confirm it still has ≥3 ghosts ≤0.2 (1.5→0.2, 2.25→0.18, 3.5→0.15 = three ghosts). Keep the backbeat assertions.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm vitest run src/progressions/audio/patterns.test.ts`
+Expected: PASS (new guard + updated ghost-snare grid + all else).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/progressions/audio/patterns.ts src/progressions/audio/patterns.test.ts
+git commit -m "feat(progressions): tighten funk bass + drums onto the one"
+```
+
+---
+
+## Task 7: Wire the funk genre + mix to the new scratch sound
+
+**Files:**
+- Modify: `src/progressions/audio/genres.ts` (`funk` entry)
+- Modify: `src/progressions/audio/sound/genreMixPresets.ts` (`funk` preset chord patch)
+- Test: `src/progressions/audio/genres.test.ts`, `src/progressions/audio/sound/genreMixPresets.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/progressions/audio/genres.test.ts`:
+
+```ts
+it("wires the funk genre to the chicken-scratch comp", () => {
+  expect(getGenreStyle("funk")!.chordPattern).toBe("funk-scratch");
+});
+```
+
+Add to `src/progressions/audio/sound/genreMixPresets.test.ts`:
+
+```ts
+it("uses the short funk-scratch guitar patch for funk", () => {
+  expect(getGenreMix("funk")!.patches.chord).toBe("chord-funk-scratch");
+});
+
+it("funk's chord patch is short-decay so the guitar can actually scratch", () => {
+  // Recurrence guard: two prior funk passes failed because the guitar was a
+  // long-ringing acoustic strum. The funk chord patch must stay short.
+  const patchId = getGenreMix("funk")!.patches.chord;
+  const patch = getChordPatch(patchId)!;
+  expect(patch.strum!.noteDurationSec).toBeLessThanOrEqual(0.3);
+});
+```
+
+Ensure `getChordPatch` is imported in `genreMixPresets.test.ts` (it already imports from `./instrumentPatches`; add `getChordPatch` if missing).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm vitest run src/progressions/audio/genres.test.ts src/progressions/audio/sound/genreMixPresets.test.ts -t "funk"`
+Expected: FAIL — funk still wired to `funk-16th` / `chord-steel-strum`.
+
+- [ ] **Step 3: Update the funk genre wiring**
+
+In `src/progressions/audio/genres.ts`, in the `funk` entry, change `chordPattern: "funk-16th"` to `chordPattern: "funk-scratch"`. Leave `bassPattern`, `drumPattern`, `drumVariations`, `swing` as-is.
+
+- [ ] **Step 4: Update the funk mix preset chord patch**
+
+In `src/progressions/audio/sound/genreMixPresets.ts`, in the `genre: "funk"` preset, change `patches: { bass: "bass-finger", chord: "chord-steel-strum", drumKit: "kit-funk" }` to use `chord: "chord-funk-scratch"`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm vitest run src/progressions/audio/genres.test.ts src/progressions/audio/sound/genreMixPresets.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/progressions/audio/genres.ts src/progressions/audio/sound/genreMixPresets.ts src/progressions/audio/genres.test.ts src/progressions/audio/sound/genreMixPresets.test.ts
+git commit -m "feat(progressions): wire funk genre + mix to the chicken-scratch guitar"
+```
+
+---
+
+## Task 8: Auto-apply genre `suggestedTempo` + retune funk tempo
+
+**Files:**
+- Modify: `src/store/progressionAtoms.ts` (`applyGenreStyleAtom`)
+- Modify: `src/progressions/audio/genres.ts` (`funk` tempo fields)
+- Test: `src/store/atoms.test.ts` (or wherever `applyGenreStyleAtom` is exercised) + `src/progressions/audio/genres.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/progressions/audio/genres.test.ts`:
+
+```ts
+it("gives funk a James Brown pocket tempo", () => {
+  const funk = getGenreStyle("funk")!;
+  expect(funk.suggestedTempo).toBeGreaterThanOrEqual(104);
+  expect(funk.suggestedTempo).toBeLessThanOrEqual(116);
+  expect(funk.tempoRange[0]).toBeLessThanOrEqual(funk.suggestedTempo);
+  expect(funk.tempoRange[1]).toBeGreaterThanOrEqual(funk.suggestedTempo);
+});
+```
+
+Add a store test for the tempo auto-apply. Create `src/store/progressionGenreTempo.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { createStore } from "jotai";
+import { applyGenreStyleAtom, progressionTempoBpmAtom } from "./progressionAtoms";
+import { getGenreStyle } from "../progressions/audio/genres";
+
+describe("applyGenreStyleAtom tempo", () => {
+  it("applies the genre's suggestedTempo to the tempo atom", () => {
+    const store = createStore();
+    store.set(progressionTempoBpmAtom, 60); // a value no genre suggests
+    store.set(applyGenreStyleAtom, "funk");
+    expect(store.get(progressionTempoBpmAtom)).toBe(getGenreStyle("funk")!.suggestedTempo);
+  });
+
+  it("applies tempo for a different genre too", () => {
+    const store = createStore();
+    store.set(applyGenreStyleAtom, "jazz");
+    expect(store.get(progressionTempoBpmAtom)).toBe(getGenreStyle("jazz")!.suggestedTempo);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm vitest run src/store/progressionGenreTempo.test.ts src/progressions/audio/genres.test.ts -t "tempo"`
+Expected: FAIL — `applyGenreStyleAtom` doesn't set tempo; funk tempo not yet retuned.
+
+- [ ] **Step 3: Add the tempo auto-apply**
+
+In `src/store/progressionAtoms.ts`, in `applyGenreStyleAtom`, add after the `set(progressionSwingAtom, genre.swing);` line:
+
+```ts
+  set(progressionTempoBpmAtom, genre.suggestedTempo);
+```
+
+Confirm `progressionTempoBpmAtom` is in scope (it is defined in the same file ~line 120).
+
+- [ ] **Step 4: Retune the funk tempo**
+
+In `src/progressions/audio/genres.ts`, in the `funk` entry, change `tempoRange: [90, 120], suggestedTempo: 100` to `tempoRange: [96, 120], suggestedTempo: 110`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm vitest run src/store/progressionGenreTempo.test.ts src/progressions/audio/genres.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Check for a now-stale genre-apply test**
+
+The existing test `applyGenreStyle does NOT revert to custom` in `src/hooks/useProgressionState.test.tsx` applies a genre and asserts the genre atom stays set. Adding a tempo write does not change that behavior, but run it to confirm:
+
+Run: `pnpm vitest run src/hooks/useProgressionState.test.tsx`
+Expected: PASS (no change needed; if it asserts tempo unchanged anywhere, update that assertion to expect the suggestedTempo).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/store/progressionAtoms.ts src/progressions/audio/genres.ts src/store/progressionGenreTempo.test.ts src/progressions/audio/genres.test.ts
+git commit -m "feat(progressions): apply genre suggestedTempo on selection; retune funk to JB pocket"
+```
+
+---
+
+## Task 9: Full verification + manual audition
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run lint**
+
+Run: `pnpm run lint`
+Expected: PASS.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `pnpm run test`
+Expected: PASS — all unit/component tests green.
+
+- [ ] **Step 3: Run the production build**
+
+Run: `pnpm run build`
+Expected: PASS (`tsc -b && vite build`).
+
+- [ ] **Step 4: Manual audition checklist (by ear)**
+
+Run `pnpm run dev`, open the app, select the **Funk** genre, load a progression, and play. Check each box only after listening:
+
+- [ ] Selecting Funk snaps the tempo to ~110 (no manual change needed).
+- [ ] The guitar is a tight, dry, muted chicken-scratch — short strokes, not a ringing acoustic strum.
+- [ ] Beat 1 ("the one") lands with a clear accented chord stab; the rest is muted scratch with space (sparse, hypnotic).
+- [ ] Bass and drums lock onto the one with the guitar; the groove feels like James Brown funk, not a generic rock/disco beat.
+- [ ] No clicks/pops on the muted scratch strokes at the funk tempo.
+- [ ] Switch to another genre and back — tempo + sound follow the genre.
+
+- [ ] **Step 5: Finalize**
+
+If all audition boxes pass, the slice is complete. Note any by-ear tuning the audition revealed (patch partials, the 0.06s choke, comp velocities, tempo) and apply as small follow-up commits. Use the superpowers:finishing-a-development-branch skill to decide on merge/PR (this branch already has PR #484 open — push the commits to it).
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** §4.1 engine articulation → Tasks 1-3; §4.2 funk patch → Task 4; §4.3 funk-scratch comp → Task 5; §4.4 bass + §4.5 drums → Task 6; §4.6 tempo auto-apply + retune → Task 8; §4.7 wiring → Task 7; §4.8 keep funk-16th → satisfied (Task 5 adds, never removes); §5 tests → each task is TDD + the recurrence guard is in Task 7 Step 1; §6 audition → Task 9. All covered.
+- **Type consistency:** `ChordArticulation` ("muted"|"accent") defined in Task 1, used in Tasks 1/3/5; `articulation?` added to `ChordHit` (Task 1) and read in `buildAllLayers` (Task 3) and `funk-scratch` (Task 5); `durationSec?` added to `PluckStringOptions` (Task 2), `ChordVoiceOptions` (Task 2), `ChordStrumEvent` (Task 3), forwarded in playback (Task 3); `chord-funk-scratch` id consistent across Tasks 4/7; `funk-scratch` id consistent across Tasks 5/7. `getChordPattern`/`getBassPattern`/`getDrumPattern`/`getChordPatch`/`getGenreStyle`/`getGenreMix` all match real exports.
+- **Ordering:** Task 1 (type+mapper) → Task 2 (voice plumbing) → Task 3 (emission, needs the field) → Task 4 (patch) → Task 5 (comp, uses articulation) → Task 6 (bass/drums) → Task 7 (wiring, needs patch+comp) → Task 8 (tempo) → Task 9 (verify). Each task's tests pass independently after its own changes.
+- **Note on Task 3 design choice:** the inline emission uses `0.06` for muted / `undefined` for accent (so accent rings the patch's own short `noteDurationSec`), rather than calling `articulationToStrumDurationSec` with a hardcoded patch duration. The helper from Task 1 documents+tests the mapping intent; the emission stays patch-agnostic. Both use the same `0.06` choke constant.

--- a/docs/superpowers/specs/2026-05-31-funk-chicken-scratch-rework-design.md
+++ b/docs/superpowers/specs/2026-05-31-funk-chicken-scratch-rework-design.md
@@ -1,0 +1,184 @@
+# Funk Genre Rework — James Brown Chicken-Scratch
+
+**Status:** Design — approved in brainstorming, ready for implementation plan.
+**Date:** 2026-05-31
+
+---
+
+## 1. Goal
+
+Replace the current generic funk backing track with an authentic **James Brown
+chicken-scratch** groove: sparse, hypnotic, "on the one," driven by a tight,
+muted, single-coil rhythm guitar. The funk genre has been tuned twice before
+(added `funk-16th` comp, reworked the kick) and still "doesn't sound funky."
+
+## 2. Root cause of the prior failures
+
+The earlier passes tuned rhythm **patterns** but never the instrument
+**timbres**. The funk guitar uses `chord-steel-strum` — a warm, long-ringing
+(~1.8 s) acoustic patch that physically cannot scratch. Chicken scratch is the
+opposite: short, dry, muted, percussive. Additionally:
+
+- The strum voice has no per-stroke note-length control, so muted scratch
+  strokes can't choke independently of ringing stabs.
+- The funk comp is a busy 10-hit 16th pattern; James Brown funk is sparse and
+  emphasizes beat 1 ("the one").
+- Selecting a genre does **not** apply its `suggestedTempo` (confirmed: `applyGenreStyleAtom` sets instrument/patterns/swing but never the tempo atom), so the funk pocket tempo is unreachable by default — `suggestedTempo`/`tempoRange` are currently dead config for every genre.
+
+## 3. Reference feel
+
+**James Brown / chicken-scratch funk:** sparse one-chord vamp, tight muted
+single-coil "chicken scratch" guitar, hard accent on beat 1, locked rhythm
+section, straight 16ths (no swing). Hypnotic, lots of muted space between hits.
+
+## 4. Scope
+
+Six coordinated changes, all isolated to funk + one additive engine feature.
+**No other genre's sound changes** (every new interface field is optional and
+defaults to today's behavior; the tempo auto-apply uses each genre's existing
+`suggestedTempo`).
+
+### 4.1 Engine: per-stroke note length in the strum voice (additive)
+
+Mirrors the proven bass-articulation pattern already in the codebase.
+
+- Add optional `articulation?: "muted" | "accent"` to the `ChordHit` interface
+  (`patterns.ts`). This is a distinct axis from the existing
+  `style?: "staccato" | "sustained"` field — `style` is read by the poly/organ
+  voices and is left untouched; `articulation` drives strum note length only.
+- Add a pure function `articulationToStrumDurationSec(articulation, patchNoteDurationSec)`
+  (next to the chord-strum threading in `buildAllLayers.ts`, alongside the
+  existing bass `articulationToDurationSec`):
+  - `"muted"` → `0.06` (hard choke — the scratch)
+  - `"accent"` or `undefined` → `patchNoteDurationSec` (rings normally — the stab)
+- `ChordStrumEvent` (in `buildAllLayers.ts`) gains optional `durationSec?: number`;
+  the chord loop sets it from the mapper, exactly as the bass loop sets its
+  `durationSec` today.
+- `ChordVoiceOptions` (`instruments/types.ts`) gains optional `durationSec?: number`.
+- The **strum voice** (`instruments/strumVoice.ts`) passes `options.durationSec`
+  through to `pluckString` as a per-note duration override. `pluckString`
+  (`string.ts`) gains an optional `durationSec` in `PluckStringOptions` that
+  overrides `spec.noteDurationSec` when present.
+- The **piano/organ voices ignore `durationSec`** — no behavior change.
+- `useProgressionAudioPlayback.ts` forwards `value.durationSec` into the
+  `scheduleChord` options (the chord strum part), mirroring how it already
+  forwards `value.style`/`value.direction`.
+
+### 4.2 New guitar patch: `chord-funk-scratch` (strum family, funk-exclusive)
+
+Bright single-coil chicken-scratch character in `CHORD_PATCHES`
+(`instrumentPatches.ts`):
+- `family: "strum"`.
+- Bright partials (energy weighted to upper harmonics so the scratch cuts).
+- Short `noteDurationSec` (~0.18 s base) and short `releaseTailSec` so even
+  voiced stabs stay tight rather than blooming like the acoustic steel-strum.
+- Percussive envelope: fast attack, quick decay.
+- Exact partials/envelope/duration values are by-ear starting points, tuned in
+  the audition.
+
+### 4.3 New chord comp: `funk-scratch` (sparse, on-the-one)
+
+New entry in `CHORD_PATTERNS`. Hard accented stab on beat 1, then mostly muted
+scratch ghosts with deliberate space. Starting shape (finalized in the plan):
+
+| beat | velocity | direction | articulation |
+|------|----------|-----------|--------------|
+| 0    | 0.95     | down      | accent       |
+| 0.5  | 0.28     | up        | muted        |
+| 0.75 | 0.3      | up        | muted        |
+| 1.5  | 0.4      | up        | muted        |
+| 2.5  | 0.28     | up        | muted        |
+| 2.75 | 0.3      | up        | muted        |
+| 3.5  | 0.35     | up        | muted        |
+
+Beat-1 velocity strictly greater than every other hit; majority of hits muted.
+
+### 4.4 Bass rework: `funk-syncopated` tightened to "the one"
+
+Keep the staccato + ghost/octave/flat-seventh vocabulary (already good). Anchor
+beat 1 harder and trim a little mid-bar busyness so the bass locks with the
+guitar's space rather than competing. Same pattern id, retuned in place. Beat-1
+hit remains the velocity-1 anchor.
+
+### 4.5 Drums rework: `funk` toward JB
+
+Harder, unmistakable downbeat (kick + backbeat emphasis on the one), simpler
+locked groove, keep the 16th hi-hats (they are the funk engine). Same pattern
+id, retuned in place. Backbeat snares (beats 2 & 4 → grid beats 1 & 3) stay at
+full velocity; beat-1 kick stays at velocity 1.
+
+### 4.6 Tempo: auto-apply genre `suggestedTempo` + retune funk
+
+- Add `set(progressionTempoBpmAtom, genre.suggestedTempo)` to
+  `applyGenreStyleAtom` so selecting any genre applies its suggested tempo
+  (fixes the dead-config bug for all genres; the funk pocket becomes reachable
+  by default).
+- Retune the funk genre's tempo for the JB pocket: `suggestedTempo` ~100 → ~110,
+  `tempoRange` → roughly `[96, 120]`. (Tunable in audition.)
+
+### 4.7 Wiring (`genres.ts` funk entry + funk mix preset)
+
+- `chordInstrument: "strum"` (unchanged), `chordPattern: "funk-scratch"`.
+- Funk **mix preset** chord patch → `chord-funk-scratch` (replaces
+  `chord-steel-strum`).
+- `bassPattern: "funk-syncopated"` (retuned), `drumPattern: "funk"` (retuned).
+- `swing: 0` stays (chicken scratch is straight 16ths).
+
+### 4.8 Not removed
+
+The now-unused `funk-16th` comp stays in `CHORD_PATTERNS` as a user-selectable
+pattern (removing it would break a fixture test and shrink the palette — same
+decision as the retired `offbeat-skank`).
+
+## 5. Testing strategy
+
+Unit tests (data/logic — pure, deterministic; TDD red-first):
+
+- `articulationToStrumDurationSec`: `"muted"` → `0.06`; `"accent"`/`undefined` →
+  the passed patch duration.
+- Strum voice forwards `durationSec` to `pluckString`; omitting it preserves
+  today's behavior (regression guard for pop/rock/blues/bossa).
+- `funk-scratch` comp: beat-1 velocity strictly greater than all other hits;
+  majority of hits carry `articulation: "muted"`; beat 1 carries
+  `articulation: "accent"`.
+- `chord-funk-scratch` patch: exists, `family === "strum"`, short
+  `noteDurationSec` (below a threshold, e.g. `<= 0.3`).
+- Funk genre wiring: `chordPattern === "funk-scratch"`; funk mix chord patch
+  === `chord-funk-scratch`.
+- `applyGenreStyleAtom` sets `progressionTempoBpmAtom` to the genre's
+  `suggestedTempo` (assert for funk; the existing genre-apply test gains a
+  tempo assertion).
+- Bass/drums "on the one" guards: funk bass beat-0 hit is the velocity-1 anchor;
+  funk drums beat-0 kick is velocity 1 — so a future edit can't silently flatten
+  the downbeat.
+
+**Recurrence guard (meta-lesson from the audio-bug saga):** a contract test that
+the **funk genre's chord patch is short-decay** (`noteDurationSec` below a
+threshold) — directly encoding "the funk guitar must be able to scratch," the
+exact thing two prior passes missed. Mirrors the existing bass-harmonics and
+jazz-brush-audibility guards.
+
+**Final verification:** `pnpm run lint && pnpm run test && pnpm run build` green,
+then a **manual by-ear audition** of the funk genre. The audition is the real
+acceptance test for timbre and feel; unit tests cannot judge whether it sounds
+like James Brown.
+
+## 6. Risks & caveats
+
+- The patch voicing (partials, envelope), the `0.06 s` mute choke, the comp
+  velocities, and the retuned tempo are **by-ear judgments**. Sensible starting
+  values are specified; expect one round of audition tuning.
+- This is funk pass #3. The design attacks the timbre + density + tempo root
+  causes (not level, which prior passes already adjusted), but final feel is
+  subjective — the audition gate is where it's confirmed.
+- The tempo auto-apply (§4.6) changes behavior for **every** genre (selecting a
+  genre now overwrites the manual tempo with the genre's suggestion). This is
+  the intended fix, but it is a cross-genre behavior change to call out — a user
+  who set a custom tempo then switches genre will have it replaced by the
+  suggestion.
+
+## 7. Out of scope
+
+- Other genres' timbres/patterns (only the shared tempo auto-apply touches them).
+- The bossa clave overhaul (tracked separately in the phrase-aware Slice 2 spec).
+- Any change to the `style` field semantics or the poly/organ chord voices.

--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -393,7 +393,7 @@ export function useProgressionAudioPlayback() {
         onEvent: (audioTime, value) => {
           const voice = eng.getChordVoiceForInstrument(instrumentRef.current, chordPatchId);
           voice.scheduleChord(audio.layers.chord, value.voicing, audioTime, {
-            velocity: value.velocity, style: value.style, direction: value.direction,
+            velocity: value.velocity, style: value.style, direction: value.direction, durationSec: value.durationSec,
           });
         },
       });

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { buildAllLayersAsync, articulationToDurationSec } from "./buildAllLayers";
+import { buildAllLayersAsync, articulationToDurationSec, articulationToStrumDurationSec } from "./buildAllLayers";
 import type { ResolvedProgressionStep } from "../progressionDomain";
 
 vi.mock("./humanize", () => ({
@@ -193,5 +193,19 @@ describe("articulationToDurationSec", () => {
   it("returns undefined for normal/omitted articulation (patch default)", () => {
     expect(articulationToDurationSec("normal", spb)).toBeUndefined();
     expect(articulationToDurationSec(undefined, spb)).toBeUndefined();
+  });
+});
+
+describe("articulationToStrumDurationSec", () => {
+  it("chokes a muted scratch stroke to a short fixed length", () => {
+    expect(articulationToStrumDurationSec("muted", 1.8)).toBeCloseTo(0.06, 5);
+  });
+
+  it("lets an accent ring for the full patch note duration", () => {
+    expect(articulationToStrumDurationSec("accent", 1.8)).toBeCloseTo(1.8, 5);
+  });
+
+  it("defaults (undefined) to the patch note duration — no behavior change", () => {
+    expect(articulationToStrumDurationSec(undefined, 0.42)).toBeCloseTo(0.42, 5);
   });
 });

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -177,6 +177,21 @@ describe("buildAllLayers", () => {
     expect(approachBar2).toBeDefined();
     expect(approachBar2?.value.note).not.toBe(approachBar1?.value.note);
   });
+
+  describe("chord strum durationSec emission", () => {
+    it("leaves durationSec undefined for a pattern with no muted hits", async () => {
+      const layers = await buildAllLayersAsync({
+        steps: [step({ id: "a", duration: { value: 1, unit: "bar" } })],
+        tempoBpm: 120, beatsPerBar: 4, swing: 0,
+        chordPatternId: "pop-8ths", bassPatternId: "root-fifth",
+        drumPatternId: "pop", drumVariations: [], loop: false,
+      });
+      expect(layers.chordStrums.length).toBeGreaterThan(0);
+      for (const s of layers.chordStrums) {
+        expect(s.value.durationSec).toBeUndefined();
+      }
+    });
+  });
 });
 
 describe("articulationToDurationSec", () => {

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { buildAllLayersAsync, articulationToDurationSec, articulationToStrumDurationSec } from "./buildAllLayers";
+import { buildAllLayersAsync, articulationToDurationSec } from "./buildAllLayers";
 import type { ResolvedProgressionStep } from "../progressionDomain";
 
 vi.mock("./humanize", () => ({
@@ -211,16 +211,3 @@ describe("articulationToDurationSec", () => {
   });
 });
 
-describe("articulationToStrumDurationSec", () => {
-  it("chokes a muted scratch stroke to a short fixed length", () => {
-    expect(articulationToStrumDurationSec("muted", 1.8)).toBeCloseTo(0.06, 5);
-  });
-
-  it("lets an accent ring for the full patch note duration", () => {
-    expect(articulationToStrumDurationSec("accent", 1.8)).toBeCloseTo(1.8, 5);
-  });
-
-  it("defaults (undefined) to the patch note duration — no behavior change", () => {
-    expect(articulationToStrumDurationSec(undefined, 0.42)).toBeCloseTo(0.42, 5);
-  });
-});

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -13,7 +13,6 @@ import {
   type CatalogDrumPattern,
   type DrumHit,
   type BassArticulation,
-  type ChordArticulation,
 } from "./patterns";
 import { applyJitter } from "./humanize";
 
@@ -105,17 +104,6 @@ export function articulationToDurationSec(
   }
 }
 
-/**
- * Translate a chord hit's articulation into a strum note length in seconds.
- * "muted" chokes the stroke to a short fixed length (the chicken-scratch);
- * "accent" or omitted rings for the patch's natural note duration.
- */
-export function articulationToStrumDurationSec(
-  articulation: ChordArticulation | undefined,
-  patchNoteDurationSec: number,
-): number {
-  return articulation === "muted" ? MUTED_STRUM_DURATION_SEC : patchNoteDurationSec;
-}
 
 interface VoicedDrumHit extends DrumHit {
   type: DrumVoice;

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -77,6 +77,9 @@ export interface BuiltLayers {
 }
 
 const OFF_BEAT_TOLERANCE = 0.01;
+/** Note length (seconds) for a muted chicken-scratch strum stroke — choked
+ *  short so it reads as percussion, not a ringing chord. */
+const MUTED_STRUM_DURATION_SEC = 0.06;
 
 function swingBeat(beat: number, swing: number): number {
   if (swing <= 0) return beat;
@@ -111,7 +114,7 @@ export function articulationToStrumDurationSec(
   articulation: ChordArticulation | undefined,
   patchNoteDurationSec: number,
 ): number {
-  return articulation === "muted" ? 0.06 : patchNoteDurationSec;
+  return articulation === "muted" ? MUTED_STRUM_DURATION_SEC : patchNoteDurationSec;
 }
 
 interface VoicedDrumHit extends DrumHit {
@@ -230,7 +233,7 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
               velocity,
               style: hit.style,
               direction: hit.direction,
-              durationSec: hit.articulation === "muted" ? 0.06 : undefined,
+              durationSec: hit.articulation === "muted" ? MUTED_STRUM_DURATION_SEC : undefined,
             },
           });
         }

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -35,6 +35,7 @@ export interface ChordStrumEvent {
   velocity: number;
   style?: StrumStyle;
   direction?: StrumDirection;
+  durationSec?: number;
 }
 
 export interface BassEvent {
@@ -229,6 +230,7 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
               velocity,
               style: hit.style,
               direction: hit.direction,
+              durationSec: hit.articulation === "muted" ? 0.06 : undefined,
             },
           });
         }

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -13,6 +13,7 @@ import {
   type CatalogDrumPattern,
   type DrumHit,
   type BassArticulation,
+  type ChordArticulation,
 } from "./patterns";
 import { applyJitter } from "./humanize";
 
@@ -98,6 +99,18 @@ export function articulationToDurationSec(
     default:
       return undefined;
   }
+}
+
+/**
+ * Translate a chord hit's articulation into a strum note length in seconds.
+ * "muted" chokes the stroke to a short fixed length (the chicken-scratch);
+ * "accent" or omitted rings for the patch's natural note duration.
+ */
+export function articulationToStrumDurationSec(
+  articulation: ChordArticulation | undefined,
+  patchNoteDurationSec: number,
+): number {
+  return articulation === "muted" ? 0.06 : patchNoteDurationSec;
 }
 
 interface VoicedDrumHit extends DrumHit {

--- a/src/progressions/audio/genres.test.ts
+++ b/src/progressions/audio/genres.test.ts
@@ -44,8 +44,12 @@ describe("genre styles", () => {
     expect(getGenreStyle("rock")!.bassPattern).toBe("pedal");
   });
 
-  it("wires the funk genre to the 16th-note funk comp, not the reggae skank", () => {
-    expect(getGenreStyle("funk")!.chordPattern).toBe("funk-16th");
+  it("wires the funk genre to the chicken-scratch comp (not the 16th-note funk comp)", () => {
+    expect(getGenreStyle("funk")!.chordPattern).not.toBe("funk-16th");
+  });
+
+  it("wires the funk genre to the chicken-scratch comp", () => {
+    expect(getGenreStyle("funk")!.chordPattern).toBe("funk-scratch");
   });
 });
 

--- a/src/progressions/audio/genres.test.ts
+++ b/src/progressions/audio/genres.test.ts
@@ -51,6 +51,14 @@ describe("genre styles", () => {
   it("wires the funk genre to the chicken-scratch comp", () => {
     expect(getGenreStyle("funk")!.chordPattern).toBe("funk-scratch");
   });
+
+  it("gives funk a James Brown pocket tempo", () => {
+    const funk = getGenreStyle("funk")!;
+    expect(funk.suggestedTempo).toBeGreaterThanOrEqual(104);
+    expect(funk.suggestedTempo).toBeLessThanOrEqual(116);
+    expect(funk.tempoRange[0]).toBeLessThanOrEqual(funk.suggestedTempo);
+    expect(funk.tempoRange[1]).toBeGreaterThanOrEqual(funk.suggestedTempo);
+  });
 });
 
 describe("genre drum variations", () => {

--- a/src/progressions/audio/genres.ts
+++ b/src/progressions/audio/genres.ts
@@ -46,7 +46,7 @@ export const GENRE_STYLES: readonly GenreStyle[] = [
   },
   {
     id: "funk", label: "Funk", chordInstrument: "strum",
-    chordPattern: "funk-16th", bassPattern: "funk-syncopated",
+    chordPattern: "funk-scratch", bassPattern: "funk-syncopated",
     drumPattern: "funk", drumVariations: ["open-hat-and-of-4"],
     tempoRange: [90, 120], suggestedTempo: 100, swing: 0,
   },

--- a/src/progressions/audio/genres.ts
+++ b/src/progressions/audio/genres.ts
@@ -48,7 +48,7 @@ export const GENRE_STYLES: readonly GenreStyle[] = [
     id: "funk", label: "Funk", chordInstrument: "strum",
     chordPattern: "funk-scratch", bassPattern: "funk-syncopated",
     drumPattern: "funk", drumVariations: ["open-hat-and-of-4"],
-    tempoRange: [90, 120], suggestedTempo: 100, swing: 0,
+    tempoRange: [96, 120], suggestedTempo: 110, swing: 0,
   },
   {
     id: "bossa-nova", label: "Bossa Nova", chordInstrument: "piano",

--- a/src/progressions/audio/instruments/strumVoice.test.ts
+++ b/src/progressions/audio/instruments/strumVoice.test.ts
@@ -70,4 +70,21 @@ describe("strumVoice", () => {
     expect(times[1]).toBeCloseTo(1.0 + STRUM_LAG_SECONDS, 4);
     expect(times[2]).toBeCloseTo(1.0 + 2 * STRUM_LAG_SECONDS, 4);
   });
+
+  it("forwards durationSec to pluckString when provided", () => {
+    strumVoice.scheduleChord(
+      {} as AudioNode,
+      ["C3", "E3", "G3"],
+      0,
+      { velocity: 0.8, durationSec: 0.06 },
+    );
+    for (const call of pluckStringSpy.mock.calls) {
+      expect((call[3] as { durationSec?: number }).durationSec).toBe(0.06);
+    }
+  });
+
+  it("omits durationSec when not provided (defaults preserved)", () => {
+    strumVoice.scheduleChord({} as AudioNode, ["C3"], 0, { velocity: 0.8 });
+    expect((pluckStringSpy.mock.calls[0]![3] as { durationSec?: number }).durationSec).toBeUndefined();
+  });
 });

--- a/src/progressions/audio/instruments/strumVoice.ts
+++ b/src/progressions/audio/instruments/strumVoice.ts
@@ -12,7 +12,7 @@ export function createStrumVoice(spec?: StrumSpec): ChordVoice {
       const voices = ordered.map((note, i) => {
         const freq = getNoteFrequency(note);
         if (!Number.isFinite(freq) || freq <= 0) return null;
-        return pluckString(dest, freq, time + i * STRUM_LAG_SECONDS, { velocity: options.velocity, spec });
+        return pluckString(dest, freq, time + i * STRUM_LAG_SECONDS, { velocity: options.velocity, spec, durationSec: options.durationSec });
       }).filter(Boolean) as Array<{ cancel: () => void }>;
       return { cancel: () => { for (const v of voices) v.cancel(); } };
     },

--- a/src/progressions/audio/instruments/types.ts
+++ b/src/progressions/audio/instruments/types.ts
@@ -9,6 +9,9 @@ export interface ChordVoiceOptions {
   style?: "staccato" | "sustained";
   /** Strum direction; up-strokes reverse the voicing order. Defaults to down. */
   direction?: "up" | "down";
+  /** Per-stroke note length override (seconds). Used by the strum voice for
+   *  muted chicken-scratch strokes; ignored by piano/organ voices. */
+  durationSec?: number;
 }
 
 export interface ChordVoice {

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -154,9 +154,9 @@ describe("funk-syncopated bass pattern", () => {
   });
 
   it("uses ghost notes, an octave pop, the fifth, and a b7 color note", () => {
-    expect(funk.hits.map((h) => h.beat)).toEqual([0, 0.75, 1.5, 2, 2.75, 3.5]);
+    expect(funk.hits.map((h) => h.beat)).toEqual([0, 0.75, 1.5, 2.5, 3.5]);
     expect(funk.hits.map((h) => h.note)).toEqual([
-      "root", "root", "octave", "fifth", "flat-seventh", "root",
+      "root", "root", "octave", "fifth", "flat-seventh",
     ]);
   });
 
@@ -167,7 +167,7 @@ describe("funk-syncopated bass pattern", () => {
   it("ghost notes are quieter than accents", () => {
     const byBeat = new Map(funk.hits.map((h) => [h.beat, h.velocity]));
     expect(byBeat.get(0.75)!).toBeLessThan(byBeat.get(0)!);
-    expect(byBeat.get(2.75)!).toBeLessThan(byBeat.get(1.5)!);
+    expect(byBeat.get(2.5)!).toBeLessThan(byBeat.get(1.5)!);
   });
 });
 
@@ -280,14 +280,14 @@ describe("funk drum ghost snares", () => {
   });
 
   it("places snares on the expected 16th-subdivision grid", () => {
-    expect(funk.snares.map((h) => h.beat)).toEqual([0.75, 1, 1.5, 2.25, 3, 3.5]);
+    expect(funk.snares.map((h) => h.beat)).toEqual([1, 1.5, 2.25, 3, 3.5]);
   });
 
   it("locks the kick to a syncopated in-the-pocket funk groove", () => {
     // The funk kick should anchor the one hardest and add a syncopated push
     // (the 'and' of beats) rather than a plain 4-on-the-floor feel.
     const byBeat = new Map(funk.kicks.map((h) => [h.beat, h.velocity]));
-    expect(funk.kicks.map((h) => h.beat)).toEqual([0, 0.75, 2.5, 3.5]);
+    expect(funk.kicks.map((h) => h.beat)).toEqual([0, 0.75, 2.5]);
     expect(byBeat.get(0)).toBe(1); // the one is the hardest
     expect(byBeat.get(0.75)!).toBeLessThan(byBeat.get(0)!); // syncopated push is softer
   });
@@ -333,5 +333,23 @@ describe("funk-scratch chord comp", () => {
     expect(byBeat.get(0)!.articulation).toBe("accent");
     const muted = funk.hits.filter((h) => h.articulation === "muted");
     expect(muted.length).toBeGreaterThanOrEqual(funk.hits.length - 1);
+  });
+});
+
+describe("funk groove locks on the one", () => {
+  it("funk-syncopated bass anchors beat 1 as the velocity-1 root", () => {
+    const bass = getBassPattern("funk-syncopated")!;
+    const one = bass.hits.find((h) => h.beat === 0)!;
+    expect(one.velocity).toBe(1);
+    expect(one.note).toBe("root");
+  });
+
+  it("funk drums put the hardest kick on the one", () => {
+    const funk = getDrumPattern("funk")!;
+    const kickOne = funk.kicks.find((h) => h.beat === 0)!;
+    expect(kickOne.velocity).toBe(1);
+    for (const k of funk.kicks) {
+      if (k.beat !== 0) expect(k.velocity).toBeLessThanOrEqual(kickOne.velocity);
+    }
   });
 });

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -86,8 +86,8 @@ describe("buildMetronomePattern", () => {
 });
 
 describe("pattern catalog", () => {
-  it("has 8 chord patterns with unique IDs", () => {
-    expect(CHORD_PATTERNS).toHaveLength(8);
+  it("has 9 chord patterns with unique IDs", () => {
+    expect(CHORD_PATTERNS).toHaveLength(9);
     const ids = CHORD_PATTERNS.map((p) => p.id);
     expect(new Set(ids).size).toBe(ids.length);
   });
@@ -313,5 +313,25 @@ describe("funk-16th chord comp pattern", () => {
   it("alternates strum direction for the 16th scratch feel", () => {
     expect(funk.hits.some((h) => h.direction === "up")).toBe(true);
     expect(funk.hits.some((h) => h.direction === "down")).toBe(true);
+  });
+});
+
+describe("funk-scratch chord comp", () => {
+  const funk = getChordPattern("funk-scratch")!;
+
+  it("exists and accents the one hardest", () => {
+    expect(funk).toBeDefined();
+    const byBeat = new Map(funk.hits.map((h) => [h.beat, h.velocity]));
+    const one = byBeat.get(0)!;
+    for (const h of funk.hits) {
+      if (h.beat !== 0) expect(h.velocity).toBeLessThan(one);
+    }
+  });
+
+  it("marks the one as an accent and the rest as muted scratches", () => {
+    const byBeat = new Map(funk.hits.map((h) => [h.beat, h]));
+    expect(byBeat.get(0)!.articulation).toBe("accent");
+    const muted = funk.hits.filter((h) => h.articulation === "muted");
+    expect(muted.length).toBeGreaterThanOrEqual(funk.hits.length - 1);
   });
 });

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -13,6 +13,8 @@
 
 type StrumDirection = "down" | "up";
 
+export type ChordArticulation = "muted" | "accent";
+
 export interface DrumHit {
   beat: number;
   velocity: number;
@@ -34,6 +36,9 @@ interface ChordHit {
   style?: "staccato" | "sustained";
   /** Strum direction; up-strokes reverse the voicing order. Defaults to down. */
   direction?: StrumDirection;
+  /** Note-length intent for the strum voice. "muted" chokes the stroke short
+   *  (chicken-scratch), "accent"/omitted rings for the patch's note duration. */
+  articulation?: ChordArticulation;
 }
 
 export interface ChordPattern {

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -252,6 +252,10 @@ export const BASS_PATTERNS: readonly CatalogBassPattern[] = [
   {
     id: "funk-syncopated",
     label: "Funk Syncopated",
+    // JB funk, locked to the one: root anchor on beat 1, a soft root ghost on
+    // the "a" of 1, an octave pop mid-bar, the fifth for color, and a b7 that
+    // leads back to the root. Sparse and staccato so it interlocks with the
+    // chicken-scratch guitar rather than crowding it.
     hits: [
       { beat: 0, velocity: 1, note: "root", articulation: "staccato" },
       { beat: 0.75, velocity: 0.4, note: "root", articulation: "staccato" },
@@ -365,6 +369,9 @@ export const DRUM_PATTERNS: readonly CatalogDrumPattern[] = [
   {
     id: "funk",
     label: "Funk",
+    // Locked on the one: hardest kick on beat 1, a syncopated push on the "a"
+    // of 1, and the "and of 3" anchor — three kicks that lock with the bass
+    // and leave space, rather than a four-on-the-floor thump.
     kicks: [
       { beat: 0, velocity: 1 },
       { beat: 0.75, velocity: 0.55 },

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -156,6 +156,22 @@ export const CHORD_PATTERNS: readonly ChordPattern[] = [
     ],
   },
   {
+    id: "funk-scratch",
+    label: "Funk Scratch",
+    // James Brown chicken-scratch: a hard accented chord stab on the one, then
+    // muted scratch ghosts with deliberate space. The "muted" hits choke short
+    // via the strum voice; the accent rings the patch's (already short) length.
+    hits: [
+      { beat: 0, velocity: 0.95, direction: "down", articulation: "accent" },
+      { beat: 0.5, velocity: 0.28, direction: "up", articulation: "muted" },
+      { beat: 0.75, velocity: 0.3, direction: "up", articulation: "muted" },
+      { beat: 1.5, velocity: 0.4, direction: "up", articulation: "muted" },
+      { beat: 2.5, velocity: 0.28, direction: "up", articulation: "muted" },
+      { beat: 2.75, velocity: 0.3, direction: "up", articulation: "muted" },
+      { beat: 3.5, velocity: 0.35, direction: "up", articulation: "muted" },
+    ],
+  },
+  {
     id: "pop-syncopated-push",
     label: "Pop Syncopated Push",
     hits: [

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -254,11 +254,10 @@ export const BASS_PATTERNS: readonly CatalogBassPattern[] = [
     label: "Funk Syncopated",
     hits: [
       { beat: 0, velocity: 1, note: "root", articulation: "staccato" },
-      { beat: 0.75, velocity: 0.45, note: "root", articulation: "staccato" },
+      { beat: 0.75, velocity: 0.4, note: "root", articulation: "staccato" },
       { beat: 1.5, velocity: 0.8, note: "octave", articulation: "staccato" },
-      { beat: 2, velocity: 0.6, note: "fifth", articulation: "staccato" },
-      { beat: 2.75, velocity: 0.5, note: "flat-seventh", articulation: "staccato" },
-      { beat: 3.5, velocity: 0.75, note: "root", articulation: "staccato" },
+      { beat: 2.5, velocity: 0.55, note: "fifth", articulation: "staccato" },
+      { beat: 3.5, velocity: 0.7, note: "flat-seventh", articulation: "staccato" },
     ],
   },
 ];
@@ -367,19 +366,13 @@ export const DRUM_PATTERNS: readonly CatalogDrumPattern[] = [
     id: "funk",
     label: "Funk",
     kicks: [
-      // In-the-pocket funk: the one hardest, a syncopated push on the "a" of 1,
-      // the classic "and of 3" anchor, and a pickup pushing back to the one —
-      // this interlocks with the funk-syncopated bass rather than thumping
-      // four-on-the-floor.
       { beat: 0, velocity: 1 },
-      { beat: 0.75, velocity: 0.6 },
-      { beat: 2.5, velocity: 0.85 },
-      { beat: 3.5, velocity: 0.5 },
+      { beat: 0.75, velocity: 0.55 },
+      { beat: 2.5, velocity: 0.8 },
     ],
     snares: [
-      { beat: 0.75, velocity: 0.15 },
       { beat: 1, velocity: 1 },
-      { beat: 1.5, velocity: 0.3 },
+      { beat: 1.5, velocity: 0.2 },
       { beat: 2.25, velocity: 0.18 },
       { beat: 3, velocity: 1 },
       { beat: 3.5, velocity: 0.15 },

--- a/src/progressions/audio/sound/genreMixPresets.test.ts
+++ b/src/progressions/audio/sound/genreMixPresets.test.ts
@@ -80,4 +80,16 @@ describe("genre mix presets", () => {
     const rock = getGenreMix("rock")!;
     expect(rock.perInstrument.bass.volumeDb).toBeLessThanOrEqual(-1);
   });
+
+  it("uses the short funk-scratch guitar patch for funk", () => {
+    expect(getGenreMix("funk")!.patches.chord).toBe("chord-funk-scratch");
+  });
+
+  it("funk's chord patch is short-decay so the guitar can actually scratch", () => {
+    // Recurrence guard: two prior funk passes failed because the guitar was a
+    // long-ringing acoustic strum. The funk chord patch must stay short.
+    const patchId = getGenreMix("funk")!.patches.chord;
+    const patch = getChordPatch(patchId)!;
+    expect(patch.strum!.noteDurationSec).toBeLessThanOrEqual(0.3);
+  });
 });

--- a/src/progressions/audio/sound/genreMixPresets.ts
+++ b/src/progressions/audio/sound/genreMixPresets.ts
@@ -99,7 +99,7 @@ export const GENRE_MIX_PRESETS: readonly GenreMix[] = [
   },
   {
     genre: "funk",
-    patches: { bass: "bass-finger", chord: "chord-steel-strum", drumKit: "kit-funk" },
+    patches: { bass: "bass-finger", chord: "chord-funk-scratch", drumKit: "kit-funk" },
     perInstrument: {
       chord: { volumeDb: -4, pan: -0.2, reverbSend: 0.06 },
       bass: { volumeDb: 0, pan: 0, reverbSend: 0.0 },

--- a/src/progressions/audio/sound/instrumentPatches.test.ts
+++ b/src/progressions/audio/sound/instrumentPatches.test.ts
@@ -87,4 +87,12 @@ describe("instrument patches", () => {
     expect(snare.noiseType).not.toBe("pink"); // brighter than dark pink
     expect(snare.volume ?? 0).toBeGreaterThan(0); // lifted via the new lever
   });
+
+  it("provides a short-decay funk scratch guitar patch", () => {
+    const patch = getChordPatch("chord-funk-scratch")!;
+    expect(patch).toBeDefined();
+    expect(patch.family).toBe("strum");
+    // Must be short so it can scratch, not bloom like the acoustic steel strum (1.8s).
+    expect(patch.strum!.noteDurationSec).toBeLessThanOrEqual(0.3);
+  });
 });

--- a/src/progressions/audio/sound/instrumentPatches.ts
+++ b/src/progressions/audio/sound/instrumentPatches.ts
@@ -107,6 +107,18 @@ export const CHORD_PATCHES: readonly ChordPatch[] = [
     },
     insert: { eq3: { low: 0, mid: 0, high: 2 } },
   },
+  {
+    id: "chord-funk-scratch", label: "Funk Scratch", family: "strum",
+    strum: {
+      // Bright single-coil chicken-scratch: upper-harmonic-weighted partials so
+      // muted scratches cut on small speakers, and a short note/release so even
+      // voiced stabs stay tight instead of ringing like the acoustic strum.
+      oscillator: { type: "custom", partials: [1, 0.9, 0.7, 0.5, 0.35, 0.25, 0.15] },
+      envelope: { attack: 0.004, decay: 0.18, sustain: 0.0, release: 0.08 },
+      noteDurationSec: 0.18, releaseTailSec: 0.4,
+    },
+    insert: { eq3: { low: -2, mid: 1, high: 3 } },
+  },
 ];
 
 export const DEFAULT_CHORD_PATCH_BY_FAMILY: Record<ChordFamily, string> = {

--- a/src/progressions/audio/string.test.ts
+++ b/src/progressions/audio/string.test.ts
@@ -76,4 +76,11 @@ describe("pluckString — Tone.Synth backend", () => {
     expect(() => h.cancel()).not.toThrow();
     expect(t.spies.dispose).not.toHaveBeenCalled();
   });
+
+  it("overrides the patch note duration with durationSec when provided", async () => {
+    const t = await tone;
+    pluckString({} as AudioNode, 220, 0, { velocity: 0.8, durationSec: 0.06 });
+    const [, duration] = t.spies.triggerAttackRelease.mock.calls[0]!;
+    expect(duration).toBeCloseTo(0.06, 3);
+  });
 });

--- a/src/progressions/audio/string.ts
+++ b/src/progressions/audio/string.ts
@@ -11,7 +11,7 @@ const DEFAULT_NOTE_DURATION = 1.8;
 const DEFAULT_RELEASE_TAIL_SEC = DEFAULT_NOTE_DURATION + DEFAULT_RELEASE + 0.15;
 
 export interface PluckedVoiceHandle { cancel: () => void; }
-export interface PluckStringOptions { velocity?: number; spec?: StrumSpec; }
+export interface PluckStringOptions { velocity?: number; spec?: StrumSpec; durationSec?: number; }
 
 type PluckPool = ReturnType<typeof createReusableVoicePool<Tone.Synth>>;
 
@@ -47,7 +47,7 @@ export function pluckString(
   if (velocity <= 0) return { cancel: () => {} };
 
   const spec = options.spec;
-  const noteDuration = spec?.noteDurationSec ?? DEFAULT_NOTE_DURATION;
+  const noteDuration = options.durationSec ?? spec?.noteDurationSec ?? DEFAULT_NOTE_DURATION;
   const releaseTail = spec?.releaseTailSec ?? DEFAULT_RELEASE_TAIL_SEC;
   const now = Tone.now();
   const playbackStartTime = Math.max(now, startTime);

--- a/src/store/progressionAtoms.ts
+++ b/src/store/progressionAtoms.ts
@@ -283,6 +283,7 @@ export const applyGenreStyleAtom = atom(null, (_get, set, genreId: string) => {
   set(progressionDrumPatternAtom, genre.drumPattern);
   set(progressionDrumVariationsAtom, genre.drumVariations);
   set(progressionSwingAtom, genre.swing);
+  set(progressionTempoBpmAtom, genre.suggestedTempo);
 });
 
 export const activeProgressionStepIndexAtom = atom(0);

--- a/src/store/progressionGenreTempo.test.ts
+++ b/src/store/progressionGenreTempo.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { createStore } from "jotai";
+import { applyGenreStyleAtom, progressionTempoBpmAtom } from "./progressionAtoms";
+import { getGenreStyle } from "../progressions/audio/genres";
+
+describe("applyGenreStyleAtom tempo", () => {
+  it("applies the genre's suggestedTempo to the tempo atom", () => {
+    const store = createStore();
+    store.set(progressionTempoBpmAtom, 60); // a value no genre suggests
+    store.set(applyGenreStyleAtom, "funk");
+    expect(store.get(progressionTempoBpmAtom)).toBe(getGenreStyle("funk")!.suggestedTempo);
+  });
+  it("applies tempo for a different genre too", () => {
+    const store = createStore();
+    store.set(applyGenreStyleAtom, "jazz");
+    expect(store.get(progressionTempoBpmAtom)).toBe(getGenreStyle("jazz")!.suggestedTempo);
+  });
+});


### PR DESCRIPTION
## Summary

Reworks the funk genre into an authentic James Brown chicken-scratch groove, and fixes a dead-config bug where selecting a genre never applied its `suggestedTempo`. Clean rebase onto `main` (supersedes #485, which had a tangled diff after #484's squash-merge).

### Root cause of "funk doesn't sound funky" (two prior passes failed)
Earlier passes tuned rhythm *patterns* but never the *instrument timbre*. Funk used `chord-steel-strum` — a warm, long-ringing (~1.8s) acoustic patch that physically cannot scratch. And the genre's `suggestedTempo` was never applied, so the pocket tempo was unreachable.

### What changed
- **Engine (additive):** per-stroke note length threaded through the strum voice via a `ChordArticulation` (`"muted" | "accent"`) enum on chord hits → `durationSec` on `ChordStrumEvent` → `ChordVoiceOptions` → `pluckString` override. `"muted"` chokes to `MUTED_STRUM_DURATION_SEC` (0.06s); `"accent"`/omitted rings the patch's own length. Defaults preserve behavior for every other genre.
- **New `chord-funk-scratch` guitar patch** — bright single-coil, short 0.18s note duration so it scratches instead of blooming.
- **New `funk-scratch` comp** — sparse, hard accent on the one, muted scratch ghosts with space.
- **Funk bass + drums** tightened to lock on the one.
- **Tempo auto-apply** — `applyGenreStyleAtom` now applies each genre's `suggestedTempo` (fixes the dead-config bug for ALL genres); funk retuned to 110bpm.

### Recurrence guard
The funk chord patch must be short-decay (`noteDurationSec <= 0.3`) — encodes "the funk guitar must be able to scratch."

## Test Plan
- [x] `pnpm run lint` — passes
- [x] `pnpm run test` — 2146 passed, 1 skipped, 1 todo
- [x] `pnpm run build` — passes
- [ ] **Manual audition** (by ear; not unit-testable): select Funk → tempo snaps to ~110; guitar is a tight muted chicken-scratch with a clear accent on the one; bass + drums lock to the one. Patch voicing, the 0.06s choke, comp velocities, and tempo are sensible defaults that may want a nudge to taste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)