### PR TITLE
feat: add keyboard and media key controls for progression playback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import audioErrorStyles from "./components/AudioErrorBanner/AudioErrorBanner.mod
 import useLayoutMode from "./hooks/useLayoutMode";
 import { useResolvedTheme } from "./hooks/useResolvedTheme";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
+import { useMediaSession } from "./hooks/useMediaSession";
 import { useTranslation } from "./hooks/useTranslation";
 import { AppHeader } from "./components/AppHeader/AppHeader";
 import { HeaderTransportCluster } from "./components/HeaderTransportCluster/HeaderTransportCluster";
@@ -60,6 +61,7 @@ function AppContent() {
   const layout = useLayoutMode();
   const theme = useResolvedTheme();
   useKeyboardShortcuts();
+  useMediaSession();
 
   useLayoutEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -11,7 +11,13 @@ import {
   progressionPlayingAtom,
   activeProgressionStepIndexAtom,
   setProgressionPlayingAtom,
+  progressionLoopEnabledAtom,
+  progressionChordEnabledAtom,
+  progressionBassEnabledAtom,
+  progressionDrumsEnabledAtom,
+  progressionMetronomeEnabledAtom,
 } from "../store/progressionAtoms";
+import { isMutedAtom } from "../store/audioAtoms";
 
 function makeWrapper(store: ReturnType<typeof createStore>) {
   return function Wrapper({ children }: { children: React.ReactNode }) {
@@ -27,6 +33,12 @@ describe("useKeyboardShortcuts", () => {
     // Seed known defaults
     store.set(scaleVisibleAtom, true);
     store.set(chordOverlayHiddenAtom, false);
+    store.set(progressionLoopEnabledAtom, false);
+    store.set(progressionChordEnabledAtom, true);
+    store.set(progressionBassEnabledAtom, true);
+    store.set(progressionDrumsEnabledAtom, true);
+    store.set(progressionMetronomeEnabledAtom, true);
+    store.set(isMutedAtom, false);
   });
 
   it("S toggles scaleVisibleAtom from true to false", () => {
@@ -197,5 +209,53 @@ describe("useKeyboardShortcuts", () => {
 
     expect(store.get(progressionPlayingAtom)).toBe(false);
     expect(store.get(activeProgressionStepIndexAtom)).toBe(0);
+  });
+
+  it("R toggles loop enabled", () => {
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "r" }); });
+    expect(store.get(progressionLoopEnabledAtom)).toBe(true);
+
+    act(() => { fireEvent.keyDown(document, { key: "R" }); });
+    expect(store.get(progressionLoopEnabledAtom)).toBe(false);
+  });
+
+  it("M toggles mute", () => {
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "m" }); });
+    expect(store.get(isMutedAtom)).toBe(true);
+
+    act(() => { fireEvent.keyDown(document, { key: "M" }); });
+    expect(store.get(isMutedAtom)).toBe(false);
+  });
+
+  it("1 toggles chord layer", () => {
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "1" }); });
+    expect(store.get(progressionChordEnabledAtom)).toBe(false);
+
+    act(() => { fireEvent.keyDown(document, { key: "1" }); });
+    expect(store.get(progressionChordEnabledAtom)).toBe(true);
+  });
+
+  it("2 toggles bass layer", () => {
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+    act(() => { fireEvent.keyDown(document, { key: "2" }); });
+    expect(store.get(progressionBassEnabledAtom)).toBe(false);
+  });
+
+  it("3 toggles drums layer", () => {
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+    act(() => { fireEvent.keyDown(document, { key: "3" }); });
+    expect(store.get(progressionDrumsEnabledAtom)).toBe(false);
+  });
+
+  it("4 toggles metronome layer", () => {
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+    act(() => { fireEvent.keyDown(document, { key: "4" }); });
+    expect(store.get(progressionMetronomeEnabledAtom)).toBe(false);
   });
 });

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -258,4 +258,44 @@ describe("useKeyboardShortcuts", () => {
     act(() => { fireEvent.keyDown(document, { key: "4" }); });
     expect(store.get(progressionMetronomeEnabledAtom)).toBe(false);
   });
