### PR TITLE
style(progression): fix harsh near-white surfaces in light-mode progression card

### DIFF
--- a/docs/superpowers/plans/2026-06-01-progression-card-light-surfaces.md
+++ b/docs/superpowers/plans/2026-06-01-progression-card-light-surfaces.md
@@ -1,0 +1,289 @@
+# Progression Card Light-Mode Surface Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restyle the Song-tab Progression card's harsh near-white light-mode surfaces (degree chip, notes strip, nav pip) and differentiate the editor panel from the active step row, in both themes.
+
+**Architecture:** CSS-only. Add three per-theme semantic tokens (`--faceplate-inset`, `--faceplate-key`, `--faceplate-surface`) whose dark values reproduce the current hardcoded `color-mix` expressions verbatim (so dark mode is byte-identical) and whose light values route through the existing warm surface ladder. Three component CSS modules then reference the tokens instead of hardcoded expressions.
+
+**Tech Stack:** CSS Modules, CSS custom properties (theme data-attribute overrides), Vite, Vitest, Playwright visual regression.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-progression-card-light-surfaces-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/styles/semantic.css` | Theme token definitions | Add 3 tokens to the light and dark faceplate blocks |
+| `src/components/SongControls/ProgressionStepList.module.css` | Step-list row + chip styling | `.chip` background → token |
+| `src/components/SongControls/SongControls.module.css` | Editor panel + pager styling | `.editor-pager` + `.editor-panel` backgrounds → token |
+| `src/components/SongControls/ChordTonesReadout.module.css` | Notes strip styling | `.readout` + `.tone` backgrounds → tokens |
+
+No TypeScript, component, or markup changes.
+
+---
+
+## Reference: token values
+
+Add identical token *names* to both theme blocks; values differ per theme.
+
+| Token | Dark value (must equal current expression) | Light value |
+|---|---|---|
+| `--faceplate-inset` | `color-mix(in srgb, var(--faceplate-bg) 60%, transparent)` | `var(--surface-well)` |
+| `--faceplate-key` | `color-mix(in srgb, var(--text-main) 3%, transparent)` | `var(--surface-card-nested)` |
+| `--faceplate-surface` | `var(--faceplate-bg-elevated)` | `var(--surface-card-top)` |
+
+Token blocks in `src/styles/semantic.css`:
+- Dark `:root` faceplate block — `--faceplate-bg: #0a121d;` near **line 214**.
+- Light `[data-theme="modern-light"]` faceplate block — `--faceplate-bg: #f6f2e9;` near **line 275**.
+- Dark `[data-theme="modern-dark"]` faceplate block — `--faceplate-bg: #0a121d;` near **line 333**.
+
+The dark `:root` block and the explicit `[data-theme="modern-dark"]` block carry identical faceplate values today; add the three tokens to **both** so an explicit dark selection and the default both resolve them.
+
+---
+
+## Task 1: Add the three tokens to the dark faceplate blocks
+
+**Files:**
+- Modify: `src/styles/semantic.css` (dark `:root` block ~line 214–221; dark `[data-theme="modern-dark"]` block ~line 333–340)
+
+- [ ] **Step 1: Read the current dark faceplate blocks**
+
+Run: open `src/styles/semantic.css` and confirm both dark blocks contain:
+```css
+  --faceplate-bg: #0a121d;
+  --faceplate-bg-elevated: #0d1726;
+  ...
+  --faceplate-divider: rgb(255 255 255 / 0.06);
+  ...
+  --faceplate-accent: var(--neon-cyan);
+```
+Confirm `--text-main` resolves to a light value in dark mode (so `--faceplate-key` stays subtle).
+
+- [ ] **Step 2: Add the tokens after `--faceplate-accent-glow` in the dark `:root` block (~line 221)**
+
+Insert:
+```css
+  /* Progression-card sunken surfaces — dark values reproduce the historical
+     inline expressions so dark mode is unchanged. Light values (in the
+     modern-light block) route through the warm surface ladder instead. */
+  --faceplate-inset: color-mix(in srgb, var(--faceplate-bg) 60%, transparent);
+  --faceplate-key: color-mix(in srgb, var(--text-main) 3%, transparent);
+  --faceplate-surface: var(--faceplate-bg-elevated);
+```
+
+- [ ] **Step 3: Add the identical block to the explicit `[data-theme="modern-dark"]` block (~line 340)**
+
+Insert the same three `--faceplate-inset` / `--faceplate-key` / `--faceplate-surface` declarations (with the same comment) after that block's `--faceplate-accent-glow`.
+
+- [ ] **Step 4: Verify the build compiles the CSS**
+
+Run: `pnpm run build`
+Expected: build succeeds (`tsc -b && vite build`), no CSS parse errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/styles/semantic.css
+git commit -m "style(theme): add faceplate inset/key/surface tokens (dark = current behavior)"
+```
+
+---
+
+## Task 2: Add the light-mode token values
+
+**Files:**
+- Modify: `src/styles/semantic.css` (light `[data-theme="modern-light"]` faceplate block ~line 275–294)
+
+- [ ] **Step 1: Confirm the ladder tokens exist in scope**
+
+Run: `grep -n "surface-well\|surface-card-nested\|surface-card-top" src/styles/themes.css`
+Expected: all three are defined in the `[data-theme="modern-light"]` block of `themes.css` (`--surface-well: #ddd8cf`, `--surface-card-nested: #f1ede3`, `--surface-card-top: #f6f2e9`). They cascade, so `semantic.css` can reference them.
+
+- [ ] **Step 2: Add the light token values after `--faceplate-accent-glow` in the modern-light block (~line 282)**
+
+Insert:
+```css
+  /* Progression-card sunken surfaces — route through the warm light ladder
+     (well < card-soft < card-nested < card-top) so these read as genuine
+     recessed wells / raised keys instead of harsh near-white. */
+  --faceplate-inset: var(--surface-well);
+  --faceplate-key: var(--surface-card-nested);
+  --faceplate-surface: var(--surface-card-top);
+```
+
+- [ ] **Step 3: Verify the build compiles the CSS**
+
+Run: `pnpm run build`
+Expected: build succeeds, no CSS parse errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/styles/semantic.css
+git commit -m "style(theme): light-mode faceplate inset/key/surface route through warm ladder"
+```
+
+---
+
+## Task 3: Re-map the inactive degree chip
+
+**Files:**
+- Modify: `src/components/SongControls/ProgressionStepList.module.css` (`.chip` ~line 219)
+
+- [ ] **Step 1: Replace the `.chip` background**
+
+Find:
+```css
+  background-color: color-mix(in srgb, var(--faceplate-bg) 60%, transparent);
+```
+in the `.chip` rule and replace with:
+```css
+  background-color: var(--faceplate-inset);
+```
+Leave `.active .chip` (the teal override) untouched.
+
+- [ ] **Step 2: Verify in the running app (light + dark)**
+
+Start the preview server if not running, open the Song tab, and confirm the Progression step list. In **light** mode the inactive numeral chips (`V`, `vi`, `IV`) read as warm sunken wells (`#ddd8cf`), not near-white. In **dark** mode they look identical to before. The active chip stays teal.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/SongControls/ProgressionStepList.module.css
+git commit -m "style(progression): inactive degree chip uses sunken inset surface"
+```
+
+---
+
+## Task 4: Re-map the nav pip and the editor panel
+
+**Files:**
+- Modify: `src/components/SongControls/SongControls.module.css` (`.editor-panel` ~line 246, `.editor-pager` ~line 314)
+
+- [ ] **Step 1: Replace the `.editor-pager` background**
+
+Find (in `.editor-pager`):
+```css
+  background-color: color-mix(in srgb, var(--faceplate-bg) 60%, transparent);
+```
+Replace with:
+```css
+  background-color: var(--faceplate-inset);
+```
+
+- [ ] **Step 2: Replace the `.editor-panel` background**
+
+Find (in `.editor-panel`):
+```css
+  background-color: color-mix(in srgb, var(--faceplate-accent) 5%, transparent);
+```
+Replace with:
+```css
+  background-color: color-mix(in srgb, var(--faceplate-accent) 5%, var(--faceplate-surface));
+```
+Leave the `.editor-panel` border (`color-mix(... var(--faceplate-accent) 28% ...)`) and `box-shadow` untouched.
+
+- [ ] **Step 3: Verify in the running app (light + dark)**
+
+Open the chord editor (right pane of the Progression card). In **light** mode:
+- The `‹ 1 / 4 ›` pager reads as a warm sunken control, not near-white.
+- The editor panel reads as a raised, teal-framed, shadowed card — distinct from a selected step row (which stays a flat teal tint). 
+
+In **dark** mode confirm the pager is unchanged and the editor panel now sits on an opaque elevated base (`#0d1726`) that separates it from the active row's tint.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/SongControls/SongControls.module.css
+git commit -m "style(progression): sunken pager + raised editor panel surface"
+```
+
+---
+
+## Task 5: Re-map the notes strip
+
+**Files:**
+- Modify: `src/components/SongControls/ChordTonesReadout.module.css` (`.readout` ~line 11, `.tone` ~line 47)
+
+- [ ] **Step 1: Replace the `.readout` background**
+
+Find (in `.readout`):
+```css
+  background-color: color-mix(in srgb, var(--faceplate-bg) 60%, transparent);
+```
+Replace with:
+```css
+  background-color: var(--faceplate-inset);
+```
+
+- [ ] **Step 2: Replace the `.tone` background**
+
+Find (in `.tone`):
+```css
+  background-color: color-mix(in srgb, var(--text-main) 3%, transparent);
+```
+Replace with:
+```css
+  background-color: var(--faceplate-key);
+```
+Leave `.tone.root` (the teal override) untouched.
+
+- [ ] **Step 3: Verify in the running app (light + dark)**
+
+Open the chord editor and inspect the NOTES strip. In **light** mode the strip reads as a sunken well (`#ddd8cf`) holding raised note keys (`#f1ede3`) — the keys no longer out-white the editor panel. The root note (`C`) keeps its teal tint. In **dark** mode the strip and keys look identical to before.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/SongControls/ChordTonesReadout.module.css
+git commit -m "style(progression): notes strip uses sunken well + raised keys"
+```
+
+---
+
+## Task 6: Full verification and snapshot refresh
+
+**Files:**
+- Modify (generated): visual-regression snapshots under `e2e/` (`app-components`, `app-overlays`)
+
+- [ ] **Step 1: Lint**
+
+Run: `pnpm run lint`
+Expected: eslint + stylelint pass with no errors.
+
+- [ ] **Step 2: Unit/component tests**
+
+Run: `pnpm run test`
+Expected: all pass. (No assertions target these `color-mix` values, so none should change; if a snapshot test references the old inline expression, update it to the token.)
+
+- [ ] **Step 3: Production build**
+
+Run: `pnpm run build`
+Expected: succeeds.
+
+- [ ] **Step 4: Final visual check in both themes**
+
+In the running app, toggle light and dark mode and review the full Progression card one more time: degree chips, pager, notes strip, and editor panel all fit the theme; dark mode shows no regression beyond the intentional editor-panel separation.
+
+- [ ] **Step 5: Refresh darwin visual snapshots**
+
+Run: `pnpm run test:visual:update`
+Expected: the `app-components` and `app-overlays` suites regenerate the light-mode Progression-card snapshots. Inspect the diffs to confirm only the intended surfaces changed.
+
+- [ ] **Step 6: Commit the snapshot updates**
+
+```bash
+git add e2e
+git commit -m "test(visual): refresh snapshots for progression card light surfaces"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §1 tokens → Tasks 1–2; §2 element re-mapping (chip/pager/readout/tones) → Tasks 3, 4 (pager), 5; §3 editor surface → Task 4; §4 verification → Task 6. All spec sections mapped.
+- **Type/name consistency:** token names `--faceplate-inset`, `--faceplate-key`, `--faceplate-surface` are used identically across Tasks 1–5.
+- **Dark-mode invariance:** dark token values in Task 1 are the verbatim expressions previously inlined in `.chip`, `.editor-pager`, `.readout` (`faceplate-bg 60% transparent`) and `.tone` (`text-main 3% transparent`); `--faceplate-surface` introduces the only intentional dark change (editor-panel base), per spec §3.

