### PR TITLE
feat(progressions): authentic bossa-nova backing track (Slice 2 §3.5)

### DIFF
--- a/docs/superpowers/plans/2026-06-01-bossa-comp-lh-rh-split.md
+++ b/docs/superpowers/plans/2026-06-01-bossa-comp-lh-rh-split.md
@@ -1,0 +1,384 @@
+# Bossa-Nova Comp LH/RH Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the bossa comp into a real two-hand piano part — LH root/fifth bass + RH rootless chords — and lower the chord register so the top note never exceeds C5.
+
+**Architecture:** `buildBossaColorVoicing` becomes a 4-note Type-B rootless voicing (7-9-3-5) based at octave 3, register-normalized so its top note ≤ C5. A new optional `ChordHit.voiceRole` lets the `bossa-comp` pattern mark bass-note hits (root@1, fifth@3) vs chord hits (off-beats); `buildAllLayersAsync` resolves bass roles to single octave-3 notes via the existing `resolveBassLineNotes`. The separate upright bass (octave 2) is unchanged.
+
+**Tech Stack:** TypeScript, Tone.js, Vitest. Package manager **pnpm**. Co-located tests.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-bossa-comp-lh-rh-split-design.md`
+
+**Builds on:** pass-1 + pass-2 bossa work already on this branch.
+
+---
+
+## File-by-file map
+
+- `src/progressions/progressionAudio.ts` — rewrite `BOSSA_COLOR_TONES` (Type-B), `BOSSA_COMP_ROOT_OCTAVE` (4→3), add `BOSSA_COMP_TOP_CEILING`, rewrite `buildBossaColorVoicing` (Type-B + octave normalization).
+- `src/progressions/audio/patterns.ts` — add `ChordHit.voiceRole`; rewrite the `bossa-comp` hits (LH bass + RH chords).
+- `src/progressions/audio/buildAllLayers.ts` — add `BOSSA_LH_OCTAVE`, resolve `bassRootVoicing`/`bassFifthVoicing`, add the `voiceRole` branch to the chord-strum voicing selection.
+- Tests: `progressionAudio.test.ts`, `patterns.test.ts`, `buildAllLayers.test.ts`.
+
+**Encoding note (used throughout):** a note string's absolute semitone is `octave*12 + pitchIndex` (e.g. `"C3"` → 36, `"C5"` → 60). The test helper `midi(n) = pitchClass + (octave+1)*12`, i.e. `midi = absolute + 12`, so `C5` is midi 72.
+
+---
+
+## Task 1: Type-B rootless voicing + register normalization
+
+**Files:**
+- Modify: `src/progressions/progressionAudio.ts`
+- Test: `src/progressions/progressionAudio.test.ts`, `src/progressions/audio/buildAllLayers.test.ts`
+
+- [ ] **Step 1: Replace the `buildBossaColorVoicing` unit tests**
+
+In `src/progressions/progressionAudio.test.ts`, replace the entire `describe("buildBossaColorVoicing", ...)` block with:
+
+```ts
+describe("buildBossaColorVoicing", () => {
+  const PC: Record<string, number> = { C: 0, "C#": 1, D: 2, "D#": 3, E: 4, F: 5, "F#": 6, G: 7, "G#": 8, A: 9, "A#": 10, B: 11 };
+  const pcSet = (notes: readonly string[]) => new Set(notes.map((n) => n.replace(/-?\d+$/, "")));
+  const midi = (n: string) => { const m = n.match(/^([A-G]#?)(-?\d+)$/)!; return PC[m[1]] + (parseInt(m[2], 10) + 1) * 12; };
+
+  it("voices a major chord as a 4-note Type-B rootless (7-9-3-5) in octave 3", () => {
+    // C maj9 Type-B: B (7) / D (9) / E (3) / G (5).
+    expect(buildBossaColorVoicing("C", "maj7")).toEqual(["B3", "D4", "E4", "G4"]);
+    expect(buildBossaColorVoicing("C", "M")).toEqual(["B3", "D4", "E4", "G4"]);
+  });
+
+  it("normalizes a high-rooted voicing down an octave so it never floats above C5", () => {
+    // A m9 Type-B would top out at E5; the normalization drops the whole voicing.
+    expect(buildBossaColorVoicing("A", "m7")).toEqual(["G3", "B3", "C4", "E4"]);
+  });
+
+  it("keeps every defined voicing 4-note, rootless, and topped at or below C5 for all roots", () => {
+    const ROOTS = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+    for (const root of ROOTS) {
+      for (const quality of ["maj7", "M", "m7", "m", "7"]) {
+        const v = buildBossaColorVoicing(root, quality);
+        expect(v, `${root}${quality} length`).toHaveLength(4);
+        expect(pcSet(v).has(root), `${root}${quality} rootless`).toBe(false);
+        const ms = v.map(midi);
+        expect(Math.max(...ms), `${root}${quality} top <= C5`).toBeLessThanOrEqual(72); // C5
+        expect(Math.min(...ms), `${root}${quality} bottom >= C3`).toBeGreaterThanOrEqual(48); // C3
+      }
+    }
+  });
+
+  it("falls back to the plain voice-led triad for a quality without a grip; [] for unknown root", () => {
+    expect(buildBossaColorVoicing("C", "dim")).toEqual(resolveChordVoicing("C", "dim", undefined, undefined));
+    expect(buildBossaColorVoicing("H", "maj7")).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm exec vitest run src/progressions/progressionAudio.test.ts -t buildBossaColorVoicing`
+Expected: FAIL — the function still returns the pass-2 3-note octave-4 voicing (`["E4","B4","D5"]`), not the new Type-B values.
+
+- [ ] **Step 3: Rewrite `buildBossaColorVoicing`**
+
+In `src/progressions/progressionAudio.ts`, replace the `BOSSA_COLOR_TONES` table, the `BOSSA_COMP_ROOT_OCTAVE` constant, and the `buildBossaColorVoicing` function with:
+
+```ts
+/**
+ * Rootless Type-B (7-9-3-5) jazz comp tones per chord quality, as semitone
+ * offsets above the chord root. The root is omitted — the piano LH and upright
+ * bass cover it. 7th is the lowest tone, so the shape sits low for its register.
+ *   +3 = b3, +4 = 3, +10 = b7, +11 = maj7, +14 = 9, +15 = b3+8ve, +16 = 3+8ve, +19 = 5+8ve
+ */
+const BOSSA_COLOR_TONES: Record<string, readonly number[]> = {
+  maj7: [11, 14, 16, 19], // 7 / 9 / 3 / 5 — maj9
+  M: [11, 14, 16, 19], // plain major voiced as maj9
+  m7: [10, 14, 15, 19], // b7 / 9 / b3 / 5 — m9
+  m: [10, 14, 15, 19], // m9
+  "7": [10, 14, 16, 19], // b7 / 9 / 3 / 5 — dom9
+};
+
+/** Comp voicing base octave (the 7th, the lowest tone, starts here). */
+const BOSSA_COMP_ROOT_OCTAVE = 3;
+/** Register ceiling — the voicing's top note must not exceed C5 (absolute 60,
+ *  i.e. octave*12 + pitchIndex). Higher-rooted voicings are dropped an octave
+ *  at a time until they fit, keeping the comp in the C3–C5 register. */
+const BOSSA_COMP_TOP_CEILING = 60;
+
+/**
+ * Build a rootless Type-B (7-9-3-5) jazz comp voicing for a chord, normalized
+ * into the C3–C5 register. Pure. Builds the four colour tones at octave 3, then
+ * transposes the whole voicing down by octaves until its top note is ≤ C5 —
+ * so even high-rooted chords (A/B) stay in the comp register rather than
+ * floating into octave 5. Falls back to the plain voice-led triad when the
+ * quality has no defined grip (dim/aug/sus/6). Returns [] for an unknown root.
+ */
+export function buildBossaColorVoicing(
+  root: string,
+  quality: string,
+  prevVoicing?: string[],
+): string[] {
+  const rootIndex = NOTES.indexOf(root);
+  if (rootIndex < 0) return [];
+  const offsets = BOSSA_COLOR_TONES[quality];
+  if (!offsets) {
+    return resolveChordVoicing(root, quality, undefined, prevVoicing);
+  }
+  const base = BOSSA_COMP_ROOT_OCTAVE * 12 + rootIndex;
+  let absolutes = offsets.map((o) => base + o);
+  while (Math.max(...absolutes) > BOSSA_COMP_TOP_CEILING) {
+    absolutes = absolutes.map((a) => a - 12);
+  }
+  return absolutes.map((a) => {
+    const note = NOTES[((a % 12) + 12) % 12];
+    return `${note}${Math.floor(a / 12)}`;
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm exec vitest run src/progressions/progressionAudio.test.ts -t buildBossaColorVoicing`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Update the dependent buildAllLayers test's expected voicing**
+
+The pass-2 test `"voices the bossa comp as rootless jazz chords (no root note)"` in `src/progressions/audio/buildAllLayers.test.ts` asserts the old voicing on `chordStrums[0]`. At this point the `bossa-comp` pattern still has a chord hit on beat 0, so `chordStrums[0]` now resolves to the new Type-B voicing. Update its first assertion:
+
+- Change `expect(out.chordStrums[0].value.voicing).toEqual(["E4", "B4", "D5"]);` to:
+  ```ts
+    expect(out.chordStrums[0].value.voicing).toEqual(["B3", "D4", "E4", "G4"]);
+  ```
+
+(The other two assertions in that test — no-C and all-sustained — still hold, because `["B3","D4","E4","G4"]` has no C. This test is reworked fully in Task 2.)
+
+- [ ] **Step 6: Run the affected files to verify green**
+
+Run: `pnpm exec vitest run src/progressions/progressionAudio.test.ts src/progressions/audio/buildAllLayers.test.ts`
+Expected: PASS — both files green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/progressions/progressionAudio.ts src/progressions/progressionAudio.test.ts src/progressions/audio/buildAllLayers.test.ts
+git commit -m "feat(progressions): Type-B rootless bossa voicing, lowered + register-normalized (Slice 2 §3.5 pass 3)"
+```
+
+---
+
+## Task 2: LH bass + RH chords (voiceRole field, pattern, engine)
+
+**Files:**
+- Modify: `src/progressions/audio/patterns.ts`, `src/progressions/audio/buildAllLayers.ts`
+- Test: `src/progressions/audio/patterns.test.ts`, `src/progressions/audio/buildAllLayers.test.ts`
+
+This task adds the `voiceRole` field, rewrites the `bossa-comp` pattern into LH bass + RH chord hits, and wires the engine to resolve bass roles to single octave-3 notes. It updates three existing assertions that hardcode the pass-2 comp shape.
+
+- [ ] **Step 1: Write/Update the failing tests**
+
+(a) In `src/progressions/audio/patterns.test.ts`, replace the `bossa-comp` test (titled `"adds a 2-bar syncopated bossa comp with rootless-jazz voicing and ringing chords"`) with:
+
+```ts
+  it("adds a 2-bar bossa comp as LH bass + RH rootless chords (all sustained)", () => {
+    const comp = getChordPattern("bossa-comp")!;
+    expect(comp.bars).toBe(2);
+    expect(comp.voicing).toBe("rootless-jazz");
+    expect(comp.hits.map((h) => h.beat)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 6, 7.5]);
+    expect(comp.hits.map((h) => h.voiceRole)).toEqual([
+      "bass-root", "chord", "bass-fifth", "chord",
+      "bass-root", "chord", "bass-fifth", "chord",
+    ]);
+    expect(comp.hits.every((h) => h.style === "sustained")).toBe(true);
+  });
+```
+
+(b) In `src/progressions/audio/buildAllLayers.test.ts`, update the comp-times test (titled `"plays the bossa comp's bar-2 syncopations on the second bar"`) — its assertion becomes the full 8-hit cell:
+
+```ts
+    expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 6, 7.5]);
+```
+
+(c) In `src/progressions/audio/buildAllLayers.test.ts`, replace the test titled `"voices the bossa comp as rootless jazz chords (no root note)"` (the one updated in Task 1 Step 5) with the role-based version:
+
+```ts
+  it("voices the bossa comp as LH bass (single notes) + RH rootless chords", async () => {
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      chordPatternId: "bossa-comp",
+      drumPatternId: "bossa",
+      bassPatternId: "bossa",
+      steps: [step({ duration: { value: 2, unit: "bar" } })], // C major
+    });
+    const at = (t: number) => out.chordStrums.find((s) => s.time === t)!;
+    expect(at(0).value.voicing).toEqual(["C3"]); // bass-root (LH, octave 3)
+    expect(at(2).value.voicing).toEqual(["G3"]); // bass-fifth (LH, octave 3)
+    expect(at(1.5).value.voicing).toEqual(["B3", "D4", "E4", "G4"]); // RH rootless chord
+    expect(out.chordStrums.every((s) => s.value.style === "sustained")).toBe(true);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm exec vitest run src/progressions/audio/patterns.test.ts src/progressions/audio/buildAllLayers.test.ts -t "bossa comp"`
+Expected: FAIL — `voiceRole` is undefined on the hits, the comp beats are still the pass-2 6-hit set, and the bass roles don't resolve to single notes yet.
+
+- [ ] **Step 3: Add the `voiceRole` field to `ChordHit`**
+
+In `src/progressions/audio/patterns.ts`, extend the `ChordHit` interface — add `voiceRole` after `articulation`:
+
+```ts
+interface ChordHit {
+  beat: number;
+  velocity: number;
+  style?: "staccato" | "sustained";
+  /** Strum direction; up-strokes reverse the voicing order. Defaults to down. */
+  direction?: StrumDirection;
+  /** Note-length + voicing intent for the strum voice.
+   *  "root" plays a single root note (anchor); "stab" rings a plain chord;
+   *  "color-stab" rings a chord with funk extensions; "muted" chokes a plain
+   *  chord short (chicken-scratch ghost). Omitted rings the patch default. */
+  articulation?: ChordArticulation;
+  /** Bossa LH/RH split (used when the pattern's voicing is "rootless-jazz"):
+   *  "bass-root"/"bass-fifth" play a single low note (LH); "chord" plays the
+   *  rootless RH voicing. Omitted behaves as "chord". */
+  voiceRole?: "bass-root" | "bass-fifth" | "chord";
+}
+```
+
+- [ ] **Step 4: Rewrite the `bossa-comp` pattern**
+
+In `src/progressions/audio/patterns.ts`, replace the entire `bossa-comp` entry in `CHORD_PATTERNS` with:
+
+```ts
+  {
+    id: "bossa-comp",
+    label: "Bossa Comp",
+    bars: 2,
+    voicing: "rootless-jazz",
+    // LH bass (root on beat 1, fifth on beat 3) + RH rootless chords on the
+    // syncopated off-beats, with two cross-barline anticipations (3.5, 7.5).
+    // Soft, ringing (sustained).
+    hits: [
+      { beat: 0, velocity: 0.6, voiceRole: "bass-root", style: "sustained" },
+      { beat: 1.5, velocity: 0.5, voiceRole: "chord", style: "sustained" },
+      { beat: 2, velocity: 0.55, voiceRole: "bass-fifth", style: "sustained" },
+      { beat: 3.5, velocity: 0.55, voiceRole: "chord", style: "sustained" },
+      { beat: 4, velocity: 0.6, voiceRole: "bass-root", style: "sustained" },
+      { beat: 4.5, velocity: 0.5, voiceRole: "chord", style: "sustained" },
+      { beat: 6, velocity: 0.55, voiceRole: "bass-fifth", style: "sustained" },
+      { beat: 7.5, velocity: 0.55, voiceRole: "chord", style: "sustained" },
+    ],
+  },
+```
+
+- [ ] **Step 5: Resolve the LH bass notes in `buildAllLayersAsync`**
+
+In `src/progressions/audio/buildAllLayers.ts`, add a module-level constant near the top (after the existing duration constants, e.g. below `ROOT_STRUM_DURATION_SEC`):
+
+```ts
+/** Piano LH bass octave for the bossa comp — an octave above the upright bass. */
+const BOSSA_LH_OCTAVE = 3;
+```
+
+Then, in the per-step voicing-intent block, immediately after the `compVoicing` computation (added in pass 2), add:
+
+```ts
+    // Bossa LH bass notes (root on beat 1, fifth on beat 3), octave 3 — single
+    // notes played by the piano under the RH rootless chords.
+    const bossaLhNotes =
+      chordPattern?.voicing === "rootless-jazz"
+        ? resolveBassLineNotes(root, quality, BOSSA_LH_OCTAVE)
+        : [];
+    const bassRootVoicing = bossaLhNotes.length > 0 ? [bossaLhNotes[0]] : voicing;
+    const bassFifthVoicing =
+      bossaLhNotes.length > 1 ? [bossaLhNotes[1]] : bassRootVoicing;
+```
+
+(`resolveBassLineNotes` is already imported in this file and returns `[root, fifth]` — or `[root]` — at the requested octave.)
+
+- [ ] **Step 6: Honour `voiceRole` in the chord-strum voicing selection**
+
+In `src/progressions/audio/buildAllLayers.ts`, the chord-strum push currently selects voicing as:
+
+```ts
+              voicing:
+                hit.articulation === "color-stab"
+                  ? colorVoicing
+                  : hit.articulation === "root"
+                    ? rootNoteVoicing
+                    : compVoicing,
+```
+
+Replace it with (bass roles take precedence; `chord`/unset falls through unchanged):
+
+```ts
+              voicing:
+                hit.voiceRole === "bass-root"
+                  ? bassRootVoicing
+                  : hit.voiceRole === "bass-fifth"
+                    ? bassFifthVoicing
+                    : hit.articulation === "color-stab"
+                      ? colorVoicing
+                      : hit.articulation === "root"
+                        ? rootNoteVoicing
+                        : compVoicing,
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `pnpm exec vitest run src/progressions/audio/patterns.test.ts src/progressions/audio/buildAllLayers.test.ts`
+Expected: PASS — both files fully green (the rewritten bossa-comp assertion, the updated comp-times assertion, the role-based voicing test, and the entire existing suite). If a different existing test fails, STOP and report.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/progressions/audio/patterns.ts src/progressions/audio/buildAllLayers.ts src/progressions/audio/patterns.test.ts src/progressions/audio/buildAllLayers.test.ts
+git commit -m "feat(progressions): bossa piano LH bass + RH chords via voiceRole (Slice 2 §3.5 pass 3)"
+```
+
+---
+
+## Task 3: Full verification + ear audition
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `pnpm run test`
+Expected: PASS — all suites green.
+
+- [ ] **Step 2: Lint**
+
+Run: `pnpm run lint`
+Expected: 0 errors. (A pre-existing warning in `src/hooks/useFretboardTopologyModel.ts` is unrelated — do not touch it.)
+
+- [ ] **Step 3: Build**
+
+Run: `pnpm run build`
+Expected: `tsc -b` type-checks clean and `vite build` succeeds.
+
+- [ ] **Step 4: Manual ear audition (required by spec §6)**
+
+Run `pnpm run dev`, open the app, select **Bossa Nova**, load a ≥4-bar progression, play. Confirm by ear:
+- the piano now reads as a two-hand part — a low root/fifth bass pulse (octave 3) under ringing rootless chords;
+- the chords are no longer too high (they sit C3–C5);
+- the piano LH locks with the upright bass (octave 2) and the clave;
+- nothing is muddy. Tune the §3.1/§3.4 tables and the piano `sustainedDurationSec` (in `src/progressions/audio/sound/instrumentPatches.ts`) by ear.
+
+Apply tweaks as small follow-up commits:
+
+```bash
+git add -A && git commit -m "fix(progressions): tune bossa comp LH/RH balance by ear (Slice 2 §3.5 pass 3)"
+```
+
+- [ ] **Step 5: Finish the branch**
+
+Use the `superpowers:finishing-a-development-branch` skill to integrate (all three passes share this branch).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §3.1 Type-B voicing + normalization → Task 1; §3.2 `voiceRole` field → Task 2 Step 3; §3.3 engine resolution (`bossaLhNotes`/`bassRootVoicing`/`bassFifthVoicing` + `voiceRole` branch) → Task 2 Steps 5–6; §3.4 pattern → Task 2 Step 4; §4 backwards-compat → unchanged jazz-comp test (kept) + the `voiceRole`-absent fallthrough; §6 tests 1–8 → Task 1 (voicing) + Task 2 (pattern + role resolution) + Task 3 (audition). No gaps.
+- **Broken-by-change tests handled:** the pass-2 `buildBossaColorVoicing` tests are replaced in Task 1 Step 1; the pass-2 buildAllLayers voicing test is bridged in Task 1 Step 5 then reworked in Task 2 Step 1c; the patterns.test.ts bossa-comp assertion and the buildAllLayers comp-times assertion are updated in Task 2 Step 1a/1b. No test is left asserting stale values.
+- **Type consistency:** `buildBossaColorVoicing` (Task 1), `ChordHit.voiceRole: "bass-root"|"bass-fifth"|"chord"` (Task 2 Step 3, read in Step 6), `BOSSA_LH_OCTAVE`/`bossaLhNotes`/`bassRootVoicing`/`bassFifthVoicing` (Task 2 Steps 5–6), `BOSSA_COMP_TOP_CEILING`/`BOSSA_COMP_ROOT_OCTAVE` (Task 1) all consistent.
+- **Octave math verified:** Type-B `("C","maj7")` → base 36, `[47,50,52,55]` → `["B3","D4","E4","G4"]`; `("A","m7")` → `[55,59,60,64]` → −12 → `["G3","B3","C4","E4"]`; `resolveBassLineNotes("C","M",3)` → `["C3","G3"]`.

--- a/docs/superpowers/plans/2026-06-01-bossa-nova-clave-comp-refinement.md
+++ b/docs/superpowers/plans/2026-06-01-bossa-nova-clave-comp-refinement.md
@@ -1,0 +1,451 @@
+# Bossa-Nova Clave & Comp Refinement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the bossa-nova clave (son → bossa) and rework the comp into ringing, rootless jazz 7th/9th voicings over a syncopated 2-bar figure with anticipations.
+
+**Architecture:** A new pure `buildBossaColorVoicing` (rootless maj9/m9/dom9, middle register) mirrors the existing `buildFunkColorVoicing`. An opt-in `ChordPattern.voicing: "rootless-jazz"` field routes the `bossa-comp` chords through it in `buildAllLayersAsync`. The clave fix and comp rhythm/articulation are data changes to existing patterns. Non-bossa patterns are byte-identical (the `voicing` field defaults to undefined).
+
+**Tech Stack:** TypeScript, Tone.js, Vitest. Package manager **pnpm**. Co-located tests.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-bossa-nova-clave-comp-refinement-design.md`
+
+**Builds on:** the pass-1 bossa work already on this branch (2-bar cell mechanism, cross-stick voice, `bossa`/`bossa-comp` patterns).
+
+---
+
+## File-by-file map
+
+- `src/progressions/progressionAudio.ts` — add `BOSSA_COLOR_TONES`, `BOSSA_COMP_ROOT_OCTAVE`, `buildBossaColorVoicing`.
+- `src/progressions/audio/patterns.ts` — add `ChordPattern.voicing`; fix `bossa` drum `crossStick` last hit `6 → 6.5`; rewrite `bossa-comp` hits (rhythm + `style:"sustained"` + `voicing`).
+- `src/progressions/audio/buildAllLayers.ts` — import `buildBossaColorVoicing`; compute `compVoicing`; use it as the comp hits' base voicing.
+- Tests: `progressionAudio.test.ts`, `patterns.test.ts`, `buildAllLayers.test.ts`.
+
+---
+
+## Task 1: Rootless jazz comp voicing (`buildBossaColorVoicing`)
+
+**Files:**
+- Modify: `src/progressions/progressionAudio.ts`
+- Test: `src/progressions/progressionAudio.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/progressions/progressionAudio.test.ts`. First add `buildBossaColorVoicing` to the existing import on line 2 (it currently imports `resolveBassLineNotes, resolveChordVoicing, resolveBassNoteForRole, buildFunkColorVoicing`). Then add this `describe`:
+
+```ts
+describe("buildBossaColorVoicing", () => {
+  const PC: Record<string, number> = { C: 0, "C#": 1, D: 2, "D#": 3, E: 4, F: 5, "F#": 6, G: 7, "G#": 8, A: 9, "A#": 10, B: 11 };
+  const pcSet = (notes: readonly string[]) => new Set(notes.map((n) => n.replace(/-?\d+$/, "")));
+  const midi = (n: string) => { const m = n.match(/^([A-G]#?)(-?\d+)$/)!; return PC[m[1]] + (parseInt(m[2], 10) + 1) * 12; };
+
+  it("voices a major chord as a rootless maj9 (3 / 7 / 9) in the middle register", () => {
+    // C maj9 rootless: E (3), B (maj7), D (9), starting in octave 4.
+    expect(buildBossaColorVoicing("C", "maj7")).toEqual(["E4", "B4", "D5"]);
+    // plain major M shares the maj9 offsets [4,11,14].
+    expect(buildBossaColorVoicing("C", "M")).toEqual(["E4", "B4", "D5"]);
+  });
+
+  it("voices a minor 7 chord as a rootless m9 (b3 / b7 / 9)", () => {
+    // A m9 rootless: C (b3), G (b7), B (9).
+    expect(buildBossaColorVoicing("A", "m7")).toEqual(["C5", "G5", "B5"]);
+    expect(pcSet(buildBossaColorVoicing("A", "m7")).has("A")).toBe(false); // rootless
+  });
+
+  it("voices a dominant 7 chord as a rootless dom9 (3 / b7 / 9)", () => {
+    const v = buildBossaColorVoicing("G", "7");
+    expect(pcSet(v)).toEqual(new Set(["B", "F", "A"])); // 3=B, b7=F, 9=A
+    expect(pcSet(v).has("G")).toBe(false); // rootless — the bass covers the root
+  });
+
+  it("keeps every defined voicing rootless and in the middle register (C4..C#6)", () => {
+    for (const [root, quality] of [["C", "maj7"], ["D", "M"], ["E", "m7"], ["G", "7"], ["B", "maj7"]] as const) {
+      const v = buildBossaColorVoicing(root, quality);
+      expect(pcSet(v).has(root), `${root}${quality} rootless`).toBe(false);
+      for (const n of v) {
+        const m = midi(n);
+        expect(m, `${root}${quality} ${n} low`).toBeGreaterThanOrEqual(60); // >= C4 (not the funk octave-3 grip)
+        expect(m, `${root}${quality} ${n} high`).toBeLessThanOrEqual(86);   // <= ~C#6
+      }
+    }
+  });
+
+  it("falls back to the plain voice-led triad for a quality without a grip", () => {
+    expect(buildBossaColorVoicing("C", "dim")).toEqual(resolveChordVoicing("C", "dim", undefined, undefined));
+  });
+
+  it("returns [] for an unknown root", () => {
+    expect(buildBossaColorVoicing("H", "maj7")).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/progressions/progressionAudio.test.ts -t buildBossaColorVoicing`
+Expected: FAIL — `buildBossaColorVoicing is not a function` (plus an import error on the missing export).
+
+- [ ] **Step 3: Implement `buildBossaColorVoicing`**
+
+In `src/progressions/progressionAudio.ts`, add this directly below the existing `buildFunkColorVoicing` function (it reuses the file-level `NOTES`, `resolveChordVoicing`, and `PROGRESSION_CHORD_ROOT_OCTAVE` already in scope):
+
+```ts
+/**
+ * Rootless jazz comp tones per chord quality, as semitone offsets above the
+ * chord root. The root (offset 0) is omitted — the bossa bass covers it.
+ * 7ths + 9ths, the bossa comp idiom. Qualities not listed get the plain triad.
+ *   +3 = b3, +4 = 3, +10 = b7, +11 = maj7, +14 = 9
+ */
+const BOSSA_COLOR_TONES: Record<string, readonly number[]> = {
+  maj7: [4, 11, 14], // 3 / 7 / 9 — maj9
+  M: [4, 11, 14], // plain major voiced as maj9 (bossa idiom)
+  m7: [3, 10, 14], // b3 / b7 / 9 — m9
+  m: [3, 10, 14], // m9
+  "7": [4, 10, 14], // 3 / b7 / 9 — dom9
+};
+
+/** Middle-register piano comp octave — true comp register, an octave above the
+ *  guitar-ish octave-3 funk grip. */
+const BOSSA_COMP_ROOT_OCTAVE = 4;
+
+/**
+ * Build a rootless jazz comp voicing (7th + 9th colour) for a chord, in the
+ * middle piano register. Pure. Mirrors `buildFunkColorVoicing`'s open-ascending
+ * shape: each colour tone is an absolute pitch (comp octave + offset). Falls
+ * back to the plain voice-led triad when the quality has no defined grip
+ * (dim/aug/sus/6). Returns [] for an unknown root. `prevVoicing` is accepted for
+ * the triad fallback; the colour tones use a fixed open shape (voice-leading the
+ * rootless grips is a future refinement).
+ */
+export function buildBossaColorVoicing(
+  root: string,
+  quality: string,
+  prevVoicing?: string[],
+): string[] {
+  const rootIndex = NOTES.indexOf(root);
+  if (rootIndex < 0) return [];
+  const offsets = BOSSA_COLOR_TONES[quality];
+  if (!offsets) {
+    return resolveChordVoicing(root, quality, undefined, prevVoicing);
+  }
+  const base = BOSSA_COMP_ROOT_OCTAVE * 12 + rootIndex;
+  return offsets.map((o) => {
+    const absolute = base + o;
+    const note = NOTES[((absolute % 12) + 12) % 12];
+    return `${note}${Math.floor(absolute / 12)}`;
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/progressions/progressionAudio.test.ts -t buildBossaColorVoicing`
+Expected: PASS (6 tests). Then run the full file `pnpm exec vitest run src/progressions/progressionAudio.test.ts` — expect all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/progressions/progressionAudio.ts src/progressions/progressionAudio.test.ts
+git commit -m "feat(progressions): rootless jazz bossa comp voicing (Slice 2 §3.5 pass 2)"
+```
+
+---
+
+## Task 2: Clave fix + comp rewrite (data)
+
+**Files:**
+- Modify: `src/progressions/audio/patterns.ts`
+- Test: `src/progressions/audio/patterns.test.ts`, `src/progressions/audio/buildAllLayers.test.ts`
+
+This task changes pattern data, which breaks three pass-1 assertions that hardcode the old beats. Update those assertions to the new values **and** add the new ones, then change the data.
+
+- [ ] **Step 1: Update + add the failing test assertions**
+
+(a) In `src/progressions/audio/patterns.test.ts`, find the `describe("bossa patterns")` block. Replace the crossStick assertion and the comp assertion with the new values, and add the new `voicing` / `style` checks. The block's three `it`s become:
+
+```ts
+  it("rewrites the bossa drum pattern as a 2-bar cell with a son-clave cross-stick", () => {
+    const bossa = getDrumPattern("bossa")!;
+    expect(bossa.bars).toBe(2);
+    expect(bossa.snares).toEqual([]); // cross-stick carries the rhythm
+    // Authentic 3-2 bossa clave: 2-side's last note on "3&" (6.5), not son's "3" (6).
+    expect(bossa.crossStick?.map((h) => h.beat)).toEqual([0, 1.5, 3, 5, 6.5]);
+  });
+
+  it("adds a 1-bar root-fifth bossa bass pattern", () => {
+    const bass = getBassPattern("bossa")!;
+    expect(bass.bars ?? 1).toBe(1);
+    expect(bass.hits.map((h) => h.note)).toEqual(["root", "fifth"]);
+  });
+
+  it("adds a 2-bar syncopated bossa comp with rootless-jazz voicing and ringing chords", () => {
+    const comp = getChordPattern("bossa-comp")!;
+    expect(comp.bars).toBe(2);
+    expect(comp.voicing).toBe("rootless-jazz");
+    expect(comp.hits.map((h) => h.beat)).toEqual([0, 1.5, 3.5, 4.5, 6, 7.5]);
+    expect(comp.hits.every((h) => h.style === "sustained")).toBe(true);
+  });
+```
+
+(b) In `src/progressions/audio/buildAllLayers.test.ts`, two pass-1 tests hardcode the old beats. Update them:
+
+- The test titled `"plays the bar-2 clave hits on the second bar of a 2-bar cell"` asserts `expect(crossSticks).toEqual([0, 1.5, 3, 5, 6]);` — change it to:
+  ```ts
+    expect(crossSticks).toEqual([0, 1.5, 3, 5, 6.5]);
+  ```
+- The test titled `"plays the bossa comp's bar-2 syncopations on the second bar"` asserts `expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 3, 4.5, 6, 7.5]);` — change it to:
+  ```ts
+    expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 3.5, 4.5, 6, 7.5]);
+  ```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm exec vitest run src/progressions/audio/patterns.test.ts -t "bossa patterns"`
+Expected: FAIL — crossStick is still `[…,6]`, comp beats are still `[…,3,…]`, and `comp.voicing` is `undefined`.
+
+Run: `pnpm exec vitest run src/progressions/audio/buildAllLayers.test.ts -t "bar-2"`
+Expected: FAIL — old hardcoded beats.
+
+- [ ] **Step 3: Add the `voicing` field to `ChordPattern`**
+
+In `src/progressions/audio/patterns.ts`, extend the `ChordPattern` interface:
+
+```ts
+export interface ChordPattern {
+  id: string;
+  label: string;
+  hits: readonly ChordHit[];
+  /** Cell length in bars (default 1). When > 1, `hits` span 0..bars*beatsPerBar
+   *  and the scheduler selects one bar per `absoluteBar % bars`. */
+  bars?: number;
+  /** Voicing strategy for this comp. Omitted = the default chord voicing.
+   *  "rootless-jazz" = buildBossaColorVoicing (rootless 7th/9th, mid register). */
+  voicing?: "rootless-jazz";
+}
+```
+
+- [ ] **Step 4: Fix the clave**
+
+In `src/progressions/audio/patterns.ts`, in the `bossa` entry of `DRUM_PATTERNS`, change the final `crossStick` hit from `beat: 6` to `beat: 6.5`:
+
+```ts
+    crossStick: [
+      { beat: 0, velocity: 0.8 },
+      { beat: 1.5, velocity: 0.7 },
+      { beat: 3, velocity: 0.75 },
+      { beat: 5, velocity: 0.7 },
+      { beat: 6.5, velocity: 0.8 },
+    ],
+```
+
+- [ ] **Step 5: Rewrite the comp**
+
+In `src/progressions/audio/patterns.ts`, replace the `bossa-comp` entry in `CHORD_PATTERNS` with:
+
+```ts
+  {
+    id: "bossa-comp",
+    label: "Bossa Comp",
+    bars: 2,
+    voicing: "rootless-jazz",
+    // Highly syncopated 2-bar partido-alto: clave-locked, two cross-barline
+    // anticipations (3.5, 7.5), soft acoustic dynamics, chords ring (sustained).
+    hits: [
+      // bar 1
+      { beat: 0, velocity: 0.6, style: "sustained" }, // downbeat anchor
+      { beat: 1.5, velocity: 0.55, style: "sustained" }, // "& of 2" (clave)
+      { beat: 3.5, velocity: 0.6, style: "sustained" }, // "& of 4" anticipates bar 2
+      // bar 2
+      { beat: 4.5, velocity: 0.55, style: "sustained" }, // "& of 1"
+      { beat: 6, velocity: 0.5, style: "sustained" }, // beat 3 (clave)
+      { beat: 7.5, velocity: 0.65, style: "sustained" }, // "& of 4" anticipates next cycle
+    ],
+  },
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pnpm exec vitest run src/progressions/audio/patterns.test.ts src/progressions/audio/buildAllLayers.test.ts`
+Expected: PASS — both files fully green (the updated bossa-patterns assertions, the updated bar-2 clave/comp time assertions, and the existing pass-1 suite).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/progressions/audio/patterns.ts src/progressions/audio/patterns.test.ts src/progressions/audio/buildAllLayers.test.ts
+git commit -m "feat(progressions): authentic bossa clave + ringing syncopated comp (Slice 2 §3.5 pass 2)"
+```
+
+---
+
+## Task 3: Wire the rootless comp voicing into the scheduler
+
+**Files:**
+- Modify: `src/progressions/audio/buildAllLayers.ts`
+- Test: `src/progressions/audio/buildAllLayers.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/progressions/audio/buildAllLayers.test.ts`, inside the top-level `describe("buildAllLayers", ...)` block:
+
+```ts
+  it("voices the bossa comp as rootless jazz chords (no root note)", async () => {
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      chordPatternId: "bossa-comp",
+      drumPatternId: "bossa",
+      bassPatternId: "bossa",
+      steps: [step({ duration: { value: 2, unit: "bar" } })], // C major
+    });
+    // C major → rootless maj9 in the middle register: E4 / B4 / D5, no C.
+    expect(out.chordStrums[0].value.voicing).toEqual(["E4", "B4", "D5"]);
+    expect(out.chordStrums.every((s) => !s.value.voicing.some((n) => n.startsWith("C") && !n.startsWith("C#")))).toBe(true);
+  });
+
+  it("leaves a default-voicing comp (jazz) using the standard rooted voicing", async () => {
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      chordPatternId: "jazz-comp",
+      steps: [step({ duration: { value: 1, unit: "bar" } })], // C major
+    });
+    // Default path: resolveChordVoicing keeps the root present (C3/E3/G3).
+    expect(out.chordStrums[0].value.voicing.some((n) => n === "C3")).toBe(true);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm exec vitest run src/progressions/audio/buildAllLayers.test.ts -t "rootless jazz"`
+Expected: FAIL — the comp still resolves the default voicing (`["C3","E3","G3"]`), so `chordStrums[0].value.voicing` is not `["E4","B4","D5"]`.
+
+- [ ] **Step 3: Import `buildBossaColorVoicing`**
+
+In `src/progressions/audio/buildAllLayers.ts`, the top imports from `"../progressionAudio"` currently read:
+
+```ts
+import {
+  resolveBassNoteForRole,
+  resolveChordVoicing,
+  resolveBassLineNotes,
+  buildFunkColorVoicing,
+} from "../progressionAudio";
+```
+
+Add `buildBossaColorVoicing`:
+
+```ts
+import {
+  resolveBassNoteForRole,
+  resolveChordVoicing,
+  resolveBassLineNotes,
+  buildFunkColorVoicing,
+  buildBossaColorVoicing,
+} from "../progressionAudio";
+```
+
+- [ ] **Step 4: Compute the comp voicing**
+
+In `src/progressions/audio/buildAllLayers.ts`, the per-step voicing-intent block currently ends with:
+
+```ts
+    const rootNoteVoicing =
+      needsRootAnchor && plainVoicing.length > 0 ? [plainVoicing[0]] : voicing;
+    const bassLineNotes = resolveBassLineNotes(root, quality);
+```
+
+Insert the comp-voicing computation between those two lines:
+
+```ts
+    const rootNoteVoicing =
+      needsRootAnchor && plainVoicing.length > 0 ? [plainVoicing[0]] : voicing;
+    // Rootless jazz comp voicing (bossa) — opt-in per pattern. Falls back to the
+    // default voicing for every other comp.
+    const compVoicing =
+      chordPattern?.voicing === "rootless-jazz"
+        ? buildBossaColorVoicing(root, quality, lastVoicing)
+        : voicing;
+    const bassLineNotes = resolveBassLineNotes(root, quality);
+```
+
+- [ ] **Step 5: Use the comp voicing as the hits' base voicing**
+
+In `src/progressions/audio/buildAllLayers.ts`, in the chord-strum push, the `voicing` selection currently reads:
+
+```ts
+              voicing:
+                hit.articulation === "color-stab"
+                  ? colorVoicing
+                  : hit.articulation === "root"
+                    ? rootNoteVoicing
+                    : voicing,
+```
+
+Change the final fallback from `voicing` to `compVoicing`:
+
+```ts
+              voicing:
+                hit.articulation === "color-stab"
+                  ? colorVoicing
+                  : hit.articulation === "root"
+                    ? rootNoteVoicing
+                    : compVoicing,
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pnpm exec vitest run src/progressions/audio/buildAllLayers.test.ts`
+Expected: PASS — all tests in the file (the two new voicing tests + the full existing suite). The default-voicing genres are unaffected (`compVoicing === voicing` when no `voicing` field).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/progressions/audio/buildAllLayers.ts src/progressions/audio/buildAllLayers.test.ts
+git commit -m "feat(progressions): route bossa comp through rootless jazz voicing (Slice 2 §3.5 pass 2)"
+```
+
+---
+
+## Task 4: Full verification + ear audition
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `pnpm run test`
+Expected: PASS — all suites green.
+
+- [ ] **Step 2: Lint**
+
+Run: `pnpm run lint`
+Expected: 0 errors. (A pre-existing warning in `src/hooks/useFretboardTopologyModel.ts` is unrelated to this work — do not touch it.)
+
+- [ ] **Step 3: Build**
+
+Run: `pnpm run build`
+Expected: `tsc -b` type-checks clean and `vite build` succeeds.
+
+- [ ] **Step 4: Manual ear audition (required by spec §6)**
+
+Run `pnpm run dev`, open the app, select the **Bossa Nova** genre, load a ≥4-bar progression, play the backing track. Confirm by ear:
+- the cross-stick reads as the **bossa** clave (the last clave note now pushes to the "& of 3"), not the previous son pattern;
+- the comp rings as **rootless jazz chords** (no thick root-position triads), soft and acoustic;
+- the comp's two anticipations (the "& of 4" pushes) lean into the next bar;
+- nothing is muddy. If the ringing chords blur, tune the piano patch's `sustainedDurationSec` (in `src/progressions/audio/sound/instrumentPatches.ts`) — do **not** revert to short stabs. Tune the §3.1/§3.4 beat tables in `patterns.ts` by ear.
+
+Apply any tweaks as small follow-up commits:
+
+```bash
+git add -A && git commit -m "fix(progressions): tune bossa <clave|comp|ring> by ear (Slice 2 §3.5 pass 2)"
+```
+
+- [ ] **Step 5: Finish the branch**
+
+Use the `superpowers:finishing-a-development-branch` skill to integrate (the pass-1 and pass-2 work share this branch).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §3.1 clave fix → Task 2; §3.2 `buildBossaColorVoicing` → Task 1; §3.3 `ChordPattern.voicing` + `compVoicing` wiring → Task 2 (field) + Task 3 (wiring); §3.4 comp rhythm/ring/dynamics → Task 2; §4 backwards-compat → Task 3 default-voicing test; §6 testing → Tasks 1–3 + Task 4 audition. No gaps.
+- **Type consistency:** `buildBossaColorVoicing` (defined Task 1, imported/used Task 3), `BOSSA_COLOR_TONES`/`BOSSA_COMP_ROOT_OCTAVE` (Task 1), `ChordPattern.voicing: "rootless-jazz"` (defined Task 2, read Task 3 as `chordPattern?.voicing === "rootless-jazz"`), `compVoicing` (Task 3) all match.
+- **Broken-by-data-change tests:** the three pass-1 assertions that hardcode the old clave/comp beats are explicitly updated in Task 2 Step 1 (two in `buildAllLayers.test.ts`, one in `patterns.test.ts`), so no test is left asserting stale values.
+- **Octave math verified:** `buildBossaColorVoicing("C","maj7")` → base `48`, offsets `[4,11,14]` → `E4/B4/D5`; `("A","m7")` → `C5/G5/B5`.

--- a/docs/superpowers/plans/2026-06-01-bossa-nova-overhaul.md
+++ b/docs/superpowers/plans/2026-06-01-bossa-nova-overhaul.md
@@ -1,0 +1,811 @@
+# Bossa-Nova Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `bossa-nova` genre sound idiomatically bossa — a 2-bar son-clave on a new cross-stick voice, a root–fifth surdo bassline, and a syncopated partido-alto comp — via a general opt-in 2-bar pattern-cell mechanism.
+
+**Architecture:** Add an optional `bars` field (default 1) to the chord/bass/drum pattern types; a pure `sliceCellToBar` helper selects one bar of a multi-bar cell keyed by the scheduler's existing monotonic `absoluteBar`. A new `crossStick` drum voice (a short MembraneSynth click) carries the clave. 1-bar patterns never enter the new path, so every other genre stays byte-identical.
+
+**Tech Stack:** TypeScript, React 19, Tone.js, Vitest + Testing Library. Package manager is **pnpm**. Tests are co-located (`*.test.ts` beside source).
+
+**Spec:** `docs/superpowers/specs/2026-06-01-bossa-nova-overhaul-design.md`
+
+---
+
+## File-by-file map
+
+- `src/progressions/audio/patterns.ts` — add `bars?: number` to `ChordPattern`, `CatalogBassPattern`, `CatalogDrumPattern`; add `crossStick?: readonly DrumHit[]` to `CatalogDrumPattern`; add `sliceCellToBar`; rewrite `bossa` drum pattern; add `bossa` bass + `bossa-comp` chord patterns.
+- `src/progressions/audio/drumKit.ts` — add `scheduleCrossStick` + its voice pool.
+- `src/progressions/audio/sound/patchTypes.ts` — add `crossStick` to `DrumVoiceParams`.
+- `src/progressions/audio/sound/instrumentPatches.ts` — add `crossStick` override to `kit-bossa`.
+- `src/progressions/audio/buildAllLayers.ts` — add `"crossStick"` to `DrumVoice`; handle it in `collectDrumHits`; apply `bars`-aware slicing in the chord/bass/drum loops.
+- `src/progressions/audio/progressionAudioEngine.ts` — re-export `scheduleCrossStick`.
+- `src/progressions/audio/genres.ts` — re-wire the `bossa-nova` row.
+- `src/hooks/useProgressionAudioPlayback.ts` — add the `crossStick` drum-dispatch case.
+
+---
+
+## Task 1: Pattern-cell data model — `bars` field, `crossStick` field, `sliceCellToBar`
+
+**Files:**
+- Modify: `src/progressions/audio/patterns.ts`
+- Test: `src/progressions/audio/patterns.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/progressions/audio/patterns.test.ts`. Add `sliceCellToBar` to the existing import block from `"./patterns"` first (it currently imports `repeatPatternToBeats`, etc.), then add this `describe`:
+
+```ts
+describe("sliceCellToBar", () => {
+  // A 2-bar cell in 4/4: beats 0..7.99. Bar 1 = [0,4), bar 2 = [4,8).
+  const CELL = [
+    { beat: 0, velocity: 0.8 },
+    { beat: 1.5, velocity: 0.7 },
+    { beat: 3, velocity: 0.75 },
+    { beat: 5, velocity: 0.7 },
+    { beat: 6, velocity: 0.8 },
+  ];
+
+  it("returns bar 1 hits with original beats for cellBarIndex 0", () => {
+    expect(sliceCellToBar(CELL, 0, 4)).toEqual([
+      { beat: 0, velocity: 0.8 },
+      { beat: 1.5, velocity: 0.7 },
+      { beat: 3, velocity: 0.75 },
+    ]);
+  });
+
+  it("returns bar 2 hits shifted back by beatsPerBar for cellBarIndex 1", () => {
+    expect(sliceCellToBar(CELL, 1, 4)).toEqual([
+      { beat: 1, velocity: 0.7 },
+      { beat: 2, velocity: 0.8 },
+    ]);
+  });
+
+  it("returns an empty array for an out-of-range cellBarIndex", () => {
+    expect(sliceCellToBar(CELL, 2, 4)).toEqual([]);
+  });
+
+  it("preserves extra hit fields (only the beat is shifted)", () => {
+    const typed = [{ beat: 5, velocity: 0.5, type: "crossStick" as const }];
+    expect(sliceCellToBar(typed, 1, 4)).toEqual([
+      { beat: 1, velocity: 0.5, type: "crossStick" },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/progressions/audio/patterns.test.ts -t sliceCellToBar`
+Expected: FAIL — `sliceCellToBar is not a function` (also a TS/import error on the missing export).
+
+- [ ] **Step 3: Add the `bars` and `crossStick` fields to the interfaces**
+
+In `src/progressions/audio/patterns.ts`, add an optional `bars` to all three pattern interfaces and `crossStick` to the drum one. Replace the three interface blocks:
+
+```ts
+export interface ChordPattern {
+  id: string;
+  label: string;
+  hits: readonly ChordHit[];
+  /** Cell length in bars (default 1). When > 1, `hits` span 0..bars*beatsPerBar
+   *  and the scheduler selects one bar per `absoluteBar % bars`. */
+  bars?: number;
+}
+```
+
+```ts
+export interface CatalogBassPattern {
+  id: string;
+  label: string;
+  hits: readonly CatalogBassHit[];
+  /** Cell length in bars (default 1). See ChordPattern.bars. */
+  bars?: number;
+}
+```
+
+```ts
+export interface CatalogDrumPattern {
+  id: string;
+  label: string;
+  kicks: readonly DrumHit[];
+  snares: readonly DrumHit[];
+  hats: readonly DrumHit[];
+  openHats?: readonly DrumHit[];
+  ride?: readonly DrumHit[];
+  /** Cross-stick / rim-click voice (bossa clave). */
+  crossStick?: readonly DrumHit[];
+  /** Cell length in bars (default 1). See ChordPattern.bars. */
+  bars?: number;
+}
+```
+
+- [ ] **Step 4: Implement `sliceCellToBar`**
+
+In `src/progressions/audio/patterns.ts`, add this directly above the existing `repeatPatternToBeats` function (keep `repeatPatternToBeats` unchanged):
+
+```ts
+/**
+ * Select the hits belonging to a single bar of a multi-bar pattern cell and
+ * shift them back to bar-local beats (0..beatsPerBar). `cellBarIndex` is
+ * `absoluteBar % bars`. Pure — used for 2-bar patterns (e.g. the bossa clave);
+ * 1-bar patterns never call this (they keep the `repeatPatternToBeats` path).
+ */
+export function sliceCellToBar<T extends { beat: number }>(
+  hits: readonly T[],
+  cellBarIndex: number,
+  beatsPerBar: number,
+): T[] {
+  const offset = cellBarIndex * beatsPerBar;
+  return hits
+    .filter((h) => h.beat >= offset && h.beat < offset + beatsPerBar)
+    .map((h) => ({ ...h, beat: h.beat - offset }));
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/progressions/audio/patterns.test.ts -t sliceCellToBar`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/progressions/audio/patterns.ts src/progressions/audio/patterns.test.ts
+git commit -m "feat(progressions): pattern-cell data model — bars field + sliceCellToBar (Slice 2 §3.5)"
+```
+
+---
+
+## Task 2: The three bossa patterns (data + resolution tests)
+
+**Files:**
+- Modify: `src/progressions/audio/patterns.ts`
+- Test: `src/progressions/audio/patterns.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/progressions/audio/patterns.test.ts`:
+
+```ts
+describe("bossa patterns", () => {
+  it("rewrites the bossa drum pattern as a 2-bar cell with a son-clave cross-stick", () => {
+    const bossa = getDrumPattern("bossa")!;
+    expect(bossa.bars).toBe(2);
+    expect(bossa.snares).toEqual([]); // cross-stick carries the rhythm
+    expect(bossa.crossStick?.map((h) => h.beat)).toEqual([0, 1.5, 3, 5, 6]);
+  });
+
+  it("adds a 1-bar root-fifth bossa bass pattern", () => {
+    const bass = getBassPattern("bossa")!;
+    expect(bass.bars ?? 1).toBe(1);
+    expect(bass.hits.map((h) => h.note)).toEqual(["root", "fifth"]);
+  });
+
+  it("adds a 2-bar syncopated bossa comp chord pattern", () => {
+    const comp = getChordPattern("bossa-comp")!;
+    expect(comp.bars).toBe(2);
+    expect(comp.hits.map((h) => h.beat)).toEqual([0, 1.5, 3, 4.5, 6, 7.5]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/progressions/audio/patterns.test.ts -t "bossa patterns"`
+Expected: FAIL — `getChordPattern("bossa-comp")` returns `undefined` (and the existing `bossa` drum pattern has a `snares` array, so `toEqual([])` fails).
+
+- [ ] **Step 3: Rewrite the `bossa` drum pattern**
+
+In `src/progressions/audio/patterns.ts`, replace the existing `bossa` entry in `DRUM_PATTERNS` (the block `{ id: "bossa", label: "Bossa Nova", kicks: [...], snares: [...], hats: EIGHTH_HATS }`) with:
+
+```ts
+  {
+    id: "bossa",
+    label: "Bossa Nova",
+    bars: 2,
+    // Soft surdo heartbeat: beats 1 & 3 of each bar.
+    kicks: [
+      { beat: 0, velocity: 0.5 },
+      { beat: 2, velocity: 0.6 },
+      { beat: 4, velocity: 0.5 },
+      { beat: 6, velocity: 0.6 },
+    ],
+    // No backbeat snare — the cross-stick clave carries the rhythm.
+    snares: [],
+    // Straight 8th hats across both bars (beats 0..7.5).
+    hats: [
+      { beat: 0, velocity: 0.4 }, { beat: 0.5, velocity: 0.3 },
+      { beat: 1, velocity: 0.4 }, { beat: 1.5, velocity: 0.3 },
+      { beat: 2, velocity: 0.4 }, { beat: 2.5, velocity: 0.3 },
+      { beat: 3, velocity: 0.4 }, { beat: 3.5, velocity: 0.3 },
+      { beat: 4, velocity: 0.4 }, { beat: 4.5, velocity: 0.3 },
+      { beat: 5, velocity: 0.4 }, { beat: 5.5, velocity: 0.3 },
+      { beat: 6, velocity: 0.4 }, { beat: 6.5, velocity: 0.3 },
+      { beat: 7, velocity: 0.4 }, { beat: 7.5, velocity: 0.3 },
+    ],
+    // 3-2 son clave: bar 1 @ 0, 1.5, 3 · bar 2 @ 5 (bar2 beat 1), 6 (bar2 beat 2).
+    crossStick: [
+      { beat: 0, velocity: 0.8 },
+      { beat: 1.5, velocity: 0.7 },
+      { beat: 3, velocity: 0.75 },
+      { beat: 5, velocity: 0.7 },
+      { beat: 6, velocity: 0.8 },
+    ],
+  },
+```
+
+- [ ] **Step 4: Add the bossa bass pattern**
+
+In `src/progressions/audio/patterns.ts`, add this entry to the `BASS_PATTERNS` array (after the `funk-syncopated` entry, before the closing `]`):
+
+```ts
+  {
+    id: "bossa",
+    label: "Bossa Nova",
+    // Root–fifth surdo (tonic–dominant alternation) — the recognizable bossa
+    // pulse. The clave lock comes from the drums + comp; this stays 1-bar.
+    hits: [
+      { beat: 0, velocity: 1, note: "root", articulation: "legato" },
+      { beat: 2, velocity: 0.8, note: "fifth", articulation: "legato" },
+    ],
+  },
+```
+
+- [ ] **Step 5: Add the bossa comp chord pattern**
+
+In `src/progressions/audio/patterns.ts`, add this entry to the `CHORD_PATTERNS` array (after the `straight-quarters` entry, before the closing `]`):
+
+```ts
+  {
+    id: "bossa-comp",
+    label: "Bossa Comp",
+    bars: 2,
+    // Syncopated partido-alto: clave-locked anticipations that leave space.
+    hits: [
+      // bar 1
+      { beat: 0, velocity: 0.7 },
+      { beat: 1.5, velocity: 0.6 },
+      { beat: 3, velocity: 0.55 },
+      // bar 2: anticipated "& of 1" push, mid-bar, "& of 4" lead into the next phrase
+      { beat: 4.5, velocity: 0.6 },
+      { beat: 6, velocity: 0.6 },
+      { beat: 7.5, velocity: 0.7 },
+    ],
+  },
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/progressions/audio/patterns.test.ts -t "bossa patterns"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/progressions/audio/patterns.ts src/progressions/audio/patterns.test.ts
+git commit -m "feat(progressions): bossa clave drum + root-fifth bass + partido-alto comp patterns (Slice 2 §3.5)"
+```
+
+---
+
+## Task 3: Cross-stick voice synthesis (`scheduleCrossStick`)
+
+**Files:**
+- Modify: `src/progressions/audio/sound/patchTypes.ts`
+- Modify: `src/progressions/audio/drumKit.ts`
+- Test: `src/progressions/audio/drumKit.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/progressions/audio/drumKit.test.ts`, add `scheduleCrossStick` to the destructured `import("./drumKit")` declarations and the `beforeEach` import assignment (mirror the existing `scheduleKick` plumbing). The declaration block currently reads:
+
+```ts
+  let scheduleKick: typeof import("./drumKit").scheduleKick;
+  let scheduleSnare: typeof import("./drumKit").scheduleSnare;
+  let scheduleHiHat: typeof import("./drumKit").scheduleHiHat;
+  let scheduleRide: typeof import("./drumKit").scheduleRide;
+```
+
+Add below it:
+
+```ts
+  let scheduleCrossStick: typeof import("./drumKit").scheduleCrossStick;
+```
+
+And change the `beforeEach` import line from:
+
+```ts
+    ({ scheduleKick, scheduleSnare, scheduleHiHat, scheduleRide } =
+      await import("./drumKit"));
+```
+
+to:
+
+```ts
+    ({ scheduleKick, scheduleSnare, scheduleHiHat, scheduleRide, scheduleCrossStick } =
+      await import("./drumKit"));
+```
+
+Then add this `describe` block inside the outer `describe("drumKit — Tone backend", ...)`:
+
+```ts
+  describe("scheduleCrossStick", () => {
+    it("constructs a MembraneSynth with a triangle click voice", () => {
+      scheduleCrossStick({} as AudioNode, 1.5);
+      expect(membraneSpies.ctorSpy).toHaveBeenCalledTimes(1);
+      const [opts] = membraneSpies.ctorSpy.mock.calls[0]!;
+      expect(opts.oscillator.type).toBe("triangle");
+      expect(opts.envelope.sustain).toBe(0);
+      expect(opts.envelope.decay).toBeCloseTo(0.06, 3);
+    });
+
+    it("triggers a high woody click (G4) at the requested time + velocity", () => {
+      scheduleCrossStick({} as AudioNode, 2.5, { velocity: 0.8 });
+      expect(membraneSpies.triggerAttackRelease).toHaveBeenCalledTimes(1);
+      const [note, , time, velocity] =
+        membraneSpies.triggerAttackRelease.mock.calls[0]!;
+      expect(note).toBe("G4");
+      expect(time).toBeCloseTo(2.5, 3);
+      expect(velocity).toBeCloseTo(0.8, 2);
+    });
+
+    it("skips zero-velocity hits (no MembraneSynth constructed)", () => {
+      scheduleCrossStick({} as AudioNode, 1, { velocity: 0 });
+      expect(membraneSpies.ctorSpy).not.toHaveBeenCalled();
+    });
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/progressions/audio/drumKit.test.ts -t scheduleCrossStick`
+Expected: FAIL — `scheduleCrossStick is not a function`.
+
+- [ ] **Step 3: Add the `crossStick` patch override field**
+
+In `src/progressions/audio/sound/patchTypes.ts`, add a `crossStick` entry to `DrumVoiceParams` (after the `ride` line):
+
+```ts
+export interface DrumVoiceParams {
+  // Partial overrides per drum voice; merged over the engine defaults.
+  kick?: { pitchDecay?: number; octaves?: number; envelope?: Partial<EnvelopeSpec> };
+  snare?: { noiseType?: "white" | "pink"; envelope?: Partial<EnvelopeSpec>; volume?: number };
+  hihat?: { decay?: number; resonance?: number; octaves?: number };
+  openHat?: { decay?: number };
+  ride?: { decay?: number; harmonicity?: number; resonance?: number; volume?: number };
+  crossStick?: { pitchDecay?: number; octaves?: number; envelope?: Partial<EnvelopeSpec> };
+}
+```
+
+- [ ] **Step 4: Implement `scheduleCrossStick`**
+
+In `src/progressions/audio/drumKit.ts`, add a dispose window constant next to the others (after the `RIDE_DISPOSE_MS` line):
+
+```ts
+const CROSS_STICK_DISPOSE_MS = 120; // cross-stick decay ~60 ms
+```
+
+Then add this section at the end of the file (after the Ride section), mirroring `scheduleKick`'s pool + schedule structure:
+
+```ts
+// ── Cross-Stick / Rim ────────────────────────────────────────────────────────
+// A dry woody "tok" for the bossa clave: a short, high-pitched MembraneSynth
+// click. Fully deterministic, no noise generation.
+const DEFAULT_CROSS_STICK_ENV = {
+  attack: 0.001,
+  decay: 0.06,
+  sustain: 0,
+  release: 0.02,
+  attackCurve: "exponential" as const,
+};
+const crossStickPools = new Map<
+  string,
+  ReturnType<typeof createReusableVoicePool<Tone.MembraneSynth>>
+>();
+function crossStickPool(kit?: DrumKitPatch) {
+  const key = kitKey(kit);
+  const existing = crossStickPools.get(key);
+  if (existing) return existing;
+  const ov = kit?.voices.crossStick;
+  const pool = createReusableVoicePool<Tone.MembraneSynth>({
+    createVoice: () =>
+      new Tone.MembraneSynth({
+        pitchDecay: ov?.pitchDecay ?? 0.008,
+        octaves: ov?.octaves ?? 2,
+        oscillator: { type: "triangle" },
+        envelope: { ...DEFAULT_CROSS_STICK_ENV, ...(ov?.envelope ?? {}) },
+      }),
+  });
+  crossStickPools.set(key, pool);
+  return pool;
+}
+
+/**
+ * Schedule a cross-stick / rim-click hit at `time`. Short MembraneSynth click
+ * (triangle, tiny pitch-decay, ~60 ms decay) — the bossa clave timbre.
+ */
+export function scheduleCrossStick(
+  dest: AudioNode,
+  time: number,
+  options: DrumHitOptions = {},
+): DrumVoiceHandle {
+  const velocity = clampVelocity(options.velocity);
+  if (velocity <= 0) return NOOP_HANDLE;
+  const now = Tone.now();
+  const playbackStartTime = Math.max(now, time);
+  const lease = crossStickPool(options.kit).lease(dest, now);
+  const busyUntil = playbackStartTime + 0.12;
+  lease.setBusyUntil(busyUntil);
+  lease.voice.triggerAttackRelease("G4", 0.05, time, velocity);
+  return deferredDisposeHandle(lease, time, busyUntil, CROSS_STICK_DISPOSE_MS);
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/progressions/audio/drumKit.test.ts -t scheduleCrossStick`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/progressions/audio/drumKit.ts src/progressions/audio/sound/patchTypes.ts src/progressions/audio/drumKit.test.ts
+git commit -m "feat(progressions): cross-stick rim voice (MembraneSynth click) (Slice 2 §3.5)"
+```
+
+---
+
+## Task 4: Wire the cross-stick voice through the engine
+
+**Files:**
+- Modify: `src/progressions/audio/buildAllLayers.ts:22` (the `DrumVoice` type) and `:121-129` (`collectDrumHits`)
+- Modify: `src/progressions/audio/progressionAudioEngine.ts:17`
+- Modify: `src/hooks/useProgressionAudioPlayback.ts:450-456`
+- Test: `src/progressions/audio/buildAllLayers.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/progressions/audio/buildAllLayers.test.ts` (inside the top-level `describe("buildAllLayers", ...)` block):
+
+```ts
+  it("emits cross-stick drum events for the bossa clave pattern", async () => {
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      drumPatternId: "bossa",
+      chordPatternId: "ballad-whole",
+      steps: [step({ duration: { value: 1, unit: "bar" } })],
+    });
+    const crossSticks = out.drums.filter((d) => d.value.type === "crossStick");
+    // Bar 1 (3-side) of the son clave: beats 0, 1.5, 3 → times 0, 1.5, 3 at 60bpm.
+    expect(crossSticks.map((d) => d.time)).toEqual([0, 1.5, 3]);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/progressions/audio/buildAllLayers.test.ts -t "cross-stick"`
+Expected: FAIL — `crossSticks` is empty (`collectDrumHits` ignores the `crossStick` array; the events never appear).
+
+- [ ] **Step 3: Add `"crossStick"` to the `DrumVoice` type**
+
+In `src/progressions/audio/buildAllLayers.ts`, change line 22:
+
+```ts
+type DrumVoice = "kick" | "snare" | "hihat" | "openHat" | "ride" | "crossStick";
+```
+
+- [ ] **Step 4: Handle `crossStick` in `collectDrumHits`**
+
+In `src/progressions/audio/buildAllLayers.ts`, add one line to `collectDrumHits` (after the `ride` loop, before `return out`):
+
+```ts
+function collectDrumHits(pattern: CatalogDrumPattern): VoicedDrumHit[] {
+  const out: VoicedDrumHit[] = [];
+  for (const h of pattern.kicks) out.push({ ...h, type: "kick" });
+  for (const h of pattern.snares) out.push({ ...h, type: "snare" });
+  for (const h of pattern.hats) out.push({ ...h, type: "hihat" });
+  for (const h of pattern.openHats ?? []) out.push({ ...h, type: "openHat" });
+  for (const h of pattern.ride ?? []) out.push({ ...h, type: "ride" });
+  for (const h of pattern.crossStick ?? []) out.push({ ...h, type: "crossStick" });
+  return out;
+}
+```
+
+- [ ] **Step 5: Re-export `scheduleCrossStick` from the engine**
+
+In `src/progressions/audio/progressionAudioEngine.ts`, change line 17:
+
+```ts
+export { scheduleCrossStick, scheduleHiHat, scheduleKick, scheduleRide, scheduleSnare } from "./drumKit";
+```
+
+- [ ] **Step 6: Add the playback dispatch case**
+
+In `src/hooks/useProgressionAudioPlayback.ts`, add a `crossStick` case to the drum `switch` (after the `ride` case, around line 455):
+
+```ts
+            case "crossStick": eng.scheduleCrossStick(audio.layers.drums, audioTime, { velocity: value.velocity, kit: drumKit }); break;
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/progressions/audio/buildAllLayers.test.ts -t "cross-stick"`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/progressions/audio/buildAllLayers.ts src/progressions/audio/progressionAudioEngine.ts src/hooks/useProgressionAudioPlayback.ts src/progressions/audio/buildAllLayers.test.ts
+git commit -m "feat(progressions): route cross-stick voice through engine + playback (Slice 2 §3.5)"
+```
+
+---
+
+## Task 5: `bars`-aware slicing in the scheduler
+
+**Files:**
+- Modify: `src/progressions/audio/buildAllLayers.ts` (chord loop ~229-261, bass loop ~263-290, drum loop ~292-312)
+- Test: `src/progressions/audio/buildAllLayers.test.ts`
+
+This task makes the second bar of a 2-bar cell actually play (the bar-2 clave hits, the comp's bar-2 syncopations). Before it, a `bars: 2` pattern falls through `repeatPatternToBeats`, which drops beats ≥ `beatsPerBar` — so only bar 1 is heard.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/progressions/audio/buildAllLayers.test.ts`. First add `sliceCellToBar` is **not** needed here; we import nothing new. Add:
+
+```ts
+  it("plays the bar-2 clave hits on the second bar of a 2-bar cell", async () => {
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      drumPatternId: "bossa",
+      chordPatternId: "ballad-whole",
+      // One 2-bar step → absolute bars 0 and 1.
+      steps: [step({ duration: { value: 2, unit: "bar" } })],
+    });
+    const crossSticks = out.drums
+      .filter((d) => d.value.type === "crossStick")
+      .map((d) => d.time);
+    // Bar 1 @ 0,1.5,3 ; bar 2 starts at 4s, clave beats 5,6 → local 1,2 → 5,6.
+    expect(crossSticks).toEqual([0, 1.5, 3, 5, 6]);
+  });
+
+  it("plays the bossa comp's bar-2 syncopations on the second bar", async () => {
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      drumPatternId: "bossa",
+      chordPatternId: "bossa-comp",
+      bassPatternId: "bossa",
+      steps: [step({ duration: { value: 2, unit: "bar" } })],
+    });
+    // comp beats 0,1.5,3 (bar1) and 4.5,6,7.5 (bar2) → times identical at 60bpm.
+    expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 3, 4.5, 6, 7.5]);
+  });
+
+  it("leaves a 1-bar pattern (rock) emitting identical hits on every bar", async () => {
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      drumPatternId: "rock",
+      chordPatternId: "ballad-whole",
+      steps: [step({ duration: { value: 2, unit: "bar" } })],
+    });
+    const kicksBar1 = out.drums.filter((d) => d.value.type === "kick" && d.time < 4).map((d) => d.time);
+    const kicksBar2 = out.drums.filter((d) => d.value.type === "kick" && d.time >= 4).map((d) => d.time - 4);
+    // rock kicks at 0, 1.5, 2 — same in both bars (the bars-default path is untouched).
+    expect(kicksBar1).toEqual([0, 1.5, 2]);
+    expect(kicksBar2).toEqual([0, 1.5, 2]);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/progressions/audio/buildAllLayers.test.ts -t "bar-2"`
+Expected: FAIL — the first two tests fail (bar-2 hits are dropped, so `crossSticks` is `[0,1.5,3,0,1.5,3]` shifted and the comp times are `[0,1.5,3,4,5.5,7]`-ish from `repeatPatternToBeats` repeating bar 1). The third test passes already (guards the default path).
+
+- [ ] **Step 3: Import `sliceCellToBar` into the scheduler**
+
+In `src/progressions/audio/buildAllLayers.ts`, add `sliceCellToBar` to the existing import from `"./patterns"` (the block that already imports `repeatPatternToBeats`):
+
+```ts
+import {
+  getBassPattern,
+  getChordPattern,
+  getDrumPattern,
+  getDrumVariation,
+  variationFiresOnBar,
+  repeatPatternToBeats,
+  sliceCellToBar,
+  type CatalogDrumPattern,
+  type DrumHit,
+  type DrumVariation,
+  type BassArticulation,
+} from "./patterns";
+```
+
+- [ ] **Step 4: Apply cell slicing in the chord loop**
+
+In `src/progressions/audio/buildAllLayers.ts`, inside `if (chordPattern && voicing.length > 0) {`, replace the line:
+
+```ts
+        const hits = repeatPatternToBeats(chordPattern.hits, eventBeats, input.beatsPerBar);
+```
+
+with:
+
+```ts
+        const chordCellBars = chordPattern.bars ?? 1;
+        const hits = isBarUnit && chordCellBars > 1
+          ? sliceCellToBar(chordPattern.hits, absoluteBar % chordCellBars, input.beatsPerBar)
+          : repeatPatternToBeats(chordPattern.hits, eventBeats, input.beatsPerBar);
+```
+
+- [ ] **Step 5: Apply cell slicing in the bass loop**
+
+In `src/progressions/audio/buildAllLayers.ts`, inside `if (bassPattern && bassLineNotes.length > 0) {`, replace the line:
+
+```ts
+        const hits = repeatPatternToBeats(bassPattern.hits, eventBeats, input.beatsPerBar);
+```
+
+with:
+
+```ts
+        const bassCellBars = bassPattern.bars ?? 1;
+        const hits = isBarUnit && bassCellBars > 1
+          ? sliceCellToBar(bassPattern.hits, absoluteBar % bassCellBars, input.beatsPerBar)
+          : repeatPatternToBeats(bassPattern.hits, eventBeats, input.beatsPerBar);
+```
+
+- [ ] **Step 6: Apply cell slicing to the drum base pattern**
+
+In `src/progressions/audio/buildAllLayers.ts`, the drum section currently reads:
+
+```ts
+      const firingVariationHits: VoicedDrumHit[] = variations
+        .filter((v) => variationFiresOnBar(v, absoluteBar))
+        .flatMap((v) => collectDrumHits(v.pattern));
+      const drumHitsForBar: VoicedDrumHit[] = [...baseDrumHits, ...firingVariationHits];
+```
+
+Replace those four lines with (slice the multi-bar base to the current bar before merging the 1-bar variation hits):
+
+```ts
+      const drumCellBars = drumPattern?.bars ?? 1;
+      const baseForBar: VoicedDrumHit[] = isBarUnit && drumCellBars > 1
+        ? sliceCellToBar(baseDrumHits, absoluteBar % drumCellBars, input.beatsPerBar)
+        : baseDrumHits;
+      const firingVariationHits: VoicedDrumHit[] = variations
+        .filter((v) => variationFiresOnBar(v, absoluteBar))
+        .flatMap((v) => collectDrumHits(v.pattern));
+      const drumHitsForBar: VoicedDrumHit[] = [...baseForBar, ...firingVariationHits];
+```
+
+Note: for the `bars > 1` drum path the sliced hits are already bar-local (beats `0..beatsPerBar`), and the subsequent `repeatPatternToBeats(drumHitsForBar, eventBeats, input.beatsPerBar)` call emits them once for the single bar (it is a no-op repeat at one-bar width) — leave that call unchanged.
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/progressions/audio/buildAllLayers.test.ts`
+Expected: PASS (all tests in the file, including the three new ones and the existing suite).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/progressions/audio/buildAllLayers.ts src/progressions/audio/buildAllLayers.test.ts
+git commit -m "feat(progressions): bars-aware cell slicing in the scheduler (Slice 2 §3.5)"
+```
+
+---
+
+## Task 6: Wire the bossa-nova genre + tune the kit
+
+**Files:**
+- Modify: `src/progressions/audio/genres.ts:53-58` (the `bossa-nova` row)
+- Modify: `src/progressions/audio/sound/instrumentPatches.ts:200-207` (`kit-bossa`)
+- Test: `src/progressions/audio/genres.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/progressions/audio/genres.test.ts`, inside the `describe("genre styles", ...)` block:
+
+```ts
+  it("wires bossa-nova to the clave drum, surdo bass, and partido-alto comp", () => {
+    const bossa = getGenreStyle("bossa-nova")!;
+    expect(bossa.chordPattern).toBe("bossa-comp");
+    expect(bossa.bassPattern).toBe("bossa");
+    expect(bossa.drumPattern).toBe("bossa");
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/progressions/audio/genres.test.ts -t "bossa-nova to the clave"`
+Expected: FAIL — `chordPattern` is `"straight-quarters"`, `bassPattern` is `"arpeggiated"`.
+
+- [ ] **Step 3: Re-wire the bossa-nova genre row**
+
+In `src/progressions/audio/genres.ts`, replace the `bossa-nova` entry:
+
+```ts
+  {
+    id: "bossa-nova", label: "Bossa Nova", chordInstrument: "piano",
+    chordPattern: "bossa-comp", bassPattern: "bossa",
+    drumPattern: "bossa", drumVariations: [],
+    tempoRange: [120, 140], suggestedTempo: 130, swing: 0,
+  },
+```
+
+- [ ] **Step 4: Add the cross-stick override to the bossa kit**
+
+In `src/progressions/audio/sound/instrumentPatches.ts`, replace the `kit-bossa` entry:
+
+```ts
+  {
+    id: "kit-bossa", label: "Bossa",
+    voices: {
+      kick: { pitchDecay: 0.05, octaves: 5, envelope: { decay: 0.28 } },
+      snare: { noiseType: "white", envelope: { decay: 0.12 } },
+      hihat: { decay: 0.04 },
+      crossStick: { pitchDecay: 0.006, octaves: 2, envelope: { decay: 0.05 } },
+    },
+  },
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm exec vitest run src/progressions/audio/genres.test.ts`
+Expected: PASS (the new test plus the existing suite — note `"references valid pattern IDs"` now resolves `bossa-comp`/`bossa`/`bossa`, and `"leaves ballad and bossa-nova without drum variations"` still holds since `drumVariations` stays `[]`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/progressions/audio/genres.ts src/progressions/audio/sound/instrumentPatches.ts src/progressions/audio/genres.test.ts
+git commit -m "feat(progressions): wire bossa-nova genre to clave/surdo/partido-alto + tune kit (Slice 2 §3.5)"
+```
+
+---
+
+## Task 7: Full verification + ear audition
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `pnpm run test`
+Expected: PASS — all suites green. If a snapshot or unrelated test fails, investigate before proceeding (do not update snapshots blindly).
+
+- [ ] **Step 2: Lint**
+
+Run: `pnpm run lint`
+Expected: no errors (eslint + stylelint clean).
+
+- [ ] **Step 3: Build**
+
+Run: `pnpm run build`
+Expected: `tsc -b` type-checks clean and `vite build` succeeds. A type error here most likely means a `bars`/`crossStick` field or the `DrumVoice` union is out of sync — fix and re-run.
+
+- [ ] **Step 4: Manual ear audition (required by spec §7 / parent §3.5)**
+
+Run `pnpm run dev`, open the app, select the **Bossa Nova** genre, load a ≥4-bar progression, and play the backing track. Confirm by ear:
+- the cross-stick plays a recognizable 2-bar son clave (not a 1-bar loop);
+- the bass reads as a root–fifth surdo pulse, not an even arpeggio;
+- the comp is syncopated and leaves space, locking with the clave;
+- nothing clips or clashes.
+
+Tune the §5 beat tables in `patterns.ts` by ear as needed; apply each tweak as a small follow-up commit:
+
+```bash
+git add src/progressions/audio/patterns.ts
+git commit -m "fix(progressions): tune bossa <clave|bass|comp> by ear (Slice 2 §3.5)"
+```
+
+- [ ] **Step 5: Finish the branch**
+
+Use the `superpowers:finishing-a-development-branch` skill to open the PR (or merge), ensuring the PR title/body follow Conventional Commits and reference Slice 2 §3.5.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §3 cell mechanism → Task 1 + Task 5; §4 cross-stick voice (all 7 touchpoints) → Tasks 1 (field), 3 (synth + patch field), 4 (type/collect/export/dispatch), 6 (kit override); §5.1 drum clave → Task 2; §5.2 bass → Task 2; §5.3 comp → Task 2; §6 genre wiring → Task 6; §7 testing + audition → Tasks 1–6 (per-task) + Task 7. No gaps.
+- **Type consistency:** `bars` (3 interfaces), `crossStick` (`CatalogDrumPattern` field, `DrumVoice` member, `DrumVoiceParams` override, dispatch case), `sliceCellToBar` (defined Task 1, imported Task 5), `scheduleCrossStick` (defined Task 3, exported Task 4, dispatched Task 4) all match across tasks.
+- **Determinism:** no `Date.now`/`Math.random` introduced; slicing is pure on `absoluteBar`.

--- a/docs/superpowers/specs/2026-06-01-bossa-comp-lh-rh-split-design.md
+++ b/docs/superpowers/specs/2026-06-01-bossa-comp-lh-rh-split-design.md
@@ -1,0 +1,249 @@
+# Bossa-Nova Comp — LH Bass + RH Chords (Slice 2 §3.5, pass 3)
+
+**Status:** Design — approved in brainstorming 2026-06-01.
+**Date:** 2026-06-01
+**Parent:** `2026-06-01-bossa-nova-clave-comp-refinement-design.md` (pass 2).
+**Builds on:** the `bossa-comp` pattern, `buildBossaColorVoicing`, and the
+`ChordPattern.voicing: "rootless-jazz"` wiring landed in pass 2.
+
+A third listening pass found the comp still off: the rootless voicings sit **too
+high**, and the piano needs to **carry its own bass note** (it sounds thin/
+disembodied with the root only in the separate upright). Research (§2) confirms
+both: bossa piano is **LH root/fifth + RH rootless chords**, with the RH top note
+kept between middle C (C4) and C5. This pass turns the single-voicing comp into a
+real two-hand piano part and lowers the chord register.
+
+---
+
+## 1. Goal
+
+1. Lower and fill out the RH comp voicing: a 4-note **Type-B rootless** voicing
+   (7-9-3-5) in the C3–C5 register, register-normalized so the top note never
+   exceeds C5 (fixes the "too high" complaint for all roots, including high ones
+   like A/B that previously floated into octave 5).
+2. Give the piano a **left hand**: root on beat 1, fifth on beat 3 (octave 3),
+   played as single low notes, while the RH plays the rootless chords on the
+   syncopated off-beats.
+
+The separate upright-bass layer is **unchanged** (root/fifth, octave 2) — it sits
+an octave below the new piano LH, the standard bossa-trio doubling.
+
+## 2. Research findings (what was missing)
+
+- **Register.** The top note of a bossa/jazz comp voicing should sit between
+  middle C (C4) and the C above it (C5); rootless voicings live ~C3–A4
+  ([pianowithjonny](https://pianowithjonny.com/piano-lessons/jazz-piano-comping-with-two-hand-voicings/),
+  [pianogroove](https://www.pianogroove.com/jazz-piano-lessons/rootless-chord-voicings/)).
+  Pass 2's voicing was based at octave 4 and topped out at D5 (C maj) / B5 (A m7) —
+  too high.
+- **Two hands.** Standard bossa/jazz piano is **LH root (beat 1) + fifth (beat 3)**
+  with **RH rootless A/B voicings** ([TJPS](https://www.thejazzpianosite.com/jazz-piano-lessons/jazz-genres/how-to-play-bossa-nova/)).
+  Type A = 3-5-7-9 (3rd lowest); **Type B = 7-9-3-5 (7th lowest)** — the latter
+  sits lower for the same chord and is the better fit for the C3–C5 target.
+- **Confirmed unchanged:** the clave, the kick/hats, the syncopated off-beat
+  feel with anticipations, and the upright bass.
+
+## 3. Architecture
+
+Two units change: the voicing function (`progressionAudio.ts`) and the comp's
+per-hit voicing resolution (`buildAllLayers.ts`). The pattern data
+(`patterns.ts`) is rewritten. No new engine concept beyond one optional
+`ChordHit` field.
+
+### 3.1 RH voicing: Type-B rootless, octave 3, register-normalized
+
+Rewrite `buildBossaColorVoicing` (`progressionAudio.ts`). Replace the 3-note
+open shape with a 4-note **Type-B (7-9-3-5)** rootless voicing based at octave 3,
+then normalize the whole voicing down by octaves until its top note is ≤ C5.
+
+```ts
+/** Rootless Type-B (7-9-3-5) comp tones per quality, as semitone offsets above
+ *  the chord root. The root is omitted — the piano LH / upright bass cover it. */
+const BOSSA_COLOR_TONES: Record<string, readonly number[]> = {
+  maj7: [11, 14, 16, 19], // 7 / 9 / 3 / 5 — maj9
+  M: [11, 14, 16, 19], // plain major voiced as maj9
+  m7: [10, 14, 15, 19], // b7 / 9 / b3 / 5 — m9
+  m: [10, 14, 15, 19], // m9
+  "7": [10, 14, 16, 19], // b7 / 9 / 3 / 5 — dom9
+};
+
+/** Comp voicing base octave (the 7th, lowest note, starts here). */
+const BOSSA_COMP_ROOT_OCTAVE = 3;
+/** Register ceiling: the voicing's top note must not exceed this absolute
+ *  semitone (C5). `absolute = octave*12 + pitchIndex`, matching the note-string
+ *  encoding used throughout this file. C5 → 5*12 + 0 = 60. */
+const BOSSA_COMP_TOP_CEILING = 60;
+```
+
+`buildBossaColorVoicing(root, quality, prevVoicing?)`:
+
+1. `rootIndex = NOTES.indexOf(root)`; return `[]` if `< 0`.
+2. `offsets = BOSSA_COLOR_TONES[quality]`; if absent, return
+   `resolveChordVoicing(root, quality, undefined, prevVoicing)` (the
+   dim/aug/sus/6 fallback, unchanged behaviour).
+3. `base = BOSSA_COMP_ROOT_OCTAVE * 12 + rootIndex`; build
+   `absolutes = offsets.map((o) => base + o)`.
+4. **Normalize:** while `Math.max(...absolutes) > BOSSA_COMP_TOP_CEILING`,
+   subtract `12` from every entry.
+5. Map each absolute to a note string:
+   `NOTES[((a % 12) + 12) % 12] + Math.floor(a / 12)`.
+
+Worked examples (codebase absolute = note-string octave × 12 + pitch index):
+- `C maj7` → base 36, `[47,50,52,55]` (top 55 ≤ 60) → `["B3","D4","E4","G4"]`.
+- `A m7` → base 45, `[55,59,60,64]`, top 64 > 60 → −12 → `[43,47,48,52]` →
+  `["G3","B3","C4","E4"]` (was `["C5","G5","B5"]` in pass 2).
+- `B maj7` → base 47, `[58,61,63,66]`, top 66 > 60 → −12 → `[46,49,51,54]` →
+  `["A#3","C#4","D#4","F#4"]`.
+
+### 3.2 The `voiceRole` field on `ChordHit`
+
+Add an optional role to `ChordHit` (`patterns.ts`):
+
+```ts
+interface ChordHit {
+  beat: number;
+  velocity: number;
+  style?: "staccato" | "sustained";
+  direction?: StrumDirection;
+  articulation?: ChordArticulation;
+  /** Bossa LH/RH split (used when the pattern's voicing is "rootless-jazz"):
+   *  "bass-root"/"bass-fifth" play a single low note (LH); "chord" plays the
+   *  rootless RH voicing. Omitted behaves as "chord". */
+  voiceRole?: "bass-root" | "bass-fifth" | "chord";
+}
+```
+
+### 3.3 Per-hit voicing resolution (`buildAllLayers.ts`)
+
+Per step, when the chord pattern opts into rootless-jazz, resolve the LH bass
+notes once (octave 3) alongside the existing `compVoicing`:
+
+```ts
+const BOSSA_LH_OCTAVE = 3; // module constant near the other layer constants
+// inside the per-step voicing block, after compVoicing:
+const bossaLhNotes =
+  chordPattern?.voicing === "rootless-jazz"
+    ? resolveBassLineNotes(root, quality, BOSSA_LH_OCTAVE) // [root, fifth] @ oct 3
+    : [];
+const bassRootVoicing = bossaLhNotes.length > 0 ? [bossaLhNotes[0]] : voicing;
+const bassFifthVoicing =
+  bossaLhNotes.length > 1 ? [bossaLhNotes[1]] : bassRootVoicing;
+```
+
+`resolveBassLineNotes` is already imported in `buildAllLayers.ts`. It returns
+`[root, fifth]` (or `[root]` when the quality has no fifth) at the requested
+octave.
+
+Extend the chord-strum push's voicing selection to honour `voiceRole` first
+(bass roles win over articulation; `chord`/unset falls through to the existing
+chain):
+
+```ts
+voicing:
+  hit.voiceRole === "bass-root"
+    ? bassRootVoicing
+    : hit.voiceRole === "bass-fifth"
+      ? bassFifthVoicing
+      : hit.articulation === "color-stab"
+        ? colorVoicing
+        : hit.articulation === "root"
+          ? rootNoteVoicing
+          : compVoicing,
+```
+
+The funk `color-stab` / `root` branches are untouched. Every non-bossa pattern
+has no `voiceRole`, so the chain behaves exactly as before. All bossa hits carry
+`style: "sustained"`, so both the single LH bass notes and the RH chords ring via
+the poly patch's `sustainedDurationSec` (no `durationSec` override needed).
+
+### 3.4 The new `bossa-comp` pattern (`patterns.ts`)
+
+```ts
+{
+  id: "bossa-comp",
+  label: "Bossa Comp",
+  bars: 2,
+  voicing: "rootless-jazz",
+  // LH bass (root on 1, fifth on 3) + RH rootless chords on the syncopated
+  // off-beats, with two cross-barline anticipations (3.5, 7.5). Soft, ringing.
+  hits: [
+    { beat: 0, velocity: 0.6, voiceRole: "bass-root", style: "sustained" },
+    { beat: 1.5, velocity: 0.5, voiceRole: "chord", style: "sustained" },
+    { beat: 2, velocity: 0.55, voiceRole: "bass-fifth", style: "sustained" },
+    { beat: 3.5, velocity: 0.55, voiceRole: "chord", style: "sustained" },
+    { beat: 4, velocity: 0.6, voiceRole: "bass-root", style: "sustained" },
+    { beat: 4.5, velocity: 0.5, voiceRole: "chord", style: "sustained" },
+    { beat: 6, velocity: 0.55, voiceRole: "bass-fifth", style: "sustained" },
+    { beat: 7.5, velocity: 0.55, voiceRole: "chord", style: "sustained" },
+  ],
+}
+```
+
+Beats/velocities are eye-tuned starting points, nudged by ear in §6.
+
+### 3.5 Notes
+
+- Determinism preserved: voicing selection is a pure function of root/quality/
+  role; the normalization loop is deterministic; no `Date.now`/`Math.random`.
+- The upright bass (octave 2, root/fifth on 1/3) is unchanged and sits an octave
+  below the piano LH (octave 3).
+- Voice-leading the rootless grips between chords remains a future refinement
+  (the shapes are fixed per chord, normalized by register only).
+
+## 4. Backwards-compatibility
+
+- `buildBossaColorVoicing` is only called for `voicing: "rootless-jazz"` patterns
+  (i.e. `bossa-comp`). Its internal change does not affect any other genre.
+- `voiceRole` is optional and only set on `bossa-comp`; every other comp omits it,
+  so the voicing-selection chain is unchanged for them.
+- The upright bass layer, the clave, the kick, and the hats are untouched.
+
+## 5. Files touched
+
+- `src/progressions/progressionAudio.ts` — rewrite `BOSSA_COLOR_TONES`,
+  `BOSSA_COMP_ROOT_OCTAVE`, add `BOSSA_COMP_TOP_CEILING`, rewrite
+  `buildBossaColorVoicing` (Type-B + normalization).
+- `src/progressions/audio/patterns.ts` — add `ChordHit.voiceRole`; rewrite the
+  `bossa-comp` hits.
+- `src/progressions/audio/buildAllLayers.ts` — add `BOSSA_LH_OCTAVE`, the
+  `bossaLhNotes` / `bassRootVoicing` / `bassFifthVoicing` resolution, and the
+  `voiceRole` branch in the chord-strum voicing selection.
+- Co-located tests: `progressionAudio.test.ts`, `patterns.test.ts`,
+  `buildAllLayers.test.ts`.
+
+## 6. Testing strategy
+
+**Unit (`progressionAudio.test.ts`) — rewrite the `buildBossaColorVoicing` block:**
+
+1. `buildBossaColorVoicing("C", "maj7")` → `["B3", "D4", "E4", "G4"]` (Type-B
+   7-9-3-5, rootless, top G4).
+2. `buildBossaColorVoicing("A", "m7")` → `["G3", "B3", "C4", "E4"]` (normalized
+   down from octave 5 — the regression that fixes "too high").
+3. Every defined voicing has 4 notes, is rootless (no root pitch class), and its
+   **top note ≤ C5** for all 12 roots × {maj7, M, m7, m, "7"} (the register
+   guarantee, including high roots A/B).
+4. A quality with no grip (e.g. `"dim"`) falls back to
+   `resolveChordVoicing("C","dim",undefined,undefined)`; an unknown root → `[]`.
+
+**Unit (`patterns.test.ts`):**
+
+5. The `bossa-comp` pattern has `bars: 2`, `voicing: "rootless-jazz"`, beats
+   `[0, 1.5, 2, 3.5, 4, 4.5, 6, 7.5]`, every hit `style: "sustained"`, and the
+   `voiceRole` sequence
+   `["bass-root","chord","bass-fifth","chord","bass-root","chord","bass-fifth","chord"]`.
+
+**Unit (`buildAllLayers.test.ts`):**
+
+6. For a C-major bossa-comp step: the strum at the `bass-root` beat (0) resolves
+   to a single note `["C3"]`; the `bass-fifth` beat (2) resolves to `["G3"]`; a
+   `chord` beat (1.5) resolves to the Type-B voicing `["B3","D4","E4","G4"]`.
+7. Every bossa-comp strum carries `style: "sustained"`.
+8. Backwards-compat: a default-voicing comp (jazz, `jazz-comp`) still resolves the
+   standard rooted voicing (contains `C3`) — the `voiceRole`/`compVoicing` path is
+   inert without the `voicing` field.
+
+**Manual ear audition (required):** play a ≥4-bar bossa progression; confirm the
+piano now reads as a two-hand bossa part (walking-ish root/fifth bass under
+ringing rootless chords), the chords are no longer too high, and it locks with
+the clave and upright bass. Tune the §3.1/§3.4 tables and the piano
+`sustainedDurationSec` by ear via small follow-up commits.

--- a/docs/superpowers/specs/2026-06-01-bossa-nova-clave-comp-refinement-design.md
+++ b/docs/superpowers/specs/2026-06-01-bossa-nova-clave-comp-refinement-design.md
@@ -1,0 +1,260 @@
+# Bossa-Nova Clave & Comp Refinement (Slice 2 §3.5, pass 2)
+
+**Status:** Design — approved in brainstorming 2026-06-01.
+**Date:** 2026-06-01
+**Parent:** `2026-06-01-bossa-nova-overhaul-design.md` (pass 1, shipped on this branch).
+**Builds on:** the 2-bar pattern-cell mechanism, the cross-stick voice, and the
+`bossa` drum / `bossa` bass / `bossa-comp` patterns already landed in pass 1.
+
+A second listening pass found the bossa nova still doesn't read as authentic.
+Research (see §2) pinned two concrete causes: the cross-stick plays the **son**
+clave, not the **bossa** clave; and the comp plays generic short-stab chords
+instead of **sustained, rootless jazz 7th/9th voicings**. This pass fixes both.
+
+---
+
+## 1. Goal
+
+Make the bossa-nova comp and clave idiomatic:
+
+1. Correct the cross-stick to the authentic **3-2 bossa clave** (one note moves).
+2. Voice the comp as **rootless jazz 7th/9th chords in the middle register**,
+   ringing/tied (sustained), softly dynamic, over a highly syncopated 2-bar
+   figure with cross-barline anticipations.
+
+The bass already satisfies the "left hand" (root/fifth on beats 1 & 3); it is
+unchanged. Kick and hats are unchanged.
+
+## 2. Research findings (what was missing)
+
+- **Clave.** The bossa nova clave is the Cuban son clave with the **second note
+  of the 2-side delayed by one eighth** (Wikipedia: *Clave (rhythm)*;
+  bossanova-gitarre.de). On the eighth-note grid (3-2 orientation):
+
+  ```
+  Count:        1  1& 2  2& 3  3& 4  4&
+  Son 3-side:   X  .  .  X  .  .  X  .   (bar 1)
+  Son 2-side:   .  X  X  .  .  .  .  .   (bar 2)  → hits on 2, 3
+  Bossa 3-side: X  .  .  X  .  .  X  .   (bar 1)  ← same as son
+  Bossa 2-side: .  X  .  .  .  X  .  .   (bar 2)  → hits on 2, 3&  (3 → 3&)
+  ```
+
+  Pass 1 shipped the **son** 2-side (`…5, 6`). The bossa 2-side is `…5, 6.5`.
+
+- **Comp.** Bossa comping is rootless jazz 7th/9th voicings in the middle
+  register, highly syncopated against the clave with frequent anticipations
+  across the bar lines, chords **ringing/tied** (not short stabs), played softly
+  (thejazzpianosite.com; jazzguitarlessons.net). Pass 1's comp used the default
+  chord voicing at the patch's short default duration — generic.
+
+- **Confirmed already-correct (unchanged):** bass = root on beat 1, fifth on
+  beat 3; straight-8th hats; soft surdo kick; swing 0.
+
+## 3. Architecture
+
+All changes reuse existing mechanisms; no new engine concepts beyond one
+optional pattern field.
+
+### 3.1 Clave fix (data only)
+
+In `patterns.ts`, the `bossa` drum pattern's `crossStick` array changes its final
+hit from cell beat `6` to `6.5`:
+
+```ts
+crossStick: [
+  { beat: 0, velocity: 0.8 },
+  { beat: 1.5, velocity: 0.7 },
+  { beat: 3, velocity: 0.75 },
+  { beat: 5, velocity: 0.7 },
+  { beat: 6.5, velocity: 0.8 },   // was 6 (son) → 6.5 (bossa 2-side, 3&)
+],
+```
+
+### 3.2 Rootless jazz comp voicing
+
+New pure function in `src/progressions/progressionAudio.ts`, mirroring the
+existing `buildFunkColorVoicing` / `FUNK_COLOR_TONES` structure:
+
+```ts
+/** Rootless jazz comp tones per quality, as semitone offsets above the chord
+ *  root. Root (offset 0) omitted — the bass covers it. 7ths + 9ths, the bossa
+ *  comp idiom. Qualities not listed fall back to the voice-led triad.
+ *   +3 = b3, +4 = 3, +10 = b7, +11 = maj7, +14 = 9 */
+const BOSSA_COLOR_TONES: Record<string, readonly number[]> = {
+  maj7: [4, 11, 14], // 3 / 7 / 9  — maj9
+  M:    [4, 11, 14], // plain major voiced as maj9 (bossa idiom)
+  m7:   [3, 10, 14], // b3 / b7 / 9 — m9
+  m:    [3, 10, 14], // m9
+  "7":  [4, 10, 14], // 3 / b7 / 9 — dom9
+};
+
+/** Middle-register piano comp octave (true comp register, above the guitar-ish
+ *  octave-3 funk grip). */
+const BOSSA_COMP_ROOT_OCTAVE = 4;
+
+export function buildBossaColorVoicing(
+  root: string,
+  quality: string,
+  prevVoicing?: string[],
+): string[] {
+  const rootIndex = NOTES.indexOf(root);
+  if (rootIndex < 0) return [];
+  const offsets = BOSSA_COLOR_TONES[quality];
+  if (!offsets) {
+    return resolveChordVoicing(root, quality, undefined, prevVoicing);
+  }
+  const base = BOSSA_COMP_ROOT_OCTAVE * 12 + rootIndex;
+  return offsets.map((o) => {
+    const absolute = base + o;
+    const note = NOTES[((absolute % 12) + 12) % 12];
+    return `${note}${Math.floor(absolute / 12)}`;
+  });
+}
+```
+
+Voice-leading the rootless shapes (smooth inversions between chords) is a future
+refinement; like funk, this ships a fixed open shape per chord. `prevVoicing` is
+accepted for signature parity / the triad fallback but does not voice-lead the
+color tones.
+
+### 3.3 Opt-in comp voicing on the pattern
+
+Add an optional field to `ChordPattern` (`patterns.ts`):
+
+```ts
+export interface ChordPattern {
+  id: string;
+  label: string;
+  hits: readonly ChordHit[];
+  bars?: number;
+  /** Voicing strategy for this comp. Omitted = the default chord voicing.
+   *  "rootless-jazz" = buildBossaColorVoicing (rootless 7th/9th, mid register). */
+  voicing?: "rootless-jazz";
+}
+```
+
+In `buildAllLayersAsync` (`buildAllLayers.ts`), inside the chord block, compute a
+comp voicing once per chord when the pattern requests it, and use it as the base
+voicing for the pattern's hits:
+
+```ts
+const usesRootlessJazz = chordPattern?.voicing === "rootless-jazz";
+const compVoicing = usesRootlessJazz
+  ? buildBossaColorVoicing(root, quality, lastVoicing)
+  : voicing;
+```
+
+Then the per-hit voicing selection (currently
+`color-stab ? colorVoicing : root ? rootNoteVoicing : voicing`) uses
+`compVoicing` as the final fallback instead of `voicing`:
+
+```ts
+voicing:
+  hit.articulation === "color-stab"
+    ? colorVoicing
+    : hit.articulation === "root"
+      ? rootNoteVoicing
+      : compVoicing,
+```
+
+`buildBossaColorVoicing` is imported from `../progressionAudio` alongside the
+existing `buildFunkColorVoicing`. Non-bossa patterns leave `voicing` undefined,
+so `compVoicing === voicing` and their output is byte-identical.
+
+### 3.4 Comp rhythm, ring, and dynamics
+
+Replace the `bossa-comp` pattern's `hits` (`patterns.ts`). Highly syncopated
+2-bar figure with two cross-barline anticipations; every hit `sustained` so the
+chords ring/tie; soft velocities (~0.5–0.65, the 60–85 acoustic range):
+
+```ts
+{
+  id: "bossa-comp",
+  label: "Bossa Comp",
+  bars: 2,
+  voicing: "rootless-jazz",
+  hits: [
+    // bar 1
+    { beat: 0,   velocity: 0.6,  style: "sustained" }, // downbeat anchor
+    { beat: 1.5, velocity: 0.55, style: "sustained" }, // "& of 2" (clave)
+    { beat: 3.5, velocity: 0.6,  style: "sustained" }, // "& of 4" anticipates bar 2
+    // bar 2
+    { beat: 4.5, velocity: 0.55, style: "sustained" }, // "& of 1"
+    { beat: 6,   velocity: 0.5,  style: "sustained" }, // beat 3 (clave)
+    { beat: 7.5, velocity: 0.65, style: "sustained" }, // "& of 4" anticipates next cycle
+  ],
+}
+```
+
+These beats/velocities are eye-tuned starting points, nudged by ear in §6.
+
+### 3.5 Architecture notes
+
+- The reference describes one pianist's left + right hands; our engine splits
+  that across the **bass instrument** (left hand) and the **piano comp**
+  (right hand). The combined output reproduces the LH/RH split. Intended.
+- `style: "sustained"` maps to the poly patch's `sustainedDurationSec`. Ringing
+  chords overlapping slightly is the intended bossa sound; if the audition finds
+  it muddy, tune `sustainedDurationSec` for the piano patch (do not revert to
+  short stabs).
+- Determinism is preserved: voicing selection is a pure function of root/quality;
+  no `Date.now` / `Math.random`.
+
+## 4. Backwards-compatibility
+
+- Only the `bossa` drum `crossStick` array and the `bossa-comp` pattern change in
+  data; only the chord block of `buildAllLayersAsync` and `progressionAudio.ts`
+  change in code.
+- The new `ChordPattern.voicing` field defaults to undefined; every non-bossa
+  comp keeps the default voicing path and is byte-identical.
+- No change to the cell mechanism, the cross-stick voice, the bass, the kick, or
+  the hats.
+
+## 5. Files touched
+
+- `src/progressions/progressionAudio.ts` — `BOSSA_COLOR_TONES`,
+  `BOSSA_COMP_ROOT_OCTAVE`, `buildBossaColorVoicing`.
+- `src/progressions/audio/patterns.ts` — `ChordPattern.voicing` field; `bossa`
+  drum `crossStick` last hit `6 → 6.5`; rewritten `bossa-comp` hits.
+- `src/progressions/audio/buildAllLayers.ts` — import `buildBossaColorVoicing`;
+  compute `compVoicing` and use it as the comp hits' base voicing.
+- Co-located tests: `progressionAudio.test.ts`, `patterns.test.ts`,
+  `buildAllLayers.test.ts`.
+
+## 6. Testing strategy
+
+**Unit (`progressionAudio.test.ts`):**
+
+1. `buildBossaColorVoicing("C", "maj7")` returns exactly the rootless maj9 tones
+   `["E4", "B4", "D5"]` (no root `C`), confirming rootless + middle register +
+   correct offsets `[4, 11, 14]`.
+2. `buildBossaColorVoicing("A", "m7")` returns the rootless m9 tones
+   (b3/b7/9 above A in octave 4): `["C5", "G5", "B5"]`.
+3. A dominant (`"7"`) returns `[3, b7, 9]` rootless; a quality with no entry
+   (e.g. `"dim"`) falls back to `resolveChordVoicing` (a non-empty voiced triad).
+4. An unknown root returns `[]`.
+
+**Unit (`patterns.test.ts`):**
+
+5. The `bossa` drum `crossStick` beats are `[0, 1.5, 3, 5, 6.5]` (bossa clave,
+   not son `…6`).
+6. The `bossa-comp` pattern has `bars: 2`, `voicing: "rootless-jazz"`, beats
+   `[0, 1.5, 3.5, 4.5, 6, 7.5]`, and every hit has `style: "sustained"`.
+
+**Unit (`buildAllLayers.test.ts`):**
+
+7. A bossa-comp step's chord strums resolve to the rootless jazz voicing — for a
+   C-major step (quality `"M"`, which `BOSSA_COLOR_TONES` voices as maj9) the
+   strum `voicing` equals `["E4","B4","D5"]` and contains no `C` (the root),
+   verifying the pattern-`voicing` path is wired. (`M` and `maj7` share the
+   `[4,11,14]` offsets, so the default-major test step avoids depending on
+   `maj7` being a defined chord quality.)
+8. The bossa-comp chord strums carry `style: "sustained"`.
+9. Backwards-compat: a default-voicing genre (e.g. jazz, `jazz-comp`) still
+   resolves the standard `resolveChordVoicing` notes (the `voicing` field absent
+   → `compVoicing === voicing`).
+
+**Manual ear audition (required):** play a ≥4-bar bossa progression; confirm the
+clave reads as bossa (not son), the comp rings as rootless jazz chords with the
+anticipated lean, and the whole bed locks together. Tune §3.1/§3.4 tables and the
+piano `sustainedDurationSec` by ear via small follow-up commits.

--- a/docs/superpowers/specs/2026-06-01-bossa-nova-overhaul-design.md
+++ b/docs/superpowers/specs/2026-06-01-bossa-nova-overhaul-design.md
@@ -1,0 +1,309 @@
+# Bossa-Nova Overhaul (Slice 2 §3.5)
+
+**Status:** Design — approved in brainstorming 2026-06-01.
+**Date:** 2026-06-01
+**Parent slice:** `2026-05-29-phrase-aware-multibar-variation-design.md` (Slice 2 §3.5).
+
+This spec implements the bossa-nova overhaul that Slice 2 deferred: an authentic
+2-bar clave drum identity (with a new cross-stick / rim voice), a bossa bassline,
+and a syncopated partido-alto chord comp — phrased together against the same
+clave. It resolves the parent spec's open question on the cross-stick voice
+(MembraneSynth click) and introduces a general 2-bar **pattern cell** mechanism
+rather than pulling the deferred §3.3 `phraseVariants` model forward.
+
+A user flagged the current bossa as "doesn't remind me of bossa" (2026-05-31).
+The current `bossa-nova` genre uses a generic 1-bar drum beat, the generic
+`arpeggiated` bass (a 4-note up-arpeggio), and `straight-quarters` chord comp —
+none of which evoke bossa.
+
+---
+
+## 1. Goal
+
+Make the `bossa-nova` genre's backing track sound idiomatically bossa:
+
+- A **2-bar son-clave** played on a new **cross-stick / rim voice**, over a soft
+  surdo "heartbeat" kick and straight-8th hats (no backbeat snare).
+- A **root–fifth surdo bassline** replacing the generic arpeggio.
+- A **syncopated partido-alto chord comp** replacing the four-even-quarters comp.
+
+All three lock to the same clave cell. The enabling structural change is a
+general, opt-in **2-bar pattern cell** mechanism (`bars` field), which leaves
+1-bar patterns byte-identical and leaves the deferred §3.3 chord-rhythm model
+free to be designed on its own terms later.
+
+## 2. Scope
+
+**In scope**
+
+- A `bars?: number` field (default `1`) on `ChordPattern`, `CatalogBassPattern`,
+  and `CatalogDrumPattern`, plus a pure `sliceCellToBar` helper and its wiring
+  into `buildAllLayersAsync`.
+- A new `crossStick` drum voice: `DrumVoice` type, `CatalogDrumPattern.crossStick`
+  array, `collectDrumHits` case, `scheduleCrossStick` (MembraneSynth click) in
+  `drumKit.ts`, engine re-export, playback dispatch case, and a
+  `DrumVoiceParams.crossStick` optional override.
+- A rewritten 2-bar `bossa` drum pattern, a new `bossa` bass pattern, a new
+  `bossa-comp` 2-bar chord pattern.
+- `bossa-nova` genre re-wiring in `genres.ts`.
+- An optional `crossStick` override on the `kit-bossa` drum kit patch.
+- Unit tests for all of the above + a manual ear audition.
+
+**Out of scope**
+
+- The deferred §3.3 phrase-aware chord rhythm (`phraseVariants`), §3.4
+  end-of-phrase bass walk, and the `phraseLengthBars` input param. The comp's
+  anticipations here are baked into a fixed 2-bar cell, not derived from
+  chord-change lookahead.
+- Any change to other genres. Every non-bossa pattern keeps `bars: 1` and is
+  byte-identical to today.
+- New drum voices beyond `crossStick`.
+- UI exposure of phrase length / cell length. The mechanism stays
+  engine-internal (genre-driven), consistent with Slice 1 and §3.2.
+
+## 3. Architecture: the 2-bar pattern cell
+
+### 3.1 Current constraint
+
+Every pattern today is 1-bar: `repeatPatternToBeats` repeats a pattern across a
+beat window in `beatsPerBar`-sized steps, dropping any `hit.beat >= beatsPerBar`.
+`buildAllLayersAsync` already loops one bar at a time and tracks a monotonic
+`absoluteBar` (never reset per step — established by the scheduler spec, PR #491).
+
+### 3.2 The `bars` field
+
+Add an optional `bars?: number` (default `1`) to `ChordPattern`,
+`CatalogBassPattern`, and `CatalogDrumPattern`. When `bars > 1`, the pattern's
+`hits` beats span the whole cell: `0 .. bars * beatsPerBar` (e.g. `0 .. 8` for a
+2-bar pattern in 4/4). Beat `0` is bar-1 downbeat; beat `4` is bar-2 downbeat.
+
+### 3.3 The `sliceCellToBar` helper (`patterns.ts`)
+
+A pure helper selects the hits for a single bar of the cell and shifts them back
+to local bar-relative beats (`0 .. beatsPerBar`):
+
+```ts
+export function sliceCellToBar<T extends { beat: number }>(
+  hits: readonly T[],
+  cellBarIndex: number, // absoluteBar % cellBars
+  beatsPerBar: number,
+): T[] {
+  const offset = cellBarIndex * beatsPerBar;
+  return hits
+    .filter((h) => h.beat >= offset && h.beat < offset + beatsPerBar)
+    .map((h) => ({ ...h, beat: h.beat - offset }));
+}
+```
+
+### 3.4 Wiring into `buildAllLayersAsync`
+
+Each of the three layer loops (chord, bass, drums) currently computes its
+per-bar hits with `repeatPatternToBeats(pattern.hits, eventBeats, beatsPerBar)`.
+Wrap that in a branch:
+
+- If `pattern.bars && pattern.bars > 1`:
+  `sliceCellToBar(pattern.hits, absoluteBar % pattern.bars, beatsPerBar)`.
+- Else: the existing `repeatPatternToBeats(...)` path, **unchanged**.
+
+For drums, the base pattern is sliced this way; firing drum *variations* stay
+1-bar (authored in `0 .. beatsPerBar`) and are merged on top after slicing, as
+today. Bossa's `drumVariations` is empty, so there is no base/variation cell
+mismatch to reconcile.
+
+Multi-bar cells assume bar-unit steps (bossa progressions are bar-based). A
+partial beat-unit step (`duration.unit === "beat"`) falls back to cell index `0`
+for a multi-bar pattern — an acceptable edge case the bossa genre never hits in
+practice.
+
+### 3.5 Determinism, backwards-compat, known limitation
+
+- Slicing is a pure function of `absoluteBar` + `bars` — no `Date.now` /
+  `Math.random`. Same input → identical event stream across runs.
+- Sliced beats are shifted into `0 .. beatsPerBar`, so the existing jitter seeds
+  (`stepIndex * 10000 + bar * 100 + beat`) stay stable. `bar` is step-local, so
+  the two bars of a cell get distinct seeds (distinct content, deterministic).
+- Any pattern with `bars: 1` (the default) never enters `sliceCellToBar` and is
+  byte-identical to today.
+- **Known limitation:** if a looped progression has an **odd** total bar count,
+  the clave cell phase-shifts at the loop boundary (bar N → back to
+  `absoluteBar 0`). Acceptable — real clave assumes even phrases, and this
+  mirrors §3.2's 4-bar-phrase fill assumption.
+
+## 4. The cross-stick / rim voice
+
+The cross-stick (rim-click) is the defining bossa timbre — a dry woody "tok".
+Synthesized as a **short, high-pitched `Tone.MembraneSynth` click**: fully
+deterministic, no noise generation (sidesteps the synchronous-noise cost that
+PR #487 backed out of the bossa snare).
+
+### 4.1 Touchpoints
+
+1. **`sound/patchTypes.ts`** — `DrumVoiceParams` gains an optional override:
+   ```ts
+   crossStick?: { pitchDecay?: number; octaves?: number; envelope?: Partial<EnvelopeSpec> };
+   ```
+   Kits use partial overrides, so no existing kit must define it; engine
+   defaults apply when omitted.
+2. **`patterns.ts`** — `CatalogDrumPattern` gains `crossStick?: readonly DrumHit[]`.
+3. **`buildAllLayers.ts`** — `DrumVoice` union gains `"crossStick"`;
+   `collectDrumHits` pushes `pattern.crossStick ?? []` with `type: "crossStick"`.
+4. **`drumKit.ts`** — new pool + `scheduleCrossStick(dest, time, options)`,
+   mirroring `scheduleKick`'s structure:
+   ```ts
+   const DEFAULT_CROSS_STICK_ENV = {
+     attack: 0.001, decay: 0.06, sustain: 0, release: 0.02,
+     attackCurve: "exponential" as const,
+   };
+   const CROSS_STICK_DISPOSE_MS = 120; // decay ~60 ms
+   // MembraneSynth: oscillator { type: "triangle" }, pitchDecay ~0.008,
+   // octaves ~2, envelope DEFAULT_CROSS_STICK_ENV merged with kit override.
+   // triggerAttackRelease("G4", 0.05, time, velocity); busyUntil = start + 0.12.
+   ```
+   `velocity <= 0` returns `NOOP_HANDLE`, as the other voices do.
+5. **`progressionAudioEngine.ts`** — re-export `scheduleCrossStick`.
+6. **`hooks/useProgressionAudioPlayback.ts`** — add to the drum dispatch switch:
+   ```ts
+   case "crossStick":
+     eng.scheduleCrossStick(audio.layers.drums, audioTime, { velocity: value.velocity, kit: drumKit });
+     break;
+   ```
+7. **`sound/instrumentPatches.ts`** — `kit-bossa` gains an optional `crossStick`
+   override to tune the woody tone (engine default works standalone).
+
+## 5. The three new bossa patterns
+
+All beat tables are eye-tuned starting points, expected to be nudged during the
+§7 ear audition (same convention as §3.2). Beats are 0-indexed quarter-note
+positions; `.5` = eighth.
+
+### 5.1 Drum clave — rewrite `bossa` in `DRUM_PATTERNS`, `bars: 2`
+
+3-2 son clave on the cross-stick; soft surdo heartbeat kick (beats 1 & 3 each
+bar); straight-8th hats both bars; no backbeat snare.
+
+```ts
+{
+  id: "bossa", label: "Bossa Nova", bars: 2,
+  kicks: [
+    { beat: 0, velocity: 0.5 }, { beat: 2, velocity: 0.6 },
+    { beat: 4, velocity: 0.5 }, { beat: 6, velocity: 0.6 },
+  ],
+  snares: [],
+  hats: [
+    { beat: 0, velocity: 0.4 }, { beat: 0.5, velocity: 0.3 }, { beat: 1, velocity: 0.4 }, { beat: 1.5, velocity: 0.3 },
+    { beat: 2, velocity: 0.4 }, { beat: 2.5, velocity: 0.3 }, { beat: 3, velocity: 0.4 }, { beat: 3.5, velocity: 0.3 },
+    { beat: 4, velocity: 0.4 }, { beat: 4.5, velocity: 0.3 }, { beat: 5, velocity: 0.4 }, { beat: 5.5, velocity: 0.3 },
+    { beat: 6, velocity: 0.4 }, { beat: 6.5, velocity: 0.3 }, { beat: 7, velocity: 0.4 }, { beat: 7.5, velocity: 0.3 },
+  ],
+  crossStick: [
+    // 3-side (bar 1): beats 0, 1.5, 3
+    { beat: 0, velocity: 0.8 }, { beat: 1.5, velocity: 0.7 }, { beat: 3, velocity: 0.75 },
+    // 2-side (bar 2): beats 5 (=bar2 beat 1), 6 (=bar2 beat 2)
+    { beat: 5, velocity: 0.7 }, { beat: 6, velocity: 0.8 },
+  ],
+}
+```
+
+### 5.2 Bass — new `bossa` pattern in `BASS_PATTERNS`, 1-bar
+
+Root–fifth surdo (tonic–dominant alternation), the recognizable bossa pulse.
+Kept 1-bar; the clave lock comes from drums + comp. The "& of 2" push is an
+audition alternative.
+
+```ts
+{
+  id: "bossa", label: "Bossa Nova",
+  hits: [
+    { beat: 0, velocity: 1, note: "root", articulation: "legato" },
+    { beat: 2, velocity: 0.8, note: "fifth", articulation: "legato" },
+  ],
+}
+```
+
+### 5.3 Chord comp — new `bossa-comp` pattern in `CHORD_PATTERNS`, `bars: 2`
+
+Syncopated partido-alto: clave-locked anticipations that leave space, phrased
+across the 2-bar cell.
+
+```ts
+{
+  id: "bossa-comp", label: "Bossa Comp", bars: 2,
+  hits: [
+    // bar 1
+    { beat: 0, velocity: 0.7 }, { beat: 1.5, velocity: 0.6 }, { beat: 3, velocity: 0.55 },
+    // bar 2: anticipated "& of 1" push, mid-bar, and an "& of 4" lead into the next phrase
+    { beat: 4.5, velocity: 0.6 }, { beat: 6, velocity: 0.6 }, { beat: 7.5, velocity: 0.7 },
+  ],
+}
+```
+
+## 6. Genre wiring (`GENRE_STYLES` in `genres.ts`)
+
+Only the `bossa-nova` row changes:
+
+| field | from | to |
+|---|---|---|
+| `chordPattern` | `straight-quarters` | `bossa-comp` |
+| `bassPattern` | `arpeggiated` | `bossa` |
+| `drumPattern` | `bossa` (1-bar) | `bossa` (2-bar rewrite, same id) |
+| `chordInstrument` | `piano` | `piano` (unchanged) |
+| `drumVariations` | `[]` | `[]` (unchanged) |
+| `swing` | `0` | `0` (unchanged) |
+| `tempoRange` / `suggestedTempo` | `[120,140]` / `130` | unchanged |
+
+## 7. Testing strategy
+
+**Unit (`patterns.test.ts`):**
+
+1. `sliceCellToBar` — for a 2-bar set of hits, `cellBarIndex: 0` returns the
+   `0..beatsPerBar` hits with original beats; `cellBarIndex: 1` returns the
+   `beatsPerBar..2*beatsPerBar` hits shifted back by `beatsPerBar`; out-of-range
+   `cellBarIndex` returns `[]`.
+2. The new `bossa` drum, `bossa` bass, and `bossa-comp` resolve via their getters
+   and carry the expected `bars` (`2`, `undefined`/`1`, `2` respectively).
+3. The rewritten `bossa` drum pattern's `crossStick` array matches the exact
+   3-2 son-clave beat layout `[0, 1.5, 3, 5, 6]`.
+
+**Unit (`drumKit.test.ts`):**
+
+4. `scheduleCrossStick` returns a handle with a `cancel` function, leases and
+   disposes from its own pool, and returns the NOOP handle for `velocity <= 0`
+   (mirrors the existing per-voice tests).
+
+**Unit (`buildAllLayers.test.ts`):**
+
+5. A ≥2-bar bossa step emits the bar-1 clave cross-stick hits on absolute bar 0
+   and the bar-2 clave hits on absolute bar 1 (verifies cell selection + beat
+   shift end-to-end).
+6. Determinism: a bossa progression built twice over a ≥4-bar span yields
+   identical chord, bass, and drum event streams.
+7. Backwards-compat: a 1-bar-pattern genre (e.g. rock) built before and after the
+   change yields an identical event stream (guards the `bars: 1` default path).
+
+**Unit (`genres.test.ts`):**
+
+8. `bossa-nova` references `bossa-comp` / `bossa` / `bossa` and every id resolves
+   (no dangling pattern ids).
+
+**Manual ear audition (required by parent spec §3.5):**
+
+Play a ≥4-bar bossa progression and confirm the clave, comp, and bass read as
+idiomatic bossa and lock together. Tune the §5 tables by ear; apply tweaks as
+small follow-up commits.
+
+## 8. Files touched
+
+- `src/progressions/audio/patterns.ts` — `bars` field on three pattern
+  interfaces; `sliceCellToBar`; `crossStick` on `CatalogDrumPattern`; rewritten
+  `bossa` drum, new `bossa` bass, new `bossa-comp` chord patterns.
+- `src/progressions/audio/buildAllLayers.ts` — `DrumVoice` `"crossStick"`;
+  `collectDrumHits` case; `bars`-aware slicing in the three layer loops.
+- `src/progressions/audio/drumKit.ts` — `scheduleCrossStick` + pool.
+- `src/progressions/audio/progressionAudioEngine.ts` — re-export.
+- `src/progressions/audio/sound/patchTypes.ts` — `DrumVoiceParams.crossStick`.
+- `src/progressions/audio/sound/instrumentPatches.ts` — `kit-bossa` crossStick
+  override.
+- `src/progressions/audio/genres.ts` — `bossa-nova` row re-wiring.
+- `src/hooks/useProgressionAudioPlayback.ts` — `crossStick` dispatch case.
+- Co-located test files: `patterns.test.ts`, `drumKit.test.ts`,
+  `buildAllLayers.test.ts`, `genres.test.ts`.

--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -482,6 +482,7 @@ export function useProgressionAudioPlayback() {
             case "hihat": eng.scheduleHiHat(audio.layers.drums, audioTime, { velocity: value.velocity, kit: drumKit }); break;
             case "openHat": eng.scheduleHiHat(audio.layers.drums, audioTime, { velocity: value.velocity, open: true, kit: drumKit }); break;
             case "ride": eng.scheduleRide(audio.layers.drums, audioTime, { velocity: value.velocity, kit: drumKit }); break;
+            case "crossStick": eng.scheduleCrossStick(audio.layers.drums, audioTime, { velocity: value.velocity, kit: drumKit }); break;
           }
         },
       });

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -298,7 +298,7 @@ describe("buildAllLayers", () => {
     expect(crossSticks).toEqual([0, 1.5, 3, 5, 6.5]);
   });
 
-  it("plays the bossa comp's bar-2 syncopations on the second bar", async () => {
+  it("plays the bossa comp off-beat chord stabs, busier in the second bar", async () => {
     const out = await buildAllLayersAsync({
       ...baseInput,
       drumPatternId: "bossa",
@@ -306,7 +306,7 @@ describe("buildAllLayers", () => {
       bassPatternId: "bossa",
       steps: [step({ duration: { value: 2, unit: "bar" } })],
     });
-    expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 5.5, 6, 7.5]);
+    expect(out.chordStrums.map((s) => s.time)).toEqual([1.5, 3.5, 4.5, 5.5, 7.5]);
   });
 
   it("leaves a 1-bar pattern (rock) emitting identical hits on every bar", async () => {
@@ -366,7 +366,7 @@ describe("buildAllLayers", () => {
       expect(a.drums).toEqual(b.drums);
     });
 
-  it("voices the bossa comp as LH bass (single notes) + RH rootless chords", async () => {
+  it("voices the bossa comp as rooted chords (root carried under the grip)", async () => {
     const out = await buildAllLayersAsync({
       ...baseInput,
       chordPatternId: "bossa-comp",
@@ -375,9 +375,9 @@ describe("buildAllLayers", () => {
       steps: [step({ duration: { value: 2, unit: "bar" } })], // C major
     });
     const at = (t: number) => out.chordStrums.find((s) => s.time === t)!;
-    expect(at(0).value.voicing).toEqual(["C3"]); // bass-root (LH, octave 3)
-    expect(at(2).value.voicing).toEqual(["G3"]); // bass-fifth (LH, octave 3)
-    expect(at(1.5).value.voicing).toEqual(["B3", "D4", "E4", "G4"]); // RH rootless chord
+    // Each off-beat stab is a rooted voicing: root C3 under the rootless grip.
+    expect(at(1.5).value.voicing).toEqual(["C3", "B3", "D4", "E4", "G4"]);
+    expect(out.chordStrums.every((s) => s.value.voicing[0] === "C3")).toBe(true); // root carried
     expect(out.chordStrums.every((s) => s.value.style === undefined)).toBe(true); // all short, no sustain
   });
 

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -375,8 +375,8 @@ describe("buildAllLayers", () => {
       bassPatternId: "bossa",
       steps: [step({ duration: { value: 2, unit: "bar" } })], // C major
     });
-    // C major → rootless maj9 in the middle register: E4 / B4 / D5, no C.
-    expect(out.chordStrums[0].value.voicing).toEqual(["E4", "B4", "D5"]);
+    // C major → rootless Type-B maj9 in the comp register: B3 / D4 / E4 / G4, no C.
+    expect(out.chordStrums[0].value.voicing).toEqual(["B3", "D4", "E4", "G4"]);
     expect(out.chordStrums.every((s) => !s.value.voicing.some((n) => n.startsWith("C") && !n.startsWith("C#")))).toBe(true);
     // …and every comp chord rings (sustained), end-to-end through the scheduler.
     expect(out.chordStrums.every((s) => s.value.style === "sustained")).toBe(true);

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -271,6 +271,18 @@ describe("buildAllLayers", () => {
     });
   });
 
+  it("emits cross-stick drum events for the bossa clave pattern", async () => {
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      drumPatternId: "bossa",
+      chordPatternId: "ballad-whole",
+      steps: [step({ duration: { value: 1, unit: "bar" } })],
+    });
+    const crossSticks = out.drums.filter((d) => d.value.type === "crossStick");
+    // Bar 1 (3-side) of the son clave: beats 0, 1.5, 3 → times 0, 1.5, 3 at 60bpm.
+    expect(crossSticks.map((d) => d.time)).toEqual([0, 1.5, 3]);
+  });
+
   describe("drum variation gating (absolute bar)", () => {
     // Two 2-bar steps = 4 absolute bars (0..3). At 60bpm each bar is 4s.
     const fourBarSteps = [

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -294,8 +294,8 @@ describe("buildAllLayers", () => {
     const crossSticks = out.drums
       .filter((d) => d.value.type === "crossStick")
       .map((d) => d.time);
-    // Bar 1 @ 0,1.5,3 ; bar 2 starts at 4s, clave beats 5,6 → local 1,2 → 5,6.
-    expect(crossSticks).toEqual([0, 1.5, 3, 5, 6]);
+    // Bar 1 @ 0,1.5,3 ; bar 2 starts at 4s, clave beats 5,6.5 → local 1,2.5 → 5,6.5.
+    expect(crossSticks).toEqual([0, 1.5, 3, 5, 6.5]);
   });
 
   it("plays the bossa comp's bar-2 syncopations on the second bar", async () => {
@@ -306,8 +306,8 @@ describe("buildAllLayers", () => {
       bassPatternId: "bossa",
       steps: [step({ duration: { value: 2, unit: "bar" } })],
     });
-    // comp beats 0,1.5,3 (bar1) and 4.5,6,7.5 (bar2) → times identical at 60bpm.
-    expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 3, 4.5, 6, 7.5]);
+    // comp beats 0,1.5,3.5 (bar1) and 4.5,6,7.5 (bar2) → times identical at 60bpm.
+    expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 3.5, 4.5, 6, 7.5]);
   });
 
   it("leaves a 1-bar pattern (rock) emitting identical hits on every bar", async () => {

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -381,6 +381,25 @@ describe("buildAllLayers", () => {
     expect(out.chordStrums.every((s) => s.value.style === undefined)).toBe(true); // all short, no sustain
   });
 
+  it("locks the bossa LH bass and upright bass to the same attack time (perfect unison)", async () => {
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      chordPatternId: "bossa-comp",
+      drumPatternId: "bossa",
+      bassPatternId: "bossa",
+      steps: [step({ duration: { value: 2, unit: "bar" } })], // 2-bar C major cell
+    });
+    // LH bass strums are single notes on beats 0, 2, 4, 6 (octave 3).
+    const lhBass = out.chordStrums.filter((s) => s.value.voicing.length === 1);
+    expect(lhBass.map((s) => s.time).sort((a, b) => a - b)).toEqual([0, 2, 4, 6]);
+    // The upright bass plays the same beats one octave lower (octave 2).
+    expect(out.bass.map((b) => b.time).sort((a, b) => a - b)).toEqual([0, 2, 4, 6]);
+    // Both voices attack at the exact same time — grid-locked, no flam.
+    for (const lh of lhBass) {
+      expect(out.bass.some((b) => b.time === lh.time)).toBe(true);
+    }
+  });
+
   it("leaves a default-voicing comp (jazz) using the standard rooted voicing", async () => {
     const out = await buildAllLayersAsync({
       ...baseInput,

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -306,7 +306,7 @@ describe("buildAllLayers", () => {
       bassPatternId: "bossa",
       steps: [step({ duration: { value: 2, unit: "bar" } })],
     });
-    expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 6, 7.5]);
+    expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 5.5, 6, 6.5, 7.5]);
   });
 
   it("leaves a 1-bar pattern (rock) emitting identical hits on every bar", async () => {

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -306,7 +306,7 @@ describe("buildAllLayers", () => {
       bassPatternId: "bossa",
       steps: [step({ duration: { value: 2, unit: "bar" } })],
     });
-    expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 5.5, 6, 6.5, 7.5]);
+    expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 5.5, 6, 7.5]);
   });
 
   it("leaves a 1-bar pattern (rock) emitting identical hits on every bar", async () => {

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -378,8 +378,9 @@ describe("buildAllLayers", () => {
     expect(at(0).value.voicing).toEqual(["C3"]); // bass-root (LH, octave 3)
     expect(at(2).value.voicing).toEqual(["G3"]); // bass-fifth (LH, octave 3)
     expect(at(1.5).value.voicing).toEqual(["B3", "D4", "E4", "G4"]); // RH rootless chord
-    expect(at(1.5).value.style).toBe("sustained"); // RH chord rings
-    expect(at(0).value.style).toBeUndefined(); // LH root is short (no sustain)
+    expect(at(2).value.style).toBe("sustained"); // LH fifth rings
+    expect(at(1.5).value.style).toBeUndefined(); // RH chord is short
+    expect(at(0).value.style).toBeUndefined(); // LH root is short
   });
 
   it("leaves a default-voicing comp (jazz) using the standard rooted voicing", async () => {

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -378,9 +378,7 @@ describe("buildAllLayers", () => {
     expect(at(0).value.voicing).toEqual(["C3"]); // bass-root (LH, octave 3)
     expect(at(2).value.voicing).toEqual(["G3"]); // bass-fifth (LH, octave 3)
     expect(at(1.5).value.voicing).toEqual(["B3", "D4", "E4", "G4"]); // RH rootless chord
-    expect(at(2).value.style).toBe("sustained"); // LH fifth rings
-    expect(at(1.5).value.style).toBeUndefined(); // RH chord is short
-    expect(at(0).value.style).toBeUndefined(); // LH root is short
+    expect(out.chordStrums.every((s) => s.value.style === undefined)).toBe(true); // all short, no sustain
   });
 
   it("leaves a default-voicing comp (jazz) using the standard rooted voicing", async () => {

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -306,8 +306,7 @@ describe("buildAllLayers", () => {
       bassPatternId: "bossa",
       steps: [step({ duration: { value: 2, unit: "bar" } })],
     });
-    // comp beats 0,1.5,3.5 (bar1) and 4.5,6,7.5 (bar2) → times identical at 60bpm.
-    expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 3.5, 4.5, 6, 7.5]);
+    expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 6, 7.5]);
   });
 
   it("leaves a 1-bar pattern (rock) emitting identical hits on every bar", async () => {
@@ -367,7 +366,7 @@ describe("buildAllLayers", () => {
       expect(a.drums).toEqual(b.drums);
     });
 
-    it("voices the bossa comp as rootless jazz chords (no root note)", async () => {
+    it("voices the bossa comp as LH bass (single notes) + RH rootless chords", async () => {
     const out = await buildAllLayersAsync({
       ...baseInput,
       chordPatternId: "bossa-comp",
@@ -375,10 +374,10 @@ describe("buildAllLayers", () => {
       bassPatternId: "bossa",
       steps: [step({ duration: { value: 2, unit: "bar" } })], // C major
     });
-    // C major → rootless Type-B maj9 in the comp register: B3 / D4 / E4 / G4, no C.
-    expect(out.chordStrums[0].value.voicing).toEqual(["B3", "D4", "E4", "G4"]);
-    expect(out.chordStrums.every((s) => !s.value.voicing.some((n) => n.startsWith("C") && !n.startsWith("C#")))).toBe(true);
-    // …and every comp chord rings (sustained), end-to-end through the scheduler.
+    const at = (t: number) => out.chordStrums.find((s) => s.time === t)!;
+    expect(at(0).value.voicing).toEqual(["C3"]); // bass-root (LH, octave 3)
+    expect(at(2).value.voicing).toEqual(["G3"]); // bass-fifth (LH, octave 3)
+    expect(at(1.5).value.voicing).toEqual(["B3", "D4", "E4", "G4"]); // RH rootless chord
     expect(out.chordStrums.every((s) => s.value.style === "sustained")).toBe(true);
   });
 

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -367,6 +367,22 @@ describe("buildAllLayers", () => {
       expect(a.drums).toEqual(b.drums);
     });
 
+    it("is deterministic for the bossa 2-bar cell across a 4-bar span (drums, bass, comp)", async () => {
+      const bossaInput = {
+        ...baseInput,
+        steps: fourBarSteps,
+        drumPatternId: "bossa",
+        bassPatternId: "bossa",
+        chordPatternId: "bossa-comp",
+        drumVariations: [] as string[],
+      };
+      const a = await buildAllLayersAsync(bossaInput);
+      const b = await buildAllLayersAsync(bossaInput);
+      expect(a.drums).toEqual(b.drums);
+      expect(a.bass).toEqual(b.bass);
+      expect(a.chordStrums).toEqual(b.chordStrums);
+    });
+
     it("counts an unavailable bar toward the absolute index (turnaround stays aligned)", async () => {
       // [2-bar C][1-bar unavailable][1-bar G] → absolute bars 0,1,(2 rest),3.
       // fill-every-4 (phase 3) must fire on absolute bar 3 = the final G bar (12..16s).

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -367,7 +367,30 @@ describe("buildAllLayers", () => {
       expect(a.drums).toEqual(b.drums);
     });
 
-    it("is deterministic for the bossa 2-bar cell across a 4-bar span (drums, bass, comp)", async () => {
+    it("voices the bossa comp as rootless jazz chords (no root note)", async () => {
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      chordPatternId: "bossa-comp",
+      drumPatternId: "bossa",
+      bassPatternId: "bossa",
+      steps: [step({ duration: { value: 2, unit: "bar" } })], // C major
+    });
+    // C major → rootless maj9 in the middle register: E4 / B4 / D5, no C.
+    expect(out.chordStrums[0].value.voicing).toEqual(["E4", "B4", "D5"]);
+    expect(out.chordStrums.every((s) => !s.value.voicing.some((n) => n.startsWith("C") && !n.startsWith("C#")))).toBe(true);
+  });
+
+  it("leaves a default-voicing comp (jazz) using the standard rooted voicing", async () => {
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      chordPatternId: "jazz-comp",
+      steps: [step({ duration: { value: 1, unit: "bar" } })], // C major
+    });
+    // Default path: resolveChordVoicing keeps the root present (C3/E3/G3).
+    expect(out.chordStrums[0].value.voicing.some((n) => n === "C3")).toBe(true);
+  });
+
+  it("is deterministic for the bossa 2-bar cell across a 4-bar span (drums, bass, comp)", async () => {
       const bossaInput = {
         ...baseInput,
         steps: fourBarSteps,

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -378,6 +378,8 @@ describe("buildAllLayers", () => {
     // C major → rootless maj9 in the middle register: E4 / B4 / D5, no C.
     expect(out.chordStrums[0].value.voicing).toEqual(["E4", "B4", "D5"]);
     expect(out.chordStrums.every((s) => !s.value.voicing.some((n) => n.startsWith("C") && !n.startsWith("C#")))).toBe(true);
+    // …and every comp chord rings (sustained), end-to-end through the scheduler.
+    expect(out.chordStrums.every((s) => s.value.style === "sustained")).toBe(true);
   });
 
   it("leaves a default-voicing comp (jazz) using the standard rooted voicing", async () => {

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -283,6 +283,47 @@ describe("buildAllLayers", () => {
     expect(crossSticks.map((d) => d.time)).toEqual([0, 1.5, 3]);
   });
 
+  it("plays the bar-2 clave hits on the second bar of a 2-bar cell", async () => {
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      drumPatternId: "bossa",
+      chordPatternId: "ballad-whole",
+      // One 2-bar step → absolute bars 0 and 1.
+      steps: [step({ duration: { value: 2, unit: "bar" } })],
+    });
+    const crossSticks = out.drums
+      .filter((d) => d.value.type === "crossStick")
+      .map((d) => d.time);
+    // Bar 1 @ 0,1.5,3 ; bar 2 starts at 4s, clave beats 5,6 → local 1,2 → 5,6.
+    expect(crossSticks).toEqual([0, 1.5, 3, 5, 6]);
+  });
+
+  it("plays the bossa comp's bar-2 syncopations on the second bar", async () => {
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      drumPatternId: "bossa",
+      chordPatternId: "bossa-comp",
+      bassPatternId: "bossa",
+      steps: [step({ duration: { value: 2, unit: "bar" } })],
+    });
+    // comp beats 0,1.5,3 (bar1) and 4.5,6,7.5 (bar2) → times identical at 60bpm.
+    expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 3, 4.5, 6, 7.5]);
+  });
+
+  it("leaves a 1-bar pattern (rock) emitting identical hits on every bar", async () => {
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      drumPatternId: "rock",
+      chordPatternId: "ballad-whole",
+      steps: [step({ duration: { value: 2, unit: "bar" } })],
+    });
+    const kicksBar1 = out.drums.filter((d) => d.value.type === "kick" && d.time < 4).map((d) => d.time);
+    const kicksBar2 = out.drums.filter((d) => d.value.type === "kick" && d.time >= 4).map((d) => d.time - 4);
+    // rock kicks at 0, 1.5, 2 — same in both bars (the bars-default path is untouched).
+    expect(kicksBar1).toEqual([0, 1.5, 2]);
+    expect(kicksBar2).toEqual([0, 1.5, 2]);
+  });
+
   describe("drum variation gating (absolute bar)", () => {
     // Two 2-bar steps = 4 absolute bars (0..3). At 60bpm each bar is 4s.
     const fourBarSteps = [

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -366,7 +366,7 @@ describe("buildAllLayers", () => {
       expect(a.drums).toEqual(b.drums);
     });
 
-    it("voices the bossa comp as LH bass (single notes) + RH rootless chords", async () => {
+  it("voices the bossa comp as LH bass (single notes) + RH rootless chords", async () => {
     const out = await buildAllLayersAsync({
       ...baseInput,
       chordPatternId: "bossa-comp",

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -298,7 +298,7 @@ describe("buildAllLayers", () => {
     expect(crossSticks).toEqual([0, 1.5, 3, 5, 6.5]);
   });
 
-  it("plays the bossa comp off-beat chord stabs, busier in the second bar", async () => {
+  it("plays the bossa comp's bar-2 syncopations on the second bar", async () => {
     const out = await buildAllLayersAsync({
       ...baseInput,
       drumPatternId: "bossa",
@@ -306,7 +306,7 @@ describe("buildAllLayers", () => {
       bassPatternId: "bossa",
       steps: [step({ duration: { value: 2, unit: "bar" } })],
     });
-    expect(out.chordStrums.map((s) => s.time)).toEqual([1.5, 3.5, 4.5, 5.5, 7.5]);
+    expect(out.chordStrums.map((s) => s.time)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 5.5, 6, 7.5]);
   });
 
   it("leaves a 1-bar pattern (rock) emitting identical hits on every bar", async () => {
@@ -366,7 +366,7 @@ describe("buildAllLayers", () => {
       expect(a.drums).toEqual(b.drums);
     });
 
-  it("voices the bossa comp as rooted chords (root carried under the grip)", async () => {
+  it("voices the bossa comp as LH bass (single notes) + RH rootless chords", async () => {
     const out = await buildAllLayersAsync({
       ...baseInput,
       chordPatternId: "bossa-comp",
@@ -375,9 +375,9 @@ describe("buildAllLayers", () => {
       steps: [step({ duration: { value: 2, unit: "bar" } })], // C major
     });
     const at = (t: number) => out.chordStrums.find((s) => s.time === t)!;
-    // Each off-beat stab is a rooted voicing: root C3 under the rootless grip.
-    expect(at(1.5).value.voicing).toEqual(["C3", "B3", "D4", "E4", "G4"]);
-    expect(out.chordStrums.every((s) => s.value.voicing[0] === "C3")).toBe(true); // root carried
+    expect(at(0).value.voicing).toEqual(["C3"]); // bass-root (LH, octave 3)
+    expect(at(2).value.voicing).toEqual(["G3"]); // bass-fifth (LH, octave 3)
+    expect(at(1.5).value.voicing).toEqual(["B3", "D4", "E4", "G4"]); // RH rootless chord
     expect(out.chordStrums.every((s) => s.value.style === undefined)).toBe(true); // all short, no sustain
   });
 

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -378,7 +378,8 @@ describe("buildAllLayers", () => {
     expect(at(0).value.voicing).toEqual(["C3"]); // bass-root (LH, octave 3)
     expect(at(2).value.voicing).toEqual(["G3"]); // bass-fifth (LH, octave 3)
     expect(at(1.5).value.voicing).toEqual(["B3", "D4", "E4", "G4"]); // RH rootless chord
-    expect(out.chordStrums.every((s) => s.value.style === "sustained")).toBe(true);
+    expect(at(1.5).value.style).toBe("sustained"); // RH chord rings
+    expect(at(0).value.style).toBeUndefined(); // LH root is short (no sustain)
   });
 
   it("leaves a default-voicing comp (jazz) using the standard rooted voicing", async () => {

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -225,6 +225,12 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
     const bassFifthVoicing =
       bossaLhNotes.length > 1 ? [bossaLhNotes[1]] : bassRootVoicing;
     const bassLineNotes = resolveBassLineNotes(root, quality);
+    // When the comp supplies its own LH bass (rootless-jazz), it doubles the
+    // upright bassline an octave up on beats 1 & 3. Grid-lock both voices'
+    // attacks (zero time jitter) so they sound in perfect unison — independent
+    // timing humanization flams two notes an octave apart. Velocity jitter still
+    // applies, and other comps keep their natural timing humanization.
+    const lockBassToGrid = chordPattern?.voicing === "rootless-jazz";
 
     const eventBeats = isBarUnit ? input.beatsPerBar : stepBeats;
     const eventSec = eventBeats * secondsPerBeat;
@@ -252,11 +258,15 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
           ? sliceCellToBar(chordPattern.hits, absoluteBar % chordCellBars, input.beatsPerBar)
           : repeatPatternToBeats(chordPattern.hits, eventBeats, input.beatsPerBar);
         for (const hit of hits) {
+          const isLhBass =
+            hit.voiceRole === "bass-root" || hit.voiceRole === "bass-fifth";
           const baseTime = barStart + swingBeat(hit.beat, input.swing) * secondsPerBeat;
           const { time: hitTime, velocity } = applyJitter({
             time: baseTime,
             velocity: hit.velocity,
             seed: stepIndex * 10000 + bar * 100 + hit.beat,
+            // LH bass doubles the upright an octave up — lock it to the grid.
+            ...(isLhBass ? { timeAmountSec: 0 } : {}),
           });
           chordStrums.push({
             time: hitTime,
@@ -307,6 +317,9 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
             time: baseTime,
             velocity: hit.velocity,
             seed: stepIndex * 10000 + bar * 100 + hit.beat + 1, // slight offset for bass
+            // Lock to the grid when the comp doubles this line (bossa LH), so
+            // the two voices attack in perfect unison instead of flamming.
+            ...(lockBassToGrid ? { timeAmountSec: 0 } : {}),
           });
           bass.push({
             time: hitTime,

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -3,7 +3,7 @@ import {
   resolveChordVoicing,
   resolveBassLineNotes,
   buildFunkColorVoicing,
-  buildBossaColorVoicing,
+  buildBossaRootedVoicing,
 } from "../progressionAudio";
 import type { ResolvedProgressionStep } from "../progressionDomain";
 import {
@@ -90,8 +90,6 @@ export const STAB_STRUM_DURATION_SEC = 0.4;
 /** Note length (seconds) for the single root-note anchor on the one — a short,
  *  tight pluck, longer than a muted ghost but well short of a ringing stab. */
 export const ROOT_STRUM_DURATION_SEC = 0.12;
-/** Piano LH bass octave for the bossa comp — an octave above the upright bass. */
-const BOSSA_LH_OCTAVE = 3;
 
 function swingBeat(beat: number, swing: number): number {
   if (swing <= 0) return beat;
@@ -209,21 +207,14 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
       : voicing;
     const rootNoteVoicing =
       needsRootAnchor && plainVoicing.length > 0 ? [plainVoicing[0]] : voicing;
-    // Rootless jazz comp voicing (bossa) — opt-in per pattern. Falls back to the
-    // default voicing for every other comp.
+    // Rooted bossa comp voicing — opt-in per pattern. The piano comp carries its
+    // own bass note (root below the rootless grip) on the off-beat chord stabs,
+    // so it no longer doubles the upright bassline on beats 1 & 3. Falls back to
+    // the default voicing for every other comp.
     const compVoicing =
       chordPattern?.voicing === "rootless-jazz"
-        ? buildBossaColorVoicing(root, quality, lastVoicing)
+        ? buildBossaRootedVoicing(root, quality, lastVoicing)
         : voicing;
-    // Bossa LH bass notes (root on beat 1, fifth on beat 3), octave 3 — single
-    // notes played by the piano under the RH rootless chords.
-    const bossaLhNotes =
-      chordPattern?.voicing === "rootless-jazz"
-        ? resolveBassLineNotes(root, quality, BOSSA_LH_OCTAVE)
-        : [];
-    const bassRootVoicing = bossaLhNotes.length > 0 ? [bossaLhNotes[0]] : voicing;
-    const bassFifthVoicing =
-      bossaLhNotes.length > 1 ? [bossaLhNotes[1]] : bassRootVoicing;
     const bassLineNotes = resolveBassLineNotes(root, quality);
 
     const eventBeats = isBarUnit ? input.beatsPerBar : stepBeats;
@@ -262,15 +253,11 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
             time: hitTime,
             value: {
               voicing:
-                hit.voiceRole === "bass-root"
-                  ? bassRootVoicing
-                  : hit.voiceRole === "bass-fifth"
-                    ? bassFifthVoicing
-                    : hit.articulation === "color-stab"
-                      ? colorVoicing
-                      : hit.articulation === "root"
-                        ? rootNoteVoicing
-                        : compVoicing,
+                hit.articulation === "color-stab"
+                  ? colorVoicing
+                  : hit.articulation === "root"
+                    ? rootNoteVoicing
+                    : compVoicing,
               velocity,
               style: hit.style,
               direction: hit.direction,

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -3,7 +3,7 @@ import {
   resolveChordVoicing,
   resolveBassLineNotes,
   buildFunkColorVoicing,
-  buildBossaRootedVoicing,
+  buildBossaColorVoicing,
 } from "../progressionAudio";
 import type { ResolvedProgressionStep } from "../progressionDomain";
 import {
@@ -90,6 +90,8 @@ export const STAB_STRUM_DURATION_SEC = 0.4;
 /** Note length (seconds) for the single root-note anchor on the one — a short,
  *  tight pluck, longer than a muted ghost but well short of a ringing stab. */
 export const ROOT_STRUM_DURATION_SEC = 0.12;
+/** Piano LH bass octave for the bossa comp — an octave above the upright bass. */
+const BOSSA_LH_OCTAVE = 3;
 
 function swingBeat(beat: number, swing: number): number {
   if (swing <= 0) return beat;
@@ -207,14 +209,21 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
       : voicing;
     const rootNoteVoicing =
       needsRootAnchor && plainVoicing.length > 0 ? [plainVoicing[0]] : voicing;
-    // Rooted bossa comp voicing — opt-in per pattern. The piano comp carries its
-    // own bass note (root below the rootless grip) on the off-beat chord stabs,
-    // so it no longer doubles the upright bassline on beats 1 & 3. Falls back to
-    // the default voicing for every other comp.
+    // Rootless jazz comp voicing (bossa) — opt-in per pattern. Falls back to the
+    // default voicing for every other comp.
     const compVoicing =
       chordPattern?.voicing === "rootless-jazz"
-        ? buildBossaRootedVoicing(root, quality, lastVoicing)
+        ? buildBossaColorVoicing(root, quality, lastVoicing)
         : voicing;
+    // Bossa LH bass notes (root on beat 1, fifth on beat 3), octave 3 — single
+    // notes played by the piano under the RH rootless chords.
+    const bossaLhNotes =
+      chordPattern?.voicing === "rootless-jazz"
+        ? resolveBassLineNotes(root, quality, BOSSA_LH_OCTAVE)
+        : [];
+    const bassRootVoicing = bossaLhNotes.length > 0 ? [bossaLhNotes[0]] : voicing;
+    const bassFifthVoicing =
+      bossaLhNotes.length > 1 ? [bossaLhNotes[1]] : bassRootVoicing;
     const bassLineNotes = resolveBassLineNotes(root, quality);
 
     const eventBeats = isBarUnit ? input.beatsPerBar : stepBeats;
@@ -253,11 +262,15 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
             time: hitTime,
             value: {
               voicing:
-                hit.articulation === "color-stab"
-                  ? colorVoicing
-                  : hit.articulation === "root"
-                    ? rootNoteVoicing
-                    : compVoicing,
+                hit.voiceRole === "bass-root"
+                  ? bassRootVoicing
+                  : hit.voiceRole === "bass-fifth"
+                    ? bassFifthVoicing
+                    : hit.articulation === "color-stab"
+                      ? colorVoicing
+                      : hit.articulation === "root"
+                        ? rootNoteVoicing
+                        : compVoicing,
               velocity,
               style: hit.style,
               direction: hit.direction,

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -12,6 +12,7 @@ import {
   getDrumVariation,
   variationFiresOnBar,
   repeatPatternToBeats,
+  sliceCellToBar,
   type CatalogDrumPattern,
   type DrumHit,
   type DrumVariation,
@@ -228,7 +229,10 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
       });
 
       if (chordPattern && voicing.length > 0) {
-        const hits = repeatPatternToBeats(chordPattern.hits, eventBeats, input.beatsPerBar);
+        const chordCellBars = chordPattern.bars ?? 1;
+        const hits = isBarUnit && chordCellBars > 1
+          ? sliceCellToBar(chordPattern.hits, absoluteBar % chordCellBars, input.beatsPerBar)
+          : repeatPatternToBeats(chordPattern.hits, eventBeats, input.beatsPerBar);
         for (const hit of hits) {
           const baseTime = barStart + swingBeat(hit.beat, input.swing) * secondsPerBeat;
           const { time: hitTime, velocity } = applyJitter({
@@ -262,7 +266,10 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
       }
 
       if (bassPattern && bassLineNotes.length > 0) {
-        const hits = repeatPatternToBeats(bassPattern.hits, eventBeats, input.beatsPerBar);
+        const bassCellBars = bassPattern.bars ?? 1;
+        const hits = isBarUnit && bassCellBars > 1
+          ? sliceCellToBar(bassPattern.hits, absoluteBar % bassCellBars, input.beatsPerBar)
+          : repeatPatternToBeats(bassPattern.hits, eventBeats, input.beatsPerBar);
         for (const hit of hits) {
           const note = resolveBassNoteForRole(
             root,
@@ -290,10 +297,14 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
         }
       }
 
+      const drumCellBars = drumPattern?.bars ?? 1;
+      const baseForBar: VoicedDrumHit[] = isBarUnit && drumCellBars > 1
+        ? sliceCellToBar(baseDrumHits, absoluteBar % drumCellBars, input.beatsPerBar)
+        : baseDrumHits;
       const firingVariationHits: VoicedDrumHit[] = variations
         .filter((v) => variationFiresOnBar(v, absoluteBar))
         .flatMap((v) => collectDrumHits(v.pattern));
-      const drumHitsForBar: VoicedDrumHit[] = [...baseDrumHits, ...firingVariationHits];
+      const drumHitsForBar: VoicedDrumHit[] = [...baseForBar, ...firingVariationHits];
       if (drumHitsForBar.length > 0) {
         const hits = repeatPatternToBeats(drumHitsForBar, eventBeats, input.beatsPerBar);
         for (const hit of hits) {

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -19,7 +19,7 @@ import {
 } from "./patterns";
 import { applyJitter } from "./humanize";
 
-type DrumVoice = "kick" | "snare" | "hihat" | "openHat" | "ride";
+type DrumVoice = "kick" | "snare" | "hihat" | "openHat" | "ride" | "crossStick";
 type StrumStyle = "staccato" | "sustained";
 type StrumDirection = "down" | "up";
 
@@ -125,6 +125,7 @@ function collectDrumHits(pattern: CatalogDrumPattern): VoicedDrumHit[] {
   for (const h of pattern.hats) out.push({ ...h, type: "hihat" });
   for (const h of pattern.openHats ?? []) out.push({ ...h, type: "openHat" });
   for (const h of pattern.ride ?? []) out.push({ ...h, type: "ride" });
+  for (const h of pattern.crossStick ?? []) out.push({ ...h, type: "crossStick" });
   return out;
 }
 

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -90,6 +90,8 @@ export const STAB_STRUM_DURATION_SEC = 0.4;
 /** Note length (seconds) for the single root-note anchor on the one — a short,
  *  tight pluck, longer than a muted ghost but well short of a ringing stab. */
 export const ROOT_STRUM_DURATION_SEC = 0.12;
+/** Piano LH bass octave for the bossa comp — an octave above the upright bass. */
+const BOSSA_LH_OCTAVE = 3;
 
 function swingBeat(beat: number, swing: number): number {
   if (swing <= 0) return beat;
@@ -213,6 +215,15 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
       chordPattern?.voicing === "rootless-jazz"
         ? buildBossaColorVoicing(root, quality, lastVoicing)
         : voicing;
+    // Bossa LH bass notes (root on beat 1, fifth on beat 3), octave 3 — single
+    // notes played by the piano under the RH rootless chords.
+    const bossaLhNotes =
+      chordPattern?.voicing === "rootless-jazz"
+        ? resolveBassLineNotes(root, quality, BOSSA_LH_OCTAVE)
+        : [];
+    const bassRootVoicing = bossaLhNotes.length > 0 ? [bossaLhNotes[0]] : voicing;
+    const bassFifthVoicing =
+      bossaLhNotes.length > 1 ? [bossaLhNotes[1]] : bassRootVoicing;
     const bassLineNotes = resolveBassLineNotes(root, quality);
 
     const eventBeats = isBarUnit ? input.beatsPerBar : stepBeats;
@@ -251,11 +262,15 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
             time: hitTime,
             value: {
               voicing:
-                hit.articulation === "color-stab"
-                  ? colorVoicing
-                  : hit.articulation === "root"
-                    ? rootNoteVoicing
-                    : compVoicing,
+                hit.voiceRole === "bass-root"
+                  ? bassRootVoicing
+                  : hit.voiceRole === "bass-fifth"
+                    ? bassFifthVoicing
+                    : hit.articulation === "color-stab"
+                      ? colorVoicing
+                      : hit.articulation === "root"
+                        ? rootNoteVoicing
+                        : compVoicing,
               velocity,
               style: hit.style,
               direction: hit.direction,

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -3,6 +3,7 @@ import {
   resolveChordVoicing,
   resolveBassLineNotes,
   buildFunkColorVoicing,
+  buildBossaColorVoicing,
 } from "../progressionAudio";
 import type { ResolvedProgressionStep } from "../progressionDomain";
 import {
@@ -206,6 +207,12 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
       : voicing;
     const rootNoteVoicing =
       needsRootAnchor && plainVoicing.length > 0 ? [plainVoicing[0]] : voicing;
+    // Rootless jazz comp voicing (bossa) — opt-in per pattern. Falls back to the
+    // default voicing for every other comp.
+    const compVoicing =
+      chordPattern?.voicing === "rootless-jazz"
+        ? buildBossaColorVoicing(root, quality, lastVoicing)
+        : voicing;
     const bassLineNotes = resolveBassLineNotes(root, quality);
 
     const eventBeats = isBarUnit ? input.beatsPerBar : stepBeats;
@@ -248,7 +255,7 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
                   ? colorVoicing
                   : hit.articulation === "root"
                     ? rootNoteVoicing
-                    : voicing,
+                    : compVoicing,
               velocity,
               style: hit.style,
               direction: hit.direction,

--- a/src/progressions/audio/drumKit.test.ts
+++ b/src/progressions/audio/drumKit.test.ts
@@ -45,6 +45,7 @@ describe("drumKit — Tone backend", () => {
   let scheduleSnare: typeof import("./drumKit").scheduleSnare;
   let scheduleHiHat: typeof import("./drumKit").scheduleHiHat;
   let scheduleRide: typeof import("./drumKit").scheduleRide;
+  let scheduleCrossStick: typeof import("./drumKit").scheduleCrossStick;
 
   beforeEach(async () => {
     const m = await membrane;
@@ -60,7 +61,7 @@ describe("drumKit — Tone backend", () => {
     n.reset();
     mt.reset();
     vi.resetModules();
-    ({ scheduleKick, scheduleSnare, scheduleHiHat, scheduleRide } =
+    ({ scheduleKick, scheduleSnare, scheduleHiHat, scheduleRide, scheduleCrossStick } =
       await import("./drumKit"));
   });
 
@@ -391,6 +392,32 @@ describe("drumKit — Tone backend", () => {
       expect(metalSpies.dispose).not.toHaveBeenCalled();
       vi.advanceTimersByTime(1600); // > RIDE_DISPOSE_MS (1500)
       expect(metalSpies.dispose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("scheduleCrossStick", () => {
+    it("constructs a MembraneSynth with a triangle click voice", () => {
+      scheduleCrossStick({} as AudioNode, 1.5);
+      expect(membraneSpies.ctorSpy).toHaveBeenCalledTimes(1);
+      const [opts] = membraneSpies.ctorSpy.mock.calls[0]!;
+      expect(opts.oscillator.type).toBe("triangle");
+      expect(opts.envelope.sustain).toBe(0);
+      expect(opts.envelope.decay).toBeCloseTo(0.06, 3);
+    });
+
+    it("triggers a high woody click (G4) at the requested time + velocity", () => {
+      scheduleCrossStick({} as AudioNode, 2.5, { velocity: 0.8 });
+      expect(membraneSpies.triggerAttackRelease).toHaveBeenCalledTimes(1);
+      const [note, , time, velocity] =
+        membraneSpies.triggerAttackRelease.mock.calls[0]!;
+      expect(note).toBe("G4");
+      expect(time).toBeCloseTo(2.5, 3);
+      expect(velocity).toBeCloseTo(0.8, 2);
+    });
+
+    it("skips zero-velocity hits (no MembraneSynth constructed)", () => {
+      scheduleCrossStick({} as AudioNode, 1, { velocity: 0 });
+      expect(membraneSpies.ctorSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/progressions/audio/drumKit.test.ts
+++ b/src/progressions/audio/drumKit.test.ts
@@ -419,6 +419,55 @@ describe("drumKit — Tone backend", () => {
       scheduleCrossStick({} as AudioNode, 1, { velocity: 0 });
       expect(membraneSpies.ctorSpy).not.toHaveBeenCalled();
     });
+
+    it("reuses one MembraneSynth for non-overlapping hits on the same destination", () => {
+      const dest = {} as AudioNode;
+      scheduleCrossStick(dest, 0, { velocity: 0.8 });
+      clock.now = 0.3; // past the first hit's busy window (0 + 0.12)
+      scheduleCrossStick(dest, 0.4, { velocity: 0.7 });
+
+      expect(membraneSpies.ctorSpy).toHaveBeenCalledTimes(1);
+      expect(membraneSpies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+    });
+
+    it("allocates separate MembraneSynths for future hits scheduled in one pass", () => {
+      const dest = {} as AudioNode;
+      scheduleCrossStick(dest, 2, { velocity: 0.8 });
+      scheduleCrossStick(dest, 2.6, { velocity: 0.7 });
+
+      expect(membraneSpies.ctorSpy).toHaveBeenCalledTimes(2);
+      expect(membraneSpies.triggerAttackRelease).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps different destinations on different leased synths", () => {
+      const firstDest = {} as AudioNode;
+      const secondDest = {} as AudioNode;
+
+      scheduleCrossStick(firstDest, 0, { velocity: 0.8 });
+      clock.now = 0.3;
+      scheduleCrossStick(secondDest, 0.4, { velocity: 0.7 });
+
+      expect(membraneSpies.ctorSpy).toHaveBeenCalledTimes(2);
+      expect(membraneTone.instances[0]?.connect).toHaveBeenCalledWith(firstDest);
+      expect(membraneTone.instances[1]?.connect).toHaveBeenCalledWith(secondDest);
+    });
+
+    it("cancel() defers dispose past the cross-stick release tail", () => {
+      const handle = scheduleCrossStick({} as AudioNode, 0);
+      handle.cancel();
+      expect(membraneSpies.dispose).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(200); // > CROSS_STICK_DISPOSE_MS (120)
+      expect(membraneSpies.dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancel() is idempotent — repeated calls dispose only once", () => {
+      const handle = scheduleCrossStick({} as AudioNode, 0);
+      handle.cancel();
+      handle.cancel();
+      handle.cancel();
+      vi.advanceTimersByTime(200);
+      expect(membraneSpies.dispose).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("kit patch overrides", () => {

--- a/src/progressions/audio/drumKit.ts
+++ b/src/progressions/audio/drumKit.ts
@@ -28,6 +28,7 @@ const SNARE_DISPOSE_MS = 300; // snare decay ~180 ms
 const HAT_CLOSED_DISPOSE_MS = 150; // closed hat decay ~50 ms
 const HAT_OPEN_DISPOSE_MS = 500; // open hat decay ~350 ms
 const RIDE_DISPOSE_MS = 1500; // ride decay ~1 s
+const CROSS_STICK_DISPOSE_MS = 120; // cross-stick decay ~60 ms
 
 const kitKey = (kit?: DrumKitPatch) => kit?.id ?? "__default";
 
@@ -308,4 +309,56 @@ export function scheduleRide(
   lease.setBusyUntil(busyUntil);
   lease.voice.triggerAttackRelease("D6", decay, time, velocity);
   return deferredDisposeHandle(lease, time, busyUntil, RIDE_DISPOSE_MS);
+}
+
+// ── Cross-Stick / Rim ────────────────────────────────────────────────────────
+// A dry woody "tok" for the bossa clave: a short, high-pitched MembraneSynth
+// click. Fully deterministic, no noise generation.
+const DEFAULT_CROSS_STICK_ENV = {
+  attack: 0.001,
+  decay: 0.06,
+  sustain: 0,
+  release: 0.02,
+  attackCurve: "exponential" as const,
+};
+const crossStickPools = new Map<
+  string,
+  ReturnType<typeof createReusableVoicePool<Tone.MembraneSynth>>
+>();
+function crossStickPool(kit?: DrumKitPatch) {
+  const key = kitKey(kit);
+  const existing = crossStickPools.get(key);
+  if (existing) return existing;
+  const ov = kit?.voices.crossStick;
+  const pool = createReusableVoicePool<Tone.MembraneSynth>({
+    createVoice: () =>
+      new Tone.MembraneSynth({
+        pitchDecay: ov?.pitchDecay ?? 0.008,
+        octaves: ov?.octaves ?? 2,
+        oscillator: { type: "triangle" },
+        envelope: { ...DEFAULT_CROSS_STICK_ENV, ...(ov?.envelope ?? {}) },
+      }),
+  });
+  crossStickPools.set(key, pool);
+  return pool;
+}
+
+/**
+ * Schedule a cross-stick / rim-click hit at `time`. Short MembraneSynth click
+ * (triangle, tiny pitch-decay, ~60 ms decay) — the bossa clave timbre.
+ */
+export function scheduleCrossStick(
+  dest: AudioNode,
+  time: number,
+  options: DrumHitOptions = {},
+): DrumVoiceHandle {
+  const velocity = clampVelocity(options.velocity);
+  if (velocity <= 0) return NOOP_HANDLE;
+  const now = Tone.now();
+  const playbackStartTime = Math.max(now, time);
+  const lease = crossStickPool(options.kit).lease(dest, now);
+  const busyUntil = playbackStartTime + 0.12;
+  lease.setBusyUntil(busyUntil);
+  lease.voice.triggerAttackRelease("G4", 0.05, time, velocity);
+  return deferredDisposeHandle(lease, time, busyUntil, CROSS_STICK_DISPOSE_MS);
 }

--- a/src/progressions/audio/genres.test.ts
+++ b/src/progressions/audio/genres.test.ts
@@ -59,6 +59,13 @@ describe("genre styles", () => {
     expect(funk.tempoRange[0]).toBeLessThanOrEqual(funk.suggestedTempo);
     expect(funk.tempoRange[1]).toBeGreaterThanOrEqual(funk.suggestedTempo);
   });
+
+  it("wires bossa-nova to the clave drum, surdo bass, and partido-alto comp", () => {
+    const bossa = getGenreStyle("bossa-nova")!;
+    expect(bossa.chordPattern).toBe("bossa-comp");
+    expect(bossa.bassPattern).toBe("bossa");
+    expect(bossa.drumPattern).toBe("bossa");
+  });
 });
 
 describe("genre drum variations", () => {

--- a/src/progressions/audio/genres.ts
+++ b/src/progressions/audio/genres.ts
@@ -52,7 +52,7 @@ export const GENRE_STYLES: readonly GenreStyle[] = [
   },
   {
     id: "bossa-nova", label: "Bossa Nova", chordInstrument: "piano",
-    chordPattern: "straight-quarters", bassPattern: "arpeggiated",
+    chordPattern: "bossa-comp", bassPattern: "bossa",
     drumPattern: "bossa", drumVariations: [],
     tempoRange: [120, 140], suggestedTempo: 130, swing: 0,
   },

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -529,8 +529,7 @@ describe("bossa patterns", () => {
       "bass-root", "chord", "bass-fifth", "chord",
       "bass-root", "chord", "bass-fifth", "chord",
     ]);
-    // Only the LH fifth rings; the LH root and RH chords are short (no sustain).
-    expect(comp.hits.filter((h) => h.voiceRole === "bass-fifth").every((h) => h.style === "sustained")).toBe(true);
-    expect(comp.hits.filter((h) => h.voiceRole !== "bass-fifth").every((h) => h.style === undefined)).toBe(true);
+    // Every hit is short — no sustain anywhere in the comp.
+    expect(comp.hits.every((h) => h.style === undefined)).toBe(true);
   });
 });

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -529,6 +529,8 @@ describe("bossa patterns", () => {
       "bass-root", "chord", "bass-fifth", "chord",
       "bass-root", "chord", "bass-fifth", "chord",
     ]);
-    expect(comp.hits.every((h) => h.style === "sustained")).toBe(true);
+    // RH chords + the LH fifth ring; the LH root is short (no sustain).
+    expect(comp.hits.filter((h) => h.voiceRole === "bass-root").every((h) => h.style === undefined)).toBe(true);
+    expect(comp.hits.filter((h) => h.voiceRole !== "bass-root").every((h) => h.style === "sustained")).toBe(true);
   });
 });

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -89,14 +89,14 @@ describe("buildMetronomePattern", () => {
 });
 
 describe("pattern catalog", () => {
-  it("has 9 chord patterns with unique IDs", () => {
-    expect(CHORD_PATTERNS).toHaveLength(9);
+  it("has 10 chord patterns with unique IDs", () => {
+    expect(CHORD_PATTERNS).toHaveLength(10);
     const ids = CHORD_PATTERNS.map((p) => p.id);
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("has 6 bass patterns with unique IDs", () => {
-    expect(BASS_PATTERNS).toHaveLength(6);
+  it("has 7 bass patterns with unique IDs", () => {
+    expect(BASS_PATTERNS).toHaveLength(7);
     const ids = BASS_PATTERNS.map((p) => p.id);
     expect(new Set(ids).size).toBe(ids.length);
   });
@@ -113,17 +113,19 @@ describe("pattern catalog", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("all pattern beats are in range [0, 4)", () => {
+  it("all pattern beats are in range [0, bars * 4)", () => {
     for (const p of CHORD_PATTERNS) {
+      const maxBeat = (p.bars ?? 1) * 4;
       for (const h of p.hits) {
         expect(h.beat).toBeGreaterThanOrEqual(0);
-        expect(h.beat).toBeLessThan(4);
+        expect(h.beat).toBeLessThan(maxBeat);
       }
     }
     for (const p of BASS_PATTERNS) {
+      const maxBeat = (p.bars ?? 1) * 4;
       for (const h of p.hits) {
         expect(h.beat).toBeGreaterThanOrEqual(0);
-        expect(h.beat).toBeLessThan(4);
+        expect(h.beat).toBeLessThan(maxBeat);
       }
     }
     const drumPatterns = [
@@ -131,11 +133,12 @@ describe("pattern catalog", () => {
       ...DRUM_VARIATIONS.map((v) => v.pattern),
     ];
     for (const p of drumPatterns) {
-      const lanes = [p.kicks, p.snares, p.hats, p.openHats, p.ride];
+      const maxBeat = (p.bars ?? 1) * 4;
+      const lanes = [p.kicks, p.snares, p.hats, p.openHats, p.ride, p.crossStick];
       for (const lane of lanes) {
         for (const h of lane ?? []) {
           expect(h.beat).toBeGreaterThanOrEqual(0);
-          expect(h.beat).toBeLessThan(4);
+          expect(h.beat).toBeLessThan(maxBeat);
         }
       }
     }
@@ -499,5 +502,26 @@ describe("sliceCellToBar", () => {
     expect(sliceCellToBar(typed, 1, 4)).toEqual([
       { beat: 1, velocity: 0.5, type: "crossStick" },
     ]);
+  });
+});
+
+describe("bossa patterns", () => {
+  it("rewrites the bossa drum pattern as a 2-bar cell with a son-clave cross-stick", () => {
+    const bossa = getDrumPattern("bossa")!;
+    expect(bossa.bars).toBe(2);
+    expect(bossa.snares).toEqual([]); // cross-stick carries the rhythm
+    expect(bossa.crossStick?.map((h) => h.beat)).toEqual([0, 1.5, 3, 5, 6]);
+  });
+
+  it("adds a 1-bar root-fifth bossa bass pattern", () => {
+    const bass = getBassPattern("bossa")!;
+    expect(bass.bars ?? 1).toBe(1);
+    expect(bass.hits.map((h) => h.note)).toEqual(["root", "fifth"]);
+  });
+
+  it("adds a 2-bar syncopated bossa comp chord pattern", () => {
+    const comp = getChordPattern("bossa-comp")!;
+    expect(comp.bars).toBe(2);
+    expect(comp.hits.map((h) => h.beat)).toEqual([0, 1.5, 3, 4.5, 6, 7.5]);
   });
 });

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -506,7 +506,7 @@ describe("sliceCellToBar", () => {
 });
 
 describe("bossa patterns", () => {
-  it("rewrites the bossa drum pattern as a 2-bar cell with a son-clave cross-stick", () => {
+  it("rewrites the bossa drum pattern as a 2-bar cell with a bossa-clave cross-stick", () => {
     const bossa = getDrumPattern("bossa")!;
     expect(bossa.bars).toBe(2);
     expect(bossa.snares).toEqual([]); // cross-stick carries the rhythm

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -520,17 +520,20 @@ describe("bossa patterns", () => {
     expect(bass.hits.map((h) => h.note)).toEqual(["root", "fifth"]);
   });
 
-  it("adds a 2-bar bossa comp: off-beat chord stabs that intensify in the second bar", () => {
+  it("adds a 2-bar bossa comp: LH bass + RH chords that intensify in the second bar", () => {
     const comp = getChordPattern("bossa-comp")!;
     expect(comp.bars).toBe(2);
     expect(comp.voicing).toBe("rootless-jazz");
-    // Only off-beat chord stabs (no on-beat bass hits — the upright covers 1 & 3).
-    expect(comp.hits.map((h) => h.beat)).toEqual([1.5, 3.5, 4.5, 5.5, 7.5]);
-    // The chords get busier in the second bar (the authentic 2-bar arc):
-    // bar 1 has 2 stabs, bar 2 has 3 anticipated off-beat stabs.
-    const beats = comp.hits.map((h) => h.beat);
-    expect(beats.filter((b) => b < 4)).toEqual([1.5, 3.5]);
-    expect(beats.filter((b) => b >= 4)).toEqual([4.5, 5.5, 7.5]);
+    expect(comp.hits.map((h) => h.beat)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 5.5, 6, 7.5]);
+    expect(comp.hits.map((h) => h.voiceRole)).toEqual([
+      "bass-root", "chord", "bass-fifth", "chord",
+      "bass-root", "chord", "chord", "bass-fifth", "chord",
+    ]);
+    // The RH chords get busier in the second bar (the authentic 2-bar arc):
+    // bar 1 has 2 chord stabs, bar 2 has 3 anticipated off-beat stabs.
+    const chordBeats = comp.hits.filter((h) => h.voiceRole === "chord").map((h) => h.beat);
+    expect(chordBeats.filter((b) => b < 4)).toEqual([1.5, 3.5]);
+    expect(chordBeats.filter((b) => b >= 4)).toEqual([4.5, 5.5, 7.5]);
     // Every hit is short — no sustain anywhere in the comp.
     expect(comp.hits.every((h) => h.style === undefined)).toBe(true);
   });

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -520,15 +520,20 @@ describe("bossa patterns", () => {
     expect(bass.hits.map((h) => h.note)).toEqual(["root", "fifth"]);
   });
 
-  it("adds a 2-bar bossa comp as LH bass + RH rootless chords (all sustained)", () => {
+  it("adds a 2-bar bossa comp: LH bass + RH chords that intensify in the second bar", () => {
     const comp = getChordPattern("bossa-comp")!;
     expect(comp.bars).toBe(2);
     expect(comp.voicing).toBe("rootless-jazz");
-    expect(comp.hits.map((h) => h.beat)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 6, 7.5]);
+    expect(comp.hits.map((h) => h.beat)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 5.5, 6, 6.5, 7.5]);
     expect(comp.hits.map((h) => h.voiceRole)).toEqual([
       "bass-root", "chord", "bass-fifth", "chord",
-      "bass-root", "chord", "bass-fifth", "chord",
+      "bass-root", "chord", "chord", "bass-fifth", "chord", "chord",
     ]);
+    // The RH chords get busier in the second bar (the authentic 2-bar arc):
+    // bar 1 has 2 chord stabs, bar 2 has 4 anticipated off-beat stabs.
+    const chordBeats = comp.hits.filter((h) => h.voiceRole === "chord").map((h) => h.beat);
+    expect(chordBeats.filter((b) => b < 4)).toEqual([1.5, 3.5]);
+    expect(chordBeats.filter((b) => b >= 4)).toEqual([4.5, 5.5, 6.5, 7.5]);
     // Every hit is short — no sustain anywhere in the comp.
     expect(comp.hits.every((h) => h.style === undefined)).toBe(true);
   });

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -520,20 +520,17 @@ describe("bossa patterns", () => {
     expect(bass.hits.map((h) => h.note)).toEqual(["root", "fifth"]);
   });
 
-  it("adds a 2-bar bossa comp: LH bass + RH chords that intensify in the second bar", () => {
+  it("adds a 2-bar bossa comp: off-beat chord stabs that intensify in the second bar", () => {
     const comp = getChordPattern("bossa-comp")!;
     expect(comp.bars).toBe(2);
     expect(comp.voicing).toBe("rootless-jazz");
-    expect(comp.hits.map((h) => h.beat)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 5.5, 6, 7.5]);
-    expect(comp.hits.map((h) => h.voiceRole)).toEqual([
-      "bass-root", "chord", "bass-fifth", "chord",
-      "bass-root", "chord", "chord", "bass-fifth", "chord",
-    ]);
-    // The RH chords get busier in the second bar (the authentic 2-bar arc):
-    // bar 1 has 2 chord stabs, bar 2 has 3 anticipated off-beat stabs.
-    const chordBeats = comp.hits.filter((h) => h.voiceRole === "chord").map((h) => h.beat);
-    expect(chordBeats.filter((b) => b < 4)).toEqual([1.5, 3.5]);
-    expect(chordBeats.filter((b) => b >= 4)).toEqual([4.5, 5.5, 7.5]);
+    // Only off-beat chord stabs (no on-beat bass hits — the upright covers 1 & 3).
+    expect(comp.hits.map((h) => h.beat)).toEqual([1.5, 3.5, 4.5, 5.5, 7.5]);
+    // The chords get busier in the second bar (the authentic 2-bar arc):
+    // bar 1 has 2 stabs, bar 2 has 3 anticipated off-beat stabs.
+    const beats = comp.hits.map((h) => h.beat);
+    expect(beats.filter((b) => b < 4)).toEqual([1.5, 3.5]);
+    expect(beats.filter((b) => b >= 4)).toEqual([4.5, 5.5, 7.5]);
     // Every hit is short — no sustain anywhere in the comp.
     expect(comp.hits.every((h) => h.style === undefined)).toBe(true);
   });

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -510,7 +510,8 @@ describe("bossa patterns", () => {
     const bossa = getDrumPattern("bossa")!;
     expect(bossa.bars).toBe(2);
     expect(bossa.snares).toEqual([]); // cross-stick carries the rhythm
-    expect(bossa.crossStick?.map((h) => h.beat)).toEqual([0, 1.5, 3, 5, 6]);
+    // Authentic 3-2 bossa clave: 2-side's last note on "3&" (6.5), not son's "3" (6).
+    expect(bossa.crossStick?.map((h) => h.beat)).toEqual([0, 1.5, 3, 5, 6.5]);
   });
 
   it("adds a 1-bar root-fifth bossa bass pattern", () => {
@@ -519,9 +520,11 @@ describe("bossa patterns", () => {
     expect(bass.hits.map((h) => h.note)).toEqual(["root", "fifth"]);
   });
 
-  it("adds a 2-bar syncopated bossa comp chord pattern", () => {
+  it("adds a 2-bar syncopated bossa comp with rootless-jazz voicing and ringing chords", () => {
     const comp = getChordPattern("bossa-comp")!;
     expect(comp.bars).toBe(2);
-    expect(comp.hits.map((h) => h.beat)).toEqual([0, 1.5, 3, 4.5, 6, 7.5]);
+    expect(comp.voicing).toBe("rootless-jazz");
+    expect(comp.hits.map((h) => h.beat)).toEqual([0, 1.5, 3.5, 4.5, 6, 7.5]);
+    expect(comp.hits.every((h) => h.style === "sustained")).toBe(true);
   });
 });

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -524,16 +524,16 @@ describe("bossa patterns", () => {
     const comp = getChordPattern("bossa-comp")!;
     expect(comp.bars).toBe(2);
     expect(comp.voicing).toBe("rootless-jazz");
-    expect(comp.hits.map((h) => h.beat)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 5.5, 6, 6.5, 7.5]);
+    expect(comp.hits.map((h) => h.beat)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 5.5, 6, 7.5]);
     expect(comp.hits.map((h) => h.voiceRole)).toEqual([
       "bass-root", "chord", "bass-fifth", "chord",
-      "bass-root", "chord", "chord", "bass-fifth", "chord", "chord",
+      "bass-root", "chord", "chord", "bass-fifth", "chord",
     ]);
     // The RH chords get busier in the second bar (the authentic 2-bar arc):
-    // bar 1 has 2 chord stabs, bar 2 has 4 anticipated off-beat stabs.
+    // bar 1 has 2 chord stabs, bar 2 has 3 anticipated off-beat stabs.
     const chordBeats = comp.hits.filter((h) => h.voiceRole === "chord").map((h) => h.beat);
     expect(chordBeats.filter((b) => b < 4)).toEqual([1.5, 3.5]);
-    expect(chordBeats.filter((b) => b >= 4)).toEqual([4.5, 5.5, 6.5, 7.5]);
+    expect(chordBeats.filter((b) => b >= 4)).toEqual([4.5, 5.5, 7.5]);
     // Every hit is short — no sustain anywhere in the comp.
     expect(comp.hits.every((h) => h.style === undefined)).toBe(true);
   });

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -520,11 +520,15 @@ describe("bossa patterns", () => {
     expect(bass.hits.map((h) => h.note)).toEqual(["root", "fifth"]);
   });
 
-  it("adds a 2-bar syncopated bossa comp with rootless-jazz voicing and ringing chords", () => {
+  it("adds a 2-bar bossa comp as LH bass + RH rootless chords (all sustained)", () => {
     const comp = getChordPattern("bossa-comp")!;
     expect(comp.bars).toBe(2);
     expect(comp.voicing).toBe("rootless-jazz");
-    expect(comp.hits.map((h) => h.beat)).toEqual([0, 1.5, 3.5, 4.5, 6, 7.5]);
+    expect(comp.hits.map((h) => h.beat)).toEqual([0, 1.5, 2, 3.5, 4, 4.5, 6, 7.5]);
+    expect(comp.hits.map((h) => h.voiceRole)).toEqual([
+      "bass-root", "chord", "bass-fifth", "chord",
+      "bass-root", "chord", "bass-fifth", "chord",
+    ]);
     expect(comp.hits.every((h) => h.style === "sustained")).toBe(true);
   });
 });

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -3,6 +3,7 @@ import {
   buildMetronomePattern,
   clipPatternToBeats,
   repeatPatternToBeats,
+  sliceCellToBar,
   CHORD_PATTERNS,
   BASS_PATTERNS,
   DRUM_PATTERNS,
@@ -461,5 +462,42 @@ describe("DRUM_VARIATIONS definitions are truthful", () => {
     expect(variationFiresOnBar(fill, 3)).toBe(true);
     expect(variationFiresOnBar(fill, 7)).toBe(true);
     expect(fill.pattern.snares.length).toBeGreaterThan(0);
+  });
+});
+
+describe("sliceCellToBar", () => {
+  // A 2-bar cell in 4/4: beats 0..7.99. Bar 1 = [0,4), bar 2 = [4,8).
+  const CELL = [
+    { beat: 0, velocity: 0.8 },
+    { beat: 1.5, velocity: 0.7 },
+    { beat: 3, velocity: 0.75 },
+    { beat: 5, velocity: 0.7 },
+    { beat: 6, velocity: 0.8 },
+  ];
+
+  it("returns bar 1 hits with original beats for cellBarIndex 0", () => {
+    expect(sliceCellToBar(CELL, 0, 4)).toEqual([
+      { beat: 0, velocity: 0.8 },
+      { beat: 1.5, velocity: 0.7 },
+      { beat: 3, velocity: 0.75 },
+    ]);
+  });
+
+  it("returns bar 2 hits shifted back by beatsPerBar for cellBarIndex 1", () => {
+    expect(sliceCellToBar(CELL, 1, 4)).toEqual([
+      { beat: 1, velocity: 0.7 },
+      { beat: 2, velocity: 0.8 },
+    ]);
+  });
+
+  it("returns an empty array for an out-of-range cellBarIndex", () => {
+    expect(sliceCellToBar(CELL, 2, 4)).toEqual([]);
+  });
+
+  it("preserves extra hit fields (only the beat is shifted)", () => {
+    const typed = [{ beat: 5, velocity: 0.5, type: "crossStick" as const }];
+    expect(sliceCellToBar(typed, 1, 4)).toEqual([
+      { beat: 1, velocity: 0.5, type: "crossStick" },
+    ]);
   });
 });

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -529,8 +529,8 @@ describe("bossa patterns", () => {
       "bass-root", "chord", "bass-fifth", "chord",
       "bass-root", "chord", "bass-fifth", "chord",
     ]);
-    // RH chords + the LH fifth ring; the LH root is short (no sustain).
-    expect(comp.hits.filter((h) => h.voiceRole === "bass-root").every((h) => h.style === undefined)).toBe(true);
-    expect(comp.hits.filter((h) => h.voiceRole !== "bass-root").every((h) => h.style === "sustained")).toBe(true);
+    // Only the LH fifth rings; the LH root and RH chords are short (no sustain).
+    expect(comp.hits.filter((h) => h.voiceRole === "bass-fifth").every((h) => h.style === "sustained")).toBe(true);
+    expect(comp.hits.filter((h) => h.voiceRole !== "bass-fifth").every((h) => h.style === undefined)).toBe(true);
   });
 });

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -41,6 +41,10 @@ interface ChordHit {
    *  "color-stab" rings a chord with funk extensions; "muted" chokes a plain
    *  chord short (chicken-scratch ghost). Omitted rings the patch default. */
   articulation?: ChordArticulation;
+  /** Bossa LH/RH split (used when the pattern's voicing is "rootless-jazz"):
+   *  "bass-root"/"bass-fifth" play a single low note (LH); "chord" plays the
+   *  rootless RH voicing. Omitted behaves as "chord". */
+  voiceRole?: "bass-root" | "bass-fifth" | "chord";
 }
 
 export interface ChordPattern {
@@ -219,17 +223,18 @@ export const CHORD_PATTERNS: readonly ChordPattern[] = [
     label: "Bossa Comp",
     bars: 2,
     voicing: "rootless-jazz",
-    // Highly syncopated 2-bar partido-alto: clave-locked, two cross-barline
-    // anticipations (3.5, 7.5), soft acoustic dynamics, chords ring (sustained).
+    // LH bass (root on beat 1, fifth on beat 3) + RH rootless chords on the
+    // syncopated off-beats, with two cross-barline anticipations (3.5, 7.5).
+    // Soft, ringing (sustained).
     hits: [
-      // bar 1
-      { beat: 0, velocity: 0.6, style: "sustained" }, // downbeat anchor
-      { beat: 1.5, velocity: 0.55, style: "sustained" }, // "& of 2" (clave)
-      { beat: 3.5, velocity: 0.6, style: "sustained" }, // "& of 4" anticipates bar 2
-      // bar 2
-      { beat: 4.5, velocity: 0.55, style: "sustained" }, // "& of 1"
-      { beat: 6, velocity: 0.5, style: "sustained" }, // beat 3 (clave)
-      { beat: 7.5, velocity: 0.65, style: "sustained" }, // "& of 4" anticipates next cycle
+      { beat: 0, velocity: 0.6, voiceRole: "bass-root", style: "sustained" },
+      { beat: 1.5, velocity: 0.5, voiceRole: "chord", style: "sustained" },
+      { beat: 2, velocity: 0.55, voiceRole: "bass-fifth", style: "sustained" },
+      { beat: 3.5, velocity: 0.55, voiceRole: "chord", style: "sustained" },
+      { beat: 4, velocity: 0.6, voiceRole: "bass-root", style: "sustained" },
+      { beat: 4.5, velocity: 0.5, voiceRole: "chord", style: "sustained" },
+      { beat: 6, velocity: 0.55, voiceRole: "bass-fifth", style: "sustained" },
+      { beat: 7.5, velocity: 0.55, voiceRole: "chord", style: "sustained" },
     ],
   },
 ];

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -224,16 +224,22 @@ export const CHORD_PATTERNS: readonly ChordPattern[] = [
     bars: 2,
     voicing: "rootless-jazz",
     // LH bass (root on beat 1, fifth on beat 3) + RH rootless chords on the
-    // syncopated off-beats, with two cross-barline anticipations (3.5, 7.5).
+    // off-beats. Authentic 2-bar arc: bar 1 is the basic sparse comp (2 stabs),
+    // bar 2 intensifies into a busier run of anticipated off-beat stabs (4).
     // Every hit is short (no sustain) — a plucky, detached comp.
     hits: [
+      // bar 1 — basic: bass on 1 & 3, chord stabs on the & of 2 and & of 4
       { beat: 0, velocity: 0.6, voiceRole: "bass-root" },
       { beat: 1.5, velocity: 0.5, voiceRole: "chord" },
       { beat: 2, velocity: 0.55, voiceRole: "bass-fifth" },
       { beat: 3.5, velocity: 0.55, voiceRole: "chord" },
+      // bar 2 — busier: chord stabs on every off-beat (& of 1/2/3/4),
+      // anticipating each following beat for forward momentum.
       { beat: 4, velocity: 0.6, voiceRole: "bass-root" },
       { beat: 4.5, velocity: 0.5, voiceRole: "chord" },
+      { beat: 5.5, velocity: 0.5, voiceRole: "chord" },
       { beat: 6, velocity: 0.55, voiceRole: "bass-fifth" },
+      { beat: 6.5, velocity: 0.5, voiceRole: "chord" },
       { beat: 7.5, velocity: 0.55, voiceRole: "chord" },
     ],
   },

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -225,16 +225,16 @@ export const CHORD_PATTERNS: readonly ChordPattern[] = [
     voicing: "rootless-jazz",
     // LH bass (root on beat 1, fifth on beat 3) + RH rootless chords on the
     // syncopated off-beats, with two cross-barline anticipations (3.5, 7.5).
-    // The chords + fifth ring (sustained); the LH root is short (no sustain).
+    // Only the LH fifth rings (sustained); the LH root and RH chords are short.
     hits: [
       { beat: 0, velocity: 0.6, voiceRole: "bass-root" },
-      { beat: 1.5, velocity: 0.5, voiceRole: "chord", style: "sustained" },
+      { beat: 1.5, velocity: 0.5, voiceRole: "chord" },
       { beat: 2, velocity: 0.55, voiceRole: "bass-fifth", style: "sustained" },
-      { beat: 3.5, velocity: 0.55, voiceRole: "chord", style: "sustained" },
+      { beat: 3.5, velocity: 0.55, voiceRole: "chord" },
       { beat: 4, velocity: 0.6, voiceRole: "bass-root" },
-      { beat: 4.5, velocity: 0.5, voiceRole: "chord", style: "sustained" },
+      { beat: 4.5, velocity: 0.5, voiceRole: "chord" },
       { beat: 6, velocity: 0.55, voiceRole: "bass-fifth", style: "sustained" },
-      { beat: 7.5, velocity: 0.55, voiceRole: "chord", style: "sustained" },
+      { beat: 7.5, velocity: 0.55, voiceRole: "chord" },
     ],
   },
 ];

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -41,10 +41,6 @@ interface ChordHit {
    *  "color-stab" rings a chord with funk extensions; "muted" chokes a plain
    *  chord short (chicken-scratch ghost). Omitted rings the patch default. */
   articulation?: ChordArticulation;
-  /** Bossa LH/RH split (used when the pattern's voicing is "rootless-jazz"):
-   *  "bass-root"/"bass-fifth" play a single low note (LH); "chord" plays the
-   *  rootless RH voicing. Omitted behaves as "chord". */
-  voiceRole?: "bass-root" | "bass-fifth" | "chord";
 }
 
 export interface ChordPattern {
@@ -223,23 +219,18 @@ export const CHORD_PATTERNS: readonly ChordPattern[] = [
     label: "Bossa Comp",
     bars: 2,
     voicing: "rootless-jazz",
-    // LH bass (root on beat 1, fifth on beat 3) + RH rootless chords on the
-    // off-beats. Authentic 2-bar arc: bar 1 is the basic sparse comp (2 stabs),
-    // bar 2 intensifies into a busier run of anticipated off-beat stabs (4).
-    // Every hit is short (no sustain) — a plucky, detached comp.
+    // Rooted chord stabs on the off-beats only — the piano carries its own bass
+    // note (root below the grip) here, while the upright bassline holds beats 1
+    // & 3, so the two no longer double. Authentic 2-bar arc: bar 1 is the basic
+    // sparse comp (2 stabs), bar 2 intensifies (3 anticipated stabs). All short.
     hits: [
-      // bar 1 — basic: bass on 1 & 3, chord stabs on the & of 2 and & of 4
-      { beat: 0, velocity: 0.6, voiceRole: "bass-root" },
-      { beat: 1.5, velocity: 0.5, voiceRole: "chord" },
-      { beat: 2, velocity: 0.55, voiceRole: "bass-fifth" },
-      { beat: 3.5, velocity: 0.55, voiceRole: "chord" },
-      // bar 2 — busier: chord stabs on the & of 1, 2 and 4, anticipating the
-      // following beats for forward momentum.
-      { beat: 4, velocity: 0.6, voiceRole: "bass-root" },
-      { beat: 4.5, velocity: 0.5, voiceRole: "chord" },
-      { beat: 5.5, velocity: 0.5, voiceRole: "chord" },
-      { beat: 6, velocity: 0.55, voiceRole: "bass-fifth" },
-      { beat: 7.5, velocity: 0.55, voiceRole: "chord" },
+      // bar 1 — basic: the & of 2 and & of 4
+      { beat: 1.5, velocity: 0.5 },
+      { beat: 3.5, velocity: 0.55 },
+      // bar 2 — busier: the & of 1, 2 and 4, anticipating the following beats
+      { beat: 4.5, velocity: 0.5 },
+      { beat: 5.5, velocity: 0.5 },
+      { beat: 7.5, velocity: 0.55 },
     ],
   },
 ];

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -225,15 +225,15 @@ export const CHORD_PATTERNS: readonly ChordPattern[] = [
     voicing: "rootless-jazz",
     // LH bass (root on beat 1, fifth on beat 3) + RH rootless chords on the
     // syncopated off-beats, with two cross-barline anticipations (3.5, 7.5).
-    // Only the LH fifth rings (sustained); the LH root and RH chords are short.
+    // Every hit is short (no sustain) — a plucky, detached comp.
     hits: [
       { beat: 0, velocity: 0.6, voiceRole: "bass-root" },
       { beat: 1.5, velocity: 0.5, voiceRole: "chord" },
-      { beat: 2, velocity: 0.55, voiceRole: "bass-fifth", style: "sustained" },
+      { beat: 2, velocity: 0.55, voiceRole: "bass-fifth" },
       { beat: 3.5, velocity: 0.55, voiceRole: "chord" },
       { beat: 4, velocity: 0.6, voiceRole: "bass-root" },
       { beat: 4.5, velocity: 0.5, voiceRole: "chord" },
-      { beat: 6, velocity: 0.55, voiceRole: "bass-fifth", style: "sustained" },
+      { beat: 6, velocity: 0.55, voiceRole: "bass-fifth" },
       { beat: 7.5, velocity: 0.55, voiceRole: "chord" },
     ],
   },

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -211,6 +211,22 @@ export const CHORD_PATTERNS: readonly ChordPattern[] = [
       { beat: 3, velocity: 0.6 },
     ],
   },
+  {
+    id: "bossa-comp",
+    label: "Bossa Comp",
+    bars: 2,
+    // Syncopated partido-alto: clave-locked anticipations that leave space.
+    hits: [
+      // bar 1
+      { beat: 0, velocity: 0.7 },
+      { beat: 1.5, velocity: 0.6 },
+      { beat: 3, velocity: 0.55 },
+      // bar 2: anticipated "& of 1" push, mid-bar, "& of 4" lead into the next phrase
+      { beat: 4.5, velocity: 0.6 },
+      { beat: 6, velocity: 0.6 },
+      { beat: 7.5, velocity: 0.7 },
+    ],
+  },
 ];
 
 export const BASS_PATTERNS: readonly CatalogBassPattern[] = [
@@ -282,6 +298,16 @@ export const BASS_PATTERNS: readonly CatalogBassPattern[] = [
       { beat: 1.5, velocity: 0.8, note: "octave", articulation: "staccato" },
       { beat: 2.5, velocity: 0.55, note: "fifth", articulation: "staccato" },
       { beat: 3.5, velocity: 0.7, note: "flat-seventh", articulation: "staccato" },
+    ],
+  },
+  {
+    id: "bossa",
+    label: "Bossa Nova",
+    // Root–fifth surdo (tonic–dominant alternation) — the recognizable bossa
+    // pulse. The clave lock comes from the drums + comp; this stays 1-bar.
+    hits: [
+      { beat: 0, velocity: 1, note: "root", articulation: "legato" },
+      { beat: 2, velocity: 0.8, note: "fifth", articulation: "legato" },
     ],
   },
 ];
@@ -361,18 +387,35 @@ export const DRUM_PATTERNS: readonly CatalogDrumPattern[] = [
   {
     id: "bossa",
     label: "Bossa Nova",
+    bars: 2,
+    // Soft surdo heartbeat: beats 1 & 3 of each bar.
     kicks: [
+      { beat: 0, velocity: 0.5 },
+      { beat: 2, velocity: 0.6 },
+      { beat: 4, velocity: 0.5 },
+      { beat: 6, velocity: 0.6 },
+    ],
+    // No backbeat snare — the cross-stick clave carries the rhythm.
+    snares: [],
+    // Straight 8th hats across both bars (beats 0..7.5).
+    hats: [
+      { beat: 0, velocity: 0.4 }, { beat: 0.5, velocity: 0.3 },
+      { beat: 1, velocity: 0.4 }, { beat: 1.5, velocity: 0.3 },
+      { beat: 2, velocity: 0.4 }, { beat: 2.5, velocity: 0.3 },
+      { beat: 3, velocity: 0.4 }, { beat: 3.5, velocity: 0.3 },
+      { beat: 4, velocity: 0.4 }, { beat: 4.5, velocity: 0.3 },
+      { beat: 5, velocity: 0.4 }, { beat: 5.5, velocity: 0.3 },
+      { beat: 6, velocity: 0.4 }, { beat: 6.5, velocity: 0.3 },
+      { beat: 7, velocity: 0.4 }, { beat: 7.5, velocity: 0.3 },
+    ],
+    // 3-2 son clave: bar 1 @ 0, 1.5, 3 · bar 2 @ 5 (bar2 beat 1), 6 (bar2 beat 2).
+    crossStick: [
       { beat: 0, velocity: 0.8 },
       { beat: 1.5, velocity: 0.7 },
-      { beat: 2, velocity: 0.8 },
-      { beat: 3.5, velocity: 0.7 },
+      { beat: 3, velocity: 0.75 },
+      { beat: 5, velocity: 0.7 },
+      { beat: 6, velocity: 0.8 },
     ],
-    snares: [
-      { beat: 0, velocity: 0.7 },
-      { beat: 1.5, velocity: 0.6 },
-      { beat: 3, velocity: 0.7 },
-    ],
-    hats: EIGHTH_HATS,
   },
   {
     id: "ballad",

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -50,6 +50,9 @@ export interface ChordPattern {
   /** Cell length in bars (default 1). When > 1, `hits` span 0..bars*beatsPerBar
    *  and the scheduler selects one bar per `absoluteBar % bars`. */
   bars?: number;
+  /** Voicing strategy for this comp. Omitted = the default chord voicing.
+   *  "rootless-jazz" = buildBossaColorVoicing (rootless 7th/9th, mid register). */
+  voicing?: "rootless-jazz";
 }
 
 interface CatalogBassHit {
@@ -215,16 +218,18 @@ export const CHORD_PATTERNS: readonly ChordPattern[] = [
     id: "bossa-comp",
     label: "Bossa Comp",
     bars: 2,
-    // Syncopated partido-alto: clave-locked anticipations that leave space.
+    voicing: "rootless-jazz",
+    // Highly syncopated 2-bar partido-alto: clave-locked, two cross-barline
+    // anticipations (3.5, 7.5), soft acoustic dynamics, chords ring (sustained).
     hits: [
       // bar 1
-      { beat: 0, velocity: 0.7 },
-      { beat: 1.5, velocity: 0.6 },
-      { beat: 3, velocity: 0.55 },
-      // bar 2: anticipated "& of 1" push, mid-bar, "& of 4" lead into the next phrase
-      { beat: 4.5, velocity: 0.6 },
-      { beat: 6, velocity: 0.6 },
-      { beat: 7.5, velocity: 0.7 },
+      { beat: 0, velocity: 0.6, style: "sustained" }, // downbeat anchor
+      { beat: 1.5, velocity: 0.55, style: "sustained" }, // "& of 2" (clave)
+      { beat: 3.5, velocity: 0.6, style: "sustained" }, // "& of 4" anticipates bar 2
+      // bar 2
+      { beat: 4.5, velocity: 0.55, style: "sustained" }, // "& of 1"
+      { beat: 6, velocity: 0.5, style: "sustained" }, // beat 3 (clave)
+      { beat: 7.5, velocity: 0.65, style: "sustained" }, // "& of 4" anticipates next cycle
     ],
   },
 ];
@@ -408,13 +413,13 @@ export const DRUM_PATTERNS: readonly CatalogDrumPattern[] = [
       { beat: 6, velocity: 0.4 }, { beat: 6.5, velocity: 0.3 },
       { beat: 7, velocity: 0.4 }, { beat: 7.5, velocity: 0.3 },
     ],
-    // 3-2 son clave: bar 1 @ 0, 1.5, 3 · bar 2 @ 5 (bar2 beat 1), 6 (bar2 beat 2).
+    // 3-2 bossa clave: bar 1 @ 0, 1.5, 3 · bar 2 @ 5 (bar2 beat 1), 6.5 (bar2 "3&").
     crossStick: [
       { beat: 0, velocity: 0.8 },
       { beat: 1.5, velocity: 0.7 },
       { beat: 3, velocity: 0.75 },
       { beat: 5, velocity: 0.7 },
-      { beat: 6, velocity: 0.8 },
+      { beat: 6.5, velocity: 0.8 },
     ],
   },
   {

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -47,6 +47,9 @@ export interface ChordPattern {
   id: string;
   label: string;
   hits: readonly ChordHit[];
+  /** Cell length in bars (default 1). When > 1, `hits` span 0..bars*beatsPerBar
+   *  and the scheduler selects one bar per `absoluteBar % bars`. */
+  bars?: number;
 }
 
 interface CatalogBassHit {
@@ -61,6 +64,8 @@ export interface CatalogBassPattern {
   id: string;
   label: string;
   hits: readonly CatalogBassHit[];
+  /** Cell length in bars (default 1). See ChordPattern.bars. */
+  bars?: number;
 }
 
 export interface CatalogDrumPattern {
@@ -71,6 +76,10 @@ export interface CatalogDrumPattern {
   hats: readonly DrumHit[];
   openHats?: readonly DrumHit[];
   ride?: readonly DrumHit[];
+  /** Cross-stick / rim-click voice (bossa clave). */
+  crossStick?: readonly DrumHit[];
+  /** Cell length in bars (default 1). See ChordPattern.bars. */
+  bars?: number;
 }
 
 export interface DrumVariation {
@@ -576,6 +585,23 @@ export function clipPatternToBeats<T extends { beat: number }>(
 ): T[] {
   if (beatsAvailable <= 0) return [];
   return pattern.filter((hit) => hit.beat < beatsAvailable);
+}
+
+/**
+ * Select the hits belonging to a single bar of a multi-bar pattern cell and
+ * shift them back to bar-local beats (0..beatsPerBar). `cellBarIndex` is
+ * `absoluteBar % bars`. Pure — used for 2-bar patterns (e.g. the bossa clave);
+ * 1-bar patterns never call this (they keep the `repeatPatternToBeats` path).
+ */
+export function sliceCellToBar<T extends { beat: number }>(
+  hits: readonly T[],
+  cellBarIndex: number,
+  beatsPerBar: number,
+): T[] {
+  const offset = cellBarIndex * beatsPerBar;
+  return hits
+    .filter((h) => h.beat >= offset && h.beat < offset + beatsPerBar)
+    .map((h) => ({ ...h, beat: h.beat - offset }));
 }
 
 /**

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -41,6 +41,10 @@ interface ChordHit {
    *  "color-stab" rings a chord with funk extensions; "muted" chokes a plain
    *  chord short (chicken-scratch ghost). Omitted rings the patch default. */
   articulation?: ChordArticulation;
+  /** Bossa LH/RH split (used when the pattern's voicing is "rootless-jazz"):
+   *  "bass-root"/"bass-fifth" play a single low note (LH); "chord" plays the
+   *  rootless RH voicing. Omitted behaves as "chord". */
+  voiceRole?: "bass-root" | "bass-fifth" | "chord";
 }
 
 export interface ChordPattern {
@@ -219,18 +223,23 @@ export const CHORD_PATTERNS: readonly ChordPattern[] = [
     label: "Bossa Comp",
     bars: 2,
     voicing: "rootless-jazz",
-    // Rooted chord stabs on the off-beats only — the piano carries its own bass
-    // note (root below the grip) here, while the upright bassline holds beats 1
-    // & 3, so the two no longer double. Authentic 2-bar arc: bar 1 is the basic
-    // sparse comp (2 stabs), bar 2 intensifies (3 anticipated stabs). All short.
+    // LH bass (root on beat 1, fifth on beat 3) + RH rootless chords on the
+    // off-beats. Authentic 2-bar arc: bar 1 is the basic sparse comp (2 stabs),
+    // bar 2 intensifies into a busier run of anticipated off-beat stabs (4).
+    // Every hit is short (no sustain) — a plucky, detached comp.
     hits: [
-      // bar 1 — basic: the & of 2 and & of 4
-      { beat: 1.5, velocity: 0.5 },
-      { beat: 3.5, velocity: 0.55 },
-      // bar 2 — busier: the & of 1, 2 and 4, anticipating the following beats
-      { beat: 4.5, velocity: 0.5 },
-      { beat: 5.5, velocity: 0.5 },
-      { beat: 7.5, velocity: 0.55 },
+      // bar 1 — basic: bass on 1 & 3, chord stabs on the & of 2 and & of 4
+      { beat: 0, velocity: 0.6, voiceRole: "bass-root" },
+      { beat: 1.5, velocity: 0.5, voiceRole: "chord" },
+      { beat: 2, velocity: 0.55, voiceRole: "bass-fifth" },
+      { beat: 3.5, velocity: 0.55, voiceRole: "chord" },
+      // bar 2 — busier: chord stabs on the & of 1, 2 and 4, anticipating the
+      // following beats for forward momentum.
+      { beat: 4, velocity: 0.6, voiceRole: "bass-root" },
+      { beat: 4.5, velocity: 0.5, voiceRole: "chord" },
+      { beat: 5.5, velocity: 0.5, voiceRole: "chord" },
+      { beat: 6, velocity: 0.55, voiceRole: "bass-fifth" },
+      { beat: 7.5, velocity: 0.55, voiceRole: "chord" },
     ],
   },
 ];

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -225,13 +225,13 @@ export const CHORD_PATTERNS: readonly ChordPattern[] = [
     voicing: "rootless-jazz",
     // LH bass (root on beat 1, fifth on beat 3) + RH rootless chords on the
     // syncopated off-beats, with two cross-barline anticipations (3.5, 7.5).
-    // Soft, ringing (sustained).
+    // The chords + fifth ring (sustained); the LH root is short (no sustain).
     hits: [
-      { beat: 0, velocity: 0.6, voiceRole: "bass-root", style: "sustained" },
+      { beat: 0, velocity: 0.6, voiceRole: "bass-root" },
       { beat: 1.5, velocity: 0.5, voiceRole: "chord", style: "sustained" },
       { beat: 2, velocity: 0.55, voiceRole: "bass-fifth", style: "sustained" },
       { beat: 3.5, velocity: 0.55, voiceRole: "chord", style: "sustained" },
-      { beat: 4, velocity: 0.6, voiceRole: "bass-root", style: "sustained" },
+      { beat: 4, velocity: 0.6, voiceRole: "bass-root" },
       { beat: 4.5, velocity: 0.5, voiceRole: "chord", style: "sustained" },
       { beat: 6, velocity: 0.55, voiceRole: "bass-fifth", style: "sustained" },
       { beat: 7.5, velocity: 0.55, voiceRole: "chord", style: "sustained" },

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -233,13 +233,12 @@ export const CHORD_PATTERNS: readonly ChordPattern[] = [
       { beat: 1.5, velocity: 0.5, voiceRole: "chord" },
       { beat: 2, velocity: 0.55, voiceRole: "bass-fifth" },
       { beat: 3.5, velocity: 0.55, voiceRole: "chord" },
-      // bar 2 — busier: chord stabs on every off-beat (& of 1/2/3/4),
-      // anticipating each following beat for forward momentum.
+      // bar 2 — busier: chord stabs on the & of 1, 2 and 4, anticipating the
+      // following beats for forward momentum.
       { beat: 4, velocity: 0.6, voiceRole: "bass-root" },
       { beat: 4.5, velocity: 0.5, voiceRole: "chord" },
       { beat: 5.5, velocity: 0.5, voiceRole: "chord" },
       { beat: 6, velocity: 0.55, voiceRole: "bass-fifth" },
-      { beat: 6.5, velocity: 0.5, voiceRole: "chord" },
       { beat: 7.5, velocity: 0.55, voiceRole: "chord" },
     ],
   },

--- a/src/progressions/audio/progressionAudioEngine.ts
+++ b/src/progressions/audio/progressionAudioEngine.ts
@@ -14,7 +14,7 @@ export type { BassEvent, ChordOnsetEvent, ChordStrumEvent, DrumEvent, MetronomeE
 export { createProgressionPart } from "./progressionPart";
 export { setLayerGain } from "./layerBuses";
 export { scheduleBassNote } from "./bass";
-export { scheduleHiHat, scheduleKick, scheduleRide, scheduleSnare } from "./drumKit";
+export { scheduleCrossStick, scheduleHiHat, scheduleKick, scheduleRide, scheduleSnare } from "./drumKit";
 export { scheduleClick } from "./metronome";
 export { clearTimeline, pauseTimeline, setActiveStep } from "./timeline";
 export { getDraw, getTransport };

--- a/src/progressions/audio/sound/instrumentPatches.ts
+++ b/src/progressions/audio/sound/instrumentPatches.ts
@@ -203,6 +203,7 @@ export const DRUM_KIT_PATCHES: readonly DrumKitPatch[] = [
       kick: { pitchDecay: 0.05, octaves: 5, envelope: { decay: 0.28 } },
       snare: { noiseType: "white", envelope: { decay: 0.12 } },
       hihat: { decay: 0.04 },
+      crossStick: { pitchDecay: 0.006, octaves: 2, envelope: { decay: 0.05 } },
     },
   },
 ];

--- a/src/progressions/audio/sound/patchTypes.ts
+++ b/src/progressions/audio/sound/patchTypes.ts
@@ -91,6 +91,7 @@ export interface DrumVoiceParams {
   hihat?: { decay?: number; resonance?: number; octaves?: number };
   openHat?: { decay?: number };
   ride?: { decay?: number; harmonicity?: number; resonance?: number; volume?: number };
+  crossStick?: { pitchDecay?: number; octaves?: number; envelope?: Partial<EnvelopeSpec> };
 }
 
 export interface DrumKitPatch {

--- a/src/progressions/progressionAudio.test.ts
+++ b/src/progressions/progressionAudio.test.ts
@@ -177,39 +177,31 @@ describe("buildBossaColorVoicing", () => {
   const pcSet = (notes: readonly string[]) => new Set(notes.map((n) => n.replace(/-?\d+$/, "")));
   const midi = (n: string) => { const m = n.match(/^([A-G]#?)(-?\d+)$/)!; return PC[m[1]] + (parseInt(m[2], 10) + 1) * 12; };
 
-  it("voices a major chord as a rootless maj9 (3 / 7 / 9) in the middle register", () => {
-    expect(buildBossaColorVoicing("C", "maj7")).toEqual(["E4", "B4", "D5"]);
-    expect(buildBossaColorVoicing("C", "M")).toEqual(["E4", "B4", "D5"]);
+  it("voices a major chord as a 4-note Type-B rootless (7-9-3-5) in octave 3", () => {
+    expect(buildBossaColorVoicing("C", "maj7")).toEqual(["B3", "D4", "E4", "G4"]);
+    expect(buildBossaColorVoicing("C", "M")).toEqual(["B3", "D4", "E4", "G4"]);
   });
 
-  it("voices a minor 7 chord as a rootless m9 (b3 / b7 / 9)", () => {
-    expect(buildBossaColorVoicing("A", "m7")).toEqual(["C5", "G5", "B5"]);
-    expect(pcSet(buildBossaColorVoicing("A", "m7")).has("A")).toBe(false);
+  it("normalizes a high-rooted voicing down an octave so it never floats above C5", () => {
+    expect(buildBossaColorVoicing("A", "m7")).toEqual(["G3", "B3", "C4", "E4"]);
   });
 
-  it("voices a dominant 7 chord as a rootless dom9 (3 / b7 / 9)", () => {
-    const v = buildBossaColorVoicing("G", "7");
-    expect(pcSet(v)).toEqual(new Set(["B", "F", "A"]));
-    expect(pcSet(v).has("G")).toBe(false);
-  });
-
-  it("keeps every defined voicing rootless and in the middle register (C4..C#6)", () => {
-    for (const [root, quality] of [["C", "maj7"], ["D", "M"], ["E", "m7"], ["G", "7"], ["B", "maj7"]] as const) {
-      const v = buildBossaColorVoicing(root, quality);
-      expect(pcSet(v).has(root), `${root}${quality} rootless`).toBe(false);
-      for (const n of v) {
-        const m = midi(n);
-        expect(m, `${root}${quality} ${n} low`).toBeGreaterThanOrEqual(60);
-        expect(m, `${root}${quality} ${n} high`).toBeLessThanOrEqual(86);
+  it("keeps every defined voicing 4-note, rootless, and topped at or below C5 for all roots", () => {
+    const ROOTS = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+    for (const root of ROOTS) {
+      for (const quality of ["maj7", "M", "m7", "m", "7"]) {
+        const v = buildBossaColorVoicing(root, quality);
+        expect(v, `${root}${quality} length`).toHaveLength(4);
+        expect(pcSet(v).has(root), `${root}${quality} rootless`).toBe(false);
+        const ms = v.map(midi);
+        expect(Math.max(...ms), `${root}${quality} top <= C5`).toBeLessThanOrEqual(72);
+        expect(Math.min(...ms), `${root}${quality} bottom >= C3`).toBeGreaterThanOrEqual(48);
       }
     }
   });
 
-  it("falls back to the plain voice-led triad for a quality without a grip", () => {
+  it("falls back to the plain voice-led triad for a quality without a grip; [] for unknown root", () => {
     expect(buildBossaColorVoicing("C", "dim")).toEqual(resolveChordVoicing("C", "dim", undefined, undefined));
-  });
-
-  it("returns [] for an unknown root", () => {
     expect(buildBossaColorVoicing("H", "maj7")).toEqual([]);
   });
 });

--- a/src/progressions/progressionAudio.test.ts
+++ b/src/progressions/progressionAudio.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveBassLineNotes, resolveChordVoicing, resolveBassNoteForRole, buildFunkColorVoicing } from "./progressionAudio";
+import { resolveBassLineNotes, resolveChordVoicing, resolveBassNoteForRole, buildFunkColorVoicing, buildBossaColorVoicing } from "./progressionAudio";
 
 describe("resolveChordVoicing", () => {
   it("stacks the C Major Triad as C-E-G at octave 3", () => {
@@ -169,5 +169,47 @@ describe("buildFunkColorVoicing", () => {
 
   it("returns [] for an unknown root", () => {
     expect(buildFunkColorVoicing("H", "7")).toEqual([]);
+  });
+});
+
+describe("buildBossaColorVoicing", () => {
+  const PC: Record<string, number> = { C: 0, "C#": 1, D: 2, "D#": 3, E: 4, F: 5, "F#": 6, G: 7, "G#": 8, A: 9, "A#": 10, B: 11 };
+  const pcSet = (notes: readonly string[]) => new Set(notes.map((n) => n.replace(/-?\d+$/, "")));
+  const midi = (n: string) => { const m = n.match(/^([A-G]#?)(-?\d+)$/)!; return PC[m[1]] + (parseInt(m[2], 10) + 1) * 12; };
+
+  it("voices a major chord as a rootless maj9 (3 / 7 / 9) in the middle register", () => {
+    expect(buildBossaColorVoicing("C", "maj7")).toEqual(["E4", "B4", "D5"]);
+    expect(buildBossaColorVoicing("C", "M")).toEqual(["E4", "B4", "D5"]);
+  });
+
+  it("voices a minor 7 chord as a rootless m9 (b3 / b7 / 9)", () => {
+    expect(buildBossaColorVoicing("A", "m7")).toEqual(["C5", "G5", "B5"]);
+    expect(pcSet(buildBossaColorVoicing("A", "m7")).has("A")).toBe(false);
+  });
+
+  it("voices a dominant 7 chord as a rootless dom9 (3 / b7 / 9)", () => {
+    const v = buildBossaColorVoicing("G", "7");
+    expect(pcSet(v)).toEqual(new Set(["B", "F", "A"]));
+    expect(pcSet(v).has("G")).toBe(false);
+  });
+
+  it("keeps every defined voicing rootless and in the middle register (C4..C#6)", () => {
+    for (const [root, quality] of [["C", "maj7"], ["D", "M"], ["E", "m7"], ["G", "7"], ["B", "maj7"]] as const) {
+      const v = buildBossaColorVoicing(root, quality);
+      expect(pcSet(v).has(root), `${root}${quality} rootless`).toBe(false);
+      for (const n of v) {
+        const m = midi(n);
+        expect(m, `${root}${quality} ${n} low`).toBeGreaterThanOrEqual(60);
+        expect(m, `${root}${quality} ${n} high`).toBeLessThanOrEqual(86);
+      }
+    }
+  });
+
+  it("falls back to the plain voice-led triad for a quality without a grip", () => {
+    expect(buildBossaColorVoicing("C", "dim")).toEqual(resolveChordVoicing("C", "dim", undefined, undefined));
+  });
+
+  it("returns [] for an unknown root", () => {
+    expect(buildBossaColorVoicing("H", "maj7")).toEqual([]);
   });
 });

--- a/src/progressions/progressionAudio.test.ts
+++ b/src/progressions/progressionAudio.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveBassLineNotes, resolveChordVoicing, resolveBassNoteForRole, buildFunkColorVoicing, buildBossaColorVoicing, buildBossaRootedVoicing } from "./progressionAudio";
+import { resolveBassLineNotes, resolveChordVoicing, resolveBassNoteForRole, buildFunkColorVoicing, buildBossaColorVoicing } from "./progressionAudio";
 
 describe("resolveChordVoicing", () => {
   it("stacks the C Major Triad as C-E-G at octave 3", () => {
@@ -203,35 +203,5 @@ describe("buildBossaColorVoicing", () => {
   it("falls back to the plain voice-led triad for a quality without a grip; [] for unknown root", () => {
     expect(buildBossaColorVoicing("C", "dim")).toEqual(resolveChordVoicing("C", "dim", undefined, undefined));
     expect(buildBossaColorVoicing("H", "maj7")).toEqual([]);
-  });
-});
-
-describe("buildBossaRootedVoicing", () => {
-  const PC: Record<string, number> = { C: 0, "C#": 1, D: 2, "D#": 3, E: 4, F: 5, "F#": 6, G: 7, "G#": 8, A: 9, "A#": 10, B: 11 };
-  const pcSet = (notes: readonly string[]) => new Set(notes.map((n) => n.replace(/-?\d+$/, "")));
-  const abs = (n: string) => { const m = /^([A-G]#?)(-?\d+)$/.exec(n)!; return parseInt(m[2], 10) * 12 + PC[m[1]]; };
-
-  it("adds the chord root below the rootless Type-B grip", () => {
-    // C maj9: rootless grip [B3,D4,E4,G4] + root C3 underneath.
-    expect(buildBossaRootedVoicing("C", "maj7")).toEqual(["C3", "B3", "D4", "E4", "G4"]);
-    // A m9: grip normalizes to [G3,B3,C4,E4]; root A drops to A2 to stay below G3.
-    expect(buildBossaRootedVoicing("A", "m7")).toEqual(["A2", "G3", "B3", "C4", "E4"]);
-  });
-
-  it("puts the root pitch class as the lowest note of the voicing for every root", () => {
-    const ROOTS = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
-    for (const root of ROOTS) {
-      for (const quality of ["maj7", "M", "m7", "m", "7"]) {
-        const v = buildBossaRootedVoicing(root, quality);
-        expect(pcSet(v).has(root), `${root}${quality} has root`).toBe(true);
-        // The added root is strictly the lowest note.
-        expect(v[0].replace(/-?\d+$/, ""), `${root}${quality} root on bottom`).toBe(root);
-        expect(Math.min(...v.map(abs)), `${root}${quality} root lowest`).toBe(abs(v[0]));
-      }
-    }
-  });
-
-  it("returns [] for an unknown root", () => {
-    expect(buildBossaRootedVoicing("H", "maj7")).toEqual([]);
   });
 });

--- a/src/progressions/progressionAudio.test.ts
+++ b/src/progressions/progressionAudio.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveBassLineNotes, resolveChordVoicing, resolveBassNoteForRole, buildFunkColorVoicing, buildBossaColorVoicing } from "./progressionAudio";
+import { resolveBassLineNotes, resolveChordVoicing, resolveBassNoteForRole, buildFunkColorVoicing, buildBossaColorVoicing, buildBossaRootedVoicing } from "./progressionAudio";
 
 describe("resolveChordVoicing", () => {
   it("stacks the C Major Triad as C-E-G at octave 3", () => {
@@ -203,5 +203,35 @@ describe("buildBossaColorVoicing", () => {
   it("falls back to the plain voice-led triad for a quality without a grip; [] for unknown root", () => {
     expect(buildBossaColorVoicing("C", "dim")).toEqual(resolveChordVoicing("C", "dim", undefined, undefined));
     expect(buildBossaColorVoicing("H", "maj7")).toEqual([]);
+  });
+});
+
+describe("buildBossaRootedVoicing", () => {
+  const PC: Record<string, number> = { C: 0, "C#": 1, D: 2, "D#": 3, E: 4, F: 5, "F#": 6, G: 7, "G#": 8, A: 9, "A#": 10, B: 11 };
+  const pcSet = (notes: readonly string[]) => new Set(notes.map((n) => n.replace(/-?\d+$/, "")));
+  const abs = (n: string) => { const m = /^([A-G]#?)(-?\d+)$/.exec(n)!; return parseInt(m[2], 10) * 12 + PC[m[1]]; };
+
+  it("adds the chord root below the rootless Type-B grip", () => {
+    // C maj9: rootless grip [B3,D4,E4,G4] + root C3 underneath.
+    expect(buildBossaRootedVoicing("C", "maj7")).toEqual(["C3", "B3", "D4", "E4", "G4"]);
+    // A m9: grip normalizes to [G3,B3,C4,E4]; root A drops to A2 to stay below G3.
+    expect(buildBossaRootedVoicing("A", "m7")).toEqual(["A2", "G3", "B3", "C4", "E4"]);
+  });
+
+  it("puts the root pitch class as the lowest note of the voicing for every root", () => {
+    const ROOTS = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+    for (const root of ROOTS) {
+      for (const quality of ["maj7", "M", "m7", "m", "7"]) {
+        const v = buildBossaRootedVoicing(root, quality);
+        expect(pcSet(v).has(root), `${root}${quality} has root`).toBe(true);
+        // The added root is strictly the lowest note.
+        expect(v[0].replace(/-?\d+$/, ""), `${root}${quality} root on bottom`).toBe(root);
+        expect(Math.min(...v.map(abs)), `${root}${quality} root lowest`).toBe(abs(v[0]));
+      }
+    }
+  });
+
+  it("returns [] for an unknown root", () => {
+    expect(buildBossaRootedVoicing("H", "maj7")).toEqual([]);
   });
 });

--- a/src/progressions/progressionAudio.ts
+++ b/src/progressions/progressionAudio.ts
@@ -151,35 +151,6 @@ export function buildBossaColorVoicing(
   });
 }
 
-/**
- * Build a *rooted* bossa comp voicing: the rootless Type-B grip from
- * `buildBossaColorVoicing` with the chord root added as the lowest note (placed
- * an octave below the grip's bottom tone). Lets the piano carry its own bass
- * note on the off-beat chord stabs — so it no longer doubles the upright
- * bassline on beats 1 and 3. Pure. Returns the plain grip when it is empty or
- * the root is unknown.
- */
-export function buildBossaRootedVoicing(
-  root: string,
-  quality: string,
-  prevVoicing?: string[],
-): string[] {
-  const upper = buildBossaColorVoicing(root, quality, prevVoicing);
-  const rootIndex = NOTES.indexOf(root);
-  if (upper.length === 0 || rootIndex < 0) return upper;
-  const lowestAbsolute = Math.min(
-    ...upper.map((n) => {
-      const m = /^([A-G]#?)(-?\d+)$/.exec(n)!;
-      return parseInt(m[2], 10) * 12 + NOTES.indexOf(m[1]);
-    }),
-  );
-  // Place the root pitch class at the highest octave strictly below the grip.
-  let rootAbsolute = Math.floor(lowestAbsolute / 12) * 12 + rootIndex;
-  if (rootAbsolute >= lowestAbsolute) rootAbsolute -= 12;
-  const rootNote = `${NOTES[((rootAbsolute % 12) + 12) % 12]}${Math.floor(rootAbsolute / 12)}`;
-  return [rootNote, ...upper];
-}
-
 export function resolveBassLineNotes(
   root: string,
   quality: string,

--- a/src/progressions/progressionAudio.ts
+++ b/src/progressions/progressionAudio.ts
@@ -101,31 +101,33 @@ export function buildFunkColorVoicing(
 }
 
 /**
- * Rootless jazz comp tones per chord quality, as semitone offsets above the
- * chord root. The root (offset 0) is omitted — the bossa bass covers it.
- * 7ths + 9ths, the bossa comp idiom. Qualities not listed get the plain triad.
- *   +3 = b3, +4 = 3, +10 = b7, +11 = maj7, +14 = 9
+ * Rootless Type-B (7-9-3-5) jazz comp tones per chord quality, as semitone
+ * offsets above the chord root. The root is omitted — the piano LH and upright
+ * bass cover it. 7th is the lowest tone, so the shape sits low for its register.
+ *   +3 = b3, +4 = 3, +10 = b7, +11 = maj7, +14 = 9, +15 = b3+8ve, +16 = 3+8ve, +19 = 5+8ve
  */
 const BOSSA_COLOR_TONES: Record<string, readonly number[]> = {
-  maj7: [4, 11, 14], // 3 / 7 / 9 — maj9
-  M: [4, 11, 14], // plain major voiced as maj9 (bossa idiom)
-  m7: [3, 10, 14], // b3 / b7 / 9 — m9
-  m: [3, 10, 14], // m9
-  "7": [4, 10, 14], // 3 / b7 / 9 — dom9
+  maj7: [11, 14, 16, 19], // 7 / 9 / 3 / 5 — maj9
+  M: [11, 14, 16, 19], // plain major voiced as maj9
+  m7: [10, 14, 15, 19], // b7 / 9 / b3 / 5 — m9
+  m: [10, 14, 15, 19], // m9
+  "7": [10, 14, 16, 19], // b7 / 9 / 3 / 5 — dom9
 };
 
-/** Middle-register piano comp octave — true comp register, an octave above the
- *  guitar-ish octave-3 funk grip. */
-const BOSSA_COMP_ROOT_OCTAVE = 4;
+/** Comp voicing base octave (the 7th, the lowest tone, starts here). */
+const BOSSA_COMP_ROOT_OCTAVE = 3;
+/** Register ceiling — the voicing's top note must not exceed C5 (absolute 60,
+ *  i.e. octave*12 + pitchIndex). Higher-rooted voicings are dropped an octave
+ *  at a time until they fit, keeping the comp in the C3–C5 register. */
+const BOSSA_COMP_TOP_CEILING = 60;
 
 /**
- * Build a rootless jazz comp voicing (7th + 9th colour) for a chord, in the
- * middle piano register. Pure. Mirrors `buildFunkColorVoicing`'s open-ascending
- * shape: each colour tone is an absolute pitch (comp octave + offset). Falls
- * back to the plain voice-led triad when the quality has no defined grip
- * (dim/aug/sus/6). Returns [] for an unknown root. `prevVoicing` is accepted for
- * the triad fallback; the colour tones use a fixed open shape (voice-leading the
- * rootless grips is a future refinement).
+ * Build a rootless Type-B (7-9-3-5) jazz comp voicing for a chord, normalized
+ * into the C3–C5 register. Pure. Builds the four colour tones at octave 3, then
+ * transposes the whole voicing down by octaves until its top note is ≤ C5 —
+ * so even high-rooted chords (A/B) stay in the comp register rather than
+ * floating into octave 5. Falls back to the plain voice-led triad when the
+ * quality has no defined grip (dim/aug/sus/6). Returns [] for an unknown root.
  */
 export function buildBossaColorVoicing(
   root: string,
@@ -139,10 +141,13 @@ export function buildBossaColorVoicing(
     return resolveChordVoicing(root, quality, undefined, prevVoicing);
   }
   const base = BOSSA_COMP_ROOT_OCTAVE * 12 + rootIndex;
-  return offsets.map((o) => {
-    const absolute = base + o;
-    const note = NOTES[((absolute % 12) + 12) % 12];
-    return `${note}${Math.floor(absolute / 12)}`;
+  let absolutes = offsets.map((o) => base + o);
+  while (Math.max(...absolutes) > BOSSA_COMP_TOP_CEILING) {
+    absolutes = absolutes.map((a) => a - 12);
+  }
+  return absolutes.map((a) => {
+    const note = NOTES[((a % 12) + 12) % 12];
+    return `${note}${Math.floor(a / 12)}`;
   });
 }
 

--- a/src/progressions/progressionAudio.ts
+++ b/src/progressions/progressionAudio.ts
@@ -151,6 +151,35 @@ export function buildBossaColorVoicing(
   });
 }
 
+/**
+ * Build a *rooted* bossa comp voicing: the rootless Type-B grip from
+ * `buildBossaColorVoicing` with the chord root added as the lowest note (placed
+ * an octave below the grip's bottom tone). Lets the piano carry its own bass
+ * note on the off-beat chord stabs — so it no longer doubles the upright
+ * bassline on beats 1 and 3. Pure. Returns the plain grip when it is empty or
+ * the root is unknown.
+ */
+export function buildBossaRootedVoicing(
+  root: string,
+  quality: string,
+  prevVoicing?: string[],
+): string[] {
+  const upper = buildBossaColorVoicing(root, quality, prevVoicing);
+  const rootIndex = NOTES.indexOf(root);
+  if (upper.length === 0 || rootIndex < 0) return upper;
+  const lowestAbsolute = Math.min(
+    ...upper.map((n) => {
+      const m = /^([A-G]#?)(-?\d+)$/.exec(n)!;
+      return parseInt(m[2], 10) * 12 + NOTES.indexOf(m[1]);
+    }),
+  );
+  // Place the root pitch class at the highest octave strictly below the grip.
+  let rootAbsolute = Math.floor(lowestAbsolute / 12) * 12 + rootIndex;
+  if (rootAbsolute >= lowestAbsolute) rootAbsolute -= 12;
+  const rootNote = `${NOTES[((rootAbsolute % 12) + 12) % 12]}${Math.floor(rootAbsolute / 12)}`;
+  return [rootNote, ...upper];
+}
+
 export function resolveBassLineNotes(
   root: string,
   quality: string,

--- a/src/progressions/progressionAudio.ts
+++ b/src/progressions/progressionAudio.ts
@@ -100,6 +100,52 @@ export function buildFunkColorVoicing(
   });
 }
 
+/**
+ * Rootless jazz comp tones per chord quality, as semitone offsets above the
+ * chord root. The root (offset 0) is omitted — the bossa bass covers it.
+ * 7ths + 9ths, the bossa comp idiom. Qualities not listed get the plain triad.
+ *   +3 = b3, +4 = 3, +10 = b7, +11 = maj7, +14 = 9
+ */
+const BOSSA_COLOR_TONES: Record<string, readonly number[]> = {
+  maj7: [4, 11, 14], // 3 / 7 / 9 — maj9
+  M: [4, 11, 14], // plain major voiced as maj9 (bossa idiom)
+  m7: [3, 10, 14], // b3 / b7 / 9 — m9
+  m: [3, 10, 14], // m9
+  "7": [4, 10, 14], // 3 / b7 / 9 — dom9
+};
+
+/** Middle-register piano comp octave — true comp register, an octave above the
+ *  guitar-ish octave-3 funk grip. */
+const BOSSA_COMP_ROOT_OCTAVE = 4;
+
+/**
+ * Build a rootless jazz comp voicing (7th + 9th colour) for a chord, in the
+ * middle piano register. Pure. Mirrors `buildFunkColorVoicing`'s open-ascending
+ * shape: each colour tone is an absolute pitch (comp octave + offset). Falls
+ * back to the plain voice-led triad when the quality has no defined grip
+ * (dim/aug/sus/6). Returns [] for an unknown root. `prevVoicing` is accepted for
+ * the triad fallback; the colour tones use a fixed open shape (voice-leading the
+ * rootless grips is a future refinement).
+ */
+export function buildBossaColorVoicing(
+  root: string,
+  quality: string,
+  prevVoicing?: string[],
+): string[] {
+  const rootIndex = NOTES.indexOf(root);
+  if (rootIndex < 0) return [];
+  const offsets = BOSSA_COLOR_TONES[quality];
+  if (!offsets) {
+    return resolveChordVoicing(root, quality, undefined, prevVoicing);
+  }
+  const base = BOSSA_COMP_ROOT_OCTAVE * 12 + rootIndex;
+  return offsets.map((o) => {
+    const absolute = base + o;
+    const note = NOTES[((absolute % 12) + 12) % 12];
+    return `${note}${Math.floor(absolute / 12)}`;
+  });
+}
+
 export function resolveBassLineNotes(
   root: string,
   quality: string,


### PR DESCRIPTION
## Summary

Overhauls the bossa-nova backing track so it reads as authentic bossa nova. Built and refined across several ear-audition passes. The core additions:

- **2-bar pattern cells.** New opt-in `bars` field on pattern types + `sliceCellToBar`, so a pattern can span two bars and the scheduler slices it per `absoluteBar % bars`. 1-bar patterns stay byte-identical (guarded), so no other genre changes.
- **Cross-stick clave voice.** A `MembraneSynth` rim-click voice wired through the engine, kit, and playback. Plays a **3-2 bossa clave** (distinct from son clave — the 2-side's second note is delayed an eighth).
- **Bossa piano comp (LH/RH split).** Left hand plays root/fifth on beats 1 & 3 (octave 3); right hand plays **rootless Type-B (7-9-3-5) jazz voicings** on the syncopated off-beats, register-normalized to C3–C5. Bar 2 intensifies (more anticipated stabs) for a real 2-bar arc. All stabs short/plucky.
- **Upright bassline** plays root/fifth on beats 1 & 3, one octave below the piano LH, in unison with it.
- **Drums:** soft surdo kick on 1 & 3, straight-8th hats, no backbeat snare — the cross-stick clave carries the rhythm.

## Why the last two commits look like a round-trip

The final two commits revert an earlier experiment (rooted off-beat chords that dropped the LH bass) and then fix the actual problem: the piano LH bass and the upright bass played the same notes an octave apart but got **independent ±15ms timing jitter**, landing up to ~30ms apart → an audible flam. The fix grid-locks both voices' attacks (zero time jitter, velocity humanization preserved) only when the comp owns its LH bass (`voicing: "rootless-jazz"`). Other genres are untouched.

## Reviewer notes

- All new behavior is gated on the bossa pattern data (`voicing: "rootless-jazz"`, `bars: 2`); non-bossa genres produce byte-identical output.
- Scale/chord rendering domains are not cross-wired — this is audio-only.
- Design + plan docs under `docs/superpowers/specs/` and `docs/superpowers/plans/` (2026-06-01 bossa-nova-*).

## Test plan

- [x] `pnpm run lint` — 0 errors (1 pre-existing unrelated warning)
- [x] `pnpm run test` — 2238 passed (incl. new unison + 2-bar-cell determinism + voicing tests)
- [x] `pnpm run build` — succeeds
- [ ] Ear audition of the bossa-nova genre in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-stick drum voice for bossa-nova and clave-style rhythms
  * Implemented complete bossa-nova genre patterns with coordinated chord, bass, and drum sequences
  * Added rootless jazz chord voicing for authentic bossa sound

* **Tests**
  * Added test coverage for new cross-stick drum voice and bossa pattern generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->