### PR TITLE
fix(hooks): suppress lint-staged informational messages with --quiet

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,7 +7,7 @@ fi
 # Resolve lint-staged from main repo's node_modules (handles worktrees without node_modules)
 LINT_STAGED="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" && cd .. && pwd -P)/node_modules/.bin/lint-staged"
 if [ -x "$LINT_STAGED" ]; then
-  exec "$LINT_STAGED"
+  exec "$LINT_STAGED" --quiet
 else
-  pnpm exec lint-staged
+  pnpm exec lint-staged --quiet
 fi


### PR DESCRIPTION
Suppress the `lint-staged could not find any staged files matching configured tasks` message when staging only non-code files (e.g., `.md`, `.json`). The `--quiet` flag still shows actual lint errors on non-zero exit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development tooling configuration to reduce verbosity during the pre-commit process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->