### PR TITLE
fix(ui): align header icon buttons with --dc-* control styling

### DIFF
--- a/docs/superpowers/plans/2026-06-01-header-button-consistency.md
+++ b/docs/superpowers/plans/2026-06-01-header-button-consistency.md
@@ -1,0 +1,109 @@
+# Header Icon Button Consistency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make header icon buttons (theme toggle, settings, mute, help) visually consistent with the rest of the app's `--dc-*` ghost-style controls.
+
+**Architecture:** Single CSS change in `shared.module.css` — swap `.icon-button` from `surface--chrome` compose to `surface--control` compose, update color/hover/active tokens to match the `--dc-*` system used by ToggleBar, Stepper, NoteGrid, LabeledSelect.
+
+**Tech Stack:** CSS Modules, CSS custom properties
+
+---
+
+### Task 1: Update .icon-button styling in shared.module.css
+
+**Files:**
+- Modify: `src/components/shared/shared.module.css:519-567`
+
+- [ ] **Step 1: Apply the CSS changes**
+
+Replace the `.icon-button` block (lines 519-567) with the updated version:
+
+```css
+/* Icon Button - shared circular button chrome for header, modal close, etc. */
+.icon-button {
+  composes: surface--control;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  flex-shrink: 0;
+  color: var(--dc-fg);
+}
+
+.icon-button:hover {
+  color: var(--dc-fg-strong);
+}
+
+.icon-button:active {
+  transform: scale(0.96);
+}
+
+.icon-button:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+}
+
+:global([data-theme="modern-dark"]) .icon-button:focus-visible {
+  outline: var(--control-focus-ring);
+  box-shadow: var(--control-focus-inset);
+}
+
+/* stylelint-disable selector-pseudo-class-no-unknown */
+.icon-button :global(.icon) {
+  width: 1.18rem;
+  height: 1.18rem;
+  color: inherit;
+}
+
+.icon-button :global(.icon-muted) {
+  color: var(--dc-fg-muted);
+}
+
+.icon-button :global(.icon-active) {
+  color: var(--dc-fg-strong);
+}
+
+/* Size variants: sm / md (default) */
+.icon-button--sm { width: 2rem;    height: 2rem;    }
+.icon-button--md { width: 2.75rem; height: 2.75rem; }
+
+.icon-button--sm :global(.icon) { width: 1rem;    height: 1rem;    }
+/* stylelint-enable selector-pseudo-class-no-unknown */
+```
+
+- [ ] **Step 2: Verify the build still compiles**
+
+Run: `pnpm run build`
+Expected: Clean exit, no errors.
+
+- [ ] **Step 3: Run linter**
+
+Run: `pnpm run lint`
+Expected: No stylelint or eslint errors.
+
+- [ ] **Step 4: Run unit tests**
+
+Run: `pnpm run test`
+Expected: All tests pass.
+
+- [ ] **Step 5: Update visual snapshots**
+
+Run: `pnpm run test:visual:update`
+Expected: Visual snapshots update to reflect new button styling.
+
+- [ ] **Step 6: Run visual tests to confirm**
+
+Run: `pnpm run test:visual`
+Expected: All visual tests pass (snapshots match updated baselines).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/shared/shared.module.css
+git commit -m "fix(ui): align header icon buttons with --dc-* control styling"
+```

--- a/docs/superpowers/specs/2026-06-01-header-button-consistency-design.md
+++ b/docs/superpowers/specs/2026-06-01-header-button-consistency-design.md
@@ -1,0 +1,58 @@
+# Header Icon Button Consistency
+
+**Date:** 2026-06-01
+
+## Problem
+
+The header icon buttons (theme toggle, settings, mute, help) use `surface--chrome` — an elevated surface with card shadow, gradient background, and lift-on-hover. All other interactive controls (ToggleBar, Stepper, NoteGrid, LabeledSelect) use the `--dc-*` flat ghost token system with cyan/teal accent colors. This makes the header buttons visually inconsistent with the rest of the app in both light and dark mode.
+
+## Design
+
+Swap `.icon-button` from `surface--chrome` to `surface--control` (the `--dc-*` token system used by every other control).
+
+### Changes to .icon-button (`shared.module.css`)
+
+| Property | Before | After |
+|---|---|---|
+| Surface compose | `surface--chrome` | `surface--control` |
+| Background | `--surface-control` (well) | `--dc-bg` (cyan ghost) |
+| Border | `--surface-control-border` | `--dc-border` |
+| Text/icon color | `--surface-control-fg-muted` | `--dc-fg` |
+| Box-shadow | `var(--elevation-card)` | none (flat) |
+| Transition | `var(--transition-surface)` | `var(--dc-transition)` |
+| Hover bg | `--surface-control-hover-bg` + gradient | `--dc-bg-hover` |
+| Hover text | `--surface-control-hover-fg` | `--dc-fg-strong` |
+| Hover border | `--surface-control-hover-border` | `--dc-border-hover` |
+| Hover transform | `translateY(-1px)` | none |
+| Active transform | `translateY(0)` | `scale(0.96)` |
+
+### What stays the same
+
+- Circular shape (`border-radius: 999px`)
+- Size variants (`--sm`: 32px, `--md`: 44px)
+- Layout properties (flex, padding, cursor, flex-shrink)
+- Focus-visible ring
+- Icon color inheritance via `color: inherit`
+
+### Token resolution by theme
+
+**Dark mode:**
+- Rest: `rgb(77 228 255 / 0.05)` bg, `rgb(77 228 255 / 0.28)` border, muted cyan icon
+- Hover: `rgb(77 228 255 / 0.08)` bg, `rgb(77 228 255 / 0.45)` border, bright cyan icon
+- Active: `scale(0.96)`
+
+**Light mode:**
+- Rest: `rgb(20 112 136 / 0.06)` bg, `rgb(20 112 136 / 0.32)` border, muted brown icon
+- Hover: `rgb(20 112 136 / 0.08)` bg, `rgb(20 112 136 / 0.50)` border, strong teal icon
+- Active: `scale(0.96)`
+
+### Files to modify
+
+- `src/components/shared/shared.module.css` — `.icon-button` and `.icon-button:hover` rules
+- Potentially `.icon-muted` / `.icon-active` icon classes if they need updated token references
+
+### Files to *not* modify
+
+- `App.tsx` — button markup stays the same
+- `semantic.css` / `tokens.css` — no token changes needed
+- `SettingsOverlay.tsx`, `HelpModal.tsx` — they use `.icon-button` too, will inherit fixes

--- a/src/components/shared/shared.module.css
+++ b/src/components/shared/shared.module.css
@@ -518,7 +518,7 @@
 
 /* Icon Button - shared circular button chrome for header, modal close, etc. */
 .icon-button {
-  composes: surface--chrome;
+  composes: surface--control;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -528,10 +528,15 @@
   border-radius: 999px;
   cursor: pointer;
   flex-shrink: 0;
+  color: var(--dc-fg);
+}
+
+.icon-button:hover {
+  color: var(--dc-fg-strong);
 }
 
 .icon-button:active {
-  transform: translateY(0);
+  transform: scale(0.96);
 }
 
 .icon-button:focus-visible {
@@ -552,11 +557,11 @@
 }
 
 .icon-button :global(.icon-muted) {
-  color: var(--text-muted);
+  color: var(--dc-fg-muted);
 }
 
 .icon-button :global(.icon-active) {
-  color: var(--surface-control-fg);
+  color: var(--dc-fg-strong);
 }
 
 /* Size variants: sm / md (default) */

--- a/src/components/shared/surface.module.css.test.ts
+++ b/src/components/shared/surface.module.css.test.ts
@@ -30,8 +30,8 @@ describe("shared.module.css icon-button size scale", () => {
     expect(css).toMatch(/\.icon-button--sm\s*\{[^}]*width:\s*2rem;[^}]*height:\s*2rem;/s);
     expect(css).toMatch(/\.icon-button--md\s*\{[^}]*width:\s*2\.75rem;/s);
   });
-  it("makes .icon-button compose the chrome surface", () => {
-    expect(css).toMatch(/\.icon-button\s*\{[^}]*composes:\s*surface--chrome/s);
+  it("makes .icon-button compose the control surface", () => {
+    expect(css).toMatch(/\.icon-button\s*\{[^}]*composes:\s*surface--control/s);
   });
 });
 


### PR DESCRIPTION
## Summary
- Swap .icon-button from `surface--chrome` to `surface--control` so header icon buttons (theme toggle, settings, mute, help) use the same flat ghost-style `--dc-*` token system as ToggleBar, Stepper, NoteGrid, and LabeledSelect
- Removes elevated card shadow, gradient bg, and hover lift
- Active state now scales to 0.96 matching all other controls
- Works in both light and dark mode

## Test Plan
- [x] `pnpm run build` - clean
- [x] `pnpm run lint` - clean (0 errors)
- [x] `pnpm run test` - 2215 passed
- [x] `pnpm run test:visual:update` - 40 passed (darwin + linux)