--- a/docs/superpowers/specs/2026-06-01-progression-card-light-surfaces-design.md
+++ b/docs/superpowers/specs/2026-06-01-progression-card-light-surfaces-design.md
@@ -1,0 +1,103 @@
+# Progression Card — Light-Mode Surface Fix
+
+**Date:** 2026-06-01
+**Scope:** CSS-only restyle of the Song-tab Progression card in `modern-light`. No TypeScript or component-logic changes.
+
+## Problem
+
+In light mode, several surfaces in the Progression card read as harsh near-white that clashes with the warm parchment theme:
+
+1. **Inactive chord-list degree chip** (`ProgressionStepList .chip`)
+2. **Chord-edit notes strip** — the readout container and its note chips (`ChordTonesReadout .readout` / `.tone`)
+3. **Chord-edit navigation pip** (`SongControls .editor-pager`)
+4. **Chord-edit editor surface** (`SongControls .editor-panel`) reads as the same material as a selected/active step row — true in both light and dark mode.
+
+### Root cause
+
+These elements were authored for the dark "faceplate" aesthetic. The three white elements derive their background from `--faceplate-bg` via `color-mix(in srgb, var(--faceplate-bg) 60%, transparent)`:
+
+- **Dark:** `--faceplate-bg = #0a121d` (near-black). Mixing 60% near-black over the panel yields a darker **sunken well** — matching the "sunken at rest" design intent in the source comments.
+- **Light:** `--faceplate-bg = #f6f2e9`, which is the **brightest** rung of the light surface ladder. The same `color-mix` now produces a surface **brighter** than its container — a harsh near-white blob. The sunken intent is inverted.
+
+The note chips compound this with `color-mix(in srgb, var(--text-main) 3%, transparent)` — a 3% ink wash over the already-near-white readout.
+
+The editor panel is the same disease in a different form: `color-mix(in srgb, var(--faceplate-accent) 5%, transparent)` lets the bright card show through a faint teal wash, so it reads as the same teal-tinted material as the active step row (`color-mix(in srgb, var(--faceplate-accent) 8%, transparent)`).
+
+The light theme already ships a proper surface ladder with genuine recessed tokens that these elements simply bypass:
+
+```
+well        #ddd8cf  (control well — distinctly sunken)
+card-soft   #e3ddd0  (PANEL-SOFT — the InspectorCard surface behind the progression card)
+base        #efebdf
+card-nested #f1ede3  (inset card)
+card-top    #f6f2e9  (PANEL — brightest card surface)
+```
+
+The InspectorCard that wraps the Progression section has a light background of `--surface-card-soft` (`#e3ddd0`), so that is the base surface behind the step list and the editor panel.
+
+## Approach
+
+**Centralized per-theme tokens.** Add three semantic tokens in `src/styles/semantic.css`, defined in both the light (`[data-theme="modern-light"]`) and dark (`[data-theme="modern-dark"]` / `:root`) faceplate blocks. Dark values reproduce the **current expressions verbatim** so dark mode is byte-identical (except the intentional editor-panel separation in §3). Light values route through the warm surface ladder. Component CSS then references the tokens instead of the hardcoded `color-mix` expressions.
+
+This was chosen over per-component `[data-theme]` overrides (scatters logic across three files, easy to drift) and inline expression swaps (repeats magic numbers, no shared source of truth). The token approach matches how the codebase already models surfaces via the ladder.
+
+## Design
+
+### 1. New tokens (`src/styles/semantic.css`)
+
+Add to **both** faceplate token blocks (light and dark):
+
+| Token | Dark value (unchanged behavior) | Light value | Role |
+|---|---|---|---|
+| `--faceplate-inset` | `color-mix(in srgb, var(--faceplate-bg) 60%, transparent)` | `var(--surface-well)` (`#ddd8cf`) | Sunken well: degree chip, nav pip, notes-strip container |
+| `--faceplate-key` | `color-mix(in srgb, var(--text-main) 3%, transparent)` | `var(--surface-card-nested)` (`#f1ede3`) | Raised note key inside the well |
+| `--faceplate-surface` | `var(--faceplate-bg-elevated)` (`#0d1726`) | `var(--surface-card-top)` (`#f6f2e9`) | Editor focal-panel base |
+
+The dark tokens carry the existing expressions so no dark surface changes. (Both the chip, pager, and readout share the same `color-mix(... faceplate-bg 60% ...)` expression today, so one token covers all three.)
+
+### 2. Element re-mapping
+
+**`src/components/SongControls/ProgressionStepList.module.css`**
+- `.chip` `background-color` → `var(--faceplate-inset)`. Inactive chip becomes a warm sunken well instead of near-white. The `.active .chip` teal override is unchanged.
+
+**`src/components/SongControls/SongControls.module.css`**
+- `.editor-pager` `background-color` → `var(--faceplate-inset)`. Sunken control in the panel header.
+
+**`src/components/SongControls/ChordTonesReadout.module.css`**
+- `.readout` `background-color` → `var(--faceplate-inset)` (sunken strip).
+- `.tone` `background-color` → `var(--faceplate-key)` (raised key). The `.tone.root` teal override is unchanged.
+
+Resulting depth ladder inside the editor panel (light): panel `#f6f2e9` (brightest) → note keys `#f1ede3` → readout well `#ddd8cf` (sunken). The note keys sit **below** the panel's brightness, so nothing out-whites its container — the harsh-white pop is eliminated, and the result mirrors the dark mode "sunken strip + raised keys" material language.
+
+### 3. Editor surface vs. active step (both modes)
+
+Teal is retained; the fix is to the **material**, not the hue.
+
+**`src/components/SongControls/SongControls.module.css`**
+- `.editor-panel` `background-color` → `color-mix(in srgb, var(--faceplate-accent) 5%, var(--faceplate-surface))`.
+
+This replaces the transparent wash (which let the container show through) with an **opaque raised base** carrying the teal whisper — light `#f6f2e9`, dark `#0d1726`. The teal border and the existing `box-shadow` are kept.
+
+The master/detail split now reads as a material difference rather than only a tint difference: the step list stays a flat tint on `card-soft`, while the editor becomes a raised, teal-framed, shadowed card. The active row (`accent 8%` flat tint) and the editor panel no longer read as the same surface, in light and dark.
+
+## Files touched
+
+- `src/styles/semantic.css` — add three tokens to the light and dark faceplate blocks.
+- `src/components/SongControls/ProgressionStepList.module.css` — `.chip` background.
+- `src/components/SongControls/SongControls.module.css` — `.editor-pager` and `.editor-panel` backgrounds.
+- `src/components/SongControls/ChordTonesReadout.module.css` — `.readout` and `.tone` backgrounds.
+
+No TypeScript, component, or markup changes.
+
+## Verification
+
+- Verify live in both light and dark mode via the dev-server preview (Song tab → Progression card; open the chord editor to see the notes strip and pager).
+- Confirm dark mode is visually unchanged apart from the intentional editor-panel separation (§3).
+- Run `pnpm run lint`, `pnpm run test`, `pnpm run build`.
+- Refresh visual-regression snapshots with `pnpm run test:visual:update` — the `app-components` and `app-overlays` suites will shift for the light-mode Progression card.
+
+## Out of scope
+
+- Dark-mode white-element restyling (the dark surfaces are already correct).
+- Any change to the active-state hue or the teal accent itself.
+- The `--faceplate-bg-elevated`-based `.editor-degree-pill` and other controls not listed above.

