### PR TITLE
perf: fix Fretboard layout thrashing and blocking renders

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -67,6 +67,7 @@ vi.mock("./core/lazyGuitarAudio", () => ({
   setGuitarAudioErrorHandler: vi.fn(),
   resumeGuitarAudio: vi.fn(),
   playGuitarNote: vi.fn(),
+  prefetchAudioModule: vi.fn(),
 }));
 
 const mockResumeGuitarAudio = vi.mocked(resumeGuitarAudio);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
   resumeGuitarAudio,
   setGuitarAudioErrorHandler,
   setGuitarMutePreference,
+  prefetchAudioModule,
 } from "./core/lazyGuitarAudio";
 import { isMutedAtom, toggleMuteAtom, audioErrorAtom } from "./store/audioAtoms";
 import { chordTypeAtom } from "./store/chordOverlayAtoms";
@@ -77,6 +78,14 @@ function AppContent() {
       setGuitarAudioErrorHandler(undefined);
     };
   }, [setAudioError]);
+
+  useEffect(() => {
+    if ("requestIdleCallback" in window) {
+      window.requestIdleCallback(() => prefetchAudioModule());
+    } else {
+      setTimeout(() => prefetchAudioModule(), 1000);
+    }
+  }, []);
 
   // Safari/iOS robustness: resume AudioContext on first interaction
   useEffect(() => {

--- a/src/components/Fretboard/Fretboard.tsx
+++ b/src/components/Fretboard/Fretboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo, lazy, Suspense } from "react";
+import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo, lazy, Suspense, useDeferredValue } from "react";
 import { clsx } from "clsx";
 import styles from "./Fretboard.module.css";
 import {
@@ -83,8 +83,10 @@ interface FretboardProps {
 }
 
 export function Fretboard(props: FretboardProps) {
-  const state = useFretboardTopologyModel();
-  const viewport = useFretboardViewportModel();
+  const baseState = useFretboardTopologyModel();
+  const state = useDeferredValue(baseState);
+  const baseViewport = useFretboardViewportModel();
+  const viewport = useDeferredValue(baseViewport);
 
   // Fallback to props for testability; default to atom-driven state.
   const tuning = props.tuning ?? viewport.currentTuning;
@@ -158,7 +160,6 @@ export function Fretboard(props: FretboardProps) {
   const startX = useRef(0);
   const scrollLeft = useRef(0);
   const dragDistance = useRef(0);
-  const offsetLeftRef = useRef(0);
   const [hasOverflow, setHasOverflow] = useState(false);
 
   useEffect(() => {
@@ -247,8 +248,7 @@ export function Fretboard(props: FretboardProps) {
     isDraggingRef.current = false;
     pendingPointerId.current = e.pointerId;
     pendingTarget.current = e.currentTarget;
-    offsetLeftRef.current = scrollRef.current.offsetLeft;
-    startX.current = e.pageX - offsetLeftRef.current;
+    startX.current = e.pageX;
     scrollLeft.current = scrollRef.current.scrollLeft;
     dragDistance.current = 0;
   }, [hasOverflow]);
@@ -263,8 +263,7 @@ export function Fretboard(props: FretboardProps) {
     }
     if (!isDraggingRef.current) return;
     e.preventDefault();
-    const x = e.pageX - offsetLeftRef.current;
-    const walk = (x - startX.current) * 1.5;
+    const walk = (e.pageX - startX.current) * 1.5;
     scrollRef.current.scrollLeft = scrollLeft.current - walk;
   }, [updateCursor]);
 

--- a/src/components/SettingsOverlay/SettingsOverlay.test.tsx
+++ b/src/components/SettingsOverlay/SettingsOverlay.test.tsx
@@ -48,6 +48,7 @@ vi.mock("../../core/lazyGuitarAudio", () => ({
   resumeGuitarAudio: vi.fn(),
   playGuitarNote: vi.fn(),
   setGuitarAudioErrorHandler: vi.fn(),
+  prefetchAudioModule: vi.fn(),
 }));
 
 function renderOverlay(store: ReturnType<typeof createStore>) {

--- a/src/core/lazyGuitarAudio.ts
+++ b/src/core/lazyGuitarAudio.ts
@@ -22,6 +22,10 @@ export function setGuitarMutePreference(mute: boolean): void {
   });
 }
 
+export function prefetchAudioModule(): void {
+  void loadAudioModule();
+}
+
 export function setGuitarAudioErrorHandler(
   nextHandler: ((message: string) => void) | undefined,
 ): void {

--- a/src/hooks/useFretboardTopologyModel.ts
+++ b/src/hooks/useFretboardTopologyModel.ts
@@ -40,6 +40,11 @@ export function useFretboardTopologyModel() {
   const showChordConnectors = useAtomValue(voicingAtom) !== "off";
   const activePosition = useAtomValue(activePositionAtom);
 
+  // Stable key for cagedShapes to avoid useMemo recomputation on every render
+  const cagedShapesKey = cagedShapes.size > 0
+    ? Array.from(cagedShapes).sort().join(',')
+    : '';
+
   let activePattern: ActivePatternType | undefined;
   let activeShape: ActiveShapeType;
   let shapeScope: ShapeScope = "global";
@@ -97,7 +102,7 @@ export function useFretboardTopologyModel() {
     rootNote, scaleName, displayFormat, preferFlats, noteSemanticMap,
     highlightNotes, boxBounds, shapePolygons, wrappedNotes,
     chordTones, chordRoot, colorNotes, hiddenNotes,
-    activePattern, activeShape, shapeScope, visibleFullChordMatches,
+    activePattern, cagedShapesKey, npsPosition, fingeringPattern, shapeScope, visibleFullChordMatches,
     chordHighlightPositions, showChordConnectors, chordBoxBounds
   ]);
 }

--- a/src/hooks/useFretboardTopologyModel.ts
+++ b/src/hooks/useFretboardTopologyModel.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { useAtomValue } from "jotai";
 import {
   chordTonesAtom,
@@ -70,7 +71,7 @@ export function useFretboardTopologyModel() {
   const visibleFullChordMatches = useAtomValue(visibleVoicingMatchesAtom);
   const chordBoxBounds = activePosition ? boxBounds : null;
 
-  return {
+  return React.useMemo(() => ({
     rootNote,
     scaleName,
     displayFormat,
@@ -89,13 +90,14 @@ export function useFretboardTopologyModel() {
     activeShape,
     shapeScope,
     fullChordMatches: visibleFullChordMatches,
-    /**
-     * Set of "stringIndex-fretIndex" keys that should render the chord-tone
-     * emphasis. Sourced from {@link chordHighlightPositionsAtom} (union of
-     * every fitting candidate's positions).
-     */
     fullChordPositions: chordHighlightPositions,
     showChordConnectors,
     chordBoxBounds,
-  };
+  }), [
+    rootNote, scaleName, displayFormat, preferFlats, noteSemanticMap,
+    highlightNotes, boxBounds, shapePolygons, wrappedNotes,
+    chordTones, chordRoot, colorNotes, hiddenNotes,
+    activePattern, activeShape, shapeScope, visibleFullChordMatches,
+    chordHighlightPositions, showChordConnectors, chordBoxBounds
+  ]);
 }

--- a/src/hooks/useFretboardViewportModel.ts
+++ b/src/hooks/useFretboardViewportModel.ts
@@ -1,15 +1,25 @@
+import React from "react";
 import { useAtomValue } from "jotai";
 import { currentTuningAtom, fretEndAtom, fretStartAtom, fretZoomAtom } from "../store/layoutAtoms";
 import { autoCenterTargetAtom } from "../store/shapeAtoms";
 import { recenterKeyAtom } from "../store/fingeringAtoms";
 
 export function useFretboardViewportModel() {
-  return {
-    currentTuning: useAtomValue(currentTuningAtom),
-    startFret: useAtomValue(fretStartAtom),
-    endFret: useAtomValue(fretEndAtom),
-    fretZoom: useAtomValue(fretZoomAtom),
-    autoCenterTarget: useAtomValue(autoCenterTargetAtom),
-    recenterKey: useAtomValue(recenterKeyAtom),
-  };
+  const currentTuning = useAtomValue(currentTuningAtom);
+  const startFret = useAtomValue(fretStartAtom);
+  const endFret = useAtomValue(fretEndAtom);
+  const fretZoom = useAtomValue(fretZoomAtom);
+  const autoCenterTarget = useAtomValue(autoCenterTargetAtom);
+  const recenterKey = useAtomValue(recenterKeyAtom);
+
+  return React.useMemo(() => ({
+    currentTuning,
+    startFret,
+    endFret,
+    fretZoom,
+    autoCenterTarget,
+    recenterKey,
+  }), [
+    currentTuning, startFret, endFret, fretZoom, autoCenterTarget, recenterKey
+  ]);
 }

--- a/src/integration.test.tsx
+++ b/src/integration.test.tsx
@@ -16,6 +16,7 @@ const lazyAudio = vi.hoisted(() => ({
   setGuitarMutePreference: vi.fn(),
   setGuitarAudioErrorHandler: vi.fn(),
   resumeGuitarAudio: vi.fn(),
+  prefetchAudioModule: vi.fn(),
 }));
 
 vi.mock("./core/lazyGuitarAudio", () => lazyAudio);


### PR DESCRIPTION
## Summary
- Fixed `mousedown` layout thrashing in Fretboard by removing a synchronous `offsetLeft` read
- Fixed `click` evaluation blocking by prefetching the Tone.js audio module on idle
- Fixed synchronous render blocking by deferring Fretboard topology updates

## Test Plan
- [x] All unit and integration tests passed via pre-push hook
- [x] Verified `Fretboard.performance.test.tsx` accurately measures the deferred rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio module prefetching during idle/startup to improve perceived load time.

* **Improvements**
  * Smoother fretboard scrolling with more responsive pointer-drag behavior.
  * Reduced unnecessary re-renders via memoization for topology and viewport data.

* **Tests**
  * Updated test mocks to reflect the new prefetch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->