### PR TITLE
fix(fretboard): drop dead interactivity/ARIA from decorative note layer

### DIFF
--- a/src/components/FretboardSVG/FretboardNote.tsx
+++ b/src/components/FretboardSVG/FretboardNote.tsx
@@ -22,47 +22,28 @@ const CAGED_SHAPE_TEXT_VAR: Record<string, string> = {
   G: "var(--caged-g-fg)",
 };
 
-const ROLE_DESCRIPTIONS: Record<string, string> = {
-  "root-active": "scale root",
-  "chord-root": "chord root",
-  "chord-tone": "chord tone",
-  "chord-tone-in-scale": "chord tone in scale",
-  "chord-tone-outside-scale": "chord tone outside scale",
-  "note-diatonic-chord": "diatonic chord tone",
-  "note-blue": "blue note",
-  "note-active": "scale note",
-  "note-scale-only": "scale note",
-  "chord-outside": "chord tone outside scale",
-  "color-tone": "color tone",
-  "key-tonic": "key tonic",
-  "note-inactive": "inactive",
-};
-
-const formatRole = (noteClass: string): string =>
-  ROLE_DESCRIPTIONS[noteClass] ?? noteClass.replace(/-/g, " ");
-
 interface FretboardNoteProps {
   note: RenderedFretboardNote;
   noteBubblePx: number;
   displayFormat: "notes" | "degrees" | "none";
   degreeColorsEnabled?: boolean;
-  onNoteClick?: (stringIndex: number, fretIndex: number, noteName: string) => void;
 }
 