--- a/src/components/SongControls/ChordTonesReadout.module.css
+++ b/src/components/SongControls/ChordTonesReadout.module.css
@@ -8,7 +8,7 @@
   padding: 0.6rem 0.75rem;
   border: 1px solid var(--faceplate-divider);
   border-radius: 8px;
-  background-color: color-mix(in srgb, var(--faceplate-bg) 60%, transparent);
+  background-color: var(--faceplate-inset);
 }
 
 .caption {
@@ -44,7 +44,7 @@
   padding: 0.3rem 0.7rem;
   border: 1px solid var(--faceplate-divider);
   border-radius: 7px;
-  background-color: color-mix(in srgb, var(--text-main) 3%, transparent);
+  background-color: var(--faceplate-key);
 }
 
 .tone.root {

--- a/src/components/SongControls/ProgressionStepList.module.css
+++ b/src/components/SongControls/ProgressionStepList.module.css
@@ -216,7 +216,7 @@
   padding: 0 0.45rem;
   border: 1px solid var(--faceplate-divider);
   border-radius: 6px;
-  background-color: color-mix(in srgb, var(--faceplate-bg) 60%, transparent);
+  background-color: var(--faceplate-inset);
   color: var(--dc-fg);
   font-family: var(--font-mono);
   font-size: 0.78rem;

--- a/src/components/SongControls/SongControls.module.css
+++ b/src/components/SongControls/SongControls.module.css
@@ -243,7 +243,7 @@
   padding: 0.85rem 1rem;
   border: 1px solid color-mix(in srgb, var(--faceplate-accent) 28%, var(--faceplate-divider));
   border-radius: 12px;
-  background-color: color-mix(in srgb, var(--faceplate-accent) 5%, transparent);
+  background-color: color-mix(in srgb, var(--faceplate-accent) 5%, var(--faceplate-surface));
   box-shadow: 0 1px 3px rgb(0 0 0 / 0.18);
 }
 
