### PR TITLE
feat(progressions): genre default drum variation sets (Slice 2 §3.2)

### DIFF
--- a/docs/superpowers/plans/2026-06-01-genre-drum-variation-sets.md
+++ b/docs/superpowers/plans/2026-06-01-genre-drum-variation-sets.md
@@ -1,0 +1,274 @@
+# Genre Default Drum Variation Sets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire genre-appropriate drum turnaround fills/accents to pop, rock, funk, jazz, and blues, authoring three new genre-tailored variations so each genre's 4-bar phrase develops idiomatically.
+
+**Architecture:** Two pure-data changes. (1) Add three `DRUM_VARIATIONS` entries (`funk-fill-4`, `jazz-turnaround-4`, `blues-fill-4`), each `barInterval: 4, barPhase: 3` so they fire on the turnaround bar (absolute bars 3, 7, 11…) via the already-shipped `variationFiresOnBar` gate. (2) Update `GENRE_STYLES.drumVariations`. The scheduler engine (`buildAllLayers.ts`) is unchanged — it already resolves and gates variations. No new drum voices.
+
+**Tech Stack:** TypeScript, Vitest. Spec: `docs/superpowers/specs/2026-06-01-genre-drum-variation-sets-design.md`.
+
+**Run all commands from the worktree root:** `/Users/isaaccocar/repos/fretboard-app/.claude/worktrees/silly-heyrovsky-52b42f`
+
+**Engine conventions (must obey):** beats are 0-indexed quarter positions `0,1,2,3`; `.5` = eighth, `.25`/`.75` = sixteenths; **no triplet positions** — shuffle feel comes from the genre `swing` param. Beat in range `[0, 4)`.
+
+---
+
+### Task 1: Author the three new drum variations
+
+**Files:**
+- Modify: `src/progressions/audio/patterns.ts` (append to `DRUM_VARIATIONS`, currently ends at line 465)
+- Test: `src/progressions/audio/patterns.test.ts`
+
+- [ ] **Step 1: Update the catalog-count test and add gating/truthfulness tests**
+
+In `src/progressions/audio/patterns.test.ts`, the existing "pattern catalog" block asserts there are 3 variations. Change it to 6:
+
+```ts
+  it("has 6 drum variations with unique IDs", () => {
+    expect(DRUM_VARIATIONS).toHaveLength(6);
+    const ids = DRUM_VARIATIONS.map((v) => v.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+```
+
+Then, inside the existing `describe("DRUM_VARIATIONS definitions are truthful", ...)` block (it already defines a `byId` helper), add three tests before its closing `});`:
+
+```ts
+  it("funk-fill-4 fires on the turnaround bar with ghost-snare hits", () => {
+    const fill = byId("funk-fill-4");
+    expect(fill.barInterval).toBe(4);
+    expect(fill.barPhase).toBe(3);
+    expect(variationFiresOnBar(fill, 3)).toBe(true);
+    expect(variationFiresOnBar(fill, 0)).toBe(false);
+    expect(fill.pattern.snares?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("jazz-turnaround-4 fires on the turnaround bar with a ride accent", () => {
+    const turn = byId("jazz-turnaround-4");
+    expect(turn.barInterval).toBe(4);
+    expect(turn.barPhase).toBe(3);
+    expect(variationFiresOnBar(turn, 3)).toBe(true);
+    expect(variationFiresOnBar(turn, 0)).toBe(false);
+    expect(turn.pattern.ride?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("blues-fill-4 fires on the turnaround bar with a snare buildup", () => {
+    const fill = byId("blues-fill-4");
+    expect(fill.barInterval).toBe(4);
+    expect(fill.barPhase).toBe(3);
+    expect(variationFiresOnBar(fill, 3)).toBe(true);
+    expect(variationFiresOnBar(fill, 7)).toBe(true);
+    expect(fill.pattern.snares?.length ?? 0).toBeGreaterThan(0);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm exec vitest run src/progressions/audio/patterns.test.ts`
+Expected: FAIL — the count test fails with "expected length 3 to be 6", and the three new tests throw `missing variation funk-fill-4` / `jazz-turnaround-4` / `blues-fill-4`.
+
+- [ ] **Step 3: Append the three variations to `DRUM_VARIATIONS`**
+
+In `src/progressions/audio/patterns.ts`, inside the `DRUM_VARIATIONS` array (after the `crash-bar-1` entry that ends at line 464, before the closing `];`), add:
+
+```ts
+  {
+    id: "funk-fill-4",
+    label: "Funk Turnaround Fill",
+    barInterval: 4,
+    barPhase: 3,
+    pattern: {
+      id: "funk-fill-4-pattern",
+      label: "Funk Fill",
+      kicks: [{ beat: 0, velocity: 0.9 }],
+      snares: [
+        { beat: 2, velocity: 0.4 },
+        { beat: 2.5, velocity: 0.5 },
+        { beat: 2.75, velocity: 0.4 },
+        { beat: 3, velocity: 0.6 },
+        { beat: 3.25, velocity: 0.6 },
+        { beat: 3.5, velocity: 0.8 },
+        { beat: 3.75, velocity: 0.9 },
+      ],
+      hats: [],
+    },
+  },
+  {
+    id: "jazz-turnaround-4",
+    label: "Jazz Turnaround",
+    barInterval: 4,
+    barPhase: 3,
+    pattern: {
+      id: "jazz-turnaround-4-pattern",
+      label: "Jazz Turnaround",
+      kicks: [],
+      snares: [
+        { beat: 2, velocity: 0.35 },
+        { beat: 2.5, velocity: 0.4 },
+        { beat: 3, velocity: 0.45 },
+        { beat: 3.5, velocity: 0.55 },
+      ],
+      hats: [],
+      ride: [{ beat: 3, velocity: 0.6 }],
+    },
+  },
+  {
+    id: "blues-fill-4",
+    label: "Blues Shuffle Fill",
+    barInterval: 4,
+    barPhase: 3,
+    pattern: {
+      id: "blues-fill-4-pattern",
+      label: "Blues Fill",
+      kicks: [{ beat: 0, velocity: 0.9 }],
+      snares: [
+        { beat: 2, velocity: 0.5 },
+        { beat: 2.5, velocity: 0.6 },
+        { beat: 3, velocity: 0.7 },
+        { beat: 3.5, velocity: 0.9 },
+      ],
+      hats: [],
+    },
+  },
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm exec vitest run src/progressions/audio/patterns.test.ts`
+Expected: PASS — all tests green, including the `[0, 4)` beat-range check (every new beat is ≤ 3.75).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/progressions/audio/patterns.ts src/progressions/audio/patterns.test.ts
+git commit -m "feat(progressions): add funk/jazz/blues turnaround drum variations"
+```
+
+---
+
+### Task 2: Wire the genre variation assignments
+
+**Files:**
+- Modify: `src/progressions/audio/genres.ts:16-59` (`GENRE_STYLES`)
+- Test: `src/progressions/audio/genres.test.ts`
+
+- [ ] **Step 1: Replace the deferral test and add positive assignment tests**
+
+In `src/progressions/audio/genres.test.ts`, the `describe("genre drum variations", ...)` block has a test titled `"does NOT assign fill-every-4 to any genre (genre default sets deferred)"`. Its premise is now invalid (we assign `fill-every-4` to pop and rock). **Delete that entire `it(...)` block** and replace it with these tests (keep the existing "wires per-bar-safe variations…" and "keeps every referenced variation id resolvable" tests as-is):
+
+```ts
+  it("gives pop and rock a turnaround fill, and rock a phrase-start crash", () => {
+    expect(getGenreStyle("pop")!.drumVariations).toContain("fill-every-4");
+    expect(getGenreStyle("rock")!.drumVariations).toContain("fill-every-4");
+    expect(getGenreStyle("rock")!.drumVariations).toContain("crash-bar-1");
+  });
+
+  it("gives funk, jazz, and blues their genre-tailored turnaround", () => {
+    expect(getGenreStyle("funk")!.drumVariations).toContain("funk-fill-4");
+    expect(getGenreStyle("jazz")!.drumVariations).toContain("jazz-turnaround-4");
+    expect(getGenreStyle("blues")!.drumVariations).toContain("blues-fill-4");
+  });
+
+  it("leaves ballad and bossa-nova without drum variations", () => {
+    expect(getGenreStyle("ballad")!.drumVariations).toEqual([]);
+    expect(getGenreStyle("bossa-nova")!.drumVariations).toEqual([]);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm exec vitest run src/progressions/audio/genres.test.ts`
+Expected: FAIL — the two new "gives …" tests fail because pop/rock/funk/jazz/blues do not yet carry the new ids. (The "leaves ballad and bossa-nova…" test already passes; the "resolvable" test still passes.)
+
+- [ ] **Step 3: Update the genre assignments**
+
+In `src/progressions/audio/genres.ts`, edit the `drumVariations` field of five genres. Apply each replacement:
+
+pop (line ~20):
+```ts
+    drumPattern: "pop", drumVariations: ["open-hat-and-of-4", "fill-every-4"],
+```
+
+rock (line ~26):
+```ts
+    drumPattern: "rock", drumVariations: ["open-hat-and-of-4", "crash-bar-1", "fill-every-4"],
+```
+
+blues (line ~32):
+```ts
+    drumPattern: "blues-shuffle", drumVariations: ["blues-fill-4"],
+```
+
+jazz (line ~38):
+```ts
+    drumPattern: "jazz-ride", drumVariations: ["jazz-turnaround-4"],
+```
+
+funk (line ~50):
+```ts
+    drumPattern: "funk", drumVariations: ["open-hat-and-of-4", "funk-fill-4"],
+```
+
+Leave `ballad` and `bossa-nova` with `drumVariations: []` unchanged.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm exec vitest run src/progressions/audio/genres.test.ts`
+Expected: PASS — all genre tests green, including the existing "keeps every referenced variation id resolvable" test (proves no dangling ids: the new `funk-fill-4`/`jazz-turnaround-4`/`blues-fill-4` all resolve via `getDrumVariation`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/progressions/audio/genres.ts src/progressions/audio/genres.test.ts
+git commit -m "feat(progressions): wire genre default drum variation sets"
+```
+
+---
+
+### Task 3: Full verification + ear audition
+
+The drum-variation engine path (gating on `absoluteBar`, merge with base pattern, cross-run determinism) is already covered by `buildAllLayers.test.ts` → `describe("drum variation gating (absolute bar)")` using `fill-every-4`, which shares the identical `barInterval: 4, barPhase: 3` path as the new variations. No new engine test is needed (DRY) — the new variations are pure data exercised through that proven path.
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `pnpm run test`
+Expected: PASS — entire suite green. Watch specifically that `buildAllLayers.test.ts` still passes (the new genre assignments do not change `baseInput`, which uses explicit `drumVariations`).
+
+- [ ] **Step 2: Run lint and build**
+
+Run: `pnpm run lint && pnpm run build`
+Expected: both succeed with no errors.
+
+- [ ] **Step 3: Ear audition (manual — required by spec §3.2 / §9)**
+
+Run: `pnpm run dev`
+For each of **pop, rock, funk, jazz, blues**: select the genre, load a progression of at least 4 bars, play it, and listen to the 4th bar of each phrase.
+
+Confirm:
+- pop / rock: the turnaround bar has an audible snare fill; rock's phrase-start (bar 1, 5, 9…) has a crash accent.
+- funk: the turnaround bar adds a syncopated ghost-snare flurry without muddying the 16th groove.
+- jazz: the turnaround is a soft brush buildup with a ride accent — not a loud rock fill.
+- blues: the turnaround is a swung shuffle fill (the genre swing should make it feel triplet-y).
+
+If any fill clashes or feels wrong, tune the beat tables in `patterns.ts` (§6 of the spec lists the starting values) and apply as a small follow-up commit. Note any by-ear adjustments made.
+
+- [ ] **Step 4: Finish the branch**
+
+Use the superpowers:finishing-a-development-branch skill to decide on merge/PR.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §6.1 `funk-fill-4` → Task 1. §6.2 `jazz-turnaround-4` → Task 1. §6.3 `blues-fill-4` → Task 1.
+- §7 genre assignments (pop, rock, funk, jazz, blues; ballad/bossa empty) → Task 2.
+- §9 unit tests (gating bars 3/7/11, resolution, ballad/bossa empty, no dangling ids) → Tasks 1–2. §9 determinism → already covered by existing `buildAllLayers.test.ts` (noted in Task 3). §9 ear audition → Task 3 Step 3.
+- §8 backwards-compat (pop/rock/funk keep `open-hat-and-of-4`; ballad/bossa byte-identical) → enforced by Task 2 assignments + the "leaves ballad and bossa-nova…" test.
+
+**Placeholder scan:** none — every code step shows complete code and exact commands.
+
+**Type consistency:** new variations are `DrumVariation` objects with `id`/`label`/`barInterval`/`barPhase`/`pattern` (a `CatalogDrumPattern` using `kicks`/`snares`/`hats`/`ride`), matching the existing entries and the `DrumVariation` interface at `patterns.ts:76-83`. Genre `drumVariations` are `string[]` of ids that all resolve via `getDrumVariation`. Test imports (`DRUM_VARIATIONS`, `variationFiresOnBar`, `getDrumVariation`, `getGenreStyle`) already exist in the respective test files.

--- a/docs/superpowers/specs/2026-06-01-genre-drum-variation-sets-design.md
+++ b/docs/superpowers/specs/2026-06-01-genre-drum-variation-sets-design.md
@@ -1,0 +1,235 @@
+# Genre Default Drum Variation Sets
+
+**Status:** Design — approved in brainstorming 2026-06-01.
+**Date:** 2026-06-01
+**Parent slice:** `2026-05-29-phrase-aware-multibar-variation-design.md` (Slice 2).
+This spec implements the **§3.2 "genre-appropriate default variation sets"
+fast-follow-up** that the scheduler spec
+(`2026-05-31-phrase-aware-scheduler-design.md`) explicitly deferred. The
+scheduler spec shipped the *mechanism* — `variationFiresOnBar` + a monotonic
+absolute-bar index in `buildAllLayersAsync` (PR #491). This spec ships the
+*content*: turnaround fills / accents wired to genres, plus three new
+genre-tailored variations.
+
+---
+
+## 1. Goal
+
+Make each genre's backing track develop over a 4-bar phrase by assigning
+genre-appropriate drum variations (turnaround fills and phrase-start accents)
+to the genres that musically call for one — and author three new variations so
+those turnarounds sound idiomatic (a funk ghost-snare flurry, a jazz brush
+turnaround, a blues shuffle fill) rather than reusing a single rock-style snare
+buildup everywhere.
+
+## 2. Scope
+
+**In scope**
+
+- Three new entries in `DRUM_VARIATIONS` (`patterns.ts`): `funk-fill-4`,
+  `jazz-turnaround-4`, `blues-fill-4`.
+- Genre assignment changes in `GENRE_STYLES` (`genres.ts`) for pop, rock, funk,
+  jazz, blues.
+- Unit tests for the new variations' gating and the genre assignments.
+- A manual ear audition pass per genre (the parent spec's required step).
+
+**Out of scope**
+
+- No new drum voices — every new variation uses existing kit voices (kick,
+  snare, ride). `drumKit.ts` / `instrumentPatches.ts` are untouched.
+- No bossa-nova work. The bossa drum identity is a 2-bar clave overhaul (§3.5);
+  a generic fill now would only get rewritten. Bossa's `drumVariations` stays
+  empty.
+- No ballad fill. Ballad is intentionally sparse; a turnaround fill fights the
+  mood. Its `drumVariations` stays empty.
+- No phrase-aware chord rhythm (§3.3), end-of-phrase bass walk (§3.4), or
+  `phraseLengthBars` input param. The fills key off each variation's own
+  `barInterval`, exactly as the scheduler spec's interval+phase model intends.
+
+## 3. Current state
+
+The mechanism is live but underused. `DRUM_VARIATIONS` defines three
+variations:
+
+- `open-hat-and-of-4` — `barInterval: 1` (fires every bar). Assigned to pop,
+  rock, funk.
+- `fill-every-4` — `barInterval: 4, barPhase: 3` (snare buildup on the 4th bar).
+  **Defined but assigned to no genre.**
+- `crash-bar-1` — `barInterval: 4, barPhase: 0` (ride accent on the 1st bar of
+  each 4-bar group). **Defined but assigned to no genre.**
+
+Genre assignments today (`genres.ts`):
+
+| Genre | drumVariations |
+|---|---|
+| pop, rock, funk | `["open-hat-and-of-4"]` |
+| blues, jazz, ballad, bossa-nova | `[]` |
+
+## 4. Engine conventions (constraints the new tables must obey)
+
+Confirmed by reading `DRUM_PATTERNS` and `DRUM_VARIATIONS` in `patterns.ts`:
+
+- Beats are **0-indexed quarter-note positions** in a 4/4 bar: `0, 1, 2, 3`.
+- Subdivisions use decimals: `.5` = eighth, `.25` / `.75` = sixteenths.
+- **No triplet subdivisions** (`.33` / `.67`) appear anywhere. Shuffle / swing
+  feel is produced by the genre `swing` param applied to off-beat eighths, not
+  by authoring triplet beat positions. New blues/jazz fills must therefore use
+  `.5` eighths and rely on the genre swing, not hand-written triplets.
+- A `DrumHit` is `{ beat, velocity }`; velocity is `0..1`.
+- A variation's `pattern` is a `CatalogDrumPattern` with optional `kicks`,
+  `snares`, `hats`, `openHats`, `ride` arrays.
+
+## 5. Firing & merge model (from the scheduler spec — unchanged)
+
+- A variation fires on absolute bar `N` when
+  `N % barInterval === (barPhase ?? 0)`, via `variationFiresOnBar`.
+- `absoluteBar` is monotonic across the whole progression (never reset per
+  step), and only feeds the gating decision — never jitter seeds.
+- On a bar where a variation fires, its hits are **merged on top of** the base
+  drum pattern's hits for that bar (base + variation, both play). A busier
+  turnaround bar is the intended "fill" effect.
+
+## 6. New variations (`DRUM_VARIATIONS` in `patterns.ts`)
+
+All three are `barInterval: 4, barPhase: 3` — they fire on the **4th bar of each
+4-bar phrase** (absolute bars 3, 7, 11, …), the turnaround position. Beat tables
+below are tuned-by-eye starting points and are expected to be nudged during the
+ear audition (§9).
+
+### 6.1 `funk-fill-4` — 16th-note ghost-snare flurry into the one
+
+```ts
+{
+  id: "funk-fill-4",
+  label: "Funk Turnaround Fill",
+  barInterval: 4,
+  barPhase: 3,
+  pattern: {
+    id: "funk-fill-4-pattern",
+    label: "Funk Fill",
+    kicks: [{ beat: 0, velocity: 0.9 }],
+    snares: [
+      { beat: 2, velocity: 0.4 },
+      { beat: 2.5, velocity: 0.5 },
+      { beat: 2.75, velocity: 0.4 },
+      { beat: 3, velocity: 0.6 },
+      { beat: 3.25, velocity: 0.6 },
+      { beat: 3.5, velocity: 0.8 },
+      { beat: 3.75, velocity: 0.9 },
+    ],
+    hats: [],
+  },
+}
+```
+
+### 6.2 `jazz-turnaround-4` — soft brush buildup + ride accent
+
+Low velocities to match the jazz base pattern's brushy dynamics (snares ~0.3,
+kicks ~0.15). A ride accent on beat 3 leads into the next phrase.
+
+```ts
+{
+  id: "jazz-turnaround-4",
+  label: "Jazz Turnaround",
+  barInterval: 4,
+  barPhase: 3,
+  pattern: {
+    id: "jazz-turnaround-4-pattern",
+    label: "Jazz Turnaround",
+    kicks: [],
+    snares: [
+      { beat: 2, velocity: 0.35 },
+      { beat: 2.5, velocity: 0.4 },
+      { beat: 3, velocity: 0.45 },
+      { beat: 3.5, velocity: 0.55 },
+    ],
+    hats: [],
+    ride: [{ beat: 3, velocity: 0.6 }],
+  },
+}
+```
+
+### 6.3 `blues-fill-4` — eighth-note shuffle fill
+
+Eighth-note snare buildup; the blues genre's `swing: 0.33` turns the off-beats
+into a triplet shuffle fill.
+
+```ts
+{
+  id: "blues-fill-4",
+  label: "Blues Shuffle Fill",
+  barInterval: 4,
+  barPhase: 3,
+  pattern: {
+    id: "blues-fill-4-pattern",
+    label: "Blues Fill",
+    kicks: [{ beat: 0, velocity: 0.9 }],
+    snares: [
+      { beat: 2, velocity: 0.5 },
+      { beat: 2.5, velocity: 0.6 },
+      { beat: 3, velocity: 0.7 },
+      { beat: 3.5, velocity: 0.9 },
+    ],
+    hats: [],
+  },
+}
+```
+
+## 7. Genre assignments (`GENRE_STYLES` in `genres.ts`)
+
+| Genre | drumVariations (new) | Rationale |
+|---|---|---|
+| pop | `["open-hat-and-of-4", "fill-every-4"]` | keep groove embellishment, add a turnaround fill on bar 4 |
+| rock | `["open-hat-and-of-4", "crash-bar-1", "fill-every-4"]` | crash on phrase-start (bar 1), snare fill on phrase-end (bar 4) — a full 4-bar arc |
+| funk | `["open-hat-and-of-4", "funk-fill-4"]` | keep groove embellishment, add the funk ghost-snare fill |
+| jazz | `["jazz-turnaround-4"]` | brush turnaround (the parent spec's canonical `bar % 4 === 3` example) |
+| blues | `["blues-fill-4"]` | shuffle turnaround fill |
+| ballad | `[]` | unchanged — intentionally sparse |
+| bossa-nova | `[]` | unchanged — defer to §3.5 clave overhaul |
+
+`fill-every-4` and `crash-bar-1` already exist with the correct
+`barInterval`/`barPhase`; assigning them is pure wiring. The phrase arc for
+rock/pop is: crash on absolute bars 0/4/8…, fill on absolute bars 3/7/11….
+
+## 8. Backwards-compat & determinism
+
+- pop/rock/funk keep `open-hat-and-of-4` (fires every bar) — their existing
+  groove is preserved; the new variations only add hits on phrase boundaries.
+- ballad and bossa-nova are byte-identical to today (still empty
+  `drumVariations`).
+- All gating is a pure function of `absoluteBar` + each variation's
+  interval/phase — no `Date.now` / `Math.random`. Same input → identical event
+  stream across runs (the scheduler spec's determinism guarantee is preserved).
+
+## 9. Testing strategy
+
+**Unit (`patterns.test.ts` / `genres.test.ts`):**
+
+1. `variationFiresOnBar(funk-fill-4, N)` is true exactly for `N % 4 === 3`
+   (bars 3, 7, 11) and false for bars 0–2, 4–6; same for `jazz-turnaround-4`
+   and `blues-fill-4`.
+2. Each new variation resolves via `getDrumVariation(id)` and has a non-empty
+   `pattern` (at least one hit array with entries).
+3. Every id listed in each genre's `drumVariations` resolves to a real
+   `DrumVariation` via `getDrumVariation` (no dangling ids) — covers all
+   genres, guarding the new assignments.
+4. ballad and bossa-nova have empty `drumVariations`.
+5. A `buildAllLayers` determinism check: a genre with a new fill (e.g. blues
+   or funk) built twice over a ≥4-bar progression yields identical drum event
+   streams.
+
+**Manual ear audition (required by the parent spec §3.2):**
+
+For each of pop, rock, funk, jazz, blues — play a ≥4-bar progression and
+confirm the turnaround bar reads as an idiomatic fill/accent and does not
+clash with the base groove. Tune the beat tables in §6 by ear; apply tweaks as
+small follow-up commits.
+
+## 10. Files touched
+
+- `src/progressions/audio/patterns.ts` — add 3 `DRUM_VARIATIONS` entries.
+- `src/progressions/audio/genres.ts` — update `drumVariations` for pop, rock,
+  funk, jazz, blues.
+- `src/progressions/audio/patterns.test.ts` — gating + resolution tests.
+- `src/progressions/audio/genres.test.ts` — assignment / no-dangling-id tests.
+- (possibly) `src/progressions/audio/buildAllLayers.test.ts` — determinism check.

--- a/src/progressions/audio/genres.test.ts
+++ b/src/progressions/audio/genres.test.ts
@@ -68,10 +68,21 @@ describe("genre drum variations", () => {
     expect(getGenreStyle("rock")!.drumVariations).toContain("open-hat-and-of-4");
   });
 
-  it("does NOT assign fill-every-4 to any genre (genre default sets deferred)", () => {
-    for (const g of GENRE_STYLES) {
-      expect(g.drumVariations, `genre ${g.id}`).not.toContain("fill-every-4");
-    }
+  it("gives pop and rock a turnaround fill, and rock a phrase-start crash", () => {
+    expect(getGenreStyle("pop")!.drumVariations).toContain("fill-every-4");
+    expect(getGenreStyle("rock")!.drumVariations).toContain("fill-every-4");
+    expect(getGenreStyle("rock")!.drumVariations).toContain("crash-bar-1");
+  });
+
+  it("gives funk, jazz, and blues their genre-tailored turnaround", () => {
+    expect(getGenreStyle("funk")!.drumVariations).toContain("funk-fill-4");
+    expect(getGenreStyle("jazz")!.drumVariations).toContain("jazz-turnaround-4");
+    expect(getGenreStyle("blues")!.drumVariations).toContain("blues-fill-4");
+  });
+
+  it("leaves ballad and bossa-nova without drum variations", () => {
+    expect(getGenreStyle("ballad")!.drumVariations).toEqual([]);
+    expect(getGenreStyle("bossa-nova")!.drumVariations).toEqual([]);
   });
 
   it("keeps every referenced variation id resolvable", () => {

--- a/src/progressions/audio/genres.ts
+++ b/src/progressions/audio/genres.ts
@@ -17,25 +17,25 @@ export const GENRE_STYLES: readonly GenreStyle[] = [
   {
     id: "pop", label: "Pop", chordInstrument: "piano",
     chordPattern: "straight-quarters", bassPattern: "root-fifth",
-    drumPattern: "pop", drumVariations: ["open-hat-and-of-4"],
+    drumPattern: "pop", drumVariations: ["open-hat-and-of-4", "fill-every-4"],
     tempoRange: [100, 130], suggestedTempo: 115, swing: 0,
   },
   {
     id: "rock", label: "Rock", chordInstrument: "strum",
     chordPattern: "pop-8ths", bassPattern: "pedal",
-    drumPattern: "rock", drumVariations: ["open-hat-and-of-4"],
+    drumPattern: "rock", drumVariations: ["open-hat-and-of-4", "crash-bar-1", "fill-every-4"],
     tempoRange: [110, 140], suggestedTempo: 120, swing: 0,
   },
   {
     id: "blues", label: "Blues", chordInstrument: "organ",
     chordPattern: "shuffle-comp", bassPattern: "shuffle",
-    drumPattern: "blues-shuffle", drumVariations: [],
+    drumPattern: "blues-shuffle", drumVariations: ["blues-fill-4"],
     tempoRange: [70, 110], suggestedTempo: 85, swing: 0.33,
   },
   {
     id: "jazz", label: "Jazz", chordInstrument: "piano",
     chordPattern: "jazz-comp", bassPattern: "walking",
-    drumPattern: "jazz-ride", drumVariations: [],
+    drumPattern: "jazz-ride", drumVariations: ["jazz-turnaround-4"],
     tempoRange: [100, 160], suggestedTempo: 130, swing: 0.33,
   },
   {
@@ -47,7 +47,7 @@ export const GENRE_STYLES: readonly GenreStyle[] = [
   {
     id: "funk", label: "Funk", chordInstrument: "strum",
     chordPattern: "funk-scratch", bassPattern: "funk-syncopated",
-    drumPattern: "funk", drumVariations: ["open-hat-and-of-4"],
+    drumPattern: "funk", drumVariations: ["open-hat-and-of-4", "funk-fill-4"],
     tempoRange: [96, 120], suggestedTempo: 110, swing: 0,
   },
   {

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -106,8 +106,8 @@ describe("pattern catalog", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("has 3 drum variations with unique IDs", () => {
-    expect(DRUM_VARIATIONS).toHaveLength(3);
+  it("has 6 drum variations with unique IDs", () => {
+    expect(DRUM_VARIATIONS).toHaveLength(6);
     const ids = DRUM_VARIATIONS.map((v) => v.id);
     expect(new Set(ids).size).toBe(ids.length);
   });
@@ -433,5 +433,33 @@ describe("DRUM_VARIATIONS definitions are truthful", () => {
     const oh = byId("open-hat-and-of-4");
     expect(oh.barInterval).toBe(1);
     expect([0, 1, 2, 3].every((b) => variationFiresOnBar(oh, b))).toBe(true);
+  });
+
+  it("funk-fill-4 fires on the turnaround bar with snare buildup hits", () => {
+    const fill = byId("funk-fill-4");
+    expect(fill.barInterval).toBe(4);
+    expect(fill.barPhase).toBe(3);
+    expect(variationFiresOnBar(fill, 3)).toBe(true);
+    expect(variationFiresOnBar(fill, 0)).toBe(false);
+    expect(fill.pattern.snares.length).toBeGreaterThan(0);
+  });
+
+  it("jazz-turnaround-4 fires on the turnaround bar with a ride accent", () => {
+    const turn = byId("jazz-turnaround-4");
+    expect(turn.barInterval).toBe(4);
+    expect(turn.barPhase).toBe(3);
+    expect(variationFiresOnBar(turn, 3)).toBe(true);
+    expect(variationFiresOnBar(turn, 0)).toBe(false);
+    expect(turn.pattern.ride).toBeDefined();
+    expect(turn.pattern.ride!.length).toBeGreaterThan(0);
+  });
+
+  it("blues-fill-4 fires on the turnaround bar with a snare buildup", () => {
+    const fill = byId("blues-fill-4");
+    expect(fill.barInterval).toBe(4);
+    expect(fill.barPhase).toBe(3);
+    expect(variationFiresOnBar(fill, 3)).toBe(true);
+    expect(variationFiresOnBar(fill, 7)).toBe(true);
+    expect(fill.pattern.snares.length).toBeGreaterThan(0);
   });
 });

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -462,6 +462,64 @@ export const DRUM_VARIATIONS: readonly DrumVariation[] = [
       ride: [{ beat: 0, velocity: 0.9 }],
     },
   },
+  {
+    id: "funk-fill-4",
+    label: "Funk Turnaround Fill",
+    barInterval: 4,
+    barPhase: 3,
+    pattern: {
+      id: "funk-fill-4-pattern",
+      label: "Funk Fill",
+      kicks: [{ beat: 0, velocity: 0.9 }],
+      snares: [
+        { beat: 2, velocity: 0.4 },
+        { beat: 2.5, velocity: 0.5 },
+        { beat: 2.75, velocity: 0.4 },
+        { beat: 3, velocity: 0.6 },
+        { beat: 3.25, velocity: 0.6 },
+        { beat: 3.5, velocity: 0.8 },
+        { beat: 3.75, velocity: 0.9 },
+      ],
+      hats: [],
+    },
+  },
+  {
+    id: "jazz-turnaround-4",
+    label: "Jazz Turnaround",
+    barInterval: 4,
+    barPhase: 3,
+    pattern: {
+      id: "jazz-turnaround-4-pattern",
+      label: "Jazz Turnaround",
+      kicks: [],
+      snares: [
+        { beat: 2, velocity: 0.35 },
+        { beat: 2.5, velocity: 0.4 },
+        { beat: 3, velocity: 0.45 },
+        { beat: 3.5, velocity: 0.55 },
+      ],
+      hats: [],
+      ride: [{ beat: 3, velocity: 0.6 }],
+    },
+  },
+  {
+    id: "blues-fill-4",
+    label: "Blues Shuffle Fill",
+    barInterval: 4,
+    barPhase: 3,
+    pattern: {
+      id: "blues-fill-4-pattern",
+      label: "Blues Fill",
+      kicks: [{ beat: 0, velocity: 0.9 }],
+      snares: [
+        { beat: 2, velocity: 0.5 },
+        { beat: 2.5, velocity: 0.6 },
+        { beat: 3, velocity: 0.7 },
+        { beat: 3.5, velocity: 0.9 },
+      ],
+      hats: [],
+    },
+  },
 ];
 
 export function getChordPattern(id: string): ChordPattern | undefined {


### PR DESCRIPTION
## Summary

Wires genre-appropriate drum turnaround fills/accents to genres — the §3.2 "genre default variation sets" fast-follow-up that the phrase-aware scheduler ([#491](https://github.com/iecg/fretboard-app/pull/491)) deferred. The gating mechanism (`variationFiresOnBar` + monotonic absolute-bar index) already shipped; this PR adds the *content* that rides that proven, untouched engine path.

- **Three new turnaround variations** in `DRUM_VARIATIONS` (`patterns.ts`), all `barInterval: 4, barPhase: 3` (fire on the 4th bar of each 4-bar phrase):
  - `funk-fill-4` — 16th-note ghost-snare flurry into the one
  - `jazz-turnaround-4` — soft brush buildup + ride accent (matches jazz's low dynamics, not a rock fill)
  - `blues-fill-4` — eighth-note buildup; the blues `swing: 0.33` turns it into a triplet shuffle fill
- **Genre assignments** (`genres.ts`): pop `[open-hat-and-of-4, fill-every-4]`, rock `[open-hat-and-of-4, crash-bar-1, fill-every-4]` (crash on phrase-start, fill on phrase-end), funk `[open-hat-and-of-4, funk-fill-4]`, jazz `[jazz-turnaround-4]`, blues `[blues-fill-4]`.
- **ballad** and **bossa-nova** intentionally left empty — ballad stays sparse; bossa's drum identity is the 2-bar clave overhaul (§3.5).

No engine changes, no new drum voices. Backwards-compatible: pop/rock/funk keep `open-hat-and-of-4`; ballad/bossa byte-identical. Fully deterministic (gating is a pure function of absolute bar).

Spec: `docs/superpowers/specs/2026-06-01-genre-drum-variation-sets-design.md`
Plan: `docs/superpowers/plans/2026-06-01-genre-drum-variation-sets.md`

## Test Plan

- [x] `pnpm run test` — 2211 pass (gating bars 3/7/11, no dangling variation ids, ballad/bossa empty, `[0,4)` beat range)
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run build` — succeeds
- [ ] **Ear audition** (per spec §9): play a ≥4-bar progression in pop/rock/funk/jazz/blues; confirm each turnaround bar reads as an idiomatic fill/accent and doesn't clash with the base groove. Beat tables are tuned-by-eye starting points — nudge by ear if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced three new drum fill variations for Funk, Jazz, and Blues genres with genre-specific turnaround patterns.
  * Enhanced drum patterns for Pop and Rock genres with additional fill variations.
  * Updated drum variation assignments across multiple genres for improved musical variety.

* **Tests**
  * Extended test coverage to verify new drum variations and ensure genre-specific patterns are correctly applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->