+// PURELY DECORATIVE. This SVG note layer lives inside an aria-hidden,
+// pointer-events:none <svg> (see FretboardSVG.tsx). All interaction and
+// accessible names are owned by FretboardHitTargetLayer's real <button>s, so
+// this component intentionally carries NO role / aria-label / tabIndex / click
+// or key handlers — a focusable element inside an aria-hidden subtree is invalid
+// ARIA, and pointer/keyboard handlers here could never fire anyway.
 export const FretboardNote = memo(function FretboardNote({
   note,
   noteBubblePx,
   displayFormat,
   degreeColorsEnabled,
-  onNoteClick,
 }: FretboardNoteProps) {
   const {
-    stringIndex,
-    fretIndex,
-    noteName,
     cx,
     cy,
-    octave,
     noteClass,
     displayValue,
     applyDimOpacity,
@@ -144,9 +125,6 @@ export const FretboardNote = memo(function FretboardNote({
 
   const baseOpacity = applyDimOpacity ? 0.8 : 1;
   const finalOpacity = baseOpacity * applyLensEmphasis.opacityBoost;
-  const roleLabel = formatRole(noteClass);
-  const ariaLabel = `${noteName}${octave} — ${roleLabel}`;
-  const interactive = !!onNoteClick && !isHidden;
   return (
     <g
       className={clsx(
@@ -154,25 +132,6 @@ export const FretboardNote = memo(function FretboardNote({
         styles[noteClass],
         isHidden && "hidden",
       )}
-      role="button"
-      aria-label={ariaLabel}
-      aria-hidden={isHidden || undefined}
-      tabIndex={interactive ? 0 : -1}
-      onClick={
-        interactive
-          ? () => onNoteClick!(stringIndex, fretIndex, noteName)
-          : undefined
-      }
-      onKeyDown={
-        interactive
-          ? (e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onNoteClick!(stringIndex, fretIndex, noteName);
-              }
-            }
-          : undefined
-      }
       data-note-role={noteClass !== "note-inactive" ? noteClass : undefined}
       data-note-shape={noteShape}
       data-note-tension={isTension || undefined}

--- a/src/components/FretboardSVG/FretboardNoteLayer.test.tsx
+++ b/src/components/FretboardSVG/FretboardNoteLayer.test.tsx
@@ -124,42 +124,6 @@ describe("FretboardNoteLayer per-note memoization", () => {
     expect(noteRenders).toEqual(["2-2"]);
   });
 
-  it("a referentially-stable onNoteClick does not defeat the per-note memo", () => {
-    // Defined once, outside any re-render — the real FretboardSVG passes a
-    // useCallback-stable handler, and this guards that load-bearing assumption.
-    const onNoteClick = () => {};
-    const notes = fourStableNotes();
-
-    const { rerender } = render(
-      <svg>
-        <FretboardNoteLayer
-          notes={notes}
-          noteBubblePx={40}
-          displayFormat="notes"
-          onNoteClick={onNoteClick}
-        />
-      </svg>,
-    );
-
-    expect(noteRenders).toHaveLength(notes.length);
-    noteRenders.length = 0;
-
-    const nextNotes = notes.slice();
-    nextNotes[1] = makeNote("note-active", { stringIndex: 1, fretIndex: 1, cx: 77 });
-
-    rerender(
-      <svg>
-        <FretboardNoteLayer
-          notes={nextNotes}
-          noteBubblePx={40}
-          displayFormat="notes"
-          onNoteClick={onNoteClick}
-        />
-      </svg>,
-    );
-
-    expect(noteRenders).toEqual(["1-1"]);
-  });
 });
 
 describe("FretboardNoteLayer", () => {
@@ -248,6 +212,25 @@ describe("FretboardNoteLayer", () => {
     expect(roles).toContain("note-active");
   });
 
+  it("renders the visible note <g> as decorative — no role, aria-label, or tabindex", () => {
+    // The visible SVG note layer lives inside an aria-hidden, pointer-events:none
+    // <svg>; interaction + accessible names are owned by FretboardHitTargetLayer's
+    // real <button>s. The decorative <g> must therefore carry NO interactive or
+    // ARIA semantics (focusable-in-aria-hidden is invalid; role/label are dead).
+    const { container } = renderLayer([
+      makeNote("note-active", { stringIndex: 0, fretIndex: 0 }),
+      makeNote("note-inactive", { stringIndex: 1, fretIndex: 1, cx: 150, cy: 30, isHidden: true }),
+    ]);
+    const groups = container.querySelectorAll('g[class*="fretboard-note"]');
+    expect(groups.length).toBe(2);
+    groups.forEach((g) => {
+      expect(g.getAttribute("role")).toBeNull();
+      expect(g.getAttribute("aria-label")).toBeNull();
+      expect(g.getAttribute("tabindex")).toBeNull();
+      expect(g.getAttribute("aria-hidden")).toBeNull();
+    });
+  });
+
   it("applies correct data-note-shape attribute for each shape type", () => {
     const { container } = renderLayer(
       [
@@ -277,9 +260,16 @@ describe("FretboardNoteLayer", () => {
     expect(paths[pathIndex]!.getAttribute("d")).toBe(squirclePath(100, 50, expectedRadius));
   });
 
-  it("hidden notes do not render with data-note-role and are aria-hidden", () => {
-    const { container } = renderLayer([makeNote("note-active", { isHidden: true })]);
-    expect(container.querySelector("g[aria-hidden='true']")).toBeTruthy();
+  it("hidden notes carry the .hidden class (display:none) and no data-note-role", () => {
+    // Visibility is driven entirely by the `.hidden` class (display:none); the
+    // decorative layer has no ARIA of its own (the whole SVG is aria-hidden).
+    // A hidden note is always note-inactive in production (see
+    // buildStaticFretboardTopology: isHidden = noteClass === "note-inactive").
+    const { container } = renderLayer([makeNote("note-inactive", { isHidden: true })]);
+    const g = container.querySelector('g[class*="fretboard-note"]')!;
+    expect(g.classList.contains("hidden")).toBe(true);
+    expect(g.getAttribute("data-note-role")).toBeNull();
+    expect(g.getAttribute("aria-hidden")).toBeNull();
   });
 
   it("lens emphasis radiusBoost is applied as CSS transform scale, not baked into SVG geometry", () => {

--- a/src/components/FretboardSVG/FretboardNoteLayer.tsx
+++ b/src/components/FretboardSVG/FretboardNoteLayer.tsx
@@ -8,16 +8,16 @@ interface FretboardNoteLayerProps {
   noteBubblePx: number;
   displayFormat: "notes" | "degrees" | "none";
   degreeColorsEnabled?: boolean;
-  onNoteClick?: (stringIndex: number, fretIndex: number, noteName: string) => void;
   animationMode?: NoteAnimationMode;
 }
 
+// Decorative-only visual layer. Interaction + accessible names live in
+// FretboardHitTargetLayer's real <button>s — this layer takes no onNoteClick.
 export const FretboardNoteLayer = memo(({
   notes,
   noteBubblePx,
   displayFormat,
   degreeColorsEnabled,
-  onNoteClick,
   animationMode = "css",
 }: FretboardNoteLayerProps) => (
   // NOTE: reading a new render-affecting field in FretboardNote? Also add it to
@@ -31,7 +31,6 @@ export const FretboardNoteLayer = memo(({
         noteBubblePx={noteBubblePx}
         displayFormat={displayFormat}
         degreeColorsEnabled={degreeColorsEnabled}
-        onNoteClick={onNoteClick}
       />
     ))}
   </g>

--- a/src/components/FretboardSVG/FretboardSVG.test.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.test.tsx
@@ -698,54 +698,52 @@ describe("FretboardSVG/FretboardSVG", () => {
   });
 
   describe("note layer a11y contract", () => {
+    // The visible SVG note layer is purely decorative: it lives inside an
+    // aria-hidden, pointer-events:none <svg>. Interaction + accessible names are
+    // owned by FretboardHitTargetLayer's real <button>s. These tests guard that
+    // split — the decorative <g> must expose NO interactive/ARIA semantics, and
+    // the buttons must carry the labels + handle activation.
     const getSvgNotes = () =>
       Array.from(
         document.querySelectorAll<SVGGElement>('g[class*="fretboard-note"]'),
       );
+    const getHitButtons = () =>
+      Array.from(document.querySelectorAll<HTMLButtonElement>("button.note-bubble"));
 
-    it("exposes each note as a button with a labelled role and aria-label", () => {
+    it("renders the visible SVG note layer as decorative — no role/aria-label/tabindex even with onNoteClick", () => {
       render(<FretboardSVG {...BASE_PROPS} onNoteClick={() => {}} />);
       const notes = getSvgNotes();
       expect(notes.length).toBeGreaterThan(0);
       notes.forEach((g) => {
-        expect(g.getAttribute("role")).toBe("button");
-        const label = g.getAttribute("aria-label") || "";
-        expect(label).toMatch(/^[A-G][#♯♭b]?\d\s—\s.+$/);
+        expect(g.getAttribute("role")).toBeNull();
+        expect(g.getAttribute("aria-label")).toBeNull();
+        expect(g.getAttribute("tabindex")).toBeNull();
+        expect(g.getAttribute("aria-hidden")).toBeNull();
       });
     });
 
-    it("aria-label includes the correct octave for open low/high E strings", () => {
-      render(<FretboardSVG {...BASE_PROPS} highlightNotes={["E"]} onNoteClick={() => {}} />);
-      const labels = getSvgNotes()
-        .map((g) => g.getAttribute("aria-label") || "")
-        .filter(Boolean);
-      expect(labels.some((l) => l.startsWith("E2 — "))).toBe(true);
-      expect(labels.some((l) => l.startsWith("E4 — "))).toBe(true);
-    });
-
-    it("toggles tabIndex based on onNoteClick presence", () => {
-      const { rerender } = render(<FretboardSVG {...BASE_PROPS} onNoteClick={() => {}} />);
-      expect(getSvgNotes().some((g) => g.getAttribute("tabindex") === "0")).toBe(true);
-      rerender(<FretboardSVG {...BASE_PROPS} />);
-      getSvgNotes().forEach((g) => {
-        expect(g.getAttribute("tabindex")).toBe("-1");
+    it("exposes accessible names + interaction on the hit-target buttons, not the SVG", () => {
+      render(<FretboardSVG {...BASE_PROPS} onNoteClick={() => {}} />);
+      const buttons = getHitButtons();
+      expect(buttons.length).toBeGreaterThan(0);
+      buttons.forEach((btn) => {
+        expect(btn.tagName).toBe("BUTTON");
+        expect(btn.getAttribute("aria-label") || "").toMatch(/ on string \d+, fret \d+/);
       });
     });
 
-    it.each([["Enter"], [" "]])("%s key invokes onNoteClick on focused note", (key) => {
+    it("clicking a hit-target button invokes onNoteClick", () => {
       const onNoteClick = vi.fn();
       render(<FretboardSVG {...BASE_PROPS} onNoteClick={onNoteClick} />);
-      fireEvent.keyDown(getSvgNotes()[0], { key });
+      fireEvent.click(getHitButtons()[0]);
       expect(onNoteClick).toHaveBeenCalledTimes(1);
     });
 
-    it("ignores unrelated keys", () => {
-      const onNoteClick = vi.fn();
-      render(<FretboardSVG {...BASE_PROPS} onNoteClick={onNoteClick} />);
-      const note = getSvgNotes()[0];
-      fireEvent.keyDown(note, { key: "a" });
-      fireEvent.keyDown(note, { key: "Tab" });
-      expect(onNoteClick).not.toHaveBeenCalled();
+    it("disables hit-target buttons when no onNoteClick is provided", () => {
+      render(<FretboardSVG {...BASE_PROPS} />);
+      const buttons = getHitButtons();
+      expect(buttons.length).toBeGreaterThan(0);
+      buttons.forEach((btn) => expect(btn.disabled).toBe(true));
     });
   });
 });

--- a/src/components/FretboardSVG/FretboardSVG.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.tsx
@@ -707,7 +707,6 @@ export function FretboardSVG({
                     noteBubblePx={noteBubblePx}
                     displayFormat={displayFormat}
                     degreeColorsEnabled={degreeColorsEnabled}
-                    onNoteClick={onNoteClick}
                     animationMode={motionPolicy.noteMode}
                   />
                 </g>


### PR DESCRIPTION
## What

The visible SVG note layer (`FretboardNote`) renders inside an `aria-hidden="true"`, `pointer-events: none` `<svg>`, yet each note `<g>` carried `role="button"`, `aria-label`, `aria-hidden`, `tabIndex`, `onClick`, and `onKeyDown` — plus an `onNoteClick` prop threaded down from `FretboardSVG`.

None of it could work:
- **`pointer-events: none`** → the `onClick`/`onKeyDown` handlers can never fire from the pointer.
- **`aria-hidden` ancestor** → the `role`/`aria-label` are invisible to assistive tech.
- **`tabIndex={0}` inside an `aria-hidden` subtree** → invalid ARIA (focusable-in-aria-hidden).

`FretboardHitTargetLayer`'s real HTML `<button>`s already own every click, focus stop, and accessible name (and spell note names correctly via `formatAccidental`).

## Change

Strip `role` / `aria-label` / `aria-hidden` / `tabIndex` / `onClick` / `onKeyDown` and the now-unused `onNoteClick` prop from `FretboardNote` and `FretboardNoteLayer`, and drop the `FretboardSVG` pass-through. The layer is now purely decorative. All `data-*` attributes, geometry, classes, and the note text are unchanged — **pixels are identical** (no visual-regression delta).

Side benefit: each note fiber is lighter (no handler closures / ARIA attrs), trimming reconcile work on every geometry-driven rebuild (resize / fret-range / tuning change).

## Why now

Found during a systematic investigation of the fretboard render path (follow-up to the playback-perf work in #492). The decorative layer's interactivity was dead weight and an a11y defect.

## Closes #493

The removed `aria-label` was the exact one flagged in #493 for sharp/flat spelling. The hit-layer button already spells it correctly, so deleting the decorative label resolves **both** the spelling concern and the conditional-`role`/`tabIndex` concern from that issue.

## Tests

- New decorative-layer guard (`FretboardNoteLayer.test.tsx`, `FretboardSVG.test.tsx`): the visible `<g>` exposes no `role`/`aria-label`/`tabindex`/`aria-hidden`, even when `onNoteClick` is provided.
- Rewrote the `note layer a11y contract` block to assert the real contract on the hit-layer `<button>`s (accessible names, click → `onNoteClick`, disabled when no handler).
- Updated the hidden-note assertion to match production (`note-inactive` + `.hidden` display:none).

## Verification

- `pnpm run lint` — 0 errors (1 pre-existing warning, untouched file)
- `pnpm run test` — 2204 passed
- `pnpm run build` — ✓