@@ -311,7 +311,7 @@
   align-items: center;
   gap: 0.1rem;
   padding: 3px;
-  background-color: color-mix(in srgb, var(--faceplate-bg) 60%, transparent);
+  background-color: var(--faceplate-inset);
   border: 1px solid var(--faceplate-divider);
   border-radius: 8px;
 }

--- a/src/components/SongControls/SongControls.module.css
+++ b/src/components/SongControls/SongControls.module.css
@@ -243,7 +243,7 @@
   padding: 0.85rem 1rem;
   border: 1px solid color-mix(in srgb, var(--faceplate-accent) 28%, var(--faceplate-divider));
   border-radius: 12px;
-  background-color: color-mix(in srgb, var(--faceplate-accent) 5%, var(--faceplate-surface));
+  background-color: var(--faceplate-surface);
   box-shadow: 0 1px 3px rgb(0 0 0 / 0.18);
 }
 

--- a/src/styles/semantic.css
+++ b/src/styles/semantic.css
@@ -219,6 +219,12 @@
   --faceplate-shadow: 0 1px 0 rgb(255 255 255 / 0.02) inset, 0 18px 40px -28px rgb(0 0 0 / 0.7);
   --faceplate-accent: var(--neon-cyan);
   --faceplate-accent-glow: var(--glow-cyan-sm);