+
+  it("ArrowRight advances step when not playing", () => {
+    store.set(setProgressionPlayingAtom, false);
+    store.set(activeProgressionStepIndexAtom, 0);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowRight" }); });
+
+    expect(store.get(activeProgressionStepIndexAtom)).toBe(1);
+  });
+
+  it("ArrowRight does nothing when playing", () => {
+    store.set(setProgressionPlayingAtom, true);
+    store.set(activeProgressionStepIndexAtom, 0);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowRight" }); });
+
+    expect(store.get(activeProgressionStepIndexAtom)).toBe(0);
+  });
+
+  it("ArrowLeft goes to previous step when not playing", () => {
+    store.set(setProgressionPlayingAtom, false);
+    store.set(activeProgressionStepIndexAtom, 2);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowLeft" }); });
+
+    expect(store.get(activeProgressionStepIndexAtom)).toBe(1);
+  });
+
+  it("ArrowLeft does nothing when playing", () => {
+    store.set(setProgressionPlayingAtom, true);
+    store.set(activeProgressionStepIndexAtom, 2);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowLeft" }); });
+
+    expect(store.get(activeProgressionStepIndexAtom)).toBe(2);
+  });
 });

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -7,6 +7,11 @@ import { createStore, Provider } from "jotai";
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
 import { scaleVisibleAtom } from "../store/scaleAtoms";
 import { chordOverlayHiddenAtom } from "../store/chordOverlayAtoms";
+import {
+  progressionPlayingAtom,
+  activeProgressionStepIndexAtom,
+  setProgressionPlayingAtom,
+} from "../store/progressionAtoms";
 
 function makeWrapper(store: ReturnType<typeof createStore>) {
   return function Wrapper({ children }: { children: React.ReactNode }) {
@@ -147,5 +152,50 @@ describe("useKeyboardShortcuts", () => {
 
     // Scale should remain unchanged after unmount
     expect(store.get(scaleVisibleAtom)).toBe(true);
+  });
+
+  it("Space toggles progression playing when not blocked", () => {
+    store.set(setProgressionPlayingAtom, false);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => {
+      fireEvent.keyDown(document, { key: " " });
+    });
+
+    expect(store.get(progressionPlayingAtom)).toBe(true);
+
+    act(() => {
+      fireEvent.keyDown(document, { key: " " });
+    });
+
+    expect(store.get(progressionPlayingAtom)).toBe(false);
+  });
+
+  it("Space does nothing when focus is in INPUT", () => {
+    store.set(setProgressionPlayingAtom, false);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    act(() => {
+      fireEvent.keyDown(input, { key: " " });
+    });
+
+    expect(store.get(progressionPlayingAtom)).toBe(false);
+    document.body.removeChild(input);
+  });
+
+  it("period stops playback and rewinds step index", () => {
+    store.set(setProgressionPlayingAtom, true);
+    store.set(activeProgressionStepIndexAtom, 2);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => {
+      fireEvent.keyDown(document, { key: "." });
+    });
+
+    expect(store.get(progressionPlayingAtom)).toBe(false);
+    expect(store.get(activeProgressionStepIndexAtom)).toBe(0);
   });
 });

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -6,7 +6,13 @@ import {
   progressionPlayingAtom,
   setProgressionPlayingAtom,
   stopProgressionPlaybackAtom,
+  progressionLoopEnabledAtom,
+  progressionChordEnabledAtom,
+  progressionBassEnabledAtom,
+  progressionDrumsEnabledAtom,
+  progressionMetronomeEnabledAtom,
 } from "../store/progressionAtoms";
