### PR TITLE
fix(fretboard): stop chord-root bubbles enlarging during playback

### DIFF
--- a/docs/superpowers/plans/2026-06-07-chord-root-bubble-size-playback.md
+++ b/docs/superpowers/plans/2026-06-07-chord-root-bubble-size-playback.md
@@ -1,0 +1,333 @@
+# Chord-root Bubble Size During Playback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the chord root note bubble from appearing disproportionately large during progression playback by removing the common-tone `radiusBoost` from the emphasis layer.
+
+**Architecture:** During playback, `getEmphasis()` gives common tones a `1.15×` `radiusBoost` that is applied as a CSS `scale()` on the entire note `<g>` (bubble + guide ring + label). Roots are almost always common tones, so they get singled out and — when also a next-chord guide target — the whole decorated cluster balloons. The fix removes that boost so playback size encodes only the existing chord-tier vs scale-tier distinction, then prunes the now-dead `commonWithNext` plumbing.
+
+**Tech Stack:** React 19 + TypeScript, Jotai atoms, Vitest, Playwright visual regression, pnpm.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-chord-root-bubble-size-playback-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility in this change |
+|---|---|
+| `src/components/FretboardSVG/utils/semantics.ts` | Remove the common-tone boost in `getEmphasis`; delete the now-orphaned local `CHORD_TONE_CLASSES` set; drop `commonWithNext` from `LeadLensContext` |
+| `src/components/FretboardSVG/utils/semantics.test.ts` | Rewrite the two "hold glow" tests to assert no boost; remove `commonWithNext` from fixtures |
+| `src/components/FretboardSVG/hooks/useEmphasisContext.ts` | Drop the `commonWithNext` field, its atom read, and the now-unused import |
+| `src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts` | Drop the `commonWithNext` pass-through |
+| `src/store/practiceLensAtoms.ts` | Unchanged — `commonTonesWithNextAtom` is kept (tested, reusable) |
+
+**Note on `CHORD_TONE_CLASSES`:** there are two unrelated sets with this name. The one being removed is the module-private set in `semantics.ts:51`, used only by the boost branch. The exported `CHORD_TONE_CLASSES` in `hooks/useChordConnectorPolylines.ts` is unrelated and stays.
+
+---
+
+### Task 1: Rewrite the two "hold glow" tests to assert no size boost (RED)
+
+These tests currently lock in the `1.15×` boost. Rewrite them to assert the desired
+post-fix behavior — a held common tone gets no enlargement. At this point the
+implementation is unchanged, so they must FAIL. `commonWithNext` is still part of
+`LeadLensContext` here, so the test contexts keep it (it is pruned in Task 3).
+
+**Files:**
+- Modify: `src/components/FretboardSVG/utils/semantics.test.ts:436-444` and `:454-461`
+
+- [ ] **Step 1: Rewrite the DURING-lead-in test**
+
+Replace the existing test at `semantics.test.ts:436-444`:
+
+```ts
+  it("a held common tone keeps its hold glow DURING the lead-in (no flicker)", () => {
+    const ctx: LeadLensContext = {
+      ...baseLeadContext, notePc: "A",
+      commonWithNext: new Set(["A"]), nextGuideTones: new Set(["B"]),
+    };
+    expect(getEmphasis("chord-tone-in-scale", false, ctx)).toEqual({
+      radiusBoost: 1.15, opacityBoost: 1,
+    });
+  });
+```
+
+with:
+
+```ts
+  it("a held common tone is NOT enlarged DURING the lead-in", () => {
+    const ctx: LeadLensContext = {
+      ...baseLeadContext, notePc: "A",
+      commonWithNext: new Set(["A"]), nextGuideTones: new Set(["B"]),
+    };
+    expect(getEmphasis("chord-tone-in-scale", false, ctx)).toEqual({
+      radiusBoost: 1, opacityBoost: 1,
+    });
+  });
+```
+
+- [ ] **Step 2: Rewrite the OUTSIDE-lead-in test**
+
+Replace the existing test at `semantics.test.ts:454-461`:
+
+```ts
+  it("outside the lead-in window, a held common tone keeps a static hold glow (no role)", () => {
+    const ctx: LeadLensContext = {
+      ...baseLeadContext, notePc: "A", commonWithNext: new Set(["A"]), leadInActive: false,
+    };
+    expect(getEmphasis("chord-tone-in-scale", false, ctx)).toEqual({
+      radiusBoost: 1.15, opacityBoost: 1,
+    });
+  });
+```
+
+with:
+
+```ts
+  it("outside the lead-in window, a held common tone is NOT enlarged (no role)", () => {
+    const ctx: LeadLensContext = {
+      ...baseLeadContext, notePc: "A", commonWithNext: new Set(["A"]), leadInActive: false,
+    };
+    expect(getEmphasis("chord-tone-in-scale", false, ctx)).toEqual({
+      radiusBoost: 1, opacityBoost: 1,
+    });
+  });
+```
+
+- [ ] **Step 3: Run the two tests to verify they FAIL**
+
+Run: `pnpm exec vitest run src/components/FretboardSVG/utils/semantics.test.ts -t "NOT enlarged"`
+Expected: FAIL — both assertions report `radiusBoost: 1.15` received vs `1` expected.
+
+- [ ] **Step 4: Commit the red tests**
+
+```bash
+git add src/components/FretboardSVG/utils/semantics.test.ts
+git commit -m "test(fretboard): assert held common tones are not enlarged during playback"
+```
+
+---
+
+### Task 2: Remove the common-tone boost in getEmphasis (GREEN)
+
+Collapse the `resting` emphasis to the base model and delete the now-unused local
+`CHORD_TONE_CLASSES` set and the `commonWithNext` destructure binding (leaving either in
+place would trip `@typescript-eslint/no-unused-vars`).
+
+**Files:**
+- Modify: `src/components/FretboardSVG/utils/semantics.ts:47-57` (delete set + doc comment), `:85` (destructure), `:90-93` (resting)
+
+- [ ] **Step 1: Delete the orphaned local `CHORD_TONE_CLASSES` set**
+
+Remove these lines (`semantics.ts:47-57`) in full:
+
+```ts
+/**
+ * Chord-tone noteClass values — a note with one of these classes is considered
+ * a "current chord tone" for the Lead lens hold/departing logic.
+ */
+const CHORD_TONE_CLASSES = new Set([
+  "chord-root",
+  "chord-root-outside",
+  "chord-tone-in-scale",
+  "chord-tone-outside-scale",
+  "note-diatonic-chord",
+]);
+```
+
+- [ ] **Step 2: Drop `commonWithNext` from the destructure**
+
+At `semantics.ts:85`, change:
+
+```ts
+  const { notePc, nextGuideTones, nextGuideToneLabels, commonWithNext, leadInActive, planningActive } = leadContext;
+```
+
+to:
+
+```ts
+  const { notePc, nextGuideTones, nextGuideToneLabels, leadInActive, planningActive } = leadContext;
+```
+
+- [ ] **Step 3: Simplify `resting` to the base model**
+
+At `semantics.ts:90-93` (line numbers before Step 1's deletion; locate by content), change:
+
+```ts
+  const resting: LensEmphasis =
+    CHORD_TONE_CLASSES.has(noteClass) && commonWithNext.has(notePc)
+      ? { radiusBoost: 1.15, opacityBoost: 1 }
+      : applyTonesBase(noteClass);
+```
+
+to:
+
+```ts
+  const resting: LensEmphasis = applyTonesBase(noteClass);
+```
+
+Leave the surrounding comment block describing `resting` (the "size/shape a note shows
+OUTSIDE the lead-in window") in place — trim its mention of the hold glow if present, but
+the resting concept still holds.
+
+- [ ] **Step 4: Run the full semantics suite to verify GREEN**
+
+Run: `pnpm exec vitest run src/components/FretboardSVG/utils/semantics.test.ts`
+Expected: PASS — all tests, including the two from Task 1, pass.
+
+- [ ] **Step 5: Lint the file to confirm no orphaned symbols**
+
+Run: `pnpm run lint`
+Expected: PASS — no `no-unused-vars` on `CHORD_TONE_CLASSES` or `commonWithNext`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/FretboardSVG/utils/semantics.ts
+git commit -m "fix(fretboard): remove common-tone size boost that enlarged chord roots during playback"
+```
+
+---
+
+### Task 3: Prune the now-dead `commonWithNext` plumbing (REFACTOR)
+
+`commonWithNext` is no longer read anywhere. Remove it from the context type, the two
+hooks that populate it, and the remaining test fixtures.
+
+**Files:**
+- Modify: `src/components/FretboardSVG/utils/semantics.ts:29-30` (type field)
+- Modify: `src/components/FretboardSVG/hooks/useEmphasisContext.ts:3,15,34,42`
+- Modify: `src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts:45`
+- Modify: `src/components/FretboardSVG/utils/semantics.test.ts:382,439,456`
+
+- [ ] **Step 1: Remove the `commonWithNext` field from `LeadLensContext`**
+
+At `semantics.ts:29-30`, delete these two lines:
+
+```ts
+  /** Notes shared between the active chord and the next chord (common tones). */
+  commonWithNext: Set<string>;
+```
+
+- [ ] **Step 2: Remove `commonWithNext` from `useEmphasisContext`**
+
+In `src/components/FretboardSVG/hooks/useEmphasisContext.ts`:
+
+Remove the import line (`:3`) `commonTonesWithNextAtom,` from the import block — final block:
+
+```ts
+import {
+  nextChordGuideTonesAtom,
+  nextChordGuideToneLabelsAtom,
+  nextChordTonesAtom,
+  incomingTonesAtom,
+  departingTonesAtom,
+  leadInActiveAtom,
+  planningWindowActiveAtom,
+} from "../../../store/practiceLensAtoms";
+```
+
+Remove the interface field (`:15`) `commonWithNext: Set<string>;` from `EmphasisContext`.
+
+Remove the atom read (`:34`) `const commonWithNext = useAtomValue(commonTonesWithNextAtom);`.
+
+Remove the `commonWithNext,` property (`:42`) from the returned object.
+
+- [ ] **Step 3: Remove the `commonWithNext` pass-through in `useAnimatedFretboardView`**
+
+In `src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts`, delete line `:45`:
+
+```ts
+        commonWithNext: emphasisContext.commonWithNext,
+```
+
+- [ ] **Step 4: Remove `commonWithNext` from the test fixtures**
+
+In `src/components/FretboardSVG/utils/semantics.test.ts`:
+
+Delete the `commonWithNext: new Set<string>(),` line from `baseLeadContext` (`:382`).
+
+In the two tests rewritten in Task 1, remove the `commonWithNext: new Set(["A"])` entry
+from each context object so they no longer reference the removed field. Final form:
+
+```ts
+  it("a held common tone is NOT enlarged DURING the lead-in", () => {
+    const ctx: LeadLensContext = {
+      ...baseLeadContext, notePc: "A", nextGuideTones: new Set(["B"]),
+    };
+    expect(getEmphasis("chord-tone-in-scale", false, ctx)).toEqual({
+      radiusBoost: 1, opacityBoost: 1,
+    });
+  });
+```
+
+```ts
+  it("outside the lead-in window, a held common tone is NOT enlarged (no role)", () => {
+    const ctx: LeadLensContext = {
+      ...baseLeadContext, notePc: "A", leadInActive: false,
+    };
+    expect(getEmphasis("chord-tone-in-scale", false, ctx)).toEqual({
+      radiusBoost: 1, opacityBoost: 1,
+    });
+  });
+```
+
+- [ ] **Step 5: Typecheck, lint, and run the affected tests**
+
+Run: `pnpm run lint`
+Expected: PASS — no unused `commonTonesWithNextAtom` import, no dangling references.
+
+Run: `pnpm exec vitest run src/components/FretboardSVG/utils/semantics.test.ts src/components/FretboardSVG/hooks`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/FretboardSVG/utils/semantics.ts src/components/FretboardSVG/hooks/useEmphasisContext.ts src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts src/components/FretboardSVG/utils/semantics.test.ts
+git commit -m "refactor(fretboard): drop unused commonWithNext emphasis plumbing"
+```
+
+---
+
+### Task 4: Full verification + refresh visual snapshots
+
+**Files:**
+- Modify (generated): darwin visual snapshots under `e2e/` for fretboard/overlay playback states
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `pnpm run test`
+Expected: PASS — full Vitest run green.
+
+- [ ] **Step 2: Build**
+
+Run: `pnpm run build`
+Expected: `tsc -b` and `vite build` succeed with no type errors.
+
+- [ ] **Step 3: Refresh darwin visual snapshots**
+
+Run: `pnpm run test:visual:update`
+Expected: snapshots for playback/overlay scenes regenerate.
+
+- [ ] **Step 4: Review the snapshot diff before committing**
+
+Run: `git status --short e2e` then inspect the changed `.png` files.
+Expected: chord-root bubbles during playback are the same size as sibling chord tones
+(no `1.15×` enlargement, no enlarged guide-ring cluster on roots). Confirm nothing else
+shifted — non-root, non-playback scenes should be unchanged. If unrelated snapshots
+changed, stop and investigate before committing.
+
+- [ ] **Step 5: Commit the refreshed snapshots**
+
+```bash
+git add e2e
+git commit -m "test(visual): refresh playback snapshots after removing chord-root size boost"
+```
+
+---
+
+## Notes for the implementer
+
+- **TDD ordering caveat:** Task 1's tests must keep `commonWithNext` in their context objects to produce a meaningful red, because the boost only triggers when `commonWithNext` contains the note's pitch class. Task 3 removes those keys once the field is deleted from the type. This is why the two tests are touched twice — it is intentional, not redundant.
+- **Do not** delete `commonTonesWithNextAtom` or its tests in `src/store/practiceLensAtoms.test.ts`. The atom is retained as a reusable selector (see spec, "Keep `commonTonesWithNextAtom`").
+- **Do not** change the root stroke width (`2.4` in `FretboardSVG.module.css:79`) or the guide-ring behavior — both are explicitly out of scope.

--- a/docs/superpowers/specs/2026-06-06-chord-root-bubble-size-playback-research.md
+++ b/docs/superpowers/specs/2026-06-06-chord-root-bubble-size-playback-research.md
@@ -1,0 +1,128 @@
+# Chord-root Bubble Size During Playback — Research
+
+Date: 2026-06-06
+Status: Research (unresolved, deferred)
+Scope: Investigation only — no implementation decisions made.
+
+## Purpose
+
+Investigate why the chord root note bubble appears larger than other chord tone bubbles during progression playback, and document the rendering chain so a fix can be designed later.
+
+## Finding: Root and non-root chord tones share the same `radiusScale`
+
+In `src/components/FretboardSVG/utils/semantics.ts:180-207`, `getNoteVisuals()` maps all chord-tone note classes to the same `RADIUS_CHORD = 0.95`:
+
+| noteClass | radiusScale | Source |
+|---|---|---|
+| `chord-root` | 0.95 | semantics.ts:185 |
+| `chord-tone-in-scale` | 0.95 | semantics.ts:186 |
+| `note-diatonic-chord` | 0.95 | semantics.ts:186 |
+
+The static base size is identical. The visual size difference during playback must come from another layer.
+
+## Root Cause: Common-tone `radiusBoost` in the emphasis layer
+
+The emphasis system (`getEmphasis()`, semantics.ts:73-115) adds a per-note `radiusBoost` multiplier during progression playback:
+
+```ts
+const resting: LensEmphasis =
+  CHORD_TONE_CLASSES.has(noteClass) && commonWithNext.has(notePc)
+    ? { radiusBoost: 1.15, opacityBoost: 1 }
+    : applyTonesBase(noteClass);
+```
+
+- Notes that are **chord tones AND common tones** (shared with the next chord) get `radiusBoost: 1.15`
+- Other chord tones get `radiusBoost: 1`
+- Scale-only / color-tone notes get `radiusBoost: 0.85`
+
+Chord roots are often common tones across chord changes, so they disproportionately receive the 1.15× boost.
+
+### How `radiusBoost` reaches the DOM
+
+In `src/components/FretboardSVG/FretboardNote.tsx:146-159`:
+
+```tsx
+style={{
+  "--emph-scale": applyLensEmphasis.radiusBoost,
+  transformOrigin: `${cx}px ${cy}px`,
+  transform: "scale(var(--emph-scale, 1))",
+} as React.CSSProperties}
+```
+
+The `radiusBoost` is applied as a CSS `transform: scale(N)` on the `<g>` element wrapping each note. This scales the entire note bubble (circle, text, ring) about its center. A `1.15` boost makes the bubble 15% larger in both dimensions.
+
+### The `baseRadius` → `r` path (unaffected by emphasis)
+
+The SVG `r` attribute is computed geometrically (no CSS scale involved):
+
+```
+baseRadius = noteBubblePx / 2               // FretboardNote.tsx:78
+radiusScale = getNoteVisuals(noteClass)      // semantics.ts:180
+taperScale = taperAwareRadiusScale(...)      // noteSizing.ts:51
+rawRadius = baseRadius * radiusScale * taperScale
+r = reduceCircleRadius(rawRadius)            // r - 2px stroke compensation
+```
+
+The CSS `scale()` transform is applied *on top* of this geometry. The emphasis system does not modify the base `r` value — it's purely a visual post-transform.
+
+## Rendering Chain Summary
+
+```
+constants.ts
+  NOTE_BUBBLE_RATIO = 0.8                  // bubble diameter = 0.8 × string row height
+
+FretboardSVG.tsx:348
+  noteBubblePx = stringRowPx * NOTE_BUBBLE_RATIO
+
+FretboardNote.tsx:78
+  baseRadius = noteBubblePx / 2
+
+semantics.ts:180
+  radiusScale = getNoteVisuals(noteClass)  // 0.95 for all chord tones
+
+noteSizing.ts:51
+  taperScale = taperAwareRadiusScale(...)  // 0.72–1.0 near nut
+
+FretboardNote.tsx:87-88
+  rawRadius = baseRadius × radiusScale × taperScale
+  r = reduceCircleRadius(rawRadius)        // subtracts 2px
+
+semantics.ts:92                            // ← only during playback
+  radiusBoost = commonTone ? 1.15 : 1
+
+FretboardNote.tsx:158
+  transform: scale(var(--emph-scale, 1))   // CSS post-transform
+```
+
+## Additional Size Cues
+
+The root note also gets a thicker stroke (`2.4px` vs `2.2px` for other chord tones in `FretboardSVG.module.css:76-97`), which may contribute to the perceived size difference during static viewing. During playback, the CSS scale dominates.
+
+## File Inventory
+
+| File | Lines | Role |
+|---|---|---|
+| `packages/core/src/constants.ts` | 14 | `NOTE_BUBBLE_RATIO = 0.8` |
+| `src/components/FretboardSVG/FretboardSVG.tsx` | 348 | `noteBubblePx` computation |
+| `src/components/FretboardSVG/FretboardNote.tsx` | 78-88, 146-159 | Radius computation + emphasis CSS transform |
+| `src/components/FretboardSVG/utils/semantics.ts` | 73-115, 180-207 | `getEmphasis()` radius boost + `getNoteVisuals()` radius scale |
+| `src/components/FretboardSVG/utils/noteSizing.ts` | 16, 51-79 | `reduceCircleRadius` + `taperAwareRadiusScale` |
+| `src/components/FretboardSVG/FretboardSVG.module.css` | 76-97 | Stroke widths per note class |
+
+## Approaches (not yet evaluated)
+
+Recorded here for when work resumes:
+
+- **A:** Remove common-tone radius boost — set `radiusBoost: 1` for all common tones. Losses the size-as-connection signal entirely.
+- **B:** Uniform chord-tone boost — give all chord tones the `1.15` boost during playback, not just common tones.
+- **C:** Repurpose the held-note cue to color/stroke instead of size — keep common-tone identity without size asymmetry.
+- **D:** Selective root exclusion — exclude `chord-root` from the boost, allowing other common tones to keep it.
+
+No recommendation was reached before the task was deferred.
+
+## Next Steps
+
+1. Choose an approach.
+2. Update `getEmphasis()` in `semantics.ts`.
+3. Update tests in `semantics.test.ts` if they assert specific `radiusBoost` values.
+4. Run visual regression tests (`pnpm run test:visual:update`) to capture the new appearance.

--- a/docs/superpowers/specs/2026-06-07-chord-root-bubble-size-playback-design.md
+++ b/docs/superpowers/specs/2026-06-07-chord-root-bubble-size-playback-design.md
@@ -1,0 +1,154 @@
+# Chord-root Bubble Size During Playback — Design
+
+Date: 2026-06-07
+Status: Design (approach approved — Approach A)
+Supersedes the open question in: `2026-06-06-chord-root-bubble-size-playback-research.md`
+
+## Problem
+
+During progression playback the chord **root** note bubble reads as disproportionately
+larger than other chord tones, and the effect worsens when that root is also a guide
+tone for the next chord. The size asymmetry is unintended and reads as visual noise
+rather than as meaningful information.
+
+## Root cause (confirmed)
+
+All chord-tone classes share the same static `radiusScale` (`RADIUS_CHORD = 0.95`,
+`semantics.ts:185`). The size difference comes entirely from the **emphasis layer**.
+
+`getEmphasis()` (`semantics.ts:90-93`) gives a `radiusBoost: 1.15` to any note that is
+both a chord tone **and** a common tone with the next chord:
+
+```ts
+const resting: LensEmphasis =
+  CHORD_TONE_CLASSES.has(noteClass) && commonWithNext.has(notePc)
+    ? { radiusBoost: 1.15, opacityBoost: 1 }
+    : applyTonesBase(noteClass);
+```
+
+Five factors compound on a current-chord root during playback:
+
+| Factor | Source | Effect on root |
+|---|---|---|
+| Chord-tier radius `0.95` | `semantics.ts:185` | Same as all chord tones (fair) |
+| Common-tone boost `1.15×` | `semantics.ts:92` | Roots are frequently common tones → boosted |
+| Match is by **pitch class**, not voicing | `commonWithNext.has(notePc)` | **Every** root position on the neck boosts, not one |
+| Thicker stroke `2.4` vs `2.2` | `FretboardSVG.module.css:79` | Static heaviness |
+| Guide-target ring + label + flash, all `×1.15` | `FretboardNote.tsx:158` scales the whole `<g>` | Footprint balloons when root = next chord's guide tone |
+
+### Correction to the research doc
+
+The research doc stated that guide-tone status "does not stack" because the
+`guide-target` / `guide-preview` branches return `resting.radiusBoost` with no extra
+multiply. That is true of the **radius number**, but misses the real mechanism: the
+`--emph-scale` (= `radiusBoost`) CSS transform is set on the entire `<g>`
+(`FretboardNote.tsx:148,158`), which wraps the guide decoration — backing disc, halo
+ring at `r + standoff`, label, and on-beat flash (`FretboardNote.tsx:167-247`). So the
+`1.15×` scales the whole decorated cluster, ring and all — not just the bubble. That is
+why a root that is also the next chord's guide target looks especially large.
+
+### Why the held-tone cue "doesn't carry through"
+
+The `1.15×` is applied uniformly to **all** common tones across **all** of their neck
+positions. It inflates a whole cloud of notes slightly rather than marking one held
+voice, so it does not communicate "this specific note sustains into the next chord."
+Because the root is almost always in that cloud, the size boost and root identity become
+conflated — size cannot mean "held" when it always coincides with "root." The voice-
+leading story is already told, more clearly, by the guide-ring lead-in countdown. The
+size boost is a weak, conflicting second telling.
+
+## Chosen approach: A — remove the common-tone size boost
+
+Stop boosting common tones. During playback, bubble size then encodes only the existing
+chord-tier vs scale-tier distinction; roots are no longer singled out by size.
+
+Approaches B (uniform boost), C (move the held cue to color/stroke), and D (exclude the
+root from the boost) were considered and recorded in the research doc. A was chosen
+because the research shows the held-tone size cue is both ineffective and overloaded, and
+because removing it is the smallest, highest-confidence, fully reversible change. If a
+held-tone cue is later judged valuable, **Approach C should be pursued as its own scoped
+visual-design task**, not folded into this fix (YAGNI).
+
+## The change
+
+### 1. `getEmphasis()` — `semantics.ts`
+
+Remove the common-tone special case. With the boost gone, the `resting` ternary
+collapses to the base model (for a chord tone, `applyTonesBase` already returns
+`{ radiusBoost: 1, opacityBoost: 1 }`):
+
+```ts
+// before
+const resting: LensEmphasis =
+  CHORD_TONE_CLASSES.has(noteClass) && commonWithNext.has(notePc)
+    ? { radiusBoost: 1.15, opacityBoost: 1 }
+    : applyTonesBase(noteClass);
+
+// after
+const resting: LensEmphasis = applyTonesBase(noteClass);
+```
+
+`notePc` and `commonWithNext` are no longer read by the resting branch. `notePc` is still
+used by the guide-target / guide-preview branches, so it stays. `commonWithNext` becomes
+unused inside `getEmphasis`.
+
+### 2. Prune the now-dead `commonWithNext` plumbing
+
+`commonWithNext` is consumed **only** by the resting boost. Remove it from the context
+type and the hooks that populate it:
+
+- `semantics.ts` — drop `commonWithNext` from `LeadLensContext` and from the destructure
+  at `semantics.ts:85`.
+- `hooks/useEmphasisContext.ts` — drop the `commonWithNext` field (`:15`, `:42`) and its
+  `useAtomValue(commonTonesWithNextAtom)` read (`:34`), and the now-unused import (`:3`).
+- `hooks/useAnimatedFretboardView.ts` — drop the `commonWithNext` pass-through (`:45`).
+
+### 3. Keep `commonTonesWithNextAtom`
+
+`commonTonesWithNextAtom` (`store/practiceLensAtoms.ts:469`) is a small pure derived
+selector with its own unit tests asserting intersection semantics. Keep it: it is a
+sensible reusable primitive and the natural input for a future Approach-C held-tone cue.
+Leaving it in place avoids churn we would otherwise reverse. (Alternative, if the team
+prefers zero orphaned exports: delete the atom and its tests in
+`store/practiceLensAtoms.test.ts`. Not recommended.)
+
+## Test impact
+
+`src/components/FretboardSVG/utils/semantics.test.ts` has two tests asserting the
+`1.15` boost that must be rewritten to assert the new behavior — a held common tone is
+now treated identically to any other chord tone (`{ radiusBoost: 1, opacityBoost: 1 }`):
+
+- `:436` "a held common tone keeps its hold glow DURING the lead-in (no flicker)"
+- `:454` "outside the lead-in window, a held common tone keeps a static hold glow"
+
+Rewrite both to assert no size boost (renaming them away from "hold glow" since that cue
+is removed), so they lock in the fix and prevent regression. The `commonWithNext` keys in
+those test contexts (`:439`, `:456`) are removed along with the context field.
+
+`store/practiceLensAtoms.test.ts` is unchanged (the atom stays).
+
+## Out of scope
+
+- Approach C (a color/stroke held-tone cue). If desired, it becomes a separate spec.
+- The static stroke-width difference (`2.4` root vs `2.2` chord tone). It is a deliberate
+  root-identity cue and is not the playback problem; leave it unchanged.
+- Guide-ring behavior. Unchanged — it remains the primary voice-leading signal.
+
+## Verification
+
+1. `pnpm run lint` — confirms no unused imports/fields remain after the prune.
+2. `pnpm run test` — semantics tests pass with the rewritten assertions.
+3. `pnpm run build`.
+4. `pnpm run test:visual:update` — capture the new playback appearance (roots no longer
+   enlarged), then review the snapshot diff to confirm the asymmetry is gone and nothing
+   else shifted.
+
+## File inventory
+
+| File | Role in change |
+|---|---|
+| `src/components/FretboardSVG/utils/semantics.ts` | Remove boost; simplify `resting`; drop `commonWithNext` from `LeadLensContext` |
+| `src/components/FretboardSVG/hooks/useEmphasisContext.ts` | Drop `commonWithNext` field + atom read + import |
+| `src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts` | Drop `commonWithNext` pass-through |
+| `src/components/FretboardSVG/utils/semantics.test.ts` | Rewrite the two "hold glow" tests to assert no boost |
+| `src/store/practiceLensAtoms.ts` | Unchanged (`commonTonesWithNextAtom` kept) |

--- a/src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts
+++ b/src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts
@@ -42,7 +42,6 @@ export function buildAnimatedFretboardNotes({
     if (hasChordOverlay && emphasisContext) {
       leadContext = {
         notePc: note.noteName,
-        commonWithNext: emphasisContext.commonWithNext,
         nextGuideTones: emphasisContext.nextGuideTones,
         nextGuideToneLabels: emphasisContext.nextGuideToneLabels,
         nextChordTones: emphasisContext.nextChordTones,

--- a/src/components/FretboardSVG/hooks/useEmphasisContext.ts
+++ b/src/components/FretboardSVG/hooks/useEmphasisContext.ts
@@ -1,6 +1,5 @@
 import { useAtomValue } from "jotai";
 import {
-  commonTonesWithNextAtom,
   nextChordGuideTonesAtom,
   nextChordGuideToneLabelsAtom,
   nextChordTonesAtom,
@@ -12,7 +11,6 @@ import {
 import { progressionPlayingAtom } from "../../../store/progressionAtoms";
 
 export interface EmphasisContext {
-  commonWithNext: Set<string>;
   nextGuideTones: Set<string>;
   nextGuideToneLabels: Map<string, string>;
   nextChordTones: Set<string>;
@@ -31,7 +29,6 @@ export function useEmphasisContext(enabled: boolean): EmphasisContext | null {
   const playing = useAtomValue(progressionPlayingAtom);
   const leadInActive = useAtomValue(leadInActiveAtom);
   const planningActive = useAtomValue(planningWindowActiveAtom);
-  const commonWithNext = useAtomValue(commonTonesWithNextAtom);
   const nextGuideTones = useAtomValue(nextChordGuideTonesAtom);
   const nextGuideToneLabels = useAtomValue(nextChordGuideToneLabelsAtom);
   const nextChordTones = useAtomValue(nextChordTonesAtom);
@@ -39,7 +36,6 @@ export function useEmphasisContext(enabled: boolean): EmphasisContext | null {
   const departingTones = useAtomValue(departingTonesAtom);
   if (!enabled || !playing) return null;
   return {
-    commonWithNext,
     nextGuideTones,
     nextGuideToneLabels,
     nextChordTones,

--- a/src/components/FretboardSVG/utils/semantics.test.ts
+++ b/src/components/FretboardSVG/utils/semantics.test.ts
@@ -433,13 +433,13 @@ describe("getEmphasis - voice-leading emphasis", () => {
     expect(getEmphasis("chord-tone-in-scale", false, ctx)).toEqual({ radiusBoost: 1, opacityBoost: 1 });
   });
 
-  it("a held common tone keeps its hold glow DURING the lead-in (no flicker)", () => {
+  it("a held common tone is NOT enlarged DURING the lead-in", () => {
     const ctx: LeadLensContext = {
       ...baseLeadContext, notePc: "A",
       commonWithNext: new Set(["A"]), nextGuideTones: new Set(["B"]),
     };
     expect(getEmphasis("chord-tone-in-scale", false, ctx)).toEqual({
-      radiusBoost: 1.15, opacityBoost: 1,
+      radiusBoost: 1, opacityBoost: 1,
     });
   });
 
@@ -451,12 +451,12 @@ describe("getEmphasis - voice-leading emphasis", () => {
     expect(getEmphasis("scale-only", false, ctx)).toEqual({ radiusBoost: 0.85, opacityBoost: 0.7 });
   });
 
-  it("outside the lead-in window, a held common tone keeps a static hold glow (no role)", () => {
+  it("outside the lead-in window, a held common tone is NOT enlarged (no role)", () => {
     const ctx: LeadLensContext = {
       ...baseLeadContext, notePc: "A", commonWithNext: new Set(["A"]), leadInActive: false,
     };
     expect(getEmphasis("chord-tone-in-scale", false, ctx)).toEqual({
-      radiusBoost: 1.15, opacityBoost: 1,
+      radiusBoost: 1, opacityBoost: 1,
     });
   });
 

--- a/src/components/FretboardSVG/utils/semantics.test.ts
+++ b/src/components/FretboardSVG/utils/semantics.test.ts
@@ -379,7 +379,6 @@ describe("semantics utils", () => {
 describe("getEmphasis - voice-leading emphasis", () => {
   const baseLeadContext: LeadLensContext = {
     notePc: "A",
-    commonWithNext: new Set<string>(),
     nextGuideTones: new Set<string>(),
     nextGuideToneLabels: new Map<string, string>(),
     nextChordTones: new Set<string>(),
@@ -435,8 +434,7 @@ describe("getEmphasis - voice-leading emphasis", () => {
 
   it("a held common tone is NOT enlarged DURING the lead-in", () => {
     const ctx: LeadLensContext = {
-      ...baseLeadContext, notePc: "A",
-      commonWithNext: new Set(["A"]), nextGuideTones: new Set(["B"]),
+      ...baseLeadContext, notePc: "A", nextGuideTones: new Set(["B"]),
     };
     expect(getEmphasis("chord-tone-in-scale", false, ctx)).toEqual({
       radiusBoost: 1, opacityBoost: 1,
@@ -453,7 +451,7 @@ describe("getEmphasis - voice-leading emphasis", () => {
 
   it("outside the lead-in window, a held common tone is NOT enlarged (no role)", () => {
     const ctx: LeadLensContext = {
-      ...baseLeadContext, notePc: "A", commonWithNext: new Set(["A"]), leadInActive: false,
+      ...baseLeadContext, notePc: "A", leadInActive: false,
     };
     expect(getEmphasis("chord-tone-in-scale", false, ctx)).toEqual({
       radiusBoost: 1, opacityBoost: 1,

--- a/src/components/FretboardSVG/utils/semantics.ts
+++ b/src/components/FretboardSVG/utils/semantics.ts
@@ -44,7 +44,6 @@ export type LeadLensContext = {
   planningActive: boolean;
 };
 
-
 /**
  * Fallback emphasis when no progression is active or no voice-leading
  * context applies. Dims scale-only / color-tone notes. Guide tones (3rd/7th)

--- a/src/components/FretboardSVG/utils/semantics.ts
+++ b/src/components/FretboardSVG/utils/semantics.ts
@@ -26,8 +26,6 @@ export type LensEmphasis = {
 export type LeadLensContext = {
   /** Pitch class of the note being classified. */
   notePc: string;
-  /** Notes shared between the active chord and the next chord (common tones). */
-  commonWithNext: Set<string>;
   /** Guide tones (3rd/7th) of the next chord. */
   nextGuideTones: Set<string>;
   /** Interval labels for the next chord's guide tones (pitch class → name, e.g. "B" → "3"). */

--- a/src/components/FretboardSVG/utils/semantics.ts
+++ b/src/components/FretboardSVG/utils/semantics.ts
@@ -44,17 +44,6 @@ export type LeadLensContext = {
   planningActive: boolean;
 };
 
-/**
- * Chord-tone noteClass values — a note with one of these classes is considered
- * a "current chord tone" for the Lead lens hold/departing logic.
- */
-const CHORD_TONE_CLASSES = new Set([
-  "chord-root",
-  "chord-root-outside",
-  "chord-tone-in-scale",
-  "chord-tone-outside-scale",
-  "note-diatonic-chord",
-]);
 
 /**
  * Fallback emphasis when no progression is active or no voice-leading
@@ -82,15 +71,11 @@ export function getEmphasis(
     return applyTonesBase(noteClass);
   }
 
-  const { notePc, nextGuideTones, nextGuideToneLabels, commonWithNext, leadInActive, planningActive } = leadContext;
+  const { notePc, nextGuideTones, nextGuideToneLabels, leadInActive, planningActive } = leadContext;
 
-  // The note's resting emphasis when not actively targeted — held common tones
-  // keep a gentle hold glow, everything else uses the base model. This is the
-  // size/shape a note shows OUTSIDE the lead-in window.
-  const resting: LensEmphasis =
-    CHORD_TONE_CLASSES.has(noteClass) && commonWithNext.has(notePc)
-      ? { radiusBoost: 1.15, opacityBoost: 1 }
-      : applyTonesBase(noteClass);
+  // The note's resting emphasis when not actively targeted — the base model.
+  // This is the size/shape a note shows OUTSIDE the lead-in window.
+  const resting: LensEmphasis = applyTonesBase(noteClass);
 
   // Landing: the next chord's guide tones get the urgent contracting ring.
   if (leadInActive && nextGuideTones.has(notePc)) {

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -465,6 +465,10 @@ export const activeChordTonesAtom = atom((get): Set<string> => {
  * Both sets use the same sharps convention so the intersection is reliable.
  * Returns an empty set when the progression is empty or the active step is
  * unresolvable.
+ *
+ * NOTE: retained as a reusable derived selector — it currently has no
+ * production consumer (the common-tone size boost that read it was removed),
+ * but is kept as the natural input for a future held-tone cue. Not dead code.
  */
 export const commonTonesWithNextAtom = atom((get): Set<string> => {
   const activeTones = get(activeChordTonesAtom);


### PR DESCRIPTION
## Summary

During progression playback the chord **root** bubble rendered disproportionately larger than sibling chord tones — and worse when the root was also the next chord's guide-tone target. Root cause: `getEmphasis()` gave every common tone a `1.15×` `radiusBoost`, applied as a CSS `scale()` on the whole note `<g>` (so it scaled the bubble **and** the guide-ring/label cluster). Roots are almost always common tones, and the match is by pitch class, so every root position on the neck inflated.

This removes the common-tone size boost (research **Approach A**): playback size now encodes only the existing chord-tier vs scale-tier distinction. The voice-leading "what's held / what's next" story is already carried by the guide-ring lead-in countdown, so nothing is lost. The now-dead `commonWithNext` plumbing is pruned end-to-end; `commonTonesWithNextAtom` is intentionally retained as a reusable selector (with a comment) for a possible future held-tone cue.

Changes:
- Remove the `1.15×` common-tone `radiusBoost`; simplify `resting` to the base model; delete the orphaned local `CHORD_TONE_CLASSES` set.
- Prune unused `commonWithNext` from `LeadLensContext`, `useEmphasisContext`, `useAnimatedFretboardView`, and test fixtures.
- Docs: research, design (Approach A), and implementation plan under `docs/superpowers/`.

## Test Plan

- [x] `pnpm run test` — full suite green (2411 passed)
- [x] `pnpm run lint` — clean (one pre-existing unrelated warning)
- [x] `pnpm run build` — succeeds
- [x] Rewrote the two emphasis tests to assert held common tones are **not** enlarged (`radiusBoost: 1`)
- [x] `pnpm run test:visual:update` — visual suite passes; **no snapshot changes** (specs capture static pre-playback states, so the playback-only boost was never in a baseline)

> Note: the visual suite does not cover the mid-playback emphasis state, so there is no snapshot proving the fix visually — it is covered by unit tests. A follow-up could add a mid-playback visual scene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed emphasis enlargement of common tones held between consecutive chords during voice-leading practice. The fretboard now displays a simplified emphasis baseline for non-target notes while maintaining guide-tone and planning indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->