### PR TITLE
fix(a11y): stop making decorative fretboard notes focusable

### DIFF
--- a/src/components/FretboardSVG/FretboardNoteLayer.test.tsx
+++ b/src/components/FretboardSVG/FretboardNoteLayer.test.tsx
@@ -126,42 +126,6 @@ describe("FretboardNoteLayer per-note memoization", () => {
     expect(noteRenders).toEqual(["2-2"]);
   });
 
-  it("a referentially-stable onNoteClick does not defeat the per-note memo", () => {
-    // Defined once, outside any re-render — the real FretboardSVG passes a
-    // useCallback-stable handler, and this guards that load-bearing assumption.
-    const onNoteClick = () => {};
-    const notes = fourStableNotes();
-
-    const { rerender } = render(
-      <svg>
-        <FretboardNoteLayer
-          notes={notes}
-          noteBubblePx={40}
-          displayFormat="notes"
-          onNoteClick={onNoteClick}
-        />
-      </svg>,
-    );
-
-    expect(noteRenders).toHaveLength(notes.length);
-    noteRenders.length = 0;
-
-    const nextNotes = notes.slice();
-    nextNotes[1] = makeNote("note-active", { stringIndex: 1, fretIndex: 1, cx: 77 });
-
-    rerender(
-      <svg>
-        <FretboardNoteLayer
-          notes={nextNotes}
-          noteBubblePx={40}
-          displayFormat="notes"
-          onNoteClick={onNoteClick}
-        />
-      </svg>,
-    );
-
-    expect(noteRenders).toEqual(["1-1"]);
-  });
 });
 
 describe("FretboardNoteLayer", () => {
@@ -352,7 +316,6 @@ describe("FretboardNote a11y contract (issue #493)", () => {
   const renderNote = (
     note: RenderedFretboardNote,
     opts: {
-      onNoteClick?: (s: number, f: number, n: string) => void;
       displayFormat?: "notes" | "degrees" | "none";
     } = {},
   ) =>
@@ -362,7 +325,6 @@ describe("FretboardNote a11y contract (issue #493)", () => {
           notes={[note]}
           noteBubblePx={40}
           displayFormat={opts.displayFormat ?? "notes"}
-          onNoteClick={opts.onNoteClick}
         />
       </svg>,
     );
@@ -400,28 +362,20 @@ describe("FretboardNote a11y contract (issue #493)", () => {
     });
   });
 
-  describe("role and tabIndex are conditional on interactivity", () => {
-    it("non-interactive notes (no onNoteClick) have no button role and no tabIndex", () => {
+  describe("the decorative layer is never focusable", () => {
+    // FretboardNoteLayer takes no onNoteClick, so FretboardNote's interactive
+    // branch is never taken: the visible <g> stays non-focusable (no role /
+    // tabIndex). A focusable element inside the aria-hidden SVG would be invalid
+    // ARIA and a dead duplicate tab stop next to the real hit-target button.
+    it("active notes have no button role and no tabIndex", () => {
       const { container } = renderNote(makeNote("note-active"));
       const g = noteGroup(container);
       expect(g.getAttribute("role")).toBeNull();
       expect(g.getAttribute("tabindex")).toBeNull();
     });
 
-    it("interactive notes expose button role and tabIndex=0", () => {
-      const { container } = renderNote(makeNote("note-active"), {
-        onNoteClick: () => {},
-      });
-      const g = noteGroup(container);
-      expect(g.getAttribute("role")).toBe("button");
-      expect(g.getAttribute("tabindex")).toBe("0");
-    });
-
-    it("hidden notes stay aria-hidden with no button role even when onNoteClick is provided", () => {
-      const { container } = renderNote(
-        makeNote("note-inactive", { isHidden: true }),
-        { onNoteClick: () => {} },
-      );
+    it("hidden notes are aria-hidden with no button role and no tabIndex", () => {
+      const { container } = renderNote(makeNote("note-inactive", { isHidden: true }));
       const g = noteGroup(container);
       expect(g.getAttribute("aria-hidden")).toBe("true");
       expect(g.getAttribute("role")).toBeNull();

--- a/src/components/FretboardSVG/FretboardNoteLayer.tsx
+++ b/src/components/FretboardSVG/FretboardNoteLayer.tsx
@@ -8,16 +8,19 @@ interface FretboardNoteLayerProps {
   noteBubblePx: number;
   displayFormat: "notes" | "degrees" | "none";
   degreeColorsEnabled?: boolean;
-  onNoteClick?: (stringIndex: number, fretIndex: number, noteName: string) => void;
   animationMode?: NoteAnimationMode;
 }
 
+// This visual layer is decorative (its <svg> is aria-hidden + pointer-events:none).
+// It intentionally does NOT receive onNoteClick: feeding a handler here would make
+// FretboardNote's notes focusable (role/tabIndex) inside an aria-hidden subtree —
+// invalid ARIA and dead duplicate tab stops. Interaction is owned by
+// FretboardHitTargetLayer's real <button>s.
 export const FretboardNoteLayer = memo(({
   notes,
   noteBubblePx,
   displayFormat,
   degreeColorsEnabled,
-  onNoteClick,
   animationMode = "css",
 }: FretboardNoteLayerProps) => (
   // NOTE: reading a new render-affecting field in FretboardNote? Also add it to
@@ -31,7 +34,6 @@ export const FretboardNoteLayer = memo(({
         noteBubblePx={noteBubblePx}
         displayFormat={displayFormat}
         degreeColorsEnabled={degreeColorsEnabled}
-        onNoteClick={onNoteClick}
       />
     ))}
   </g>

--- a/src/components/FretboardSVG/FretboardSVG.test.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.test.tsx
@@ -698,31 +698,31 @@ describe("FretboardSVG/FretboardSVG", () => {
   });
 
   describe("note layer a11y contract", () => {
+    // The visible SVG note layer renders inside an aria-hidden, pointer-events:none
+    // <svg>. Interaction + focus are owned by FretboardHitTargetLayer's real
+    // <button>s. The decorative <g>s must therefore NEVER be focusable (no role /
+    // tabindex / click / key handlers) — a focusable element inside an aria-hidden
+    // subtree is invalid ARIA and would create dead duplicate tab stops alongside
+    // the hit buttons. (The <g> keeps a descriptive aria-label, which is inert
+    // because the parent SVG is aria-hidden.)
     const getSvgNotes = () =>
       Array.from(
         document.querySelectorAll<SVGGElement>('g[class*="fretboard-note"]'),
       );
+    const getHitButtons = () =>
+      Array.from(document.querySelectorAll<HTMLButtonElement>("button.note-bubble"));
 
-    it("exposes interactive notes as labelled buttons and gives non-interactive notes no role", () => {
+    it("never makes the visible SVG notes focusable, even with onNoteClick", () => {
       render(<FretboardSVG {...BASE_PROPS} onNoteClick={() => {}} />);
       const notes = getSvgNotes();
       expect(notes.length).toBeGreaterThan(0);
-      const interactive = notes.filter((g) => g.getAttribute("aria-hidden") !== "true");
-      const hidden = notes.filter((g) => g.getAttribute("aria-hidden") === "true");
-      expect(interactive.length).toBeGreaterThan(0);
-      interactive.forEach((g) => {
-        expect(g.getAttribute("role")).toBe("button");
-        const label = g.getAttribute("aria-label") || "";
-        expect(label).toMatch(/^[A-G][#♯♭b]?\d\s—\s.+$/);
-      });
-      // aria-hidden (non-interactive) notes must not advertise a button role.
-      hidden.forEach((g) => {
+      notes.forEach((g) => {
         expect(g.getAttribute("role")).toBeNull();
         expect(g.getAttribute("tabindex")).toBeNull();
       });
     });
 
-    it("aria-label includes the correct octave for open low/high E strings", () => {
+    it("keeps the descriptive aria-label with correct octave for open low/high E strings", () => {
       render(<FretboardSVG {...BASE_PROPS} highlightNotes={["E"]} onNoteClick={() => {}} />);
       const labels = getSvgNotes()
         .map((g) => g.getAttribute("aria-label") || "")
@@ -731,31 +731,24 @@ describe("FretboardSVG/FretboardSVG", () => {
       expect(labels.some((l) => l.startsWith("E4 — "))).toBe(true);
     });
 
-    it("toggles tabIndex based on onNoteClick presence", () => {
-      const { rerender } = render(<FretboardSVG {...BASE_PROPS} onNoteClick={() => {}} />);
-      expect(getSvgNotes().some((g) => g.getAttribute("tabindex") === "0")).toBe(true);
-      // Without onNoteClick no note is interactive, so none is focusable.
-      rerender(<FretboardSVG {...BASE_PROPS} />);
-      getSvgNotes().forEach((g) => {
-        expect(g.getAttribute("tabindex")).toBeNull();
-        expect(g.getAttribute("role")).toBeNull();
+    it("exposes accessible names + interaction on the hit-target buttons", () => {
+      render(<FretboardSVG {...BASE_PROPS} onNoteClick={() => {}} />);
+      const buttons = getHitButtons();
+      expect(buttons.length).toBeGreaterThan(0);
+      buttons.forEach((btn) => {
+        expect(btn.tagName).toBe("BUTTON");
+        expect(btn.getAttribute("aria-label") || "").toMatch(/ on string \d+, fret \d+/);
       });
     });
 
-    it.each([["Enter"], [" "]])("%s key invokes onNoteClick on focused note", (key) => {
+    it("clicking a hit-target button invokes onNoteClick; disabled without a handler", () => {
       const onNoteClick = vi.fn();
-      render(<FretboardSVG {...BASE_PROPS} onNoteClick={onNoteClick} />);
-      fireEvent.keyDown(getSvgNotes()[0], { key });
+      const { rerender } = render(<FretboardSVG {...BASE_PROPS} onNoteClick={onNoteClick} />);
+      fireEvent.click(getHitButtons()[0]);
       expect(onNoteClick).toHaveBeenCalledTimes(1);
-    });
 
-    it("ignores unrelated keys", () => {
-      const onNoteClick = vi.fn();
-      render(<FretboardSVG {...BASE_PROPS} onNoteClick={onNoteClick} />);
-      const note = getSvgNotes()[0];
-      fireEvent.keyDown(note, { key: "a" });
-      fireEvent.keyDown(note, { key: "Tab" });
-      expect(onNoteClick).not.toHaveBeenCalled();
+      rerender(<FretboardSVG {...BASE_PROPS} />);
+      getHitButtons().forEach((btn) => expect(btn.disabled).toBe(true));
     });
   });
 });

--- a/src/components/FretboardSVG/FretboardSVG.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.tsx
@@ -707,7 +707,6 @@ export function FretboardSVG({
                     noteBubblePx={noteBubblePx}
                     displayFormat={displayFormat}
                     degreeColorsEnabled={degreeColorsEnabled}
-                    onNoteClick={onNoteClick}
                     animationMode={motionPolicy.noteMode}
                   />
                 </g>


### PR DESCRIPTION
## Follow-up to #494

#494 fixed the fretboard note `aria-label` spelling and made `role`/`tabIndex` **conditional** on `interactive = !!onNoteClick && !isHidden`. But `FretboardSVG` still passes `onNoteClick` to `FretboardNoteLayer`, so for every visible note `interactive` is `true` — leaving `role="button"` + `tabIndex={0}` on the `<g>`, which lives inside the `aria-hidden="true"`, `pointer-events:none` SVG.

### Why that's a bug
- **Invalid ARIA** — a focusable element inside an `aria-hidden` subtree (axe `aria-hidden-focus`).
- **Real keyboard-nav defect** — `FretboardHitTargetLayer` already renders the real focusable `<button>` per position. So a keyboard user gets **two tab stops per note**: the working button, plus a phantom `<g>` that announces nothing (its label is hidden by `aria-hidden`) and does nothing visible (`pointer-events:none`).

### The fix (minimal, non-reverting)
Stop passing `onNoteClick` to `FretboardNoteLayer` and drop the prop from the layer. With no handler, **#494's own conditionals** leave the decorative `<g>` with no `role`/`tabIndex`/`onClick`/`onKeyDown` — no longer focusable. Interaction and focus stay entirely on the hit-target buttons.

- `FretboardNote` is **not** touched — it keeps #494's `displayName`/`aria-label` work (inert under `aria-hidden`) and conditional logic.
- Its `onNoteClick` prop + interactive branch remain (now unused in production), deliberately, to keep this a minimal change on top of #494 rather than a revert.
- All `data-*` attributes, geometry, classes, and note text unchanged → **pixels identical**, no visual-regression delta.

## Tests

- New guard: with `onNoteClick` provided to `FretboardSVG`, **no** visible `<g>` is focusable (`role`/`tabindex` null).
- Reworked the `note layer a11y contract` block + `FretboardNoteLayer` a11y tests to assert the decorative layer is never focusable and that accessible names + click/keyboard activation live on the hit-target `<button>`s.
- Kept #494's octave/flat-spelling `aria-label` assertions (the label is retained, just inert).

## Verification
- `pnpm run lint` — 0 errors (1 pre-existing warning, untouched file)
- `pnpm run test` — 2209 passed
- `pnpm run build` — ✓

Relates to #493 (resolved by #494); this closes the residual focusable-in-aria-hidden gap that #494 left.