+import { toggleMuteAtom } from "../store/audioAtoms";
 
 export function useKeyboardShortcuts() {
   const store = useStore();
@@ -34,6 +40,41 @@ export function useKeyboardShortcuts() {
         case ".":
           e.preventDefault();
           store.set(stopProgressionPlaybackAtom);
+          break;
+        case "r":
+        case "R":
+          store.set(
+            progressionLoopEnabledAtom,
+            !store.get(progressionLoopEnabledAtom),
+          );
+          break;
+        case "m":
+        case "M":
+          store.set(toggleMuteAtom);
+          break;
+        case "1":
+          store.set(
+            progressionChordEnabledAtom,
+            !store.get(progressionChordEnabledAtom),
+          );
+          break;
+        case "2":
+          store.set(
+            progressionBassEnabledAtom,
+            !store.get(progressionBassEnabledAtom),
+          );
+          break;
+        case "3":
+          store.set(
+            progressionDrumsEnabledAtom,
+            !store.get(progressionDrumsEnabledAtom),
+          );
+          break;
+        case "4":
+          store.set(
+            progressionMetronomeEnabledAtom,
+            !store.get(progressionMetronomeEnabledAtom),
+          );
           break;
         case "s":
         case "S":

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,15 +1,18 @@
 import { useEffect } from "react";
-import { useSetAtom } from "jotai";
+import { useStore } from "jotai";
 import { scaleVisibleAtom } from "../store/scaleAtoms";
 import { chordOverlayHiddenAtom } from "../store/chordOverlayAtoms";
+import {
+  progressionPlayingAtom,
+  setProgressionPlayingAtom,
+  stopProgressionPlaybackAtom,
+} from "../store/progressionAtoms";
 
 export function useKeyboardShortcuts() {
-  const setScaleVisible = useSetAtom(scaleVisibleAtom);
-  const setChordHidden = useSetAtom(chordOverlayHiddenAtom);
+  const store = useStore();
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      // Ignore when typing into form fields or selects.
       const target = e.target as HTMLElement | null;
       if (
         target?.tagName === "INPUT" ||
@@ -18,17 +21,33 @@ export function useKeyboardShortcuts() {
         target?.isContentEditable
       )
         return;
-      // Don't hijack browser shortcuts (Cmd+S, Ctrl+S, Alt+S, etc.).
       if (e.metaKey || e.ctrlKey || e.altKey) return;
-      if (e.key === "s" || e.key === "S") {
-        e.preventDefault();
-        setScaleVisible((v) => !v);
-      } else if (e.key === "c" || e.key === "C") {
-        e.preventDefault();
-        setChordHidden((v) => !v);
+
+      switch (e.key) {
+        case " ":
+          e.preventDefault();
+          store.set(
+            setProgressionPlayingAtom,
+            !store.get(progressionPlayingAtom),
+          );
+          break;
+        case ".":
+          e.preventDefault();
+          store.set(stopProgressionPlaybackAtom);
+          break;
+        case "s":
+        case "S":
+          e.preventDefault();
+          store.set(scaleVisibleAtom, !store.get(scaleVisibleAtom));
+          break;
+        case "c":
+        case "C":
+          e.preventDefault();
+          store.set(chordOverlayHiddenAtom, !store.get(chordOverlayHiddenAtom));
+          break;
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [setScaleVisible, setChordHidden]);
+  }, [store]);
 }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -11,6 +11,8 @@ import {
   progressionBassEnabledAtom,
   progressionDrumsEnabledAtom,
   progressionMetronomeEnabledAtom,
+  previousProgressionStepAtom,
+  advanceProgressionPlaybackAtom,
 } from "../store/progressionAtoms";
 import { toggleMuteAtom } from "../store/audioAtoms";
 
@@ -75,6 +77,16 @@ export function useKeyboardShortcuts() {
             progressionMetronomeEnabledAtom,
             !store.get(progressionMetronomeEnabledAtom),
           );
+          break;
+        case "ArrowLeft":
+          if (store.get(progressionPlayingAtom)) return;
+          e.preventDefault();
+          store.set(previousProgressionStepAtom);
+          break;
+        case "ArrowRight":
+          if (store.get(progressionPlayingAtom)) return;
+          e.preventDefault();
+          store.set(advanceProgressionPlaybackAtom);
           break;
         case "s":
         case "S":

--- a/src/hooks/useMediaSession.test.tsx
+++ b/src/hooks/useMediaSession.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import React from "react";
+import { createStore, Provider } from "jotai";
+import { useMediaSession } from "./useMediaSession";
+import {
+  progressionPlayingAtom,
+  activeProgressionStepIndexAtom,
+  setProgressionPlayingAtom,
+} from "../store/progressionAtoms";
+
+function makeWrapper(store: ReturnType<typeof createStore>) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <Provider store={store}>{children}</Provider>;
+  };
+}
+
+vi.stubGlobal(
+  "MediaMetadata",
+  class MediaMetadata {
+    title: string;
+    artist: string;
+    album: string;
+    constructor(init: { title: string; artist: string; album: string }) {
+      this.title = init.title;
+      this.artist = init.artist;
+      this.album = init.album;
+    }
+  },
+);
+
+const originalMediaSession = navigator.mediaSession;
+
+describe("useMediaSession", () => {
+  let store: ReturnType<typeof createStore>;
+  let handlers: Record<string, () => void>;
+
+  beforeEach(() => {
+    store = createStore();
+    store.set(setProgressionPlayingAtom, false);
+    store.set(activeProgressionStepIndexAtom, 0);
+
+    handlers = {};
+    Object.defineProperty(navigator, "mediaSession", {
+      value: {
+        setActionHandler: vi.fn((action: string, handler: (() => void) | null) => {
+          handlers[action] = handler ?? (() => {});
+        }),
+        metadata: null,
+      },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "mediaSession", {
+      value: originalMediaSession,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("sets metadata on mount", () => {
+    renderHook(() => useMediaSession(), { wrapper: makeWrapper(store) });
+    expect(navigator.mediaSession?.metadata).toBeInstanceOf(MediaMetadata);
+  });
+
+  it('play handler calls setProgressionPlaying(true)', () => {
+    renderHook(() => useMediaSession(), { wrapper: makeWrapper(store) });
+    act(() => { handlers.play(); });
+    expect(store.get(progressionPlayingAtom)).toBe(true);
+  });
+
+  it('pause handler calls setProgressionPlaying(false)', () => {
+    store.set(setProgressionPlayingAtom, true);
+    renderHook(() => useMediaSession(), { wrapper: makeWrapper(store) });
+    act(() => { handlers.pause(); });
+    expect(store.get(progressionPlayingAtom)).toBe(false);
+  });
+
+  it('stop handler calls stopProgressionPlayback', () => {
+    store.set(setProgressionPlayingAtom, true);
+    store.set(activeProgressionStepIndexAtom, 2);
+    renderHook(() => useMediaSession(), { wrapper: makeWrapper(store) });
+    act(() => { handlers.stop(); });
+    expect(store.get(progressionPlayingAtom)).toBe(false);
+    expect(store.get(activeProgressionStepIndexAtom)).toBe(0);
+  });
+
+  it('nexttrack advances step when not playing', () => {
+    store.set(activeProgressionStepIndexAtom, 0);
+    renderHook(() => useMediaSession(), { wrapper: makeWrapper(store) });
+    act(() => { handlers.nexttrack(); });
+    expect(store.get(activeProgressionStepIndexAtom)).toBe(1);
+  });
+
+  it('nexttrack does nothing when playing', () => {
+    store.set(setProgressionPlayingAtom, true);
+    store.set(activeProgressionStepIndexAtom, 0);
+    renderHook(() => useMediaSession(), { wrapper: makeWrapper(store) });
+    act(() => { handlers.nexttrack(); });
+    expect(store.get(activeProgressionStepIndexAtom)).toBe(0);
+  });
+
+  it('previoustrack goes to previous step when not playing', () => {
+    store.set(activeProgressionStepIndexAtom, 2);
+    renderHook(() => useMediaSession(), { wrapper: makeWrapper(store) });
+    act(() => { handlers.previoustrack(); });
+    expect(store.get(activeProgressionStepIndexAtom)).toBe(1);
+  });
+
+  it('previoustrack does nothing when playing', () => {
+    store.set(setProgressionPlayingAtom, true);
+    store.set(activeProgressionStepIndexAtom, 2);
+    renderHook(() => useMediaSession(), { wrapper: makeWrapper(store) });
+    act(() => { handlers.previoustrack(); });
+    expect(store.get(activeProgressionStepIndexAtom)).toBe(2);
+  });
+
+  it("clears handlers on unmount", () => {
+    const { unmount } = renderHook(() => useMediaSession(), {
+      wrapper: makeWrapper(store),
+    });
+    // The cleanup sets each handler to null
+    unmount();
+    const actionNames = ["play", "pause", "stop", "previoustrack", "nexttrack"];
+    for (const action of actionNames) {
+      expect(
+        (navigator.mediaSession as NonNullable<typeof navigator.mediaSession>).setActionHandler,
+      ).toHaveBeenCalledWith(action, null);
+    }
+  });
+});

--- a/src/hooks/useMediaSession.ts
+++ b/src/hooks/useMediaSession.ts
@@ -24,6 +24,8 @@ export function useMediaSession() {
       ["play", () => store.set(setProgressionPlayingAtom, true)],
       ["pause", () => store.set(setProgressionPlayingAtom, false)],
       ["stop", () => store.set(stopProgressionPlaybackAtom)],
+      // Disabled during playback — the step index advances automatically
+      // and manual nudging would conflict with the audio timeline.
       [
         "previoustrack",
         () => {
@@ -43,19 +45,28 @@ export function useMediaSession() {
     ];
 
     for (const [action, handler] of handlers) {
-      navigator.mediaSession.setActionHandler(
-        action as MediaSessionAction,
-        handler,
-      );
+      try {
+        navigator.mediaSession.setActionHandler(
+          action as MediaSessionAction,
+          handler,
+        );
+      } catch {
+        // Some browsers throw for unsupported-but-valid action types;
+        // swallow so remaining handlers still register.
+      }
     }
 
     return () => {
       if (!("mediaSession" in navigator) || !navigator.mediaSession) return;
       for (const [action] of handlers) {
-        navigator.mediaSession.setActionHandler(
-          action as MediaSessionAction,
-          null,
-        );
+        try {
+          navigator.mediaSession.setActionHandler(
+            action as MediaSessionAction,
+            null,
+          );
+        } catch {
+          // Same guard as above — non-fatal if an action is unknown.
+        }
       }
     };
   }, [store]);

--- a/src/hooks/useMediaSession.ts
+++ b/src/hooks/useMediaSession.ts
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+import { useStore } from "jotai";
+import {
+  progressionPlayingAtom,
+  setProgressionPlayingAtom,
+  stopProgressionPlaybackAtom,
+  previousProgressionStepAtom,
+  advanceProgressionPlaybackAtom,
+} from "../store/progressionAtoms";
+
+export function useMediaSession() {
+  const store = useStore();
+
+  useEffect(() => {
+    if (!("mediaSession" in navigator)) return;
+
+    navigator.mediaSession.metadata = new MediaMetadata({
+      title: "FretFlow",
+      artist: "",
+      album: "",
+    });
+
+    const handlers: [string, () => void][] = [
+      ["play", () => store.set(setProgressionPlayingAtom, true)],
+      ["pause", () => store.set(setProgressionPlayingAtom, false)],
+      ["stop", () => store.set(stopProgressionPlaybackAtom)],
+      [
+        "previoustrack",
+        () => {
+          if (!store.get(progressionPlayingAtom)) {
+            store.set(previousProgressionStepAtom);
+          }
+        },
+      ],
+      [
+        "nexttrack",
+        () => {
+          if (!store.get(progressionPlayingAtom)) {
+            store.set(advanceProgressionPlaybackAtom);
+          }
+        },
+      ],
+    ];
+
+    for (const [action, handler] of handlers) {
+      navigator.mediaSession.setActionHandler(
+        action as MediaSessionAction,
+        handler,
+      );
+    }
+
+    return () => {
+      if (!("mediaSession" in navigator) || !navigator.mediaSession) return;
+      for (const [action] of handlers) {
+        navigator.mediaSession.setActionHandler(
+          action as MediaSessionAction,
+          null,
+        );
+      }
+    };
+  }, [store]);
+}


### PR DESCRIPTION
## Summary
- **Keyboard shortcuts:** Space (play/stop), period (stop+rewind), R (loop toggle), M (mute), 1-4 (instrument layer toggles), ArrowLeft/Right (step navigation, disabled during playback)
- **Media Session API:** Hardware media keys (play/pause/stop/previoustrack/nexttrack) now control playback via `navigator.mediaSession`
- Refactored `useKeyboardShortcuts` to use Jotai `useStore()` for stable event handler references

## Test Plan
- All 2100+ existing tests pass
- Build succeeds (tsc + vite build)
- New test coverage for all shortcuts and media session scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Media Session integration enables playback control via device media buttons
  * Enhanced keyboard shortcuts: Space (play/pause), `.` (stop), `R` (loop toggle), `M` (mute), `1`–`4` (layer controls), arrow keys (step navigation)

* **Tests**
  * Expanded keyboard shortcut test coverage for progression controls
  * Added comprehensive Media Session integration test suite

<!-- end of auto-generated comment: release notes by coderabbit.ai -->