### PR TITLE
perf(audio): break play/stop & genre-switch jank into sub-50ms tasks

### DIFF
--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -38,6 +38,27 @@ import { startVisualClock, stopVisualClock } from "../progressions/audio/visualC
 
 const SCHEDULE_LEAD_SECONDS = 0.05;
 
+/**
+ * A real MACROTASK yield (not a microtask). `getEngine()` resolves as a
+ * microtask once the engine module is cached, and microtasks drain inside the
+ * task that scheduled them — so the entire play-start continuation
+ * (AudioContext creation → signal-graph materialization → five Tone.Part
+ * constructions → transport start) chains into a SINGLE long task whenever the
+ * built-layers cache is warm (e.g. the idle background build already ran, so
+ * there is no `buildAllLayersAsync` await to break the chain). That single task
+ * measured ~110-260ms and surfaced as `[Violation] 'click'/'pointerup' handler
+ * took …ms` input-latency warnings.
+ *
+ * Awaiting this between the heavy phases forces each onto its own macrotask, so
+ * no single task exceeds the ~50ms responsiveness budget. Timing is unaffected:
+ * the Transport is held stopped (rewound to 0) across the whole continuation and
+ * only `.start()`ed at the very end, so the only observable effect is that audio
+ * onset is deferred by a few imperceptible milliseconds — already masked by the
+ * 150ms loading-spinner deferral.
+ */
+const yieldToMacrotask = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
 function readLayoutTier(): "mobile" | "tablet" | "desktop" {
   if (typeof document === "undefined") return "desktop";
   const t = document
@@ -356,6 +377,12 @@ export function useProgressionAudioPlayback() {
       eng.setLayerGain(audio.layers, "drums", store.get(progressionDrumsEnabledAtom));
       eng.setLayerGain(audio.layers, "metronome", store.get(progressionMetronomeEnabledAtom));
 
+      // Yield before the signal-graph materialization so the (one-time, ~40ms)
+      // AudioContext + layer-bus construction above doesn't share a task with
+      // the graph build below. See `yieldToMacrotask`.
+      await yieldToMacrotask();
+      if (gen !== genRef.current) return;
+
       const mix = eng.getGenreMix(store.get(progressionGenreStyleAtom)) ?? eng.DEFAULT_GENRE_MIX;
       const tier = resolveActiveTier(eng, store.get(audioQualityAtom));
       eng.configureProgressionGraph(eng.planSignalGraph(eng.TIER_PROFILES[tier], mix));
@@ -425,6 +452,15 @@ export function useProgressionAudioPlayback() {
       clearTimeout(loadingTimer);
       if (gen !== genRef.current) return;
       if (built.chordOnsets.length === 0) { tearDownAndStop(); return; }
+
+      // Yield before constructing the five Tone.Parts. On a warm build cache the
+      // `buildAllLayersAsync` await above is skipped, so without this break the
+      // graph materialization and the ~35ms Part construction run in one task.
+      // The Parts are built atomically (no yields between them) so the
+      // generation check below is the only point a stale run can bail — there is
+      // never a half-built Part set. See `yieldToMacrotask`.
+      await yieldToMacrotask();
+      if (gen !== genRef.current) return;
 
       // The Transport was rewound to 0 up front (see the restart-tier reset at
       // the top of this effect), so partStart is TRANSPORT-RELATIVE: a small lead
@@ -599,11 +635,21 @@ export function useProgressionAudioPlayback() {
   }, [loopEnabled, setPlaying]);
 
   // Quality/genre change → rebuild the mix graph in place (no Part rebuild).
+  // Deferred to a macrotask so the ~30ms graph materialization never shares a
+  // task with the React commit that triggered it: a genre switch re-renders the
+  // backing-track controls, and running the rebuild in that same commit task
+  // pushed the click/pointerup handlers past Chrome's input-latency budget.
+  // Audio keeps playing through the previous graph for the few milliseconds
+  // until the reconfigure lands; the cleanup cancels a still-pending rebuild
+  // when the genre/quality changes again before it runs.
   useEffect(() => {
     if (!engine || !playing) return;
     const eng = engine;
-    const mix = eng.getGenreMix(genreId) ?? eng.DEFAULT_GENRE_MIX;
-    const tier = resolveActiveTier(eng, quality);
-    eng.configureProgressionGraph(eng.planSignalGraph(eng.TIER_PROFILES[tier], mix));
+    const timer = setTimeout(() => {
+      const mix = eng.getGenreMix(genreId) ?? eng.DEFAULT_GENRE_MIX;
+      const tier = resolveActiveTier(eng, quality);
+      eng.configureProgressionGraph(eng.planSignalGraph(eng.TIER_PROFILES[tier], mix));
+    }, 0);
+    return () => clearTimeout(timer);
   }, [genreId, quality, playing]);
 }


### PR DESCRIPTION
## What

Eliminates the main-thread `[Violation]` warnings (~110–260ms) on the `click`/`pointerup`/`mousedown` handlers when clicking **Play/Stop** or **switching the backing-track genre while playing**.

## Why (root cause)

Profiling with live instrumentation + the Long Animation Frames API showed the jank is **not** React re-render fan-out:

| What | Cost |
|---|---|
| Fretboard emphasis rebuild (150 notes) | ~1ms |
| Whole progression subscriber fan-out on warm play/stop | < 50ms (no long task, even in dev) |
| Cold play-start | **111–122ms single long task** |

The blocking work is the **audio engine**. Phase breakdown of the 111ms task:
- `materializeSignalGraph` (Tone.js node graph): **~30ms**
- Tone.Part construction (5 parts): **~13–35ms**
- one-time `new AudioContext()` + Tone binding: **~45ms** (gesture-gated)

`getEngine()` resolves as a **microtask**, so the play-start continuation (graph build → `buildAllLayersAsync` → 5 Part constructions → transport start) chains into a **single macrotask** whenever the layer cache is warm (no `buildAllLayersAsync` `await` to break it). A genre switch additionally rebuilds the graph inside the React commit task. That fused work is what the input handlers were blamed for.

The naive fix (`startTransition`) was previously backed out because it tagged every progression-atom subscriber's rerender to the transition and tripped React's ">10 fibers" warning — and, per the profiling, it would have targeted work that's already cheap (~1ms).

## The fix — `src/hooks/useProgressionAudioPlayback.ts`

Insert real macrotask yields between the heavy phases so each lands on its own sub-50ms task:

1. **Yield before signal-graph materialization** — isolates the one-time AudioContext/ctx setup.
2. **Yield before Part construction** — the key split, needed because a warm build cache skips the only pre-existing `await`. The 5 Parts stay atomic (no yields between them), so the generation re-check is the single bail point — there is never a half-built Part set.
3. **Defer the quality/genre graph reconfigure** off the React commit task it's triggered from, with cleanup to cancel a superseded rebuild.

**Timing is unaffected:** the Transport is held stopped (rewound to 0) across the whole continuation and only `.start()`ed at the very end, so audio onset shifts by a few imperceptible milliseconds (already masked by the existing 150ms loading-spinner deferral). Each yield re-checks the `gen` token to bail on rapid re-toggles, matching the effect's existing staleness pattern.

## Verification

- **Browser:** warm play/stop now produces **no >50ms long task** (was a fused 111–260ms); cold first-play drops to the irreducible one-time `AudioContext` creation (gesture-gated, can't be moved off the click). Playback advances correctly with no console errors.
- `pnpm run lint` — 0 errors
- `pnpm run test` — 2215 passed (incl. all 21 audio-playback tests)
- `pnpm run build` — success
- CodeRabbit review — no findings

## Reviewer notes

- Touches timing-critical audio code; the transport-stopped-until-end invariant and the `partStart`-relative scheduling are preserved.
- The genre-switch path could not be measured directly (its Radix `Select` doesn't accept synthetic events and CDP clicks were unreliable in the test harness); it is addressed structurally — graph build and Part build are now guaranteed-separate tasks, neither sharing a task with the React commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input latency spikes during audio playback initialization and when changing audio quality or genre settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->