### PR TITLE
fix(audio): remove synchronous pink noise generation from bossa snare

### DIFF
--- a/src/progressions/audio/sound/instrumentPatches.ts
+++ b/src/progressions/audio/sound/instrumentPatches.ts
@@ -178,7 +178,7 @@ export const DRUM_KIT_PATCHES: readonly DrumKitPatch[] = [
     id: "kit-bossa", label: "Bossa",
     voices: {
       kick: { pitchDecay: 0.05, octaves: 5, envelope: { decay: 0.28 } },
-      snare: { noiseType: "pink", envelope: { decay: 0.12 } },
+      snare: { noiseType: "white", envelope: { decay: 0.12 } },
       hihat: { decay: 0.04 },
     },
   },


### PR DESCRIPTION
## Summary
- Replaced the `noiseType: "pink"` configuration with `"white"` in the `kit-bossa` snare patch.
- Tone.js generates pink noise offline via an intensive algorithm that blocks the main thread for 10 seconds of sample generation.
- Changing it to white noise removes the main-thread blocking behavior entirely, eliminating the massive delay when selecting the Bossa Nova genre.

## Test Plan
- [ ] Load the fretboard app locally.
- [ ] Navigate to the backing track / playback controls.
- [ ] Change the genre to Bossa Nova.
- [ ] Verify that playback initializes instantly without freezing the browser tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted snare drum sound in the bossa drum kit for improved audio quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->