### PR TITLE
refactor(fretboard): remove dead code from anticipation-pulse removal

### DIFF
--- a/src/components/FretboardSVG/FretboardNote.tsx
+++ b/src/components/FretboardSVG/FretboardNote.tsx
@@ -185,7 +185,6 @@ export const FretboardNote = memo(function FretboardNote({
       data-note-tension={isTension || undefined}
       data-note-guide-tone={isGuideTone || undefined}
       data-full-chord-mode={fullChordShape || undefined}
-      data-lens-emphasis={applyLensEmphasis.glowColor ?? undefined}
       data-transition-role={transitionRole ?? undefined}
       data-in-region={note.isInRegion ? "true" : undefined}
       data-scale-degree={degreeColorsEnabled ? scaleDegree : undefined}

--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -390,9 +390,9 @@
   opacity: 0.68;
 }
 
-/* Lead lens emphasis — applied via data-lens-emphasis attribute (Task 4.5).
-   radiusBoost/opacityBoost are applied inline by FretboardNoteLayer.tsx via CSS transform scale.
-   Glow is now a dedicated underlay element (.note-glow-underlay) instead of an SVG filter. */
+/* Lead lens emphasis — radiusBoost/opacityBoost are applied inline by
+   FretboardNoteLayer.tsx via CSS transform scale. Glow is a dedicated underlay
+   element (.note-glow-underlay, keyed off data-glow) instead of an SVG filter. */
 
 /* Voice-leading glow underlay — fades/scales on the compositor (no SVG filter animation).
    Selector is `.fretboard-note circle.note-glow-underlay` (specificity 0,2,1, placed after

--- a/src/components/FretboardSVG/FretboardSVG.test.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.test.tsx
@@ -500,7 +500,7 @@ describe("FretboardSVG/FretboardSVG", () => {
       store,
     );
 
-    expect(container.querySelectorAll('[data-lens-emphasis="var(--note-incoming)"]').length).toBeGreaterThan(0);
+    expect(container.querySelectorAll('[data-transition-role="incoming"]').length).toBeGreaterThan(0);
   });
 
   describe("shape scope and membership", () => {

--- a/src/components/FretboardSVG/FretboardSVG.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.tsx
@@ -9,7 +9,6 @@ import {
 import { fingeringPatternAtom } from "../../store/fingeringAtoms";
 import { intervalPairsAtom } from "../../store/shapeAtoms";
 import { scaleDegreeColorsEnabledAtom } from "../../store/uiAtoms";
-import { progressionTempoBpmAtom } from "../../store/progressionAtoms";
 import { leadInActiveAtom, leadInDurationMsAtom } from "../../store/practiceLensAtoms";
 import { useFretboardPlaybackSnapshot } from "./hooks/useFretboardPlaybackSnapshot";
 import { STRING_ROW_PX_TABLET } from "../../layout/responsive";
@@ -330,8 +329,6 @@ export function FretboardSVG({
   const degreeColorsEnabled = useAtomValue(scaleDegreeColorsEnabledAtom);
   const fingeringPattern = useAtomValue(fingeringPatternAtom);
   const intervalPairs = useAtomValue(intervalPairsAtom);
-  const bpm = useAtomValue(progressionTempoBpmAtom);
-  const beatDurationSec = bpm > 0 ? 60 / bpm : 0.5;
   const leadInActive = useAtomValue(leadInActiveAtom);
   const leadInDurationMs = useAtomValue(leadInDurationMsAtom);
 
@@ -628,7 +625,6 @@ export function FretboardSVG({
       data-transition-phase={leadInActive ? "lead-in" : undefined}
       data-testid="fretboard-svg"
       style={{
-        "--beat-duration": `${beatDurationSec}s`,
         "--lead-in-duration": `${leadInDurationMs}ms`,
       } as CSSProperties}
     >

--- a/src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts
+++ b/src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts
@@ -44,7 +44,6 @@ export function buildAnimatedFretboardNotes({
       leadContext = {
         notePc: note.noteName,
         commonWithNext: emphasisContext.commonWithNext,
-        nextGuideTones: emphasisContext.nextGuideTones,
         nextChordTones: emphasisContext.nextChordTones,
         incomingTones: emphasisContext.incomingTones,
         departingTones: emphasisContext.departingTones,

--- a/src/components/FretboardSVG/hooks/useEmphasisContext.ts
+++ b/src/components/FretboardSVG/hooks/useEmphasisContext.ts
@@ -1,7 +1,6 @@
 import { useAtomValue } from "jotai";
 import {
   commonTonesWithNextAtom,
-  nextChordGuideTonesAtom,
   nextChordTonesAtom,
   incomingTonesAtom,
   departingTonesAtom,
@@ -11,7 +10,6 @@ import { progressionPlayingAtom } from "../../../store/progressionAtoms";
 
 export interface EmphasisContext {
   commonWithNext: Set<string>;
-  nextGuideTones: Set<string>;
   nextChordTones: Set<string>;
   incomingTones: Set<string>;
   departingTones: Set<string>;
@@ -27,14 +25,12 @@ export function useEmphasisContext(enabled: boolean): EmphasisContext | null {
   const playing = useAtomValue(progressionPlayingAtom);
   const leadInActive = useAtomValue(leadInActiveAtom);
   const commonWithNext = useAtomValue(commonTonesWithNextAtom);
-  const nextGuideTones = useAtomValue(nextChordGuideTonesAtom);
   const nextChordTones = useAtomValue(nextChordTonesAtom);
   const incomingTones = useAtomValue(incomingTonesAtom);
   const departingTones = useAtomValue(departingTonesAtom);
   if (!enabled || !playing) return null;
   return {
     commonWithNext,
-    nextGuideTones,
     nextChordTones,
     incomingTones,
     departingTones,

--- a/src/components/FretboardSVG/utils/semantics.test.ts
+++ b/src/components/FretboardSVG/utils/semantics.test.ts
@@ -302,7 +302,6 @@ describe("getEmphasis - voice-leading emphasis", () => {
   const baseLeadContext: LeadLensContext = {
     notePc: "A",
     commonWithNext: new Set<string>(),
-    nextGuideTones: new Set<string>(),
     nextChordTones: new Set<string>(),
     incomingTones: new Set<string>(),
     departingTones: new Set<string>(),

--- a/src/components/FretboardSVG/utils/semantics.ts
+++ b/src/components/FretboardSVG/utils/semantics.ts
@@ -31,8 +31,6 @@ export type LeadLensContext = {
   notePc: string;
   /** Notes shared between the active chord and the next chord (common tones). */
   commonWithNext: Set<string>;
-  /** Guide tones (3rd/7th) of the next chord — kept for clarity / future use. */
-  nextGuideTones: Set<string>;
   /** ALL pitch classes of the next chord. */
   nextChordTones: Set<string>;
   /** Pitch classes the next chord introduces (`next − current`). */

--- a/src/progressions/audio/visualClock.ts
+++ b/src/progressions/audio/visualClock.ts
@@ -22,7 +22,7 @@ export function subscribeVisualClock(cb: FrameCallback): () => void {
 // PERF NOTE (2026-06-01): this rAF loop is cheap — profiling measured ~117ms of
 // requestAnimationFrame across a ~24.7s capture (~0.08ms/frame), with no per-frame
 // React subscribers to progressionVisualFrameAtom (only the derived
-// anticipationActiveAtom, which flips at thresholds, and ProgressionPlayhead's
+// leadInActiveAtom, which flips at thresholds, and ProgressionPlayhead's
 // compositor-thread WAAPI callback — neither re-renders per frame). The playback
 // jank/violations were the FretboardNoteLayer re-render, not this loop (see
 // docs/superpowers/plans/2026-06-01-playback-render-perf.md). Do not throttle

--- a/src/store/practiceLensAtoms.test.ts
+++ b/src/store/practiceLensAtoms.test.ts
@@ -8,8 +8,8 @@ import {
 } from "./chordOverlayAtoms";
 import { fingeringPatternAtom } from "./fingeringAtoms";
 import { makeAtomStore } from "../test-utils/renderWithAtoms";
-import { practiceCuesAtom, noteSemanticMapAtom, nextChordTonesAtom, commonTonesWithNextAtom, nextChordGuideTonesAtom, beatPositionAtom, activeStepDurationBeatsAtom, isInAnticipationWindow, anticipationActiveAtom, computeLeadInWindowMs, isInLeadInWindow, activeChordTonesAtom, incomingTonesAtom, departingTonesAtom, leadInActiveAtom, leadInDurationMsAtom } from "./practiceLensAtoms";
-import { progressionStepsAtom, activeProgressionStepIndexAtom, progressionTempoBpmAtom, progressionStepDeadlineAtom, beatsPerBarAtom, activeResolvedProgressionStepAtom, displayedStepIndexPrimitiveAtom, setProgressionActiveStepIndexAtom, setProgressionPlayingAtom, progressionLoopEnabledAtom, progressionPlayingStateAtom, progressionStepDurationMsAtom, progressionBarDurationMsAtom } from "./progressionAtoms";
+import { practiceCuesAtom, noteSemanticMapAtom, nextChordTonesAtom, commonTonesWithNextAtom, beatPositionAtom, activeStepDurationBeatsAtom, computeLeadInWindowMs, isInLeadInWindow, activeChordTonesAtom, incomingTonesAtom, departingTonesAtom, leadInActiveAtom, leadInDurationMsAtom } from "./practiceLensAtoms";
+import { progressionStepsAtom, progressionTempoBpmAtom, progressionStepDeadlineAtom, beatsPerBarAtom, activeResolvedProgressionStepAtom, displayedStepIndexPrimitiveAtom, setProgressionActiveStepIndexAtom, setProgressionPlayingAtom, progressionLoopEnabledAtom, progressionPlayingStateAtom, progressionStepDurationMsAtom, progressionBarDurationMsAtom } from "./progressionAtoms";
 import { progressionVisualFrameAtom } from "./progressionVisualAtoms";
 import { rootNoteAtom, scaleNameAtom, scaleVisibleAtom, colorNotesAtom, effectiveColorNotesAtom, toggleScaleVisibleAtom } from "./scaleAtoms";
 import { effectiveShapeDataAtom } from "./shapeAtoms";
@@ -343,7 +343,6 @@ describe("nextChordTonesAtom / commonTonesWithNextAtom", () => {
       [displayedStepIndexPrimitiveAtom, 1],
     ]);
     expect(store.get(nextChordTonesAtom)).toEqual(new Set());
-    expect(store.get(nextChordGuideTonesAtom)).toEqual(new Set());
   });
 
   it("nextChordTonesAtom still wraps around when loop is enabled and active step is the last step", () => {
@@ -479,66 +478,6 @@ describe("beatPositionAtom (Task 4.3)", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// nextChordGuideTonesAtom
-// ---------------------------------------------------------------------------
-
-describe("nextChordGuideTonesAtom", () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
-  function makeDefaultStore() {
-    const store = createStore();
-    const unsub = store.sub(progressionStepsAtom, () => {});
-    unsub();
-    return store;
-  }
-
-  it("returns the 3rd and 7th of the next chord (I→V in C Major: G Major has no 7th → returns 3rd B)", () => {
-    const store = makeDefaultStore();
-    const guideTones = store.get(nextChordGuideTonesAtom);
-    expect(guideTones).toEqual(new Set(["B"]));
-  });
-
-  it("returns both 3rd and 7th for a seventh chord", () => {
-    const store = makeDefaultStore();
-    const steps = store.get(progressionStepsAtom);
-    const updatedSteps = steps.map((s, i) =>
-      i === 1 ? { ...s, qualityOverride: "7" } : s
-    );
-    store.set(progressionStepsAtom, updatedSteps);
-    const guideTones = store.get(nextChordGuideTonesAtom);
-    expect(guideTones.has("B")).toBe(true);
-    expect(guideTones.has("F")).toBe(true);
-    expect(guideTones.size).toBe(2);
-  });
-
-  it("returns empty set when next chord has no guide tones (power chord)", () => {
-    const store = makeDefaultStore();
-    const steps = store.get(progressionStepsAtom);
-    const updatedSteps = steps.map((s, i) =>
-      i === 1 ? { ...s, qualityOverride: "5" } : s
-    );
-    store.set(progressionStepsAtom, updatedSteps);
-    expect(store.get(nextChordGuideTonesAtom)).toEqual(new Set());
-  });
-
-  it("returns empty set when progression is empty", () => {
-    const store = makeDefaultStore();
-    store.set(progressionStepsAtom, []);
-    expect(store.get(nextChordGuideTonesAtom)).toEqual(new Set());
-  });
-
-  it("wraps around: last step's next guide tones come from the first step", () => {
-    const store = makeDefaultStore();
-    store.set(activeProgressionStepIndexAtom, 3);
-    const guideTones = store.get(nextChordGuideTonesAtom);
-    expect(guideTones.has("E")).toBe(true);
-    expect(guideTones.size).toBe(1);
-  });
-});
-
 describe("chord-visual derivations follow displayedProgressionStepIndexAtom during playback", () => {
   it("activeResolvedProgressionStepAtom mirrors RAF-written index while playing", () => {
     const store = createStore();
@@ -606,49 +545,6 @@ describe("noteSemanticMapAtom — referential stability", () => {
     const second = store.get(noteSemanticMapAtom);
 
     expect(second).toBe(first);
-  });
-});
-
-describe("isInAnticipationWindow", () => {
-  it("is false when stepDurationBeats is non-positive", () => {
-    expect(isInAnticipationWindow(0.99, 0)).toBe(false);
-    expect(isInAnticipationWindow(0.99, -1)).toBe(false);
-  });
-  it("is false before the last beat", () => {
-    // 4-beat step: threshold = 3/4 = 0.75
-    expect(isInAnticipationWindow(0.74, 4)).toBe(false);
-  });
-  it("is true at/after the start of the last beat", () => {
-    expect(isInAnticipationWindow(0.75, 4)).toBe(true);
-    expect(isInAnticipationWindow(0.99, 4)).toBe(true);
-  });
-  it("treats a 1-beat step as always in-window", () => {
-    expect(isInAnticipationWindow(0, 1)).toBe(true);
-  });
-});
-
-describe("anticipationActiveAtom", () => {
-  it("is false when not playing", () => {
-    const store = createStore();
-    store.set(progressionPlayingStateAtom, false);
-    store.set(progressionVisualFrameAtom, {
-      stepIndex: 0, globalFraction: 0.9, localFraction: 0.9, paused: false,
-    });
-    expect(store.get(anticipationActiveAtom)).toBe(false);
-  });
-  it("is false when there is no frame", () => {
-    const store = createStore();
-    store.set(progressionPlayingStateAtom, true);
-    store.set(progressionVisualFrameAtom, null);
-    expect(store.get(anticipationActiveAtom)).toBe(false);
-  });
-  it("is false when paused", () => {
-    const store = createStore();
-    store.set(progressionPlayingStateAtom, true);
-    store.set(progressionVisualFrameAtom, {
-      stepIndex: 0, globalFraction: 0.9, localFraction: 0.9, paused: true,
-    });
-    expect(store.get(anticipationActiveAtom)).toBe(false);
   });
 });
 

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -3,7 +3,6 @@ import {
   NOTES,
   ENHARMONICS,
   INTERVAL_NAMES,
-  CHORD_DEFINITIONS,
   getNoteDisplay,
   formatAccidental,
   getDiatonicChord,
@@ -95,19 +94,6 @@ function memoizeNoteSemanticMap(next: Map<string, NoteSemantics>): Map<string, N
   }
   cachedNoteSemanticMap = next;
   return next;
-}
-
-/**
- * True when the playhead is inside the final beat of the active step — the
- * window in which the next chord's guide tones are previewed (anticipation).
- * Pure so it can be unit-tested without atom plumbing.
- */
-export function isInAnticipationWindow(
-  localFraction: number,
-  stepDurationBeats: number,
-): boolean {
-  if (stepDurationBeats <= 0) return false;
-  return localFraction >= (stepDurationBeats - 1) / stepDurationBeats;
 }
 
 /** Proportion of the step the lead-in ramp occupies (the final half). */
@@ -458,68 +444,14 @@ export const departingTonesAtom = atom((get): Set<string> => {
 });
 
 /**
- * Pitch-class set of guide tones (3rd and 7th) for the chord at the *next*
- * progression step. Used by the Lead lens anticipation window: when the
- * beat position enters the last beat of the current step, notes matching
- * these pitch classes receive "anticipation" emphasis.
- *
- * Guide tone detection mirrors `chordMembersAtom` / `GUIDE_TONE_RAW`:
- * filters ChordDefinition members whose name is b3, 3, b7, or 7, then
- * resolves the note from root + semitone offset.
- *
- * Returns an empty set when:
- * - The progression is empty.
- * - The next step is unavailable or missing root/quality.
- * - The next chord has no recognizable guide tones (e.g. power chords).
- */
-export const nextChordGuideTonesAtom = atom((get): Set<string> => {
-  const steps = get(resolvedProgressionStepsAtom);
-  if (steps.length === 0) return new Set();
-  const active = get(displayedProgressionStepIndexAtom);
-  if (active === steps.length - 1 && !get(progressionLoopEnabledAtom)) {
-    return new Set();
-  }
-  const nextIndex = (active + 1) % steps.length;
-  const step = steps[nextIndex];
-  if (!step || step.unavailable || step.root === null || step.quality === null) {
-    return new Set();
-  }
-  const def = CHORD_DEFINITIONS[step.quality];
-  if (!def) return new Set();
-  const rootIndex = NOTES.indexOf(step.root);
-  if (rootIndex === -1) return new Set();
-  const guideTones = new Set<string>();
-  for (const member of def.members) {
-    if (GUIDE_TONE_RAW.has(member.name)) {
-      guideTones.add(NOTES[(rootIndex + member.semitone) % 12]);
-    }
-  }
-  return guideTones;
-});
-
-/**
- * Duration of the active progression step in beats.
- *
- * Exported for reuse in Task 4.5 (anticipation window check:
- * `beatPosition >= stepDurationBeats - 1`).
+ * Duration of the active progression step in beats. Derived from the active
+ * step's `duration` and the current meter (`beatsPerBar`).
  */
 export const activeStepDurationBeatsAtom = atom((get): number => {
   const step = get(activeResolvedProgressionStepAtom);
   if (!step || step.unavailable) return 0;
   const beatsPerBar = get(beatsPerBarAtom);
   return getProgressionDurationBeats(step.duration, beatsPerBar);
-});
-
-/**
- * Discrete anticipation phase. Reads the per-frame visual-frame atom but its
- * VALUE only flips at the last-beat threshold, so Jotai subscribers re-render
- * at most twice per step instead of every animation frame.
- */
-export const anticipationActiveAtom = atom((get): boolean => {
-  if (!get(progressionPlayingAtom)) return false;
-  const frame = get(progressionVisualFrameAtom);
-  if (!frame || frame.paused) return false;
-  return isInAnticipationWindow(frame.localFraction, get(activeStepDurationBeatsAtom));
 });
 
 /**


### PR DESCRIPTION
## Summary

Pure, no-behavior-change cleanup of dead code left behind when the chord-transition rework (#511) replaced the old binary "anticipation pulse" with the lead-in ghost-ring preview. Each removed symbol was referenced only by its own tests, or not at all.

- **`practiceLensAtoms.ts`** — remove `isInAnticipationWindow` + `anticipationActiveAtom`, and the now-unused `nextChordGuideTonesAtom` (its `nextGuideTones` pass-through was never read by `getEmphasis`); prune their tests and the orphaned `CHORD_DEFINITIONS` import.
- **`semantics.ts` / `useEmphasisContext.ts` / `useAnimatedFretboardView.ts`** — drop the dead `nextGuideTones` field from `LeadLensContext`/`EmphasisContext` and its plumbing.
- **`FretboardSVG.tsx`** — stop computing `beatDurationSec` / writing the unused `--beat-duration` custom property (no CSS reads it after the pulse keyframe was deleted), plus the now-unused `progressionTempoBpmAtom` import.
- **`FretboardNote.tsx`** — drop the `data-lens-emphasis` attribute (no production CSS reads it; glow keys off `data-glow`); switch the one test hook that queried it to `data-transition-role="incoming"`.
- **`visualClock.ts`** — refresh the stale `anticipationActiveAtom` comment to `leadInActiveAtom`.

Net: 9 insertions, 194 deletions across 11 files. No runtime behavior change.

## Test Plan
- [x] `pnpm exec tsc -b` clean
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run test` — 2280 pass (+ skipped/todo)
- [x] `pnpm run build` succeeds

## Notes
- Rebased onto current `main` (post-#511 merge) so the diff is the cleanup alone.
- Independent of the voice-leading-motion PR (#512); both touch a few of the same files, so whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)