+  /* Progression-card sunken surfaces — dark values reproduce the historical
+     inline expressions so dark mode is unchanged. Light values (in the
+     modern-light block) route through the warm surface ladder instead. */
+  --faceplate-inset: color-mix(in srgb, var(--faceplate-bg) 60%, transparent);
+  --faceplate-key: color-mix(in srgb, var(--text-main) 3%, transparent);
+  --faceplate-surface: var(--faceplate-bg-elevated);
 
   /* DAW control recipe — compact cyan-on-navy interactive surface. Generalizes
      the TransportBar --tb-* pattern for shared input controls (toggles,
@@ -338,6 +344,12 @@
   --faceplate-shadow: 0 1px 0 rgb(255 255 255 / 0.02) inset, 0 18px 40px -28px rgb(0 0 0 / 0.7);
   --faceplate-accent: var(--neon-cyan);
   --faceplate-accent-glow: var(--glow-cyan-sm);
+  /* Progression-card sunken surfaces — dark values reproduce the historical
+     inline expressions so dark mode is unchanged. Light values (in the
+     modern-light block) route through the warm surface ladder instead. */
+  --faceplate-inset: color-mix(in srgb, var(--faceplate-bg) 60%, transparent);
+  --faceplate-key: color-mix(in srgb, var(--text-main) 3%, transparent);
+  --faceplate-surface: var(--faceplate-bg-elevated);
 
   /* DAW control — dark mode: navy substrate, bright cyan accent, neon glow.
      Re-declared explicitly to mirror the faceplate token convention. */

