### PR TITLE
refactor(styles): drop dead --fretboard-note-fill-tension-emph token

### DIFF
--- a/src/styles/semantic.css
+++ b/src/styles/semantic.css
@@ -199,7 +199,6 @@
   --fretboard-note-fill-chord-tone:     #141e28;
   --fretboard-note-fill-scale-only:     #121a26;
   --fretboard-note-fill-chord-outside:  #28160a;
-  --fretboard-note-fill-tension-emph:   #6c2800;
   --fretboard-note-fill-tension-strong: #8a3300;
   --fretboard-note-fill-guide-emph:     #5f3408;
   --fretboard-note-fill-deemphasis-chord:  #141e28;

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -296,7 +296,6 @@
   --fretboard-note-fill-chord-tone:     color-mix(in srgb, #147088 18%, #f6f2e9); /* CYAN 18% into PANEL */
   --fretboard-note-fill-scale-only:     #e3ddd8;                                   /* PANEL-SOFT — neutral */
   --fretboard-note-fill-chord-outside:  color-mix(in srgb, #b1431b 40%, #f6f2e9); /* ORANGE 40% into PANEL */
-  --fretboard-note-fill-tension-emph:   color-mix(in srgb, #b1431b 55%, #f6f2e9); /* ORANGE 55% into PANEL */
   --fretboard-note-fill-tension-strong: color-mix(in srgb, #b1431b 70%, #f6f2e9); /* ORANGE 70% into PANEL */
   --fretboard-note-fill-guide-emph:     color-mix(in srgb, #147088 35%, #f6f2e9); /* CYAN 35% into PANEL */
   --fretboard-note-fill-deemphasis-chord:  var(--fretboard-guide-tones-deemphasis-fill);


### PR DESCRIPTION
## Summary

The `--fretboard-note-fill-tension-emph` custom property has **zero `var()` consumers** in `src/` or `packages/` on `main` (the dashed-orange chord-root tension fill rule that used it is gone). This removes its two now-dead definitions:

- `src/styles/themes.css` (light palette)
- `src/styles/semantic.css` (dark palette)

## What was deliberately *not* removed

`--neon-orange-dim` was also flagged as a removal candidate but is **left in place**. It is currently unconsumed, but it belongs to the symmetric neon palette (`cyan` / `orange` / `violet` × `base` / `bright` / `dim`):

- `--neon-cyan-dim` is actively consumed (`--note-ring-dim`).
- `--neon-violet-dim` is likewise unconsumed yet retained.

The triads are maintained as a coherent set rather than pruned token-by-token, so removing `--neon-orange-dim` alone would break the palette's symmetry. Per the original guidance, when uncertain, the palette member stays.

## Verification

- `pnpm run lint` → 0 errors (1 pre-existing `exhaustive-deps` warning in `useFretboardTopologyModel.ts`, unrelated).
- `pnpm run build` → succeeds.

## Note

A sibling token `--fretboard-note-fill-tension-strong` is also defined and currently has no `var()` consumers — out of scope here, but a likely follow-up dead-code candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)