### PR TITLE
fix(a11y): fretboard note aria-label spelling + conditional button role

### DIFF
--- a/src/components/FretboardSVG/FretboardHitTargetLayer.test.tsx
+++ b/src/components/FretboardSVG/FretboardHitTargetLayer.test.tsx
@@ -12,6 +12,7 @@ function makeNote(overrides: Partial<NoteData> = {}): NoteData {
     noteName: "C",
     octave: 4,
     noteClass: "note-active",
+    displayName: "C",
     displayValue: "C",
     applyDimOpacity: false,
     applyLensEmphasis: { radiusBoost: 1, opacityBoost: 1 },

--- a/src/components/FretboardSVG/FretboardNote.tsx
+++ b/src/components/FretboardSVG/FretboardNote.tsx
@@ -64,6 +64,7 @@ export const FretboardNote = memo(function FretboardNote({
     cy,
     octave,
     noteClass,
+    displayName,
     displayValue,
     applyDimOpacity,
     applyLensEmphasis,
@@ -145,7 +146,9 @@ export const FretboardNote = memo(function FretboardNote({
   const baseOpacity = applyDimOpacity ? 0.8 : 1;
   const finalOpacity = baseOpacity * applyLensEmphasis.opacityBoost;
   const roleLabel = formatRole(noteClass);
-  const ariaLabel = `${noteName}${octave} — ${roleLabel}`;
+  // Announce the same flat/sharp spelling sighted users see (e.g. "B♭", not the
+  // internal sharp "A#"). displayName carries the scale-aware spelling. #493
+  const ariaLabel = `${formatAccidental(displayName)}${octave} — ${roleLabel}`;
   const interactive = !!onNoteClick && !isHidden;
   return (
     <g
@@ -154,10 +157,10 @@ export const FretboardNote = memo(function FretboardNote({
         styles[noteClass],
         isHidden && "hidden",
       )}
-      role="button"
+      role={interactive ? "button" : undefined}
       aria-label={ariaLabel}
       aria-hidden={isHidden || undefined}
-      tabIndex={interactive ? 0 : -1}
+      tabIndex={interactive ? 0 : undefined}
       onClick={
         interactive
           ? () => onNoteClick!(stringIndex, fretIndex, noteName)

--- a/src/components/FretboardSVG/FretboardNoteLayer.test.tsx
+++ b/src/components/FretboardSVG/FretboardNoteLayer.test.tsx
@@ -27,6 +27,7 @@ import {
   squirclePath,
 } from "./utils/noteSizing";
 import {
+  formatAccidental,
   RADIUS_SCALE_CHORD_ROOT,
   RADIUS_SCALE_CHORD_TONE,
   RADIUS_SCALE_NOTE_ACTIVE,
@@ -53,6 +54,7 @@ function makeNote(noteClass: NoteClass, overrides: Partial<RenderedFretboardNote
     noteName: "C",
     octave: 4,
     noteClass,
+    displayName: "C",
     displayValue: "C",
     applyDimOpacity: false,
     applyLensEmphasis: { radiusBoost: 1, opacityBoost: 1 },
@@ -343,5 +345,87 @@ describe("FretboardNoteLayer", () => {
       </svg>,
     );
     expect(container.querySelector('[data-motion="css"]')).toBeTruthy();
+  });
+});
+
+describe("FretboardNote a11y contract (issue #493)", () => {
+  const renderNote = (
+    note: RenderedFretboardNote,
+    opts: {
+      onNoteClick?: (s: number, f: number, n: string) => void;
+      displayFormat?: "notes" | "degrees" | "none";
+    } = {},
+  ) =>
+    render(
+      <svg>
+        <FretboardNoteLayer
+          notes={[note]}
+          noteBubblePx={40}
+          displayFormat={opts.displayFormat ?? "notes"}
+          onNoteClick={opts.onNoteClick}
+        />
+      </svg>,
+    );
+
+  const noteGroup = (container: HTMLElement) =>
+    container.querySelector<SVGGElement>('g[class*="fretboard-note"]')!;
+
+  describe("aria-label uses the visible display spelling, not internal sharps", () => {
+    it("announces the flat spelling when the visible label is a flat", () => {
+      // Internal storage is sharps ("A#"); the visible label resolves to the
+      // scale-aware flat ("Bb"). The screen-reader label must match what is seen.
+      const { container } = renderNote(
+        makeNote("note-active", { noteName: "A#", displayName: "Bb", octave: 4 }),
+      );
+      const label = noteGroup(container).getAttribute("aria-label") ?? "";
+      expect(label).toContain(formatAccidental("Bb")); // "B♭"
+      expect(label).not.toContain("A#");
+      expect(label).not.toContain("A♯");
+    });
+
+    it("uses displayName for the pitch even in degrees display mode", () => {
+      // displayValue (visible text) is a degree in degrees mode, but the spoken
+      // label must still announce the pitch — sourced from displayName.
+      const { container } = renderNote(
+        makeNote("note-active", {
+          noteName: "C#",
+          displayName: "Db",
+          displayValue: "2",
+          octave: 5,
+        }),
+        { displayFormat: "degrees" },
+      );
+      const label = noteGroup(container).getAttribute("aria-label") ?? "";
+      expect(label).toContain(`${formatAccidental("Db")}5`); // "D♭5"
+    });
+  });
+
+  describe("role and tabIndex are conditional on interactivity", () => {
+    it("non-interactive notes (no onNoteClick) have no button role and no tabIndex", () => {
+      const { container } = renderNote(makeNote("note-active"));
+      const g = noteGroup(container);
+      expect(g.getAttribute("role")).toBeNull();
+      expect(g.getAttribute("tabindex")).toBeNull();
+    });
+
+    it("interactive notes expose button role and tabIndex=0", () => {
+      const { container } = renderNote(makeNote("note-active"), {
+        onNoteClick: () => {},
+      });
+      const g = noteGroup(container);
+      expect(g.getAttribute("role")).toBe("button");
+      expect(g.getAttribute("tabindex")).toBe("0");
+    });
+
+    it("hidden notes stay aria-hidden with no button role even when onNoteClick is provided", () => {
+      const { container } = renderNote(
+        makeNote("note-inactive", { isHidden: true }),
+        { onNoteClick: () => {} },
+      );
+      const g = noteGroup(container);
+      expect(g.getAttribute("aria-hidden")).toBe("true");
+      expect(g.getAttribute("role")).toBeNull();
+      expect(g.getAttribute("tabindex")).toBeNull();
+    });
   });
 });

--- a/src/components/FretboardSVG/FretboardSVG.test.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.test.tsx
@@ -703,14 +703,22 @@ describe("FretboardSVG/FretboardSVG", () => {
         document.querySelectorAll<SVGGElement>('g[class*="fretboard-note"]'),
       );
 
-    it("exposes each note as a button with a labelled role and aria-label", () => {
+    it("exposes interactive notes as labelled buttons and gives non-interactive notes no role", () => {
       render(<FretboardSVG {...BASE_PROPS} onNoteClick={() => {}} />);
       const notes = getSvgNotes();
       expect(notes.length).toBeGreaterThan(0);
-      notes.forEach((g) => {
+      const interactive = notes.filter((g) => g.getAttribute("aria-hidden") !== "true");
+      const hidden = notes.filter((g) => g.getAttribute("aria-hidden") === "true");
+      expect(interactive.length).toBeGreaterThan(0);
+      interactive.forEach((g) => {
         expect(g.getAttribute("role")).toBe("button");
         const label = g.getAttribute("aria-label") || "";
         expect(label).toMatch(/^[A-G][#♯♭b]?\d\s—\s.+$/);
+      });
+      // aria-hidden (non-interactive) notes must not advertise a button role.
+      hidden.forEach((g) => {
+        expect(g.getAttribute("role")).toBeNull();
+        expect(g.getAttribute("tabindex")).toBeNull();
       });
     });
 
@@ -726,9 +734,11 @@ describe("FretboardSVG/FretboardSVG", () => {
     it("toggles tabIndex based on onNoteClick presence", () => {
       const { rerender } = render(<FretboardSVG {...BASE_PROPS} onNoteClick={() => {}} />);
       expect(getSvgNotes().some((g) => g.getAttribute("tabindex") === "0")).toBe(true);
+      // Without onNoteClick no note is interactive, so none is focusable.
       rerender(<FretboardSVG {...BASE_PROPS} />);
       getSvgNotes().forEach((g) => {
-        expect(g.getAttribute("tabindex")).toBe("-1");
+        expect(g.getAttribute("tabindex")).toBeNull();
+        expect(g.getAttribute("role")).toBeNull();
       });
     });
 

--- a/src/components/FretboardSVG/hooks/buildStaticFretboardTopology.ts
+++ b/src/components/FretboardSVG/hooks/buildStaticFretboardTopology.ts
@@ -250,12 +250,16 @@ export function buildStaticFretboardTopology({
 
       if (isNoteHidden) continue;
 
-      let displayValue = getNoteDisplayInScale(
+      // Scale-aware spelled pitch (e.g. "A#" → "Bb" in F major). This is the
+      // pitch the visible "notes"-mode label shows; the a11y aria-label reuses
+      // it so screen readers announce the same spelling. See issue #493.
+      const displayName = getNoteDisplayInScale(
         noteName,
         rootNote,
         scale,
         preferFlats,
       );
+      let displayValue = displayName;
       if (displayFormat === "degrees" && rootNote) {
         const noteIdx = NOTES.indexOf(noteName);
         if (rootIdx !== -1 && noteIdx !== -1) {
@@ -307,6 +311,7 @@ export function buildStaticFretboardTopology({
         noteName,
         octave,
         noteClass: finalNoteClass,
+        displayName,
         displayValue,
         applyDimOpacity,
         applyLensEmphasis: DEFAULT_LENS_EMPHASIS,

--- a/src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts
+++ b/src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts
@@ -166,6 +166,7 @@ describe("buildRenderedFretboardNotes (object identity)", () => {
       noteName: "C",
       octave: 4,
       noteClass: "note-active",
+      displayName: "C",
       displayValue: "C",
       applyDimOpacity: false,
       applyLensEmphasis: { radiusBoost: 1, opacityBoost: 1 },

--- a/src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts
+++ b/src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts
@@ -104,6 +104,7 @@ function renderedNoteSignature(
     note.noteName,
     note.octave,
     note.noteClass,
+    note.displayName,
     note.displayValue,
     note.cx,
     note.cy,

--- a/src/components/FretboardSVG/hooks/useChordConnectorPolylines.test.ts
+++ b/src/components/FretboardSVG/hooks/useChordConnectorPolylines.test.ts
@@ -45,6 +45,7 @@ function makeNote(
     noteName,
     octave: 4,
     noteClass,
+    displayName: noteName,
     displayValue: noteName,
     applyDimOpacity: false,
     applyLensEmphasis: { radiusBoost: 1, opacityBoost: 1 },

--- a/src/components/FretboardSVG/hooks/useChordConnectorPolylines.ts
+++ b/src/components/FretboardSVG/hooks/useChordConnectorPolylines.ts
@@ -460,6 +460,7 @@ function createExplicitSourceCombo(
     noteName,
     octave: 4,
     noteClass: "chord-tone-in-scale",
+    displayName: noteName,
     displayValue: noteName,
     applyDimOpacity: false,
     applyLensEmphasis: { radiusBoost: 1, opacityBoost: 1 },

--- a/src/components/FretboardSVG/hooks/useNoteData.ts
+++ b/src/components/FretboardSVG/hooks/useNoteData.ts
@@ -24,6 +24,10 @@ export interface NoteData {
   noteName: string;
   octave: number;
   noteClass: string;
+  /** Scale-aware spelled pitch (e.g. "Bb"), independent of displayFormat. The
+   * visible note label in "notes" mode and the a11y aria-label both source from
+   * this so screen-reader output matches what is shown. See issue #493. */
+  displayName: string;
   displayValue: string;
   applyDimOpacity: boolean;
   applyLensEmphasis: LensEmphasis;

--- a/src/components/FretboardSVG/hooks/useStaticFretboardTopology.test.ts
+++ b/src/components/FretboardSVG/hooks/useStaticFretboardTopology.test.ts
@@ -130,4 +130,39 @@ describe("useStaticFretboardTopology", () => {
     expect(result.current.find((note) => note.positionKey === "0-2")?.noteClass).toBe("note-active");
     expect(result.current.find((note) => note.positionKey === "0-2")?.applyDimOpacity).toBe(true);
   });
+
+  describe("displayName (issue #493 a11y spelling)", () => {
+    // In F major the chromatic "A#" is spelled "Bb". displayName must carry the
+    // scale-aware spelling so screen-reader labels match the visible note text.
+    const F_MAJOR_PROPS = {
+      ...TOPOLOGY_PROPS,
+      fretboardLayout: [["F", "F#", "G", "G#", "A", "A#"]],
+      totalColumns: 5,
+      maxFret: 6,
+      highlightNotes: ["F", "G", "A", "A#"],
+      chordTones: ["F", "A", "C"],
+      rootNote: "F",
+      chordRoot: "F",
+      tuning: ["F3"],
+    };
+
+    it("spells displayName scale-aware, matching displayValue in notes mode", () => {
+      const { result } = renderHook(() => useStaticFretboardTopology(F_MAJOR_PROPS));
+      const aSharp = result.current.find((note) => note.positionKey === "0-5");
+      expect(aSharp?.noteName).toBe("A#");
+      expect(aSharp?.displayName).toBe("Bb");
+      // In notes mode the visible label IS displayValue, so they must agree.
+      expect(aSharp?.displayValue).toBe("Bb");
+    });
+
+    it("keeps displayName as the pitch while displayValue becomes a degree", () => {
+      const { result } = renderHook(() => useStaticFretboardTopology({
+        ...F_MAJOR_PROPS,
+        displayFormat: "degrees" as const,
+      }));
+      const aSharp = result.current.find((note) => note.positionKey === "0-5");
+      expect(aSharp?.displayName).toBe("Bb");
+      expect(aSharp?.displayValue).not.toBe("Bb");
+    });
+  });
 });


### PR DESCRIPTION
Closes #493. Follow-up from #492 (deferred to keep that PR a byte-identical perf refactor). Both are **pre-existing** per-note behaviors in `FretboardNote.tsx`, not regressions.

## What changed

### 1. aria-label now matches the visible spelling
The note `<g>`'s `aria-label` was built from the raw internal note name — always stored as a **sharp** (`A#4`) — while the visible `<text>` shows the scale-aware spelling via `formatAccidental(displayValue)` (`B♭`). Screen-reader users heard a different pitch spelling than sighted users saw.

A render-time `displayName` (scale-aware spelled pitch from `getNoteDisplayInScale` — the same source that produces the visible *notes*-mode label) is now:
- threaded through `NoteData` → `buildStaticFretboardTopology` (single source for both `displayName` and `displayValue`),
- added to `renderedNoteSignature` in `useAnimatedFretboardView.ts` so the per-note identity cache invalidates when the spelling changes (honors the in-code stale-render guard),
- used for the aria-label as `formatAccidental(displayName) + octave + role`.

This makes the `<g>` label agree with both the visible `<text>` and the sibling hit-target `<button>`.

### 2. `role="button"` is now conditional
`role="button"` and `tabIndex` were applied unconditionally even though `interactive = !!onNoteClick && !isHidden` was already computed. Both are now gated on `interactive`; `aria-hidden` is retained for hidden notes. (`onClick`/`onKeyDown` were already conditional.) Impact is small in practice — the live app always passes `onNoteClick` and hidden notes are `aria-hidden` — but the semantics are now correct.

## Testing
- New component tests: aria-label uses display spelling (including a `A#`→`B♭` case and a degrees-mode case), and conditional `role`/`tabIndex` (non-interactive → no role/tab; interactive → button/0; hidden → aria-hidden, no role).
- New builder tests: `displayName` is scale-aware (`A#`→`Bb` in F major) and equals `displayValue` in notes mode while diverging in degrees mode.
- Updated the existing `FretboardSVG` a11y-contract tests to the corrected role/tabIndex semantics.
- The change is **aria/role/tabIndex only** — no pixel impact, so visual-regression snapshots are unaffected (full vitest DOM-snapshot suite passed with no mismatch).

`pnpm run lint` (clean), `pnpm run test` (2213 pass), and `pnpm run build` all pass locally.

> Note: live browser preview was skipped — the preview infra attached to a stale dev server from a sibling worktree holding port 5173, so it would have tested unrelated code. The integration tests render the real `FretboardSVG` DOM and assert these exact attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen reader accessibility: notes now announce with scale-aware spelling (e.g., "Bb" instead of "A#"), matching their visual display on the fretboard.
  * Enhanced keyboard interaction patterns: non-interactive notes no longer expose button semantics or unnecessary focus targets.

* **Tests**
  * Expanded accessibility test coverage for note display and keyboard interaction behavior across display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->