--- a/src/styles/semantic.css
+++ b/src/styles/semantic.css
@@ -286,12 +286,14 @@
   --faceplate-shadow: 0 1px 0 rgb(255 255 255 / 0.7) inset, 0 8px 20px -16px rgb(0 0 0 / 0.18);
   --faceplate-accent: #147088;
   --faceplate-accent-glow: 0 0 4px rgb(20 112 136 / 0.20);
-  /* Progression-card sunken surfaces — route through the warm light ladder
-     (well < card-soft < card-nested < card-top) so these read as genuine
-     recessed wells / raised keys instead of harsh near-white. */
+  /* Progression-card surfaces — routed through the warm light ladder so the
+     card-in-card hierarchy reads as tan depth, never near-white:
+       inset   = sunken well (degree chip, pager, notes-strip container)
+       key     = note-key chip sitting in the well
+       surface = the nested focal editor card (lifted above the progression card) */
   --faceplate-inset: var(--surface-well);
-  --faceplate-key: var(--surface-card-nested);
-  --faceplate-surface: var(--surface-card-top);
+  --faceplate-key: var(--surface-card-key);
+  --faceplate-surface: var(--surface-card-inset);
 
   /* DAW control — light mode: warm cream surfaces with CYAN teal accents.
      Reference palette: BG #ebebdc, PANEL #f6f2e9, CYAN #147088, INK #2a251d. */

