### PR TITLE
ci(ci): ignore docs/superpowers/ in change detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths-ignore:
       - '**.md'
+      - 'docs/superpowers/**'
       - 'LICENSE'
       - '.husky/**'
   pull_request:
@@ -34,6 +35,7 @@ jobs:
             code:
               - '**'
               - '!**.md'
+              - '!docs/superpowers/**'
               - '!LICENSE'
               - '!.husky/**'
 


### PR DESCRIPTION
Add `docs/superpowers/**` to both `paths-ignore` on push and the `paths-filter` exclusion list in the `changes` job, so CI skips test/build/e2e/visual when only superpowers docs change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow to skip unnecessary jobs when updating documentation in specific folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->