--- a/src/styles/semantic.css
+++ b/src/styles/semantic.css
@@ -286,6 +286,12 @@
   --faceplate-shadow: 0 1px 0 rgb(255 255 255 / 0.7) inset, 0 8px 20px -16px rgb(0 0 0 / 0.18);
   --faceplate-accent: #147088;
   --faceplate-accent-glow: 0 0 4px rgb(20 112 136 / 0.20);
+  /* Progression-card sunken surfaces — route through the warm light ladder
+     (well < card-soft < card-nested < card-top) so these read as genuine
+     recessed wells / raised keys instead of harsh near-white. */
+  --faceplate-inset: var(--surface-well);
+  --faceplate-key: var(--surface-card-nested);
+  --faceplate-surface: var(--surface-card-top);
 
   /* DAW control — light mode: warm cream surfaces with CYAN teal accents.
      Reference palette: BG #ebebdc, PANEL #f6f2e9, CYAN #147088, INK #2a251d. */

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -40,6 +40,8 @@
   --surface-card-top:    #f6f2e9; /* PANEL — cream card surface (reference palette) */
   --surface-card-nested: #f1ede3; /* inset card: visibly recessed from card-top (reference palette) */
   --surface-card-soft:   #e3ddd0; /* PANEL-SOFT — recessed surface for tab cards / status bar (reference palette) */
+  --surface-card-inset:  #e8e1d2; /* card-in-card: nested focal panel (chord editor) — warm tan lifted just above card-soft, far below PANEL white */
+  --surface-card-key:    #ece6d8; /* note-key chip inside the editor's sunken notes well — warm tan, never near-white */
   --surface-well:        #ddd8cf; /* control well: distinctly sunken below PANEL-SOFT (reference palette) */
   --surface-strip:       var(--surface-card-top); /* practice/chord strip: card-aligned */
   --surface-float:       #f6f2e9; /* floating overlay (dropdown, modal): PANEL elevation */


### PR DESCRIPTION
## Summary

The Song-tab Progression card had several surfaces that resolved to harsh near-white in **light mode**, clashing with the warm-parchment theme:

- the inactive chord-list degree chip, the chord-edit notes strip, and the navigation pip rendered brighter than their containers, and
- the nested chord-editor card read as near-white **and** too similar to the teal-tinted active step row (also true in dark mode).

**Root cause:** these elements derived their background from `--faceplate-bg` via `color-mix(... 60%, transparent)`. In dark mode `--faceplate-bg` is near-black, so that mix produces a sunken well (the intended look). In light mode `--faceplate-bg` is the *brightest* rung of the surface ladder (`#f6f2e9`), so the same mix inverts the intent into a harsh near-white blob.

## What changed (CSS only — no TS/markup)

- Added per-theme tokens in `semantic.css` — **dark values reproduce the previous inline expressions verbatim, so dark mode is unchanged:**
  - `--faceplate-inset` — sunken well (degree chip, pager, notes-strip container) → light routes to `--surface-well` (`#ddd8cf`).
  - `--faceplate-key` — note-key chip → light routes to a warm tan.
  - `--faceplate-surface` — the nested editor card base.
- Added two warm-tan ladder tokens in `themes.css` for the **card-in-card** hierarchy:
  - `--surface-card-inset` (`#e8e1d2`) — the nested editor card, lifted just above the progression card (`#e3ddd0`), far below PANEL white.
  - `--surface-card-key` (`#ece6d8`) — the note keys.
- Dropped the teal *fill* on `.editor-panel`; the teal **border + shadow** now carry focus, separating the editor from the teal-tinted active step row in both themes.

Resulting light depth ladder (all warm tan, zero near-white): editor card `#e8e1d2` → keys `#ece6d8` → progression card `#e3ddd0` → wells/chips `#ddd8cf`.

## Verification

- `pnpm run lint`, `pnpm run test` (2209 passing), `pnpm run build` all green.
- Verified live in both light and dark mode via dev-server preview; dark mode visually unchanged apart from the intentional editor-card separation.
- Regenerated darwin **and** linux visual snapshots — **no diffs** on either platform: the changes fall under the suite's `threshold: 0.1` per-pixel tolerance, and the desktop progression spec captures the progression *track*, not the Song-tab editor card. (Coverage gap noted below.)

## Test Plan

- [ ] Light mode → Song tab → confirm the degree chips, notes strip, nav pip, and editor card read as warm tan (no near-white) and the editor card is distinct from the active step row.
- [ ] Dark mode → confirm no regression beyond the editor card's sharper separation from the active row.

> Note: the light-mode Song-tab editor card is not covered by a visual-regression baseline (desktop spec captures only the progression track; the mobile light capture is under threshold). A follow-up could add a `progression-song-editor-light` snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)