### PR TITLE
feat(guide-tone): continuous countdown ring with beat-tick notches

### DIFF
--- a/docs/superpowers/plans/2026-06-07-guide-tone-countdown-ring.md
+++ b/docs/superpowers/plans/2026-06-07-guide-tone-countdown-ring.md
@@ -1,0 +1,1041 @@
+# Guide-Tone Countdown Ring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the two-phase breathe→drain guide-tone hint with one continuous clockwise drain over a single countdown window, plus static beat-tick notches on the halo track, so a player can read how much chord time remains.
+
+**Architecture:** A new single countdown window (`min(step, 2·bar)`) and `active` flag collapse today's planning + lead-in atoms for the animated ring. A pure tick-fraction function (capped at 4 segments) drives static notch positions, threaded as a prop to `FretboardNote`. CSS runs one `stroke-dashoffset` drain over `--guide-duration` with a brightness + gentle looming ramp; the existing on-beat flash stays as the climax. The change is additive first (new atoms/fields), then the emphasis pipeline switches to the single flag, then dead two-phase code is removed.
+
+**Tech Stack:** React 19 + TypeScript, Jotai atoms, CSS Modules, Vitest + Testing Library, Playwright visual regression. Package manager: **pnpm**.
+
+**Spec:** [docs/superpowers/specs/2026-06-07-guide-tone-countdown-ring-design.md](../specs/2026-06-07-guide-tone-countdown-ring-design.md)
+
+**Implementation note on the intensity ramp:** the spec calls for "stroke-width + brightness." The core ring's `stroke-width` is locked with `!important` (to beat the note-role descendant rules — see `FretboardSVG.module.css:250`), and CSS animations cannot override an `!important` declaration. So the escalation is implemented as **core brightness (opacity ramp) + a gentle whole-ring looming scale** on the ring group — same "increasing salience as the beat approaches" intent, no `!important` fight. This is the one deliberate deviation from the spec's literal wording.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `src/store/practiceLensAtoms.ts` | Window/tick pure math + countdown atoms | Modify |
+| `src/store/practiceLensAtoms.test.ts` | Unit tests for the above | Modify |
+| `src/components/FretboardSVG/hooks/useEmphasisContext.ts` | Atom→context bridge | Modify |
+| `src/components/FretboardSVG/utils/semantics.ts` | `getEmphasis` single-role logic + types | Modify |
+| `src/components/FretboardSVG/utils/semantics.test.ts` | `getEmphasis` tests | Modify |
+| `src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts` | Per-note `LeadLensContext` build | Modify |
+| `src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts` | Build tests | Modify |
+| `src/components/FretboardSVG/FretboardNote.tsx` | Single drain phase + notches + ramp | Modify |
+| `src/components/FretboardSVG/FretboardNote.test.tsx` | Note render tests | Modify |
+| `src/components/FretboardSVG/FretboardNoteLayer.tsx` | Thread `countdownTicks` prop | Modify |
+| `src/components/FretboardSVG/FretboardSVG.tsx` | `--guide-duration` var, ticks prop, phase attr | Modify |
+| `src/components/FretboardSVG/FretboardSVG.test.tsx` | Board-attr / CSS-var tests | Modify |
+| `src/components/FretboardSVG/FretboardSVG.module.css` | Single drain + ramp + tick styles | Modify |
+| `e2e/**` (fretboard-svg snapshots) | Visual regression baselines | Regenerate |
+
+---
+
+## Task 1: Pure window + tick math
+
+**Files:**
+- Modify: `src/store/practiceLensAtoms.ts` (add after `isInPlanningWindow`, ~line 174)
+- Test: `src/store/practiceLensAtoms.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/store/practiceLensAtoms.test.ts`. First extend the import on line 11 to include the two new symbols:
+
+```ts
+// add to the existing import from "./practiceLensAtoms":
+  isInCountdownWindow,
+  computeCountdownTickFractions,
+```
+
+Then append these `describe` blocks after the `isInPlanningWindow` block (after line 734):
+
+```ts
+// ---------------------------------------------------------------------------
+// isInCountdownWindow — single continuous countdown window
+// ---------------------------------------------------------------------------
+
+describe("isInCountdownWindow", () => {
+  it("is active across the whole step when step <= 2 bars", () => {
+    // step 2000, bar 2000: window = min(2000, 4000) = 2000 -> start fraction 0
+    expect(isInCountdownWindow(0, 2000, 2000)).toBe(true);
+    expect(isInCountdownWindow(0.99, 2000, 2000)).toBe(true);
+  });
+
+  it("caps the window at 2 bars for long chords", () => {
+    // step 8000, bar 2000: window = min(8000, 4000) = 4000 -> start fraction 0.5
+    expect(isInCountdownWindow(0.49, 8000, 2000)).toBe(false);
+    expect(isInCountdownWindow(0.5, 8000, 2000)).toBe(true);
+  });
+
+  it("returns false for a non-positive step duration", () => {
+    expect(isInCountdownWindow(0.5, 0, 2000)).toBe(false);
+    expect(isInCountdownWindow(0.5, -100, 2000)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeCountdownTickFractions — beat/bar boundary notches, capped at 4
+// ---------------------------------------------------------------------------
+
+describe("computeCountdownTickFractions", () => {
+  it("one tick per beat boundary when <= 4 beats", () => {
+    // 4 beats -> 4 segments -> interior ticks at 1/4, 2/4, 3/4
+    expect(computeCountdownTickFractions(4000, 1000, 4000)).toEqual([0.25, 0.5, 0.75]);
+  });
+
+  it("two beats yields a single midpoint tick", () => {
+    expect(computeCountdownTickFractions(2000, 1000, 4000)).toEqual([0.5]);
+  });
+
+  it("suppresses ticks below 2 beats", () => {
+    expect(computeCountdownTickFractions(1000, 1000, 4000)).toEqual([]);
+  });
+
+  it("collapses to bar boundaries when > 4 beats and bars in 2..4", () => {
+    // 8 beats, 2 bars -> segment by bar -> one tick at 0.5
+    expect(computeCountdownTickFractions(8000, 1000, 4000)).toEqual([0.5]);
+    // 12 beats, 3 bars -> ticks at 1/3, 2/3
+    expect(computeCountdownTickFractions(12000, 1000, 4000)).toEqual([1 / 3, 2 / 3]);
+  });
+
+  it("falls back to 4 even segments when bars also exceed 4", () => {
+    // 20 beats, 5 bars -> 4 even segments -> 0.25, 0.5, 0.75
+    expect(computeCountdownTickFractions(20000, 1000, 4000)).toEqual([0.25, 0.5, 0.75]);
+  });
+
+  it("returns [] for non-positive window or beat length", () => {
+    expect(computeCountdownTickFractions(0, 1000, 4000)).toEqual([]);
+    expect(computeCountdownTickFractions(4000, 0, 4000)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm run test src/store/practiceLensAtoms.test.ts -t "isInCountdownWindow"`
+Expected: FAIL — `isInCountdownWindow is not a function` / `computeCountdownTickFractions is not a function`.
+
+- [ ] **Step 3: Implement the two pure functions**
+
+In `src/store/practiceLensAtoms.ts`, insert after `isInPlanningWindow` (after line 174, before the `stepRelativeFraction` doc comment on line 176):
+
+```ts
+/**
+ * True when the playhead is inside the single continuous countdown window — the
+ * union of the old planning + landing windows. The window spans the final
+ * `min(step, PLANNING_RUNWAY_BARS · bar)` of the step and ends exactly on the
+ * beat. Pure so it is unit-testable without atom plumbing.
+ */
+export function isInCountdownWindow(
+  stepFraction: number,
+  stepDurationMs: number,
+  barDurationMs = Infinity,
+): boolean {
+  if (stepDurationMs <= 0) return false;
+  const windowMs = Math.min(stepDurationMs, PLANNING_RUNWAY_BARS * barDurationMs);
+  if (windowMs <= 0) return false;
+  const startFraction = 1 - windowMs / stepDurationMs;
+  return stepFraction >= startFraction;
+}
+
+/** Lowest beat count that shows interior ticks (a lone tick is noise). */
+const MIN_TICK_BEATS = 2;
+/** Subitizing cap — at most this many segments (≤ 3 interior ticks). */
+const MAX_TICK_SEGMENTS = 4;
+
+/**
+ * Window-fractions in (0,1) at which to draw static beat/bar boundary notches.
+ *
+ * - ≤ 4 beats → one segment per beat (subitizable at a glance).
+ * - > 4 beats → collapse to bar lines when there are 2–4 bars, else 4 even
+ *   segments (caps interior ticks at 3 — the ~4-object subitizing limit).
+ * - < 2 beats → no ticks.
+ *
+ * Pure so it is unit-testable. `windowMs`/`beatMs`/`barMs` are all in ms.
+ */
+export function computeCountdownTickFractions(
+  windowMs: number,
+  beatMs: number,
+  barMs: number,
+): number[] {
+  if (windowMs <= 0 || beatMs <= 0) return [];
+  const beats = Math.round(windowMs / beatMs);
+  if (beats < MIN_TICK_BEATS) return [];
+
+  let segments: number;
+  if (beats <= MAX_TICK_SEGMENTS) {
+    segments = beats;
+  } else {
+    const bars = barMs > 0 ? Math.round(windowMs / barMs) : 0;
+    segments = bars >= 2 && bars <= MAX_TICK_SEGMENTS ? bars : MAX_TICK_SEGMENTS;
+  }
+
+  const ticks: number[] = [];
+  for (let i = 1; i < segments; i++) ticks.push(i / segments);
+  return ticks;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm run test src/store/practiceLensAtoms.test.ts -t "isInCountdownWindow"` then `pnpm run test src/store/practiceLensAtoms.test.ts -t "computeCountdownTickFractions"`
+Expected: PASS for both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/practiceLensAtoms.ts src/store/practiceLensAtoms.test.ts
+git commit -m "feat(guide-tone): countdown window + tick-fraction pure math"
+```
+
+---
+
+## Task 2: Countdown atoms
+
+**Files:**
+- Modify: `src/store/practiceLensAtoms.ts` (add after `planningWindowActiveAtom`, ~line 665)
+- Test: `src/store/practiceLensAtoms.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend the import on line 11 of `src/store/practiceLensAtoms.test.ts` to add:
+
+```ts
+  guideCountdownWindowMsAtom,
+  guideCountdownActiveAtom,
+  guideCountdownTickFractionsAtom,
+```
+
+Append after the `transition perf budget` describe block (end of file). This reuses the existing `makePlayingStore` helper pattern (see lines 785–792) — copy a local helper into this block:
+
+```ts
+describe("guide countdown atoms", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  function makePlayingStore() {
+    const store = createStore();
+    const unsub = store.sub(progressionStepsAtom, () => {});
+    unsub();
+    store.set(progressionPlayingStateAtom, true);
+    return store;
+  }
+
+  it("guideCountdownWindowMsAtom = min(step, 2·bar)", () => {
+    const store = makePlayingStore();
+    const step = store.get(progressionStepDurationMsAtom);
+    const bar = store.get(progressionBarDurationMsAtom);
+    expect(store.get(guideCountdownWindowMsAtom)).toBe(Math.min(step, 2 * bar));
+  });
+
+  it("guideCountdownTickFractionsAtom matches the pure helper for the active step", () => {
+    const store = makePlayingStore();
+    const windowMs = store.get(guideCountdownWindowMsAtom);
+    const bar = store.get(progressionBarDurationMsAtom);
+    const beatsPerBar = store.get(beatsPerBarAtom);
+    const beatMs = beatsPerBar > 0 ? bar / beatsPerBar : 0;
+    expect(store.get(guideCountdownTickFractionsAtom)).toEqual(
+      computeCountdownTickFractions(windowMs, beatMs, bar),
+    );
+  });
+
+  it("guideCountdownActiveAtom is false outside the window and true inside", () => {
+    const store = makePlayingStore();
+    store.set(displayedStepIndexPrimitiveAtom, 0);
+    const stepMs = store.get(progressionStepDurationMsAtom);
+    const bar = store.get(progressionBarDurationMsAtom);
+    const windowMs = Math.min(stepMs, 2 * bar);
+    store.set(progressionVisualFrameAtom, { stepIndex: 0, globalFraction: 0.1, localFraction: 0.1, paused: false });
+
+    // Deadline far in the future → step barely started → outside the window.
+    store.set(progressionStepDeadlineAtom, Date.now() + windowMs + 1000);
+    expect(store.get(guideCountdownActiveAtom)).toBe(false);
+
+    // Deadline inside the window → active.
+    store.set(progressionStepDeadlineAtom, Date.now() + windowMs - 50);
+    expect(store.get(guideCountdownActiveAtom)).toBe(true);
+  });
+
+  it("guideCountdownActiveAtom holds across the boundary gap (audio ahead of displayed)", () => {
+    const store = makePlayingStore();
+    store.set(displayedStepIndexPrimitiveAtom, 0);
+    // Audio frame already on the next step while the fretboard still shows step 0.
+    store.set(progressionVisualFrameAtom, { stepIndex: 1, globalFraction: 0.0, localFraction: 0.0, paused: false });
+    expect(store.get(guideCountdownActiveAtom)).toBe(true);
+  });
+});
+```
+
+(`progressionStepsAtom`, `progressionPlayingStateAtom`, `displayedStepIndexPrimitiveAtom`, `progressionVisualFrameAtom`, `progressionStepDeadlineAtom`, `progressionStepDurationMsAtom`, `progressionBarDurationMsAtom`, `beatsPerBarAtom` are already imported at the top of this test file — they are used by the existing lead-in/perf blocks.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm run test src/store/practiceLensAtoms.test.ts -t "guide countdown atoms"`
+Expected: FAIL — the three atoms are not exported.
+
+- [ ] **Step 3: Implement the atoms**
+
+In `src/store/practiceLensAtoms.ts`, add after `planningWindowActiveAtom` (after line 665):
+
+```ts
+/**
+ * Length of the single continuous countdown window, in ms — `min(step, 2·bar)`.
+ * Written to the `--guide-duration` CSS custom property so the drain lasts
+ * exactly the window. Changes only when the active step / tempo changes.
+ */
+export const guideCountdownWindowMsAtom = atom((get): number => {
+  const step = get(progressionStepDurationMsAtom);
+  const bar = get(progressionBarDurationMsAtom);
+  return Math.min(step, PLANNING_RUNWAY_BARS * bar);
+});
+
+/**
+ * Window-fractions for the static beat-tick notches on the countdown ring.
+ * Derived from the countdown window and meter via
+ * {@link computeCountdownTickFractions}. Recomputes only on step/tempo/meter
+ * change — never per frame.
+ */
+export const guideCountdownTickFractionsAtom = atom((get): number[] => {
+  const windowMs = get(guideCountdownWindowMsAtom);
+  const bar = get(progressionBarDurationMsAtom);
+  const beatsPerBar = get(beatsPerBarAtom);
+  const beatMs = beatsPerBar > 0 ? bar / beatsPerBar : 0;
+  return computeCountdownTickFractions(windowMs, beatMs, bar);
+});
+
+/**
+ * Single continuous countdown phase — the union of the old planning + landing
+ * windows. True whenever the playhead is inside {@link isInCountdownWindow} for
+ * the active step, AND (like {@link leadInActiveAtom}) held true across the
+ * boundary-gap where the audio frame leads the displayed step. Reads the
+ * per-frame visual frame, but its VALUE only flips at the window threshold, so
+ * subscribers re-render at most twice per step.
+ */
+export const guideCountdownActiveAtom = atom((get): boolean => {
+  if (!get(progressionPlayingAtom)) return false;
+  const frame = get(progressionVisualFrameAtom);
+  if (!frame || frame.paused) return false;
+  const displayed = get(displayedProgressionStepIndexAtom);
+  // Boundary gap: audio has crossed into a later step than the fretboard shows —
+  // hold the ring on until the displayed shape catches up (same as lead-in).
+  if (frame.stepIndex !== displayed) return true;
+  // Only trust the step fraction when the deadline's step matches displayed.
+  if (get(activeProgressionStepIndexAtom) !== displayed) return false;
+  const deadline = get(progressionStepDeadlineAtom);
+  if (deadline == null) return false;
+  const stepMs = get(progressionStepDurationMsAtom);
+  const stepFraction = stepRelativeFraction(deadline, Date.now(), stepMs);
+  return isInCountdownWindow(stepFraction, stepMs, get(progressionBarDurationMsAtom));
+});
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm run test src/store/practiceLensAtoms.test.ts -t "guide countdown atoms"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/practiceLensAtoms.ts src/store/practiceLensAtoms.test.ts
+git commit -m "feat(guide-tone): countdown window/active/tick atoms"
+```
+
+---
+
+## Task 3: Expose countdown fields on the emphasis context (additive)
+
+**Files:**
+- Modify: `src/components/FretboardSVG/hooks/useEmphasisContext.ts`
+
+This task is additive — it adds `guideCountdownActive` + `countdownTicks` to `EmphasisContext` while leaving `leadInActive`/`planningActive` in place, so the codebase still compiles. The switch happens in Task 4.
+
+- [ ] **Step 1: Add the new atoms to the imports**
+
+In `src/components/FretboardSVG/hooks/useEmphasisContext.ts`, extend the import block (lines 2–10):
+
+```ts
+import {
+  nextChordGuideTonesAtom,
+  nextChordGuideToneLabelsAtom,
+  nextChordTonesAtom,
+  incomingTonesAtom,
+  departingTonesAtom,
+  leadInActiveAtom,
+  planningWindowActiveAtom,
+  guideCountdownActiveAtom,
+  guideCountdownTickFractionsAtom,
+} from "../../../store/practiceLensAtoms";
+```
+
+- [ ] **Step 2: Extend the interface and the returned object**
+
+Replace the `EmphasisContext` interface (lines 13–21) with:
+
+```ts
+export interface EmphasisContext {
+  nextGuideTones: Set<string>;
+  nextGuideToneLabels: Map<string, string>;
+  nextChordTones: Set<string>;
+  incomingTones: Set<string>;
+  departingTones: Set<string>;
+  leadInActive: boolean;
+  planningActive: boolean;
+  guideCountdownActive: boolean;
+  countdownTicks: number[];
+}
+```
+
+Replace the body of `useEmphasisContext` (lines 28–47) with:
+
+```ts
+export function useEmphasisContext(enabled: boolean): EmphasisContext | null {
+  const playing = useAtomValue(progressionPlayingAtom);
+  const leadInActive = useAtomValue(leadInActiveAtom);
+  const planningActive = useAtomValue(planningWindowActiveAtom);
+  const guideCountdownActive = useAtomValue(guideCountdownActiveAtom);
+  const countdownTicks = useAtomValue(guideCountdownTickFractionsAtom);
+  const nextGuideTones = useAtomValue(nextChordGuideTonesAtom);
+  const nextGuideToneLabels = useAtomValue(nextChordGuideToneLabelsAtom);
+  const nextChordTones = useAtomValue(nextChordTonesAtom);
+  const incomingTones = useAtomValue(incomingTonesAtom);
+  const departingTones = useAtomValue(departingTonesAtom);
+  if (!enabled || !playing) return null;
+  return {
+    nextGuideTones,
+    nextGuideToneLabels,
+    nextChordTones,
+    incomingTones,
+    departingTones,
+    leadInActive,
+    planningActive,
+    guideCountdownActive,
+    countdownTicks,
+  };
+}
+```
+
+- [ ] **Step 3: Verify the project still type-checks**
+
+Run: `pnpm run test src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts`
+Expected: PASS (existing tests still green — the new fields are optional additions consumers don't yet read).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/FretboardSVG/hooks/useEmphasisContext.ts
+git commit -m "feat(guide-tone): expose countdown active + ticks on emphasis context"
+```
+
+---
+
+## Task 4: Switch `getEmphasis` to the single countdown role
+
+**Files:**
+- Modify: `src/components/FretboardSVG/utils/semantics.ts`
+- Modify: `src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts`
+- Test: `src/components/FretboardSVG/utils/semantics.test.ts`
+- Test: `src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts`
+
+- [ ] **Step 1: Update the failing tests first**
+
+In `src/components/FretboardSVG/utils/semantics.test.ts`, find the test at line 468 (`marks a next-chord guide tone as 'guide-preview' during the planning window`). Replace that test — and adjust any sibling test that passes `leadInActive`/`planningActive` — so the context uses the new single flag. The replacement test:
+
+```ts
+it("marks a next-chord guide tone as 'guide-target' during the countdown window", () => {
+  const e = getEmphasis("chord-tone-in-scale", true, {
+    notePc: "B",
+    nextGuideTones: new Set(["B"]),
+    nextGuideToneLabels: new Map([["B", "3"]]),
+    nextChordTones: new Set(["B", "D", "G"]),
+    incomingTones: new Set(["B"]),
+    departingTones: new Set(),
+    guideCountdownActive: true,
+  });
+  expect(e.transitionRole).toBe("guide-target");
+  expect(e.guideTargetLabel).toBe("3");
+});
+
+it("returns the resting emphasis when the countdown window is inactive", () => {
+  const e = getEmphasis("chord-tone-in-scale", true, {
+    notePc: "B",
+    nextGuideTones: new Set(["B"]),
+    nextGuideToneLabels: new Map([["B", "3"]]),
+    nextChordTones: new Set(["B", "D", "G"]),
+    incomingTones: new Set(["B"]),
+    departingTones: new Set(),
+    guideCountdownActive: false,
+  });
+  expect(e.transitionRole).toBeUndefined();
+});
+```
+
+Search the rest of `semantics.test.ts` for any other object literal that sets `leadInActive:` or `planningActive:` and replace those keys with `guideCountdownActive:` (true where either was true).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm run test src/components/FretboardSVG/utils/semantics.test.ts`
+Expected: FAIL — `LeadLensContext` still requires `leadInActive`/`planningActive`; `guideCountdownActive` is not a known property.
+
+- [ ] **Step 3: Update `LeadLensContext` and `getEmphasis`**
+
+In `src/components/FretboardSVG/utils/semantics.ts`, replace the two phase fields in `LeadLensContext` (lines 39–42):
+
+```ts
+  /** True while the single continuous countdown window is open. */
+  guideCountdownActive: boolean;
+```
+
+Replace the body of `getEmphasis` after the `if (!leadContext)` guard (lines 71–96) with:
+
+```ts
+  const { notePc, nextGuideTones, nextGuideToneLabels, guideCountdownActive } = leadContext;
+
+  // The note's resting emphasis when not actively targeted — the base model.
+  const resting: LensEmphasis = applyTonesBase(noteClass);
+
+  // Countdown: the next chord's guide tones get the single continuous ring.
+  if (guideCountdownActive && nextGuideTones.has(notePc)) {
+    return {
+      radiusBoost: resting.radiusBoost,
+      opacityBoost: 1,
+      transitionRole: "guide-target",
+      guideTargetLabel: nextGuideToneLabels.get(notePc),
+    };
+  }
+  return resting;
+```
+
+Leave `TransitionRole` (line 9) as `"guide-target" | "guide-preview"` for now — `"guide-preview"` becomes unused but the union stays valid; it is removed in Task 8.
+
+- [ ] **Step 4: Update the per-note context build**
+
+In `src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts`, replace the `leadContext` assignment (lines 43–52) with:
+
+```ts
+      leadContext = {
+        notePc: note.noteName,
+        nextGuideTones: emphasisContext.nextGuideTones,
+        nextGuideToneLabels: emphasisContext.nextGuideToneLabels,
+        nextChordTones: emphasisContext.nextChordTones,
+        incomingTones: emphasisContext.incomingTones,
+        departingTones: emphasisContext.departingTones,
+        guideCountdownActive: emphasisContext.guideCountdownActive,
+      };
+```
+
+- [ ] **Step 5: Update any build-test that sets the old flags**
+
+In `src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts`, search for `leadInActive`/`planningActive` in any `EmphasisContext` literal and replace with `guideCountdownActive` (and add `countdownTicks: []` if the literal is a full `EmphasisContext`). Run the file to see exact failures:
+
+Run: `pnpm run test src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts`
+Expected before fix: FAIL (type/shape mismatch). Fix each literal, then re-run.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pnpm run test src/components/FretboardSVG/utils/semantics.test.ts src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/FretboardSVG/utils/semantics.ts src/components/FretboardSVG/utils/semantics.test.ts src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts
+git commit -m "feat(guide-tone): single countdown role in getEmphasis"
+```
+
+---
+
+## Task 5: FretboardNote — single drain phase + notches + `countdownTicks` prop
+
+**Files:**
+- Modify: `src/components/FretboardSVG/FretboardNote.tsx`
+- Modify: `src/components/FretboardSVG/FretboardNoteLayer.tsx`
+- Test: `src/components/FretboardSVG/FretboardNote.test.tsx`
+
+- [ ] **Step 1: Update the failing tests first**
+
+In `src/components/FretboardSVG/FretboardNote.test.tsx`:
+
+Replace the `guide-preview` ring test (lines 145–155) with a notch-rendering test, and update the backing test (lines 195–199). Replace those two tests with:
+
+```ts
+  it("renders no ring for a note without a transition role", () => {
+    const { container } = renderNote(makeNote({ transitionRole: undefined }));
+    expect(container.querySelector("[data-guide-ring]")).toBeNull();
+  });
+
+  it("renders beat-tick notches for a primary guide-target note when ticks are provided", () => {
+    const { container } = renderNote(
+      makeNote({ transitionRole: "guide-target", isInRegion: true }),
+      { countdownTicks: [0.25, 0.5, 0.75] },
+    );
+    expect(container.querySelectorAll("[data-guide-tick]")).toHaveLength(3);
+  });
+
+  it("renders no notches for a secondary (out-of-region) guide-target note", () => {
+    const { container } = renderNote(
+      makeNote({ transitionRole: "guide-target", isInRegion: false }),
+      { countdownTicks: [0.25, 0.5, 0.75] },
+    );
+    expect(container.querySelectorAll("[data-guide-tick]")).toHaveLength(0);
+  });
+```
+
+Find the `renderNote` helper near the top of the file. It currently renders `<FretboardNote note={...} .../>` inside an `<svg>`. Add an optional second argument so tests can pass `countdownTicks`:
+
+```ts
+  function renderNote(
+    note: RenderedFretboardNote,
+    extra?: { countdownTicks?: number[] },
+  ) {
+    return render(
+      <svg>
+        <FretboardNote
+          note={note}
+          noteBubblePx={24}
+          displayFormat="notes"
+          countdownTicks={extra?.countdownTicks}
+        />
+      </svg>,
+    );
+  }
+```
+
+(If the existing helper signature differs, adapt — the key change is forwarding `countdownTicks`.) Also confirm `makeNote` supports an `isInRegion` field; it is part of `RenderedFretboardNote`, so add `isInRegion: false` to the `makeNote` defaults if missing, and allow overrides.
+
+Update the landing test at line 157 to also assert `data-guide-phase='landing'` still holds for `guide-target` (unchanged behavior). The test at line 145 referencing `'preview'` is the one being replaced above.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm run test src/components/FretboardSVG/FretboardNote.test.tsx`
+Expected: FAIL — `countdownTicks` is not a prop; no `[data-guide-tick]` elements.
+
+- [ ] **Step 3: Add the prop + collapse the phase mapping**
+
+In `src/components/FretboardSVG/FretboardNote.tsx`:
+
+Add to `FretboardNoteProps` (after line 38, before `onNoteClick`):
+
+```ts
+  /** Window-fractions (0,1) for static beat-tick notches on the countdown ring. */
+  countdownTicks?: number[];
+```
+
+Add `countdownTicks` to the destructured params (after `numStrings,` on line 47):
+
+```ts
+  countdownTicks,
+```
+
+Replace the `guidePhase` computation (lines 71–76) with the single-role mapping:
+
+```ts
+  const guidePhase = transitionRole === "guide-target" ? "landing" : undefined;
+```
+
+Add a tick-length constant near the top of the file (after the `formatRole` definition, ~line 28):
+
+```ts
+// Arc length (in pathLength=100 units) of a single tick notch on the ring.
+const TICK_ARC_LEN = 1.2;
+```
+
+- [ ] **Step 4: Render the notches inside the ring group**
+
+In `FretboardNote.tsx`, inside the `<motion.g>` ring group, after the flash `<circle>` (line 226) and before the closing `</motion.g>` (line 227), add:
+
+```tsx
+            {/* Static beat-tick notches — dark pips on the halo track that the
+                green core sweeps past, giving a countable "segment done" read.
+                Only on PRIMARY (in-region) targets, and only when the step has
+                enough beats to warrant ticks (countdownTicks empty otherwise).
+                Drawn with the SAME pathLength=100 circle parametrization as the
+                drain so each notch sits exactly where the hand is at that
+                window-fraction — no trig, no origin/direction mismatch.
+                NOTE: if a snapshot shows the notches mirrored relative to the
+                drain hand, flip the sign of strokeDashoffset (use `100 * f`). */}
+            {note.isInRegion &&
+              countdownTicks?.map((f, i) => (
+                <circle
+                  key={`tick-${i}`}
+                  className={styles["note-guide-ring-tick"]}
+                  data-guide-tick="true"
+                  cx={cx}
+                  cy={cy}
+                  r={ringR}
+                  pathLength={100}
+                  strokeDasharray={`${TICK_ARC_LEN} ${100 - TICK_ARC_LEN}`}
+                  strokeDashoffset={-100 * f}
+                  aria-hidden="true"
+                />
+              ))}
+```
+
+- [ ] **Step 5: Thread the prop through the layer**
+
+In `src/components/FretboardSVG/FretboardNoteLayer.tsx`:
+
+Add to `FretboardNoteLayerProps` (after line 14):
+
+```ts
+  /** Window-fractions for the countdown ring's beat-tick notches. */
+  countdownTicks?: number[];
+```
+
+Add `countdownTicks` to the destructured props (after `numStrings,` on line 29):
+
+```ts
+  countdownTicks,
+```
+
+Pass it to each `FretboardNote` (inside the map, after `numStrings={numStrings}` on line 43):
+
+```tsx
+        countdownTicks={countdownTicks}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pnpm run test src/components/FretboardSVG/FretboardNote.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/FretboardSVG/FretboardNote.tsx src/components/FretboardSVG/FretboardNoteLayer.tsx src/components/FretboardSVG/FretboardNote.test.tsx
+git commit -m "feat(guide-tone): single drain phase + beat-tick notches in FretboardNote"
+```
+
+---
+
+## Task 6: FretboardSVG — `--guide-duration`, ticks prop, phase attr
+
+**Files:**
+- Modify: `src/components/FretboardSVG/FretboardSVG.tsx`
+- Test: `src/components/FretboardSVG/FretboardSVG.test.tsx`
+
+- [ ] **Step 1: Update the failing tests first**
+
+In `src/components/FretboardSVG/FretboardSVG.test.tsx`, update the two tests at lines 851–887. The board now exposes `--guide-duration` and `data-transition-phase="countdown"` while the countdown window is active. Replace those tests:
+
+```ts
+    it("exposes --guide-duration and data-transition-phase during the countdown window", () => {
+      // (Keep the same store/frame/deadline setup the original test used to put
+      // the playhead inside the window — only the assertions change.)
+      const board = screen.getByTestId("fretboard-svg");
+      expect(board.style.getPropertyValue("--guide-duration")).toMatch(/\d+ms/);
+      expect(board.getAttribute("data-transition-phase")).toBe("countdown");
+    });
+
+    it("data-transition-phase is absent when the playhead is outside the countdown window", () => {
+      // (Same setup as the original "outside the lead-in window" test.)
+      const board = screen.getByTestId("fretboard-svg");
+      expect(board.getAttribute("data-transition-phase")).toBeNull();
+    });
+```
+
+Keep the existing arrange/setup lines from the original two tests (the store seeding that drives `guideCountdownActiveAtom` true/false) — only swap the assertions and the test titles. If the original setup drove `leadInActiveAtom` via deadline inside the 50% window, that same setup also puts the playhead inside the countdown window (the countdown window is a superset), so the "active" test stays valid. For the "outside" test, ensure the deadline is far enough out that `isInCountdownWindow` is false (deadline > now + 2·bar).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm run test src/components/FretboardSVG/FretboardSVG.test.tsx -t "data-transition-phase"`
+Expected: FAIL — board still emits `--lead-in-duration` / `"lead-in"`.
+
+- [ ] **Step 3: Swap the atom wiring**
+
+In `src/components/FretboardSVG/FretboardSVG.tsx`:
+
+Replace the import on line 11:
+
+```ts
+import { guideCountdownActiveAtom, guideCountdownWindowMsAtom, guideCountdownTickFractionsAtom } from "../../store/practiceLensAtoms";
+```
+
+Replace the two `useAtomValue` lines (323–324) with:
+
+```ts
+  const guideCountdownActive = useAtomValue(guideCountdownActiveAtom);
+  const guideCountdownWindowMs = useAtomValue(guideCountdownWindowMsAtom);
+  const countdownTicks = useAtomValue(guideCountdownTickFractionsAtom);
+```
+
+Find every other use of `leadInActive` in this file (it previously came from `leadInActiveAtom`). The board attribute on line 611 used `leadInActive`; replace line 611 with:
+
+```tsx
+      data-transition-phase={guideCountdownActive ? "countdown" : undefined}
+```
+
+Replace the style block (lines 613–616) with:
+
+```tsx
+      style={{
+        "--guide-duration": `${guideCountdownWindowMs}ms`,
+      } as CSSProperties}
+```
+
+Pass ticks to the note layer — in the `<FretboardNoteLayer .../>` (lines 697–705), add after `numStrings={numStrings}`:
+
+```tsx
+                    countdownTicks={countdownTicks}
+```
+
+- [ ] **Step 4: Resolve any remaining `leadInActive` references**
+
+Run: `grep -n "leadInActive\|leadInDurationMs\|planningDurationMs\|lead-in-duration\|planning-duration" src/components/FretboardSVG/FretboardSVG.tsx`
+Expected: no matches. If any remain (e.g. an unused import of `leadInDurationMsAtom`/`planningDurationMsAtom`), delete them.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm run test src/components/FretboardSVG/FretboardSVG.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/FretboardSVG/FretboardSVG.tsx src/components/FretboardSVG/FretboardSVG.test.tsx
+git commit -m "feat(guide-tone): drive countdown ring from single window in FretboardSVG"
+```
+
+---
+
+## Task 7: CSS — single continuous drain + ramp + tick notches
+
+**Files:**
+- Modify: `src/components/FretboardSVG/FretboardSVG.module.css`
+
+No new unit test (CSS behavior is covered by the visual regression suite in Task 9). Each step is a concrete edit.
+
+- [ ] **Step 1: Point the backing disc at the single phase**
+
+Replace the two backing rules (lines 227–233) with one (the `preview` phase no longer exists):
+
+```css
+.note-target-backing[data-guide-phase="landing"] {
+  opacity: 0.52;
+}
+```
+
+- [ ] **Step 2: Remove the breathe, run one drain over the full window**
+
+Delete the planning/breathe rule and keyframes (lines 281–298). Replace the landing core rule (lines 300–309) with a continuous drain plus a brightness ramp over `--guide-duration`:
+
+```css
+/* Countdown — the green core DRAINS clockwise around the dark halo track, like
+   a clock hand, over the WHOLE countdown window, reaching empty exactly on the
+   beat. A brightness (opacity) ramp escalates salience as the beat nears; the
+   stroke weight stays constant (its `!important` lock can't be animated). The
+   on-beat flash is the climax. `pathLength=100` (set in FretboardNote) lets the
+   dash maths be radius-independent. */
+.note-guide-ring[data-guide-phase="landing"][data-guide-primary="true"] .note-guide-ring-core {
+  stroke-dasharray: 100;
+  animation:
+    note-guide-ring-drain var(--guide-duration, 4s) linear both,
+    note-guide-ring-ramp var(--guide-duration, 4s) ease-in both;
+}
+
+@keyframes note-guide-ring-drain {
+  from { stroke-dashoffset: 0; }
+  to   { stroke-dashoffset: 100; }
+}
+
+@keyframes note-guide-ring-ramp {
+  0%   { opacity: 0.72; }
+  70%  { opacity: 0.88; }
+  100% { opacity: 1; }
+}
+```
+
+- [ ] **Step 3: Add the looming scale on the ring group**
+
+After the core rule above, add a gentle whole-ring looming scale over the window (composited transform — cheap). The ring group already has `transform-box: fill-box; transform-origin: center`:
+
+```css
+/* Looming — the whole countdown ring scales up very slightly across the window
+   so the target reads as "approaching" (increasing-salience cue). Transform is
+   GPU-composited, so this adds no per-frame paint. */
+.note-guide-ring[data-guide-phase="landing"][data-guide-primary="true"] {
+  animation: note-guide-ring-loom var(--guide-duration, 4s) ease-in both;
+}
+
+@keyframes note-guide-ring-loom {
+  from { transform: scale(1); }
+  to   { transform: scale(1.06); }
+}
+```
+
+- [ ] **Step 4: Style the tick notches**
+
+After the flash rules (after line 338), add:
+
+```css
+/* Beat-tick notches — short dark pips on the halo track at beat/bar
+   boundaries. Drawn over the halo + core so they read as gauge marks the green
+   hand sweeps past. Static (no animation) → zero per-frame paint. Stroke wider
+   than the halo so each pip visibly crosses the whole track. */
+.note-guide-ring-tick {
+  fill: none !important;
+  stroke: rgb(0 0 0 / 0.7) !important;
+  stroke-width: 5.5 !important;
+  pointer-events: none;
+}
+```
+
+- [ ] **Step 5: Update reduced-motion**
+
+Replace the reduced-motion block (lines 342–348) so it also kills the ramp + loom, and keeps the ticks as a static gauge over a full (non-draining) ring:
+
+```css
+/* Reduced motion: no drain, no ramp, no loom, no flash — a static full ring
+   plus static tick notches still marks the target and conveys the beat grid;
+   only the live countdown motion is dropped. */
+@media (prefers-reduced-motion: reduce) {
+  .note-guide-ring[data-guide-phase="landing"][data-guide-primary="true"],
+  .note-guide-ring[data-guide-phase="landing"] .note-guide-ring-core,
+  .note-guide-ring[data-guide-phase="landing"] .note-guide-ring-flash {
+    animation: none;
+  }
+}
+```
+
+- [ ] **Step 6: Verify no stale `--planning-duration` / breathe references remain**
+
+Run: `grep -n "planning-duration\|breathe\|guide-preview\|data-guide-phase=\"preview\"" src/components/FretboardSVG/FretboardSVG.module.css`
+Expected: no matches.
+
+- [ ] **Step 7: Lint the stylesheet + run the component tests**
+
+Run: `pnpm run lint`
+Expected: PASS (eslint + stylelint).
+
+Run: `pnpm run test src/components/FretboardSVG/FretboardNote.test.tsx src/components/FretboardSVG/FretboardSVG.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/FretboardSVG/FretboardSVG.module.css
+git commit -m "feat(guide-tone): continuous drain + brightness/loom ramp + tick notch CSS"
+```
+
+---
+
+## Task 8: Cleanup — remove dead two-phase code
+
+**Files:**
+- Modify: `src/components/FretboardSVG/utils/semantics.ts`
+- Modify: `src/components/FretboardSVG/hooks/useEmphasisContext.ts`
+- Modify: `src/components/FretboardSVG/FretboardNote.tsx`
+- Modify: tests touched below
+
+This removes the now-unused `guide-preview` role and the `leadInActive`/`planningActive` context fields. Do this only after confirming nothing else consumes them.
+
+- [ ] **Step 1: Confirm the old symbols are unused outside their definitions**
+
+Run:
+```bash
+grep -rn "guide-preview\|planningActive\|\bleadInActive\b" src/components --include='*.ts' --include='*.tsx' | grep -v ".test."
+```
+Expected: matches only in the files listed for this task (definitions about to be removed). `leadInActiveAtom`, `planningWindowActiveAtom`, `leadInDurationMsAtom`, `planningDurationMsAtom` remain defined in `practiceLensAtoms.ts` with their own tests — leave those atoms in place (they are still independently tested and harmless); this task only removes the *component-layer* consumption.
+
+- [ ] **Step 2: Remove `guide-preview` from the type and phase mapping**
+
+In `src/components/FretboardSVG/utils/semantics.ts`, change line 9:
+
+```ts
+export type TransitionRole = "guide-target";
+```
+
+In `src/components/FretboardSVG/FretboardNote.tsx`, confirm `guidePhase` (now `transitionRole === "guide-target" ? "landing" : undefined`) has no remaining `"guide-preview"` reference (it was already collapsed in Task 5). Run: `grep -n "guide-preview" src/components/FretboardSVG/FretboardNote.tsx` → expect no matches.
+
+- [ ] **Step 3: Drop the unused context fields**
+
+In `src/components/FretboardSVG/hooks/useEmphasisContext.ts`:
+- Remove `leadInActive` and `planningActive` from the `EmphasisContext` interface.
+- Remove their `useAtomValue` reads and their keys in the returned object.
+- Remove `leadInActiveAtom` and `planningWindowActiveAtom` from the import.
+
+- [ ] **Step 4: Remove any test references to the dropped fields**
+
+Run:
+```bash
+grep -rn "planningActive\|leadInActive\b" src/components/FretboardSVG --include='*.test.ts' --include='*.test.tsx'
+```
+For each match in `useEmphasisContext`/`useAnimatedFretboardView`/`semantics` tests, delete the field from the `EmphasisContext`/`LeadLensContext` literal (the `guideCountdownActive` field already replaces them from Tasks 3–4).
+
+- [ ] **Step 5: Run the affected suites**
+
+Run: `pnpm run test src/components/FretboardSVG`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/FretboardSVG
+git commit -m "refactor(guide-tone): remove dead two-phase preview machinery"
+```
+
+---
+
+## Task 9: Visual regression + full verification
+
+**Files:**
+- Regenerate: `e2e/**` darwin snapshots for the `fretboard-svg` suite
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `pnpm run test`
+Expected: PASS (entire suite green).
+
+- [ ] **Step 2: Lint**
+
+Run: `pnpm run lint`
+Expected: PASS.
+
+- [ ] **Step 3: Build**
+
+Run: `pnpm run build`
+Expected: `tsc -b` + `vite build` succeed with no type errors.
+
+- [ ] **Step 4: Refresh darwin visual snapshots**
+
+The guide ring's rendered output changed (single drain, ticks, ramp), so the committed fretboard snapshots will differ intentionally.
+
+Run: `pnpm run test:visual:update`
+Expected: updated PNG baselines under the `fretboard-svg` (and any overlay) suites.
+
+- [ ] **Step 5: Re-run the visual suite to confirm green against the new baselines**
+
+Run: `pnpm run test:visual`
+Expected: PASS.
+
+- [ ] **Step 6: Review the snapshot diffs by eye**
+
+Open the changed snapshot PNGs (git diff shows them) and confirm: the next chord's guide tones show a single green drain over the whole chord, dark tick notches divide the ring at beat boundaries (≤ 3 interior ticks), and the on-beat flash still fires. No leftover breathing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add e2e
+git commit -m "test(guide-tone): refresh fretboard visual snapshots for countdown ring"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check:**
+- Behavior (single drain + ticks, secondary unchanged) → Tasks 4, 5, 7. ✓
+- Window `min(step, 2·bar)` + collapsed flag → Tasks 1, 2. ✓
+- Ticks (angle from time-fraction, adaptive cap 4, <2-beat suppression, static, derived in atoms) → Tasks 1, 2, 5. ✓
+- Intensity ramp (escalate, gentle early) → Task 7 (brightness + loom; stroke-width deviation documented in header). ✓
+- Edge cases: reduced-motion → Task 7 Step 5; short step (no ticks) → Task 1 (`< 2 beats → []`); meter → Task 1 (bar/beat collapse); secondary targets → Task 5 (`note.isInRegion` gate). ✓
+- Performance (per-frame ≈ one drain; ticks static; loom composited) → Tasks 5, 7. ✓
+- Files touched list → matches the File Structure table. ✓
+- Testing (window/tick unit tests, visual refresh, reduced-motion) → Tasks 1, 2, 9. ✓
+
+**Type consistency:** `guideCountdownActive` used identically across `EmphasisContext`, `LeadLensContext`, and atoms. `countdownTicks: number[]` flows `guideCountdownTickFractionsAtom` → `EmphasisContext`/FretboardSVG prop → `FretboardNoteLayer` → `FretboardNote`. `TransitionRole` narrows to `"guide-target"` only in Task 8 (after all `"guide-preview"` emitters are gone). CSS var renamed `--lead-in-duration`/`--planning-duration` → `--guide-duration` consistently in Tasks 6 (set) and 7 (consume).

--- a/docs/superpowers/specs/2026-06-07-guide-tone-countdown-ring-design.md
+++ b/docs/superpowers/specs/2026-06-07-guide-tone-countdown-ring-design.md
@@ -1,0 +1,180 @@
+# Guide-Tone Countdown Ring — Design
+
+**Date:** 2026-06-07
+**Status:** Approved (design); pending implementation plan
+**Supersedes:** the two-phase breathe→drain model in
+[2026-06-05-guide-tone-planning-preview-design.md](2026-06-05-guide-tone-planning-preview-design.md)
+
+## Problem
+
+The guide-tone hint marks the next chord's guide tones (3rd, 7th) with a ring
+on the fretboard. Today it runs two phases on primary (in-region) targets:
+
+1. **Planning ("preview"):** a green ring that *breathes* on opacity over the
+   runway before the change.
+2. **Landing ("lead-in"):** the green core *drains* clockwise (like a clock
+   hand) to empty exactly on the beat, with an on-beat flash.
+
+The breathing phase does not convey *when* the change lands — it only signals
+"a change is coming." Only the drain conveys timing, and it covers just the
+final ~50% of the step (floored at 600 ms). Players get no readable countdown
+for the early part of the chord, so they cannot plan a phrase against the clock.
+
+## Goal
+
+Convey timing clearly across the whole chord, so a player can read how much
+time remains and plan a phrase — without a meaningful performance regression.
+
+## Approach (chosen: Hybrid "C")
+
+Replace breathe→drain on primary targets with **one continuous clockwise drain**
+over a single countdown window, plus **static beat-tick notches** on the dark
+halo track. The arc sweeping past each notch gives a countable "segment done"
+read with zero extra animation. The existing on-beat flash remains as the
+climax. Secondary (out-of-region) targets are unchanged: quiet static rings.
+
+### Alternatives considered
+
+- **A — single continuous drain only (idea #2 pure).** Cleanest, lowest node
+  count, but at slow tempo a long arc creeps almost imperceptibly early on —
+  weak "how much time left" read in the first half. Rejected: ticks fix the
+  slow-creep read for negligible cost.
+- **B — segmented / multi-bar drains (idea #1 pure).** Most countable, but most
+  nodes + sequencing logic, and the research shows discrete timers *lower*
+  perceived urgency near the beat — the opposite of what's wanted at landing.
+  Rejected.
+
+## Research basis
+
+**Performance.** SVG `stroke-dashoffset` (the drain) is a CPU repaint every
+frame — not GPU-composited — though repaint-only (no layout), so cheap per
+ring. `opacity`/`transform` are composited and near-free. The drain cost scales
+with how long it runs × how many rings animate at once. Static ticks never
+repaint, so segmentation's countability can be had without segmentation's
+animation cost.
+- [High CPU when animating stroke-dashoffset (Chromium)](https://bugs.chromium.org/p/chromium/issues/detail?id=167569)
+- [Hardware-accelerated animations (Chrome for Developers)](https://developer.chrome.com/blog/hardware-accelerated-animations)
+
+**Continuous vs. segmented timers.** Continuous timers read as *more urgent*;
+discrete/segmented timers read as *more countable* but less urgent. A heavily
+animated interval feels *longer* (filled-duration illusion). A continuous
+countdown needs a sharp coincidence event at the target — handled by the
+existing on-beat flash.
+- [Discrete vs. continuous timer bars (JOV)](https://jov.arvojournals.org/article.aspx?articleid=2809850)
+- [Countdown timer speed trade-off (ACM TOCHI)](https://dl.acm.org/doi/10.1145/3380961)
+- [Malleability of time through progress bars (PMC)](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9213475/)
+
+**Tick density.** Counting "at a glance" without scanning (subitizing) holds
+only to ~3–4 items; beyond that the eye scans/counts. Matches the ~4
+simultaneous-clock limit (Gu et al. 2014) already cited in the code. → cap
+ticks at 4.
+- [Subitizing (Wikipedia)](https://en.wikipedia.org/wiki/Subitizing)
+- [Subitizing vs. counting attention (Springer)](https://link.springer.com/article/10.3758/BF03205493)
+
+**Intensity ramp.** Looming / increasing-intensity cues capture attention and
+raise perceived urgency more than static or dimming cues, and the late benefit
+comes specifically from the rising intensity profile. Caveat: maxing salience
+too early *hurts* reaction time (a "sweet spot" trade-off). → ramp modestly
+early, reserve peak for the final lead-in + flash.
+- [Looming cue urgency (ScienceDirect)](https://www.sciencedirect.com/science/article/pii/S2405844023102611)
+- [Auditory looming late benefit (Scientific Reports)](https://www.nature.com/articles/s41598-018-36033-8)
+- [High salience can slow RT (Scientific Reports)](https://www.nature.com/articles/s41598-024-58953-4)
+
+**Tick style.** No direct study; grounded in the codebase's own constraints +
+alert-contrast research: the dark halo exists specifically for legibility over
+any wood, and the ring must stay distinct from note markers. Radial notches
+cut across the high-contrast halo → read as a gauge the arc sweeps. Dots on the
+core path risk reading as note markers; gaps in the halo erase its contrast job
+exactly at the boundaries.
+
+## Detailed design
+
+### 1. Behavior
+
+Primary (in-region) guide targets show one continuous clockwise drain over a
+single countdown window, with static beat-tick notches on the halo track and
+the existing on-beat flash as the climax. Secondary (out-of-region) targets are
+unchanged — quiet static rings at reduced opacity, no drain, no ticks.
+
+### 2. Countdown window
+
+The drain spans a single window ending exactly on the beat, of length
+`min(step, PLANNING_RUNWAY_BARS × bar)` — reusing today's planning + lead-in
+window math. Normal chords (≤ 2 bars) get a "whole chord" countdown; very long
+chords stay capped so the drain never starts absurdly early.
+
+New atoms collapse today's `planningWindowActiveAtom` / `leadInActiveAtom` into
+a single window for primary targets:
+
+- `guideCountdownWindowMsAtom` — window length in ms (the `min(...)` above).
+- `guideCountdownActiveAtom` — true while the playhead is inside that window.
+
+`leadInActiveAtom` / `planningWindowActiveAtom` and their durations may be
+retired for primary-target rendering once the single window replaces them;
+confirm no other consumer depends on the split before removing.
+
+### 3. Beat-tick notches
+
+Notch positions = beat boundaries inside the window, expressed as a time
+fraction → angle on the ring (clockwise from top, matching the drain origin).
+
+- **Adaptive cap at 4:** one notch per beat when the window spans ≤ 4 beats;
+  beyond that, collapse to bar lines, or ≤ 4 evenly spaced if bar lines still
+  exceed 4.
+- **Suppressed when the window spans < 2 beats** (a lone notch is noise).
+- Rendered as short **static radial lines across the dark halo** — drawn once,
+  no per-frame repaint.
+- Positions derived in `practiceLensAtoms` (pure, testable) and passed to
+  `FretboardNote`.
+
+### 4. Intensity ramp
+
+The core stroke-width and brightness interpolate from thin/dim at window start
+to thick/bright at the beat, via a single CSS animation keyed to the same
+`--guide-duration`. Early intensity stays modest (sweet-spot); peak weight is
+reserved for the final lead-in, with the on-beat flash as the climax.
+
+### 5. Edge cases
+
+- **Reduced motion:** static full ring + static ticks, no drain, no flash
+  (extends today's `prefers-reduced-motion` rule). The ticks remain as a static
+  gauge.
+- **Short step (1 beat):** drain only, no interior ticks.
+- **Meter:** ticks honor `beatsPerBar`; the cap collapses to bar lines when
+  beats > 4.
+- **Secondary (out-of-region) targets:** unchanged.
+
+### 6. Performance
+
+Per-frame cost ≈ one drain — the same arc as today, now spanning the full
+window instead of the final ~50%. That longer active window is the one real
+increase, bounded by the ~2–4 primary rings on screen. Ticks (static) and the
+intensity ramp (same already-repainting arc) add no per-frame repaint beyond
+that arc. Net: modestly above today, far below the segmented alternative (B).
+
+### 7. Files touched
+
+- `src/store/practiceLensAtoms.ts` — countdown-window atoms + tick-position
+  derivation; collapse phase flags for primary targets.
+- `src/components/FretboardSVG/utils/semantics.ts` (`getEmphasis`) — single
+  countdown transition role for primary; keep quiet-static for secondary.
+- `src/components/FretboardSVG/FretboardNote.tsx` — render notches; single
+  drain; intensity ramp; pass window/beats.
+- `src/components/FretboardSVG/FretboardSVG.module.css` — drop breathe; single
+  drain over `--guide-duration`; ramp keyframes; tick styles; reduced-motion.
+- `src/components/FretboardSVG/FretboardSVG.tsx` — set `--guide-duration`.
+
+### 8. Testing
+
+- Unit tests for the countdown-window and tick-position math in
+  `practiceLensAtoms.test.ts` (window length, adaptive cap at 4, < 2-beat
+  suppression, meter handling, angle mapping).
+- Visual-regression snapshot refresh for the `fretboard-svg` e2e suite.
+- Reduced-motion path: static ring + ticks, no drain/flash.
+
+## Out of scope
+
+- Changing audio/playback timing or the underlying step/bar duration model.
+- Re-coloring or re-shaping note markers.
+- Secondary-target behavior.
+- Any progression-track / playhead UI changes.

--- a/src/components/FretboardSVG/FretboardNote.test.tsx
+++ b/src/components/FretboardSVG/FretboardNote.test.tsx
@@ -25,13 +25,17 @@ function makeNote(overrides: Partial<RenderedFretboardNote> = {}): RenderedFretb
   };
 }
 
-function renderNote(note: RenderedFretboardNote) {
+function renderNote(
+  note: RenderedFretboardNote,
+  extra?: { countdownTicks?: number[] },
+) {
   return render(
     <svg>
       <FretboardNote
         note={note}
         noteBubblePx={40}
         displayFormat="notes"
+        countdownTicks={extra?.countdownTicks}
       />
     </svg>,
   );
@@ -142,16 +146,25 @@ describe("FretboardNote — chromatic diamond rendering", () => {
 
 
 describe("FretboardNote — two-phase guide ring", () => {
-  it("renders the ring with data-guide-phase='preview' for a guide-preview note", () => {
+  it("renders no ring for a note without a transition role", () => {
+    const { container } = renderNote(makeNote({ transitionRole: undefined }));
+    expect(container.querySelector("[data-guide-ring]")).toBeNull();
+  });
+
+  it("renders beat-tick notches for a primary guide-target note when ticks are provided", () => {
     const { container } = renderNote(
-      makeNote({
-        transitionRole: "guide-preview",
-        applyLensEmphasis: { radiusBoost: 1, opacityBoost: 1, guideTargetLabel: "3" },
-      }),
+      makeNote({ transitionRole: "guide-target", isInRegion: true }),
+      { countdownTicks: [0.25, 0.5, 0.75] },
     );
-    const ring = container.querySelector("[data-guide-ring]");
-    expect(ring).not.toBeNull();
-    expect(ring?.getAttribute("data-guide-phase")).toBe("preview");
+    expect(container.querySelectorAll("[data-guide-tick]")).toHaveLength(3);
+  });
+
+  it("renders no notches for a secondary (out-of-region) guide-target note", () => {
+    const { container } = renderNote(
+      makeNote({ transitionRole: "guide-target", isInRegion: false }),
+      { countdownTicks: [0.25, 0.5, 0.75] },
+    );
+    expect(container.querySelectorAll("[data-guide-tick]")).toHaveLength(0);
   });
 
   it("renders the ring with data-guide-phase='landing' for a guide-target note", () => {
@@ -192,11 +205,11 @@ describe("FretboardNote — two-phase guide ring", () => {
   });
 
   it("renders the incoming-hue backing disc tagged with the phase for a target note", () => {
-    const { container } = renderNote(makeNote({ transitionRole: "guide-preview" }));
+    const { container } = renderNote(makeNote({ transitionRole: "guide-target" }));
     const backing = container.querySelector("[data-guide-phase]:not([data-guide-ring])");
     expect(backing).not.toBeNull();
     expect(backing?.tagName.toLowerCase()).toBe("circle");
-    expect(backing?.getAttribute("data-guide-phase")).toBe("preview");
+    expect(backing?.getAttribute("data-guide-phase")).toBe("landing");
   });
 
   it("renders no backing disc when there is no transition role", () => {

--- a/src/components/FretboardSVG/FretboardNote.tsx
+++ b/src/components/FretboardSVG/FretboardNote.tsx
@@ -27,21 +27,23 @@ const ROLE_DESCRIPTIONS: Record<string, string> = {
 const formatRole = (noteClass: string): string =>
   ROLE_DESCRIPTIONS[noteClass] ?? noteClass.replace(/-/g, " ");
 
-// Half-length (user units) of a beat-tick mark measured ALONG the ring
-// (tangentially). Each tick is a straight <line> tangent to the ring at its beat
-// angle — NOT a dash on a circle and NOT a radial spoke:
-//   - Tangent (along the ring) → at the common 4-beat positions the ticks are a
-//     clean HORIZONTAL mark at top/bottom and a VERTICAL mark at left/right.
-//   - A straight independent segment has no sub-pixel dash seam, so every tick
-//     (including the anchor at fraction 0) renders identically — fixing the
-//     thicker-first-tick artifact of the old dashed-circle notch.
-//   - Centered on ringR with the core's stroke-width (2.75, via CSS) it stays
-//     CO-RADIAL with the green core: it occupies the core band on every note
-//     type and never spurs outside the ring (the old radial <line> reached past
-//     ringR and read as a nub outside big chord-tone bubbles).
-// Kept short so the tangent's tiny outward bulge (√(ringR²+L²) − ringR ≈ 0.3px)
-// stays well inside the core half-width (~1.375).
-const TICK_HALF_LEN = 2.5;
+// Beat-tick geometry. Each tick is a short radial <line> drawn just INSIDE the
+// marker rim (NOT on the outer drain ring) at its beat angle — clock-style.
+// Root cause of the long "ticks outside the circle" saga: the drain ring sits at
+// ringR = r + standoff (standoff ≥ 3px), so ringR > r for EVERY note. Anything
+// drawn on the ring is therefore outside the marker circle by construction — most
+// obvious on big, filled chord-tone bubbles. Putting the ticks inside the marker
+// rim (radius < r) is the only placement that reads as "inside the circle" on
+// every note type.
+//   - TICK_RIM_GAP: gap from the marker edge (r) to the tick's OUTER end, so the
+//     mark sits clearly inside the rim, not on it.
+//   - TICK_LEN: radial length, pointing inward toward the center. At the common
+//     4-beat positions the marks are axis-aligned (horizontal at 3/9, vertical at
+//     12/6) — clock ticks.
+// The ticks render in their own group OUTSIDE the looming ring group, so the
+// ring's ~6% loom never drifts a tick back across the rim.
+const TICK_RIM_GAP = 0.6;
+const TICK_LEN = 2.8;
 
 interface FretboardNoteProps {
   note: RenderedFretboardNote;
@@ -237,43 +239,47 @@ export const FretboardNote = memo(function FretboardNote({
                 beat (the gradual drain alone has no crisp "now" instant). CSS
                 only animates it in the landing phase. */}
             <circle className={styles["note-guide-ring-flash"]} cx={cx} cy={cy} r={ringR} />
-            {/* Static beat-tick marks — short BRIGHT segments the green core
-                sweeps past, giving a countable "segment done" read. Only on
-                PRIMARY (in-region) targets, and only when the step has enough
-                beats to warrant ticks (countdownTicks empty otherwise). Each is a
-                straight <line> TANGENT to the ring at its beat angle
-                (θ = 2π·f, drain origin at 3 o'clock, sweeping clockwise): at the
-                common 4-beat positions the marks are horizontal (top/bottom) and
-                vertical (left/right). Centered on ringR with the core's
-                stroke-width (CSS), each mark is co-radial with the green core —
-                contained in the ring band on every note type (scale tone or
-                chord tone), with no dash seam and no radial spur. */}
-            {note.isInRegion &&
-              countdownTicks?.map((f, i) => {
-                const theta = 2 * Math.PI * f;
-                const cos = Math.cos(theta);
-                const sin = Math.sin(theta);
-                // Point on the ring at this beat fraction.
-                const px = cx + ringR * cos;
-                const py = cy + ringR * sin;
-                // Tangent unit vector (perpendicular to the radius) — the mark
-                // lies ALONG the ring, so it is axis-aligned at the cardinal
-                // beat positions.
-                const tx = -sin;
-                const ty = cos;
-                return (
-                  <line
-                    key={`tick-${i}`}
-                    className={styles["note-guide-ring-tick"]}
-                    data-guide-tick="true"
-                    x1={px - TICK_HALF_LEN * tx}
-                    y1={py - TICK_HALF_LEN * ty}
-                    x2={px + TICK_HALF_LEN * tx}
-                    y2={py + TICK_HALF_LEN * ty}
-                    aria-hidden="true"
-                  />
-                );
-              })}
+          </motion.g>
+        )}
+      </AnimatePresence>
+      {/* Static beat-tick marks — short BRIGHT radial ticks just INSIDE the
+          marker rim at each beat boundary, giving a countable "segment done"
+          read. Only on PRIMARY (in-region) targets, and only when the step has
+          enough beats to warrant ticks (countdownTicks empty otherwise). Each is
+          a <line> at angle θ = 2π·f (drain origin at 3 o'clock, sweeping
+          clockwise) drawn from just inside the rim (r − TICK_RIM_GAP) inward by
+          TICK_LEN — clock ticks: axis-aligned at the 4-beat cardinal positions.
+          Rendered in THIS group rather than the ring group above so the ring's
+          loom never scales a tick back across the rim. */}
+      <AnimatePresence>
+        {guidePhase && note.isInRegion && (
+          <motion.g
+            key="guide-ticks"
+            data-guide-ticks="true"
+            aria-hidden="true"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={guideFade}
+          >
+            {countdownTicks?.map((f, i) => {
+              const theta = 2 * Math.PI * f;
+              const cos = Math.cos(theta);
+              const sin = Math.sin(theta);
+              const outer = r - TICK_RIM_GAP;
+              const inner = outer - TICK_LEN;
+              return (
+                <line
+                  key={`tick-${i}`}
+                  className={styles["note-guide-ring-tick"]}
+                  data-guide-tick="true"
+                  x1={cx + cos * inner}
+                  y1={cy + sin * inner}
+                  x2={cx + cos * outer}
+                  y2={cy + sin * outer}
+                />
+              );
+            })}
           </motion.g>
         )}
       </AnimatePresence>

--- a/src/components/FretboardSVG/FretboardNote.tsx
+++ b/src/components/FretboardSVG/FretboardNote.tsx
@@ -176,18 +176,18 @@ export const FretboardNote = memo(function FretboardNote({
         />
       )}
       {shapeEl}
-      {/* Two-phase target ring. A dark halo under a coloured core (a 2-colour
+      {/* Countdown target ring. A dark halo under a coloured core (a 2-colour
           "Oreo" ring) keeps it legible over any fill and on light or dark wood.
           Drawn ON TOP of the marker (after shapeEl): a filled chord/root note is
           opaque and — enlarged by the taper scale + the root's playback radius
           boost — would otherwise occlude the ring's inner edge, leaving only a
           sliver. The ring sits at a standoff OUTSIDE the marker, so painting it
           last keeps the full halo + core visible on every note type.
-          Phase rides stroke-weight + opacity (planning thin/dim → landing
-          thick/bright); CSS animates the landing CONTRACTION (scale), motion
-          owns OPACITY so AnimatePresence fades it in on mount and OUT on removal
-          — decoupling the fade-out from React's startTransition-jittered unmount
-          (the boundary flash). */}
+          The core DRAINS clockwise over the whole countdown window (CSS), with a
+          brightness ramp + gentle looming scale escalating toward the beat;
+          motion owns the group OPACITY so AnimatePresence fades it in on mount
+          and OUT on removal — decoupling the fade-out from React's
+          startTransition-jittered unmount (the boundary flash). */}
       <AnimatePresence>
         {guidePhase && (
           <motion.g
@@ -202,11 +202,10 @@ export const FretboardNote = memo(function FretboardNote({
             data-guide-primary={note.isInRegion ? "true" : "false"}
             aria-hidden="true"
             initial={{ opacity: 0 }}
-            // Primary targets hold full group opacity in BOTH phases so the
-            // brightness matches at the breathe→drain handoff; the calmer
-            // "passive" feel comes from the core breathe's dips (whose peaks
-            // equal the landing brightness), not a dimmer group. Secondary
-            // (out-of-region) targets are quiet static markers.
+            // Primary targets hold full group opacity; the escalating salience
+            // comes from the core's brightness ramp + looming scale over the
+            // countdown window, not a dimmer group. Secondary (out-of-region)
+            // targets are quiet static markers at reduced opacity.
             animate={{ opacity: note.isInRegion ? 1 : 0.4 }}
             exit={{ opacity: 0 }}
             transition={guideFade}

--- a/src/components/FretboardSVG/FretboardNote.tsx
+++ b/src/components/FretboardSVG/FretboardNote.tsx
@@ -27,15 +27,13 @@ const ROLE_DESCRIPTIONS: Record<string, string> = {
 const formatRole = (noteClass: string): string =>
   ROLE_DESCRIPTIONS[noteClass] ?? noteClass.replace(/-/g, " ");
 
-// Arc length (in pathLength=100 units) of a single tick notch on the ring.
-const TICK_ARC_LEN = 1.2;
-
-// Angular offset (degrees) applied to BOTH the drain origin and the ticks so
-// they rotate together (alignment preserved). It moves the ticks off the
-// 3-o'clock / 9-o'clock cardinal points — where the horizontal string crosses
-// the ring — onto the diagonals (1:30 / 4:30 / 7:30 / 10:30). Without it a tick
-// lands on the string wire and the two white marks merge into a stray streak.
-const RING_ANGLE_OFFSET_DEG = 45;
+// Radial LENGTH (user units) of a beat-tick mark — how far it spans across the
+// ring band. Each tick is drawn as an explicit <line> via trig (not a dash on a
+// circle), so every tick is identical geometry rotated to its own angle: crisp
+// and consistent, with no sub-pixel dash seam (the old arc-dash made the anchor
+// tick render thicker). ~2.4 stays inside the green core (2.75) so the mark is
+// contained within the ring band and never reads as a spoke sticking into wood.
+const TICK_LEN = 2.4;
 
 interface FretboardNoteProps {
   note: RenderedFretboardNote;
@@ -225,39 +223,41 @@ export const FretboardNote = memo(function FretboardNote({
               cy={cy}
               r={ringR}
               pathLength={100}
-              transform={`rotate(${RING_ANGLE_OFFSET_DEG} ${cx} ${cy})`}
             />
             {/* On-beat flash — a bright ring that blooms outward as the core
                 drains empty, giving a sharp coincidence landmark exactly on the
                 beat (the gradual drain alone has no crisp "now" instant). CSS
                 only animates it in the landing phase. */}
             <circle className={styles["note-guide-ring-flash"]} cx={cx} cy={cy} r={ringR} />
-            {/* Static beat-tick notches — bright pips on the halo track that the
-                green core sweeps past, giving a countable "segment done" read.
-                Only on PRIMARY (in-region) targets, and only when the step has
-                enough beats to warrant ticks (countdownTicks empty otherwise).
-                Drawn with the SAME pathLength=100 circle parametrization AND the
-                same rotate() offset as the drain core, so each notch sits exactly
-                where the hand is at that window-fraction (alignment preserved)
-                while clearing the horizontal string at 3/9 o'clock.
-                NOTE: if a snapshot shows the notches mirrored relative to the
-                drain hand, flip the sign of strokeDashoffset (use `100 * f`). */}
+            {/* Static beat-tick marks — short BRIGHT radial lines crossing the
+                ring at each beat boundary, giving a countable "segment done"
+                read. Only on PRIMARY (in-region) targets, and only when the step
+                has enough beats to warrant ticks (countdownTicks empty otherwise).
+                Each is an explicit <line> at angle 2π·f (matching the drain's
+                origin at 3 o'clock, sweeping clockwise), so all ticks are
+                identical geometry — crisp and consistent, no dash-seam artifact.
+                At the 4-beat cardinal positions the lines are vertical (12/6) and
+                horizontal (3/9). */}
             {note.isInRegion &&
-              countdownTicks?.map((f, i) => (
-                <circle
-                  key={`tick-${i}`}
-                  className={styles["note-guide-ring-tick"]}
-                  data-guide-tick="true"
-                  cx={cx}
-                  cy={cy}
-                  r={ringR}
-                  pathLength={100}
-                  strokeDasharray={`${TICK_ARC_LEN} ${100 - TICK_ARC_LEN}`}
-                  strokeDashoffset={-100 * f}
-                  transform={`rotate(${RING_ANGLE_OFFSET_DEG} ${cx} ${cy})`}
-                  aria-hidden="true"
-                />
-              ))}
+              countdownTicks?.map((f, i) => {
+                const a = 2 * Math.PI * f;
+                const cos = Math.cos(a);
+                const sin = Math.sin(a);
+                const inner = ringR - TICK_LEN / 2;
+                const outer = ringR + TICK_LEN / 2;
+                return (
+                  <line
+                    key={`tick-${i}`}
+                    className={styles["note-guide-ring-tick"]}
+                    data-guide-tick="true"
+                    x1={cx + inner * cos}
+                    y1={cy + inner * sin}
+                    x2={cx + outer * cos}
+                    y2={cy + outer * sin}
+                    aria-hidden="true"
+                  />
+                );
+              })}
           </motion.g>
         )}
       </AnimatePresence>

--- a/src/components/FretboardSVG/FretboardNote.tsx
+++ b/src/components/FretboardSVG/FretboardNote.tsx
@@ -27,17 +27,21 @@ const ROLE_DESCRIPTIONS: Record<string, string> = {
 const formatRole = (noteClass: string): string =>
   ROLE_DESCRIPTIONS[noteClass] ?? noteClass.replace(/-/g, " ");
 
-// Arc length (in pathLength=100 units) of a single beat-tick notch. Each tick is
-// a dashed <circle> drawn with the SAME geometry as the green core (cx, cy,
-// r=ringR) and the SAME stroke-width — so it is CO-RADIAL with the core and
-// occupies exactly the core band on every note type (scale tone or chord tone),
-// without hardcoding the band's radii (an explicit <line> did, and protruded on
-// chord-tone notes whose effective ring band differs).
-// MUST be a whole number so TICK_ARC_LEN + (100 - TICK_ARC_LEN) sums to exactly
-// the pathLength (100): a fractional value (e.g. 1.2) is not exact in binary
-// float, so the dash pattern leaves a sliver of a second dash at the seam
-// (offset 0), making the anchor (first) tick render visibly thicker.
-const TICK_ARC_LEN = 2;
+// Half-length (user units) of a beat-tick mark measured ALONG the ring
+// (tangentially). Each tick is a straight <line> tangent to the ring at its beat
+// angle — NOT a dash on a circle and NOT a radial spoke:
+//   - Tangent (along the ring) → at the common 4-beat positions the ticks are a
+//     clean HORIZONTAL mark at top/bottom and a VERTICAL mark at left/right.
+//   - A straight independent segment has no sub-pixel dash seam, so every tick
+//     (including the anchor at fraction 0) renders identically — fixing the
+//     thicker-first-tick artifact of the old dashed-circle notch.
+//   - Centered on ringR with the core's stroke-width (2.75, via CSS) it stays
+//     CO-RADIAL with the green core: it occupies the core band on every note
+//     type and never spurs outside the ring (the old radial <line> reached past
+//     ringR and read as a nub outside big chord-tone bubbles).
+// Kept short so the tangent's tiny outward bulge (√(ringR²+L²) − ringR ≈ 0.3px)
+// stays well inside the core half-width (~1.375).
+const TICK_HALF_LEN = 2.5;
 
 interface FretboardNoteProps {
   note: RenderedFretboardNote;
@@ -233,33 +237,43 @@ export const FretboardNote = memo(function FretboardNote({
                 beat (the gradual drain alone has no crisp "now" instant). CSS
                 only animates it in the landing phase. */}
             <circle className={styles["note-guide-ring-flash"]} cx={cx} cy={cy} r={ringR} />
-            {/* Static beat-tick notches — short BRIGHT marks the green core sweeps
-                past, giving a countable "segment done" read. Only on PRIMARY
-                (in-region) targets, and only when the step has enough beats to
-                warrant ticks (countdownTicks empty otherwise). Drawn as a dashed
-                <circle> with the SAME cx/cy/r=ringR (and same stroke-width via
-                CSS) as the green core, so each notch is CO-RADIAL with the core
-                and stays within the ring band on every note type — no hardcoded
-                radii to drift on chord-tone notes. `pathLength=100` makes the
-                dash maths radius-independent; offset -100*f places the notch
-                where the drain hand is at that window-fraction.
-                NOTE: if a snapshot shows the notches mirrored relative to the
-                drain hand, flip the sign of strokeDashoffset (use `100 * f`). */}
+            {/* Static beat-tick marks — short BRIGHT segments the green core
+                sweeps past, giving a countable "segment done" read. Only on
+                PRIMARY (in-region) targets, and only when the step has enough
+                beats to warrant ticks (countdownTicks empty otherwise). Each is a
+                straight <line> TANGENT to the ring at its beat angle
+                (θ = 2π·f, drain origin at 3 o'clock, sweeping clockwise): at the
+                common 4-beat positions the marks are horizontal (top/bottom) and
+                vertical (left/right). Centered on ringR with the core's
+                stroke-width (CSS), each mark is co-radial with the green core —
+                contained in the ring band on every note type (scale tone or
+                chord tone), with no dash seam and no radial spur. */}
             {note.isInRegion &&
-              countdownTicks?.map((f, i) => (
-                <circle
-                  key={`tick-${i}`}
-                  className={styles["note-guide-ring-tick"]}
-                  data-guide-tick="true"
-                  cx={cx}
-                  cy={cy}
-                  r={ringR}
-                  pathLength={100}
-                  strokeDasharray={`${TICK_ARC_LEN} ${100 - TICK_ARC_LEN}`}
-                  strokeDashoffset={-100 * f}
-                  aria-hidden="true"
-                />
-              ))}
+              countdownTicks?.map((f, i) => {
+                const theta = 2 * Math.PI * f;
+                const cos = Math.cos(theta);
+                const sin = Math.sin(theta);
+                // Point on the ring at this beat fraction.
+                const px = cx + ringR * cos;
+                const py = cy + ringR * sin;
+                // Tangent unit vector (perpendicular to the radius) — the mark
+                // lies ALONG the ring, so it is axis-aligned at the cardinal
+                // beat positions.
+                const tx = -sin;
+                const ty = cos;
+                return (
+                  <line
+                    key={`tick-${i}`}
+                    className={styles["note-guide-ring-tick"]}
+                    data-guide-tick="true"
+                    x1={px - TICK_HALF_LEN * tx}
+                    y1={py - TICK_HALF_LEN * ty}
+                    x2={px + TICK_HALF_LEN * tx}
+                    y2={py + TICK_HALF_LEN * ty}
+                    aria-hidden="true"
+                  />
+                );
+              })}
           </motion.g>
         )}
       </AnimatePresence>

--- a/src/components/FretboardSVG/FretboardNote.tsx
+++ b/src/components/FretboardSVG/FretboardNote.tsx
@@ -30,6 +30,13 @@ const formatRole = (noteClass: string): string =>
 // Arc length (in pathLength=100 units) of a single tick notch on the ring.
 const TICK_ARC_LEN = 1.2;
 
+// Angular offset (degrees) applied to BOTH the drain origin and the ticks so
+// they rotate together (alignment preserved). It moves the ticks off the
+// 3-o'clock / 9-o'clock cardinal points — where the horizontal string crosses
+// the ring — onto the diagonals (1:30 / 4:30 / 7:30 / 10:30). Without it a tick
+// lands on the string wire and the two white marks merge into a stray streak.
+const RING_ANGLE_OFFSET_DEG = 45;
+
 interface FretboardNoteProps {
   note: RenderedFretboardNote;
   noteBubblePx: number;
@@ -218,19 +225,21 @@ export const FretboardNote = memo(function FretboardNote({
               cy={cy}
               r={ringR}
               pathLength={100}
+              transform={`rotate(${RING_ANGLE_OFFSET_DEG} ${cx} ${cy})`}
             />
             {/* On-beat flash — a bright ring that blooms outward as the core
                 drains empty, giving a sharp coincidence landmark exactly on the
                 beat (the gradual drain alone has no crisp "now" instant). CSS
                 only animates it in the landing phase. */}
             <circle className={styles["note-guide-ring-flash"]} cx={cx} cy={cy} r={ringR} />
-            {/* Static beat-tick notches — dark pips on the halo track that the
+            {/* Static beat-tick notches — bright pips on the halo track that the
                 green core sweeps past, giving a countable "segment done" read.
                 Only on PRIMARY (in-region) targets, and only when the step has
                 enough beats to warrant ticks (countdownTicks empty otherwise).
-                Drawn with the SAME pathLength=100 circle parametrization as the
-                drain so each notch sits exactly where the hand is at that
-                window-fraction — no trig, no origin/direction mismatch.
+                Drawn with the SAME pathLength=100 circle parametrization AND the
+                same rotate() offset as the drain core, so each notch sits exactly
+                where the hand is at that window-fraction (alignment preserved)
+                while clearing the horizontal string at 3/9 o'clock.
                 NOTE: if a snapshot shows the notches mirrored relative to the
                 drain hand, flip the sign of strokeDashoffset (use `100 * f`). */}
             {note.isInRegion &&
@@ -245,6 +254,7 @@ export const FretboardNote = memo(function FretboardNote({
                   pathLength={100}
                   strokeDasharray={`${TICK_ARC_LEN} ${100 - TICK_ARC_LEN}`}
                   strokeDashoffset={-100 * f}
+                  transform={`rotate(${RING_ANGLE_OFFSET_DEG} ${cx} ${cy})`}
                   aria-hidden="true"
                 />
               ))}
@@ -257,8 +267,8 @@ export const FretboardNote = memo(function FretboardNote({
             key="guide-label"
             className={styles["note-guide-label"]}
             data-guide-label="true"
-            x={cx + r + 2}
-            y={cy - r - 2}
+            x={cx + ringR + 3}
+            y={cy - ringR - 1}
             aria-hidden="true"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}

--- a/src/components/FretboardSVG/FretboardNote.tsx
+++ b/src/components/FretboardSVG/FretboardNote.tsx
@@ -27,18 +27,17 @@ const ROLE_DESCRIPTIONS: Record<string, string> = {
 const formatRole = (noteClass: string): string =>
   ROLE_DESCRIPTIONS[noteClass] ?? noteClass.replace(/-/g, " ");
 
-// Beat-tick geometry. Each tick is an explicit <line> via trig (not a dash on a
-// circle), so every tick is identical geometry rotated to its own angle: crisp
-// and consistent, with no sub-pixel dash seam (the old arc-dash made the anchor
-// tick render thicker).
-// TICK_LEN is the radial length; TICK_OUTWARD is how far it reaches PAST the ring
-// centerline (ringR) toward the wood. Both are kept small so the whole mark sits
-// inside the green core band (half-width ~1.375) — the mark is biased inward and
-// never spurs outside the visible ring, even on big chord-tone bubbles. Two
-// ticks always fall on the horizontal string (3/9 o'clock); containing them this
-// way keeps them from reading as nubs poking out along the string.
-const TICK_LEN = 2;
-const TICK_OUTWARD = 0.8;
+// Arc length (in pathLength=100 units) of a single beat-tick notch. Each tick is
+// a dashed <circle> drawn with the SAME geometry as the green core (cx, cy,
+// r=ringR) and the SAME stroke-width — so it is CO-RADIAL with the core and
+// occupies exactly the core band on every note type (scale tone or chord tone),
+// without hardcoding the band's radii (an explicit <line> did, and protruded on
+// chord-tone notes whose effective ring band differs).
+// MUST be a whole number so TICK_ARC_LEN + (100 - TICK_ARC_LEN) sums to exactly
+// the pathLength (100): a fractional value (e.g. 1.2) is not exact in binary
+// float, so the dash pattern leaves a sliver of a second dash at the seam
+// (offset 0), making the anchor (first) tick render visibly thicker.
+const TICK_ARC_LEN = 2;
 
 interface FretboardNoteProps {
   note: RenderedFretboardNote;
@@ -234,35 +233,33 @@ export const FretboardNote = memo(function FretboardNote({
                 beat (the gradual drain alone has no crisp "now" instant). CSS
                 only animates it in the landing phase. */}
             <circle className={styles["note-guide-ring-flash"]} cx={cx} cy={cy} r={ringR} />
-            {/* Static beat-tick marks — short BRIGHT radial lines crossing the
-                ring at each beat boundary, giving a countable "segment done"
-                read. Only on PRIMARY (in-region) targets, and only when the step
-                has enough beats to warrant ticks (countdownTicks empty otherwise).
-                Each is an explicit <line> at angle 2π·f (matching the drain's
-                origin at 3 o'clock, sweeping clockwise), so all ticks are
-                identical geometry — crisp and consistent, no dash-seam artifact.
-                At the 4-beat cardinal positions the lines are vertical (12/6) and
-                horizontal (3/9). */}
+            {/* Static beat-tick notches — short BRIGHT marks the green core sweeps
+                past, giving a countable "segment done" read. Only on PRIMARY
+                (in-region) targets, and only when the step has enough beats to
+                warrant ticks (countdownTicks empty otherwise). Drawn as a dashed
+                <circle> with the SAME cx/cy/r=ringR (and same stroke-width via
+                CSS) as the green core, so each notch is CO-RADIAL with the core
+                and stays within the ring band on every note type — no hardcoded
+                radii to drift on chord-tone notes. `pathLength=100` makes the
+                dash maths radius-independent; offset -100*f places the notch
+                where the drain hand is at that window-fraction.
+                NOTE: if a snapshot shows the notches mirrored relative to the
+                drain hand, flip the sign of strokeDashoffset (use `100 * f`). */}
             {note.isInRegion &&
-              countdownTicks?.map((f, i) => {
-                const a = 2 * Math.PI * f;
-                const cos = Math.cos(a);
-                const sin = Math.sin(a);
-                const outer = ringR + TICK_OUTWARD;
-                const inner = outer - TICK_LEN;
-                return (
-                  <line
-                    key={`tick-${i}`}
-                    className={styles["note-guide-ring-tick"]}
-                    data-guide-tick="true"
-                    x1={cx + inner * cos}
-                    y1={cy + inner * sin}
-                    x2={cx + outer * cos}
-                    y2={cy + outer * sin}
-                    aria-hidden="true"
-                  />
-                );
-              })}
+              countdownTicks?.map((f, i) => (
+                <circle
+                  key={`tick-${i}`}
+                  className={styles["note-guide-ring-tick"]}
+                  data-guide-tick="true"
+                  cx={cx}
+                  cy={cy}
+                  r={ringR}
+                  pathLength={100}
+                  strokeDasharray={`${TICK_ARC_LEN} ${100 - TICK_ARC_LEN}`}
+                  strokeDashoffset={-100 * f}
+                  aria-hidden="true"
+                />
+              ))}
           </motion.g>
         )}
       </AnimatePresence>

--- a/src/components/FretboardSVG/FretboardNote.tsx
+++ b/src/components/FretboardSVG/FretboardNote.tsx
@@ -27,13 +27,18 @@ const ROLE_DESCRIPTIONS: Record<string, string> = {
 const formatRole = (noteClass: string): string =>
   ROLE_DESCRIPTIONS[noteClass] ?? noteClass.replace(/-/g, " ");
 
-// Radial LENGTH (user units) of a beat-tick mark — how far it spans across the
-// ring band. Each tick is drawn as an explicit <line> via trig (not a dash on a
+// Beat-tick geometry. Each tick is an explicit <line> via trig (not a dash on a
 // circle), so every tick is identical geometry rotated to its own angle: crisp
 // and consistent, with no sub-pixel dash seam (the old arc-dash made the anchor
-// tick render thicker). ~2.4 stays inside the green core (2.75) so the mark is
-// contained within the ring band and never reads as a spoke sticking into wood.
-const TICK_LEN = 2.4;
+// tick render thicker).
+// TICK_LEN is the radial length; TICK_OUTWARD is how far it reaches PAST the ring
+// centerline (ringR) toward the wood. Both are kept small so the whole mark sits
+// inside the green core band (half-width ~1.375) — the mark is biased inward and
+// never spurs outside the visible ring, even on big chord-tone bubbles. Two
+// ticks always fall on the horizontal string (3/9 o'clock); containing them this
+// way keeps them from reading as nubs poking out along the string.
+const TICK_LEN = 2;
+const TICK_OUTWARD = 0.8;
 
 interface FretboardNoteProps {
   note: RenderedFretboardNote;
@@ -243,8 +248,8 @@ export const FretboardNote = memo(function FretboardNote({
                 const a = 2 * Math.PI * f;
                 const cos = Math.cos(a);
                 const sin = Math.sin(a);
-                const inner = ringR - TICK_LEN / 2;
-                const outer = ringR + TICK_LEN / 2;
+                const outer = ringR + TICK_OUTWARD;
+                const inner = outer - TICK_LEN;
                 return (
                   <line
                     key={`tick-${i}`}

--- a/src/components/FretboardSVG/FretboardNote.tsx
+++ b/src/components/FretboardSVG/FretboardNote.tsx
@@ -27,23 +27,15 @@ const ROLE_DESCRIPTIONS: Record<string, string> = {
 const formatRole = (noteClass: string): string =>
   ROLE_DESCRIPTIONS[noteClass] ?? noteClass.replace(/-/g, " ");
 
-// Beat-tick geometry. Each tick is a short radial <line> drawn just INSIDE the
-// marker rim (NOT on the outer drain ring) at its beat angle — clock-style.
-// Root cause of the long "ticks outside the circle" saga: the drain ring sits at
-// ringR = r + standoff (standoff ≥ 3px), so ringR > r for EVERY note. Anything
-// drawn on the ring is therefore outside the marker circle by construction — most
-// obvious on big, filled chord-tone bubbles. Putting the ticks inside the marker
-// rim (radius < r) is the only placement that reads as "inside the circle" on
-// every note type.
-//   - TICK_RIM_GAP: gap from the marker edge (r) to the tick's OUTER end, so the
-//     mark sits clearly inside the rim, not on it.
-//   - TICK_LEN: radial length, pointing inward toward the center. At the common
-//     4-beat positions the marks are axis-aligned (horizontal at 3/9, vertical at
-//     12/6) — clock ticks.
-// The ticks render in their own group OUTSIDE the looming ring group, so the
-// ring's ~6% loom never drifts a tick back across the rim.
-const TICK_RIM_GAP = 0.6;
-const TICK_LEN = 2.8;
+// Radial half-length (user units) of a beat-tick mark, centered on the drain
+// track (ringR). Each tick is a short radial <line> spanning ringR ± this, so it
+// crosses the track band (core stroke-width 2.75 → half-width ~1.375) and reads
+// as a clock tick ON the track. Anchoring to ringR — each note's OWN track radius
+// (ringR = r + standoff) — places the tick precisely on the track for both chord
+// tones and in-scale tones despite their different marker sizes, with no per-type
+// parameters. Kept ≤ the halo half-width (~2.375) so the tick stays within the
+// ring's footprint and never spurs into bare wood.
+const TICK_HALF_LEN = 2;
 
 interface FretboardNoteProps {
   note: RenderedFretboardNote;
@@ -239,47 +231,39 @@ export const FretboardNote = memo(function FretboardNote({
                 beat (the gradual drain alone has no crisp "now" instant). CSS
                 only animates it in the landing phase. */}
             <circle className={styles["note-guide-ring-flash"]} cx={cx} cy={cy} r={ringR} />
-          </motion.g>
-        )}
-      </AnimatePresence>
-      {/* Static beat-tick marks — short BRIGHT radial ticks just INSIDE the
-          marker rim at each beat boundary, giving a countable "segment done"
-          read. Only on PRIMARY (in-region) targets, and only when the step has
-          enough beats to warrant ticks (countdownTicks empty otherwise). Each is
-          a <line> at angle θ = 2π·f (drain origin at 3 o'clock, sweeping
-          clockwise) drawn from just inside the rim (r − TICK_RIM_GAP) inward by
-          TICK_LEN — clock ticks: axis-aligned at the 4-beat cardinal positions.
-          Rendered in THIS group rather than the ring group above so the ring's
-          loom never scales a tick back across the rim. */}
-      <AnimatePresence>
-        {guidePhase && note.isInRegion && (
-          <motion.g
-            key="guide-ticks"
-            data-guide-ticks="true"
-            aria-hidden="true"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={guideFade}
-          >
-            {countdownTicks?.map((f, i) => {
-              const theta = 2 * Math.PI * f;
-              const cos = Math.cos(theta);
-              const sin = Math.sin(theta);
-              const outer = r - TICK_RIM_GAP;
-              const inner = outer - TICK_LEN;
-              return (
-                <line
-                  key={`tick-${i}`}
-                  className={styles["note-guide-ring-tick"]}
-                  data-guide-tick="true"
-                  x1={cx + cos * inner}
-                  y1={cy + sin * inner}
-                  x2={cx + cos * outer}
-                  y2={cy + sin * outer}
-                />
-              );
-            })}
+            {/* Static beat-tick marks — short BRIGHT radial ticks centered on the
+                drain track (ringR) at each beat boundary, giving a countable
+                "segment done" read as the green core drains past them. Only on
+                PRIMARY (in-region) targets, and only when the step has enough
+                beats to warrant ticks (countdownTicks empty otherwise). Each is a
+                <line> at angle θ = 2π·f (drain origin at 3 o'clock, sweeping
+                clockwise), spanning ringR ± TICK_HALF_LEN so it crosses the track
+                band — clock ticks: axis-aligned at the 4-beat cardinal positions.
+                Anchored to ringR (each note's OWN track radius), so chord tones
+                and in-scale tones — different marker sizes, hence different ringR
+                — both get ticks precisely on their track without per-type tuning.
+                Rendered INSIDE the ring group so the ring's loom scales the ticks
+                WITH the track, keeping them locked on it through the countdown. */}
+            {note.isInRegion &&
+              countdownTicks?.map((f, i) => {
+                const theta = 2 * Math.PI * f;
+                const cos = Math.cos(theta);
+                const sin = Math.sin(theta);
+                const inner = ringR - TICK_HALF_LEN;
+                const outer = ringR + TICK_HALF_LEN;
+                return (
+                  <line
+                    key={`tick-${i}`}
+                    className={styles["note-guide-ring-tick"]}
+                    data-guide-tick="true"
+                    x1={cx + cos * inner}
+                    y1={cy + sin * inner}
+                    x2={cx + cos * outer}
+                    y2={cy + sin * outer}
+                    aria-hidden="true"
+                  />
+                );
+              })}
           </motion.g>
         )}
       </AnimatePresence>

--- a/src/components/FretboardSVG/FretboardNote.tsx
+++ b/src/components/FretboardSVG/FretboardNote.tsx
@@ -27,6 +27,9 @@ const ROLE_DESCRIPTIONS: Record<string, string> = {
 const formatRole = (noteClass: string): string =>
   ROLE_DESCRIPTIONS[noteClass] ?? noteClass.replace(/-/g, " ");
 
+// Arc length (in pathLength=100 units) of a single tick notch on the ring.
+const TICK_ARC_LEN = 1.2;
+
 interface FretboardNoteProps {
   note: RenderedFretboardNote;
   noteBubblePx: number;
@@ -35,6 +38,8 @@ interface FretboardNoteProps {
   neckWidthPx?: number;
   neckHeight?: number;
   numStrings?: number;
+  /** Window-fractions (0,1) for static beat-tick notches on the countdown ring. */
+  countdownTicks?: number[];
   onNoteClick?: (stringIndex: number, fretIndex: number, noteName: string) => void;
 }
 
@@ -45,6 +50,7 @@ export const FretboardNote = memo(function FretboardNote({
   neckWidthPx,
   neckHeight,
   numStrings,
+  countdownTicks,
   onNoteClick,
 }: FretboardNoteProps) {
   const {
@@ -68,12 +74,7 @@ export const FretboardNote = memo(function FretboardNote({
 
   const prefersReducedMotion = useReducedMotion();
   const guideFade = { duration: prefersReducedMotion ? 0 : 0.18, ease: "easeOut" as const };
-  const guidePhase =
-    transitionRole === "guide-target"
-      ? "landing"
-      : transitionRole === "guide-preview"
-        ? "preview"
-        : undefined;
+  const guidePhase = transitionRole === "guide-target" ? "landing" : undefined;
 
   const baseRadius = noteBubblePx / 2;
   const { radiusScale, noteShape } = getNoteVisuals(noteClass);
@@ -224,6 +225,30 @@ export const FretboardNote = memo(function FretboardNote({
                 beat (the gradual drain alone has no crisp "now" instant). CSS
                 only animates it in the landing phase. */}
             <circle className={styles["note-guide-ring-flash"]} cx={cx} cy={cy} r={ringR} />
+            {/* Static beat-tick notches — dark pips on the halo track that the
+                green core sweeps past, giving a countable "segment done" read.
+                Only on PRIMARY (in-region) targets, and only when the step has
+                enough beats to warrant ticks (countdownTicks empty otherwise).
+                Drawn with the SAME pathLength=100 circle parametrization as the
+                drain so each notch sits exactly where the hand is at that
+                window-fraction — no trig, no origin/direction mismatch.
+                NOTE: if a snapshot shows the notches mirrored relative to the
+                drain hand, flip the sign of strokeDashoffset (use `100 * f`). */}
+            {note.isInRegion &&
+              countdownTicks?.map((f, i) => (
+                <circle
+                  key={`tick-${i}`}
+                  className={styles["note-guide-ring-tick"]}
+                  data-guide-tick="true"
+                  cx={cx}
+                  cy={cy}
+                  r={ringR}
+                  pathLength={100}
+                  strokeDasharray={`${TICK_ARC_LEN} ${100 - TICK_ARC_LEN}`}
+                  strokeDashoffset={-100 * f}
+                  aria-hidden="true"
+                />
+              ))}
           </motion.g>
         )}
       </AnimatePresence>

--- a/src/components/FretboardSVG/FretboardNoteLayer.tsx
+++ b/src/components/FretboardSVG/FretboardNoteLayer.tsx
@@ -12,6 +12,8 @@ interface FretboardNoteLayerProps {
   neckWidthPx?: number;
   neckHeight?: number;
   numStrings?: number;
+  /** Window-fractions for the countdown ring's beat-tick notches. */
+  countdownTicks?: number[];
 }
 
 // This visual layer is decorative (its <svg> is aria-hidden + pointer-events:none).
@@ -27,6 +29,7 @@ export const FretboardNoteLayer = memo(({
   neckWidthPx,
   neckHeight,
   numStrings,
+  countdownTicks,
 }: FretboardNoteLayerProps) => (
   // NOTE: reading a new render-affecting field in FretboardNote? Also add it to
   // `renderedNoteSignature` in useAnimatedFretboardView.ts, or cached notes will
@@ -41,6 +44,7 @@ export const FretboardNoteLayer = memo(({
         neckWidthPx={neckWidthPx}
         neckHeight={neckHeight}
         numStrings={numStrings}
+        countdownTicks={countdownTicks}
       />
     ))}
   </g>

--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -224,10 +224,6 @@
   pointer-events: none;
 }
 
-.note-target-backing[data-guide-phase="preview"] {
-  opacity: 0.42;
-}
-
 .note-target-backing[data-guide-phase="landing"] {
   opacity: 0.52;
 }
@@ -278,39 +274,40 @@
   stroke-width: 4.75 !important;
 }
 
-/* Planning — a calm presence: a full green ring that gently BREATHES on opacity
-   only (no scale). Motion keeps it visible on chord tones, but breathing on
-   opacity (not size) means there is nothing to 'jump' when landing begins. */
-/* Runs ONCE across the planning window (--planning-duration) and RESOLVES TO
-   FULL brightness at 100% — i.e. exactly as the landing drain begins — so the
-   handoff from breathing to draining has no brightness jump. Two gentle dips
-   give the "breathing" feel; the peaks (opacity 1) match the landing ring. */
-.note-guide-ring[data-guide-phase="preview"][data-guide-primary="true"] .note-guide-ring-core {
-  animation: note-guide-ring-breathe var(--planning-duration, 1.7s) ease-in-out both;
-}
-
-@keyframes note-guide-ring-breathe {
-  0%   { opacity: 1; }
-  30%  { opacity: 0.55; }
-  55%  { opacity: 1; }
-  80%  { opacity: 0.55; }
-  100% { opacity: 1; }
-}
-
-/* Landing — the green core DRAINS clockwise around the dark halo track, like a
-   clock hand, reaching empty exactly on the beat. This conveys the precise
-   moment of landing far better than a small scale contraction, reads at any
-   stroke weight, and — because nothing scales — continues seamlessly from the
-   planning ring with no jump. `pathLength=100` (set in FretboardNote) lets the
+/* Countdown — the green core DRAINS clockwise around the dark halo track, like
+   a clock hand, over the WHOLE countdown window, reaching empty exactly on the
+   beat. A brightness (opacity) ramp escalates salience as the beat nears; the
+   stroke weight stays constant (its `!important` lock can't be animated). The
+   on-beat flash is the climax. `pathLength=100` (set in FretboardNote) lets the
    dash maths be radius-independent. */
 .note-guide-ring[data-guide-phase="landing"][data-guide-primary="true"] .note-guide-ring-core {
   stroke-dasharray: 100;
-  animation: note-guide-ring-drain var(--lead-in-duration, 0.6s) linear both;
+  animation:
+    note-guide-ring-drain var(--guide-duration, 4s) linear both,
+    note-guide-ring-ramp var(--guide-duration, 4s) ease-in both;
 }
 
 @keyframes note-guide-ring-drain {
   from { stroke-dashoffset: 0; }
   to   { stroke-dashoffset: 100; }
+}
+
+@keyframes note-guide-ring-ramp {
+  0%   { opacity: 0.72; }
+  70%  { opacity: 0.88; }
+  100% { opacity: 1; }
+}
+
+/* Looming — the whole countdown ring scales up very slightly across the window
+   so the target reads as "approaching" (increasing-salience cue). Transform is
+   GPU-composited, so this adds no per-frame paint. */
+.note-guide-ring[data-guide-phase="landing"][data-guide-primary="true"] {
+  animation: note-guide-ring-loom var(--guide-duration, 4s) ease-in both;
+}
+
+@keyframes note-guide-ring-loom {
+  from { transform: scale(1); }
+  to   { transform: scale(1.06); }
 }
 
 /* On-beat flash — a bright ring that blooms outward, peaking exactly as the
@@ -329,7 +326,7 @@
 }
 
 .note-guide-ring[data-guide-phase="landing"][data-guide-primary="true"] .note-guide-ring-flash {
-  animation: note-guide-ring-flash var(--lead-in-duration, 0.6s) ease-in both;
+  animation: note-guide-ring-flash var(--guide-duration, 4s) ease-in both;
 }
 
 @keyframes note-guide-ring-flash {
@@ -337,10 +334,22 @@
   100%    { opacity: 0.95; transform: scale(1.3); }
 }
 
-/* Reduced motion: no breathe, no drain — a static full ring still marks the
-   target; only the live countdown is dropped. */
+/* Beat-tick notches — short dark pips on the halo track at beat/bar
+   boundaries. Drawn over the halo + core so they read as gauge marks the green
+   hand sweeps past. Static (no animation) → zero per-frame paint. Stroke wider
+   than the halo so each pip visibly crosses the whole track. */
+.note-guide-ring-tick {
+  fill: none !important;
+  stroke: rgb(0 0 0 / 0.7) !important;
+  stroke-width: 5.5 !important;
+  pointer-events: none;
+}
+
+/* Reduced motion: no drain, no ramp, no loom, no flash — a static full ring
+   plus static tick notches still marks the target and conveys the beat grid;
+   only the live countdown motion is dropped. */
 @media (prefers-reduced-motion: reduce) {
-  .note-guide-ring[data-guide-phase="preview"] .note-guide-ring-core,
+  .note-guide-ring[data-guide-phase="landing"][data-guide-primary="true"],
   .note-guide-ring[data-guide-phase="landing"] .note-guide-ring-core,
   .note-guide-ring[data-guide-phase="landing"] .note-guide-ring-flash {
     animation: none;

--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -361,9 +361,13 @@
    plus static tick notches still marks the target and conveys the beat grid;
    only the live countdown motion is dropped. */
 @media (prefers-reduced-motion: reduce) {
+  /* Match the animation rules' specificity (0,4,0) by including
+     [data-guide-primary="true"] — without it these descendant selectors are
+     (0,3,0) and LOSE to the drain/ramp/flash rules, leaving motion on for users
+     who asked for reduced motion. */
   .note-guide-ring[data-guide-phase="landing"][data-guide-primary="true"],
-  .note-guide-ring[data-guide-phase="landing"] .note-guide-ring-core,
-  .note-guide-ring[data-guide-phase="landing"] .note-guide-ring-flash {
+  .note-guide-ring[data-guide-phase="landing"][data-guide-primary="true"] .note-guide-ring-core,
+  .note-guide-ring[data-guide-phase="landing"][data-guide-primary="true"] .note-guide-ring-flash {
     animation: none;
   }
 }

--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -334,16 +334,15 @@
   100%    { opacity: 0.95; transform: scale(1.3); }
 }
 
-/* Beat-tick marks — short BRIGHT radial ticks just INSIDE the marker rim at
+/* Beat-tick marks — short BRIGHT radial ticks centered on the drain track at
    beat/bar boundaries (plus an anchor at the start/beat line). A light mark reads
    in both light and dark modes — unlike a dark one, which vanished on dark wood
    and merged with the strings' dark drop shadows. Bright + hard-edged ≠ soft
-   achromatic shadow. Each mark is a short radial <line> pointing inward from the
-   rim (clock ticks; axis-aligned at the 4-beat cardinal positions), drawn at
-   radius < r so it sits inside the circle on every note type — the outer drain
-   ring (at ringR > r) is a halo OUTSIDE the marker, so ticks could never read as
-   "inside the circle" there. A thin stroke + round caps keep the short mark
-   crisp. Static (no animation) → zero per-frame paint. */
+   achromatic shadow. Each mark is a short radial <line> spanning the track band
+   at its beat angle (clock ticks; axis-aligned at the 4-beat cardinal positions),
+   anchored to each note's own track radius (ringR) so it lands precisely on the
+   track for both chord tones and in-scale tones. A thin stroke + round caps keep
+   the short mark crisp. Static (no animation) → zero per-frame paint. */
 .note-guide-ring-tick {
   fill: none !important;
   stroke: rgb(255 255 255 / 0.95) !important;

--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -254,12 +254,9 @@
 }
 
 /* Dark contrast halo — sits ~1px proud of the core on each side so the coloured
-   ring reads crisply over light maple, dark rosewood, and any marker fill.
-   Near-opaque so it fully masks whatever passes under the ring (notably the
-   bright string wire), giving the green core and the white beat-tick pips a
-   consistent dark backing instead of a brightened patch where a string crosses. */
+   ring reads crisply over light maple, dark rosewood, and any marker fill. */
 .note-guide-ring-halo {
-  stroke: rgb(0 0 0 / 0.9) !important;
+  stroke: rgb(0 0 0 / 0.55) !important;
 }
 
 .note-guide-ring-core {

--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -334,18 +334,18 @@
   100%    { opacity: 0.95; transform: scale(1.3); }
 }
 
-/* Beat-tick notches — short BRIGHT pips on the ring at beat/bar boundaries
-   (plus an anchor at the start/beat line). A light pip reads in both light and
-   dark modes — unlike a dark pip, which vanished on dark wood and merged with
-   the strings' dark drop shadows. Bright + hard-edged ≠ soft achromatic shadow.
-   Stroke width matches the GREEN CORE (not the wider dark halo) so each pip is
-   a notch CONTAINED WITHIN the visible green ring — a wider pip protrudes past
-   the green band as a white spur/spike and reads as an artifact. Static (no
-   animation) → zero per-frame paint. */
+/* Beat-tick marks — short BRIGHT radial <line>s crossing the ring at beat/bar
+   boundaries (plus an anchor at the start/beat line). A light mark reads in both
+   light and dark modes — unlike a dark one, which vanished on dark wood and
+   merged with the strings' dark drop shadows. Bright + hard-edged ≠ soft
+   achromatic shadow. `stroke-width` here is the mark's THICKNESS (the line's
+   width); its radial LENGTH is TICK_LEN in FretboardNote. Kept thin so the mark
+   reads as a crisp tick, not a block. Static (no animation) → zero per-frame
+   paint. */
 .note-guide-ring-tick {
   fill: none !important;
   stroke: rgb(255 255 255 / 0.92) !important;
-  stroke-width: 2.75 !important;
+  stroke-width: 1.6 !important;
   pointer-events: none;
 }
 

--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -334,18 +334,19 @@
   100%    { opacity: 0.95; transform: scale(1.3); }
 }
 
-/* Beat-tick marks — short BRIGHT radial <line>s crossing the ring at beat/bar
-   boundaries (plus an anchor at the start/beat line). A light mark reads in both
-   light and dark modes — unlike a dark one, which vanished on dark wood and
-   merged with the strings' dark drop shadows. Bright + hard-edged ≠ soft
-   achromatic shadow. `stroke-width` here is the mark's THICKNESS (the line's
-   width); its radial LENGTH is TICK_LEN in FretboardNote. Kept thin so the mark
-   reads as a crisp tick, not a block. Static (no animation) → zero per-frame
+/* Beat-tick notches — short BRIGHT marks on the ring at beat/bar boundaries
+   (plus an anchor at the start/beat line). A light mark reads in both light and
+   dark modes — unlike a dark one, which vanished on dark wood and merged with
+   the strings' dark drop shadows. Bright + hard-edged ≠ soft achromatic shadow.
+   The notch is a dashed <circle> sharing the core's geometry, so this
+   `stroke-width` MUST match the core's (2.75): that makes the notch CO-RADIAL
+   with the green core — it occupies exactly the core band and never spurs
+   outside the ring on any note type. Static (no animation) → zero per-frame
    paint. */
 .note-guide-ring-tick {
   fill: none !important;
   stroke: rgb(255 255 255 / 0.92) !important;
-  stroke-width: 1.6 !important;
+  stroke-width: 2.75 !important;
   pointer-events: none;
 }
 

--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -334,19 +334,20 @@
   100%    { opacity: 0.95; transform: scale(1.3); }
 }
 
-/* Beat-tick notches — short BRIGHT marks on the ring at beat/bar boundaries
+/* Beat-tick marks — short BRIGHT segments on the ring at beat/bar boundaries
    (plus an anchor at the start/beat line). A light mark reads in both light and
    dark modes — unlike a dark one, which vanished on dark wood and merged with
    the strings' dark drop shadows. Bright + hard-edged ≠ soft achromatic shadow.
-   The notch is a dashed <circle> sharing the core's geometry, so this
-   `stroke-width` MUST match the core's (2.75): that makes the notch CO-RADIAL
-   with the green core — it occupies exactly the core band and never spurs
-   outside the ring on any note type. Static (no animation) → zero per-frame
-   paint. */
+   Each mark is a straight <line> tangent to the ring (horizontal/vertical at the
+   4-beat cardinal positions); this `stroke-width` MUST match the core's (2.75)
+   so the mark spans exactly the core band — CO-RADIAL with the green core,
+   contained on every note type and never spurring outside the ring. Round caps
+   keep the short segment crisp. Static (no animation) → zero per-frame paint. */
 .note-guide-ring-tick {
   fill: none !important;
   stroke: rgb(255 255 255 / 0.92) !important;
   stroke-width: 2.75 !important;
+  stroke-linecap: round;
   pointer-events: none;
 }
 

--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -334,14 +334,18 @@
   100%    { opacity: 0.95; transform: scale(1.3); }
 }
 
-/* Beat-tick notches — short dark pips on the halo track at beat/bar
-   boundaries. Drawn over the halo + core so they read as gauge marks the green
-   hand sweeps past. Static (no animation) → zero per-frame paint. Stroke wider
-   than the halo so each pip visibly crosses the whole track. */
+/* Beat-tick notches — short BRIGHT pips on the halo track at beat/bar
+   boundaries (plus an anchor at the start/beat line). Drawn over the halo +
+   core so they read as gauge marks the green hand sweeps past. A light pip sits
+   on the always-dark halo, so it reads in both light and dark modes — unlike a
+   dark pip, which vanished on dark wood and merged with the strings' dark drop
+   shadows. Bright + hard-edged ≠ soft achromatic shadow. Width matches the halo
+   so each pip fills the track exactly without overhanging onto the wood. Static
+   (no animation) → zero per-frame paint. */
 .note-guide-ring-tick {
   fill: none !important;
-  stroke: rgb(0 0 0 / 0.7) !important;
-  stroke-width: 5.5 !important;
+  stroke: rgb(255 255 255 / 0.92) !important;
+  stroke-width: 4.75 !important;
   pointer-events: none;
 }
 

--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -197,7 +197,13 @@
   stroke-width: 3.6;
 }
 
-:global([data-theme="modern-light"]) .fretboard-note:not(.scale-only):not(.color-tone):not(.note-inactive) circle {
+/* Compensate ONLY the marker circle's radius for the heavier light-mode stroke.
+   The guide-ring circles carry their own geometric radius (ringR) via the SVG `r`
+   attribute and must be EXEMPT: a bare `circle` selector also matched them and
+   pulled the drain track in to the marker radius (collapse = standoff + 0.4px,
+   larger on bigger notes), which made the beat ticks — positioned at ringR — read
+   as poking out past the track into the wood on big chord-tone bubbles. */
+:global([data-theme="modern-light"]) .fretboard-note:not(.scale-only):not(.color-tone):not(.note-inactive) circle:not(.note-guide-ring-halo):not(.note-guide-ring-core):not(.note-guide-ring-flash) {
   r: calc(var(--note-r) * 1px - 0.4px);
 }
 

--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -334,18 +334,18 @@
   100%    { opacity: 0.95; transform: scale(1.3); }
 }
 
-/* Beat-tick notches — short BRIGHT pips on the halo track at beat/bar
-   boundaries (plus an anchor at the start/beat line). Drawn over the halo +
-   core so they read as gauge marks the green hand sweeps past. A light pip sits
-   on the always-dark halo, so it reads in both light and dark modes — unlike a
-   dark pip, which vanished on dark wood and merged with the strings' dark drop
-   shadows. Bright + hard-edged ≠ soft achromatic shadow. Width matches the halo
-   so each pip fills the track exactly without overhanging onto the wood. Static
-   (no animation) → zero per-frame paint. */
+/* Beat-tick notches — short BRIGHT pips on the ring at beat/bar boundaries
+   (plus an anchor at the start/beat line). A light pip reads in both light and
+   dark modes — unlike a dark pip, which vanished on dark wood and merged with
+   the strings' dark drop shadows. Bright + hard-edged ≠ soft achromatic shadow.
+   Stroke width matches the GREEN CORE (not the wider dark halo) so each pip is
+   a notch CONTAINED WITHIN the visible green ring — a wider pip protrudes past
+   the green band as a white spur/spike and reads as an artifact. Static (no
+   animation) → zero per-frame paint. */
 .note-guide-ring-tick {
   fill: none !important;
   stroke: rgb(255 255 255 / 0.92) !important;
-  stroke-width: 4.75 !important;
+  stroke-width: 2.75 !important;
   pointer-events: none;
 }
 

--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -254,9 +254,12 @@
 }
 
 /* Dark contrast halo — sits ~1px proud of the core on each side so the coloured
-   ring reads crisply over light maple, dark rosewood, and any marker fill. */
+   ring reads crisply over light maple, dark rosewood, and any marker fill.
+   Near-opaque so it fully masks whatever passes under the ring (notably the
+   bright string wire), giving the green core and the white beat-tick pips a
+   consistent dark backing instead of a brightened patch where a string crosses. */
 .note-guide-ring-halo {
-  stroke: rgb(0 0 0 / 0.55) !important;
+  stroke: rgb(0 0 0 / 0.9) !important;
 }
 
 .note-guide-ring-core {

--- a/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/src/components/FretboardSVG/FretboardSVG.module.css
@@ -334,19 +334,20 @@
   100%    { opacity: 0.95; transform: scale(1.3); }
 }
 
-/* Beat-tick marks — short BRIGHT segments on the ring at beat/bar boundaries
-   (plus an anchor at the start/beat line). A light mark reads in both light and
-   dark modes — unlike a dark one, which vanished on dark wood and merged with
-   the strings' dark drop shadows. Bright + hard-edged ≠ soft achromatic shadow.
-   Each mark is a straight <line> tangent to the ring (horizontal/vertical at the
-   4-beat cardinal positions); this `stroke-width` MUST match the core's (2.75)
-   so the mark spans exactly the core band — CO-RADIAL with the green core,
-   contained on every note type and never spurring outside the ring. Round caps
-   keep the short segment crisp. Static (no animation) → zero per-frame paint. */
+/* Beat-tick marks — short BRIGHT radial ticks just INSIDE the marker rim at
+   beat/bar boundaries (plus an anchor at the start/beat line). A light mark reads
+   in both light and dark modes — unlike a dark one, which vanished on dark wood
+   and merged with the strings' dark drop shadows. Bright + hard-edged ≠ soft
+   achromatic shadow. Each mark is a short radial <line> pointing inward from the
+   rim (clock ticks; axis-aligned at the 4-beat cardinal positions), drawn at
+   radius < r so it sits inside the circle on every note type — the outer drain
+   ring (at ringR > r) is a halo OUTSIDE the marker, so ticks could never read as
+   "inside the circle" there. A thin stroke + round caps keep the short mark
+   crisp. Static (no animation) → zero per-frame paint. */
 .note-guide-ring-tick {
   fill: none !important;
-  stroke: rgb(255 255 255 / 0.92) !important;
-  stroke-width: 2.75 !important;
+  stroke: rgb(255 255 255 / 0.95) !important;
+  stroke-width: 1.6 !important;
   stroke-linecap: round;
   pointer-events: none;
 }

--- a/src/components/FretboardSVG/FretboardSVG.test.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 import "../../styles/index.css";
 import "../../styles/themes.css";
 import { FretboardSVG } from "../FretboardSVG/FretboardSVG";
@@ -848,7 +848,7 @@ describe("FretboardSVG/FretboardSVG", () => {
   });
 
   describe("lead-in board signals", () => {
-    it("exposes --lead-in-duration and data-transition-phase during the lead-in window", () => {
+    it("exposes --guide-duration and data-transition-phase='countdown' during the countdown window", () => {
       const store = createStore();
       store.set(progressionStepsAtom, [
         { id: "i", degree: "I", duration: { value: 1, unit: "bar" }, qualityOverride: null, manualRoot: null },
@@ -859,16 +859,16 @@ describe("FretboardSVG/FretboardSVG", () => {
       store.set(progressionVisualFrameAtom, { stepIndex: 0, globalFraction: 0.375, localFraction: 0.75, paused: false });
       store.set(progressionStepDeadlineAtom, Date.now() + 100);
 
-      const { container } = renderWithStore(
+      renderWithStore(
         <FretboardSVG {...BASE_PROPS} {...C_MAJOR} highlightNotes={["C", "E", "G", "B", "D"]} />,
         store,
       );
-      const board = container.querySelector('[data-testid="fretboard-svg"]') as HTMLElement;
-      expect(board.getAttribute("data-transition-phase")).toBe("lead-in");
-      expect(board.style.getPropertyValue("--lead-in-duration")).not.toBe("");
+      const board = screen.getByTestId("fretboard-svg");
+      expect(board.style.getPropertyValue("--guide-duration")).toMatch(/\d+ms/);
+      expect(board.getAttribute("data-transition-phase")).toBe("countdown");
     });
 
-    it("data-transition-phase is absent when the frame is outside the lead-in window", () => {
+    it("data-transition-phase is absent when the frame is outside the countdown window", () => {
       const store = createStore();
       store.set(progressionStepsAtom, [
         { id: "i", degree: "I", duration: { value: 1, unit: "bar" }, qualityOverride: null, manualRoot: null },
@@ -878,12 +878,16 @@ describe("FretboardSVG/FretboardSVG", () => {
       store.set(setProgressionPlayingAtom, true);
       // localFraction 0.0 is well before the lead-in window starts (~0.5)
       store.set(progressionVisualFrameAtom, { stepIndex: 0, globalFraction: 0.0, localFraction: 0.0, paused: false });
+      // Deadline more than one step ahead — the "step has started" guard
+      // (deadline - now > stepMs) prevents guideCountdownActiveAtom from firing.
+      // At 120 BPM / 4 beats per bar: stepMs ≈ 2000 ms; 3× that is safely outside.
+      store.set(progressionStepDeadlineAtom, Date.now() + 6000);
 
-      const { container } = renderWithStore(
+      renderWithStore(
         <FretboardSVG {...BASE_PROPS} {...C_MAJOR} highlightNotes={["C", "E", "G", "B", "D"]} />,
         store,
       );
-      const board = container.querySelector('[data-testid="fretboard-svg"]') as HTMLElement;
+      const board = screen.getByTestId("fretboard-svg");
       expect(board.getAttribute("data-transition-phase")).toBeNull();
     });
 

--- a/src/components/FretboardSVG/FretboardSVG.test.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.test.tsx
@@ -16,6 +16,7 @@ import {
   progressionStepsAtom,
   beatsPerBarAtom,
   progressionStepDeadlineAtom,
+  progressionStepDurationMsAtom,
 } from "../../store/progressionAtoms";
 import { progressionVisualFrameAtom } from "../../store/progressionVisualAtoms";
 
@@ -880,8 +881,10 @@ describe("FretboardSVG/FretboardSVG", () => {
       store.set(progressionVisualFrameAtom, { stepIndex: 0, globalFraction: 0.0, localFraction: 0.0, paused: false });
       // Deadline more than one step ahead — the "step has started" guard
       // (deadline - now > stepMs) prevents guideCountdownActiveAtom from firing.
-      // At 120 BPM / 4 beats per bar: stepMs ≈ 2000 ms; 3× that is safely outside.
-      store.set(progressionStepDeadlineAtom, Date.now() + 6000);
+      // Derive from the active step duration so this stays correct if the tempo
+      // or defaults change; 3× is safely outside the window.
+      const stepMs = store.get(progressionStepDurationMsAtom);
+      store.set(progressionStepDeadlineAtom, Date.now() + stepMs * 3);
 
       renderWithStore(
         <FretboardSVG {...BASE_PROPS} {...C_MAJOR} highlightNotes={["C", "E", "G", "B", "D"]} />,

--- a/src/components/FretboardSVG/FretboardSVG.tsx
+++ b/src/components/FretboardSVG/FretboardSVG.tsx
@@ -8,7 +8,7 @@ import {
 } from "@fretflow/core";
 import { fingeringPatternAtom } from "../../store/fingeringAtoms";
 import { intervalPairsAtom } from "../../store/shapeAtoms";
-import { leadInActiveAtom, leadInDurationMsAtom, planningDurationMsAtom } from "../../store/practiceLensAtoms";
+import { guideCountdownActiveAtom, guideCountdownWindowMsAtom, guideCountdownTickFractionsAtom } from "../../store/practiceLensAtoms";
 import { useFretboardPlaybackSnapshot } from "./hooks/useFretboardPlaybackSnapshot";
 import { STRING_ROW_PX_TABLET } from "../../layout/responsive";
 import styles from "./FretboardSVG.module.css";
@@ -319,9 +319,9 @@ export function FretboardSVG({
   void effectiveZoom;
   const fingeringPattern = useAtomValue(fingeringPatternAtom);
   const intervalPairs = useAtomValue(intervalPairsAtom);
-  const leadInActive = useAtomValue(leadInActiveAtom);
-  const leadInDurationMs = useAtomValue(leadInDurationMsAtom);
-  const planningDurationMs = useAtomValue(planningDurationMsAtom);
+  const guideCountdownActive = useAtomValue(guideCountdownActiveAtom);
+  const guideCountdownWindowMs = useAtomValue(guideCountdownWindowMsAtom);
+  const countdownTicks = useAtomValue(guideCountdownTickFractionsAtom);
 
   // Playback snapshot is subscribed here (inside the lazy boundary) so that
   // frame ticks stay contained to FretboardSVG rather than re-rendering the
@@ -608,11 +608,10 @@ export function FretboardSVG({
       aria-label={ariaLabel}
       className={styles["fretboard-board"]}
       data-full-chord-mode={fullChordVoicings?.length ? "true" : undefined}
-      data-transition-phase={leadInActive ? "lead-in" : undefined}
+      data-transition-phase={guideCountdownActive ? "countdown" : undefined}
       data-testid="fretboard-svg"
       style={{
-        "--lead-in-duration": `${leadInDurationMs}ms`,
-        "--planning-duration": `${planningDurationMs}ms`,
+        "--guide-duration": `${guideCountdownWindowMs}ms`,
       } as CSSProperties}
     >
       <div
@@ -702,6 +701,7 @@ export function FretboardSVG({
                     neckWidthPx={neckWidthPx}
                     neckHeight={neckHeight}
                     numStrings={numStrings}
+                    countdownTicks={countdownTicks}
                   />
                 </g>
                 <ChordConnectorEvaluator {...connectorProps} pass="above" />

--- a/src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts
+++ b/src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts
@@ -239,10 +239,10 @@ describe("useAnimatedFretboardView — no per-frame recompute", () => {
   it("does not re-run when the visual frame advances within the same step", () => {
     const store = makePlayingStore(0.6);
     // Seed a deadline 30% into the step's remaining time so the step fraction
-    // (~0.7) is genuinely inside the lead-in window and leadInActiveAtom is
-    // TRUE — the invariant under test ("a frame advance within the step does
-    // not re-run the hook") matters most while the lead-in is on. Without a
-    // deadline leadInActive would be false and the test would pass vacuously.
+    // (~0.7) is genuinely inside the countdown window and guideCountdownActiveAtom
+    // is TRUE — the invariant under test ("a frame advance within the step does
+    // not re-run the hook") matters most while the countdown is on. Without a
+    // deadline guideCountdownActive would be false and the test would pass vacuously.
     store.set(progressionStepDeadlineAtom, Date.now() + store.get(progressionStepDurationMsAtom) * 0.3);
     const wrapper = makeWrapper(store);
     let renders = 0;
@@ -268,6 +268,6 @@ describe("useAnimatedFretboardView — no per-frame recompute", () => {
         paused: false,
       });
     });
-    expect(renders).toBe(before); // leadInActive unchanged -> no React re-render
+    expect(renders).toBe(before); // guideCountdownActive unchanged -> no React re-render
   });
 });

--- a/src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts
+++ b/src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts
@@ -64,8 +64,10 @@ function makeWrapper(store: ReturnType<typeof createStore>) {
 }
 
 describe("useAnimatedFretboardView", () => {
-  it("updates rendered notes when emphasis context crosses the lead-in threshold", () => {
-    // localFraction=0.25 → below the lead-in window threshold (0.5)
+  it("applies guide-target emphasis to the next chord's guide tone while the countdown window is open", () => {
+    // With a 1-bar step and the 2-bar countdown window, the countdown spans the
+    // full step, so guideCountdownActive is true from the moment playback starts.
+    // B is the 3rd of V (G major) — a guide tone for the next chord (step 1).
     const store = makePlayingStore(0.25);
     const wrapper = makeWrapper(store);
 
@@ -87,11 +89,16 @@ describe("useAnimatedFretboardView", () => {
       { wrapper },
     );
 
-    const initialTopology = result.current.topology;
-    const initialView = result.current.view;
-    const initialBNote = initialView.renderedNotes.find((note) => note.noteName === "B");
+    const bNote = result.current.view.renderedNotes.find((note) => note.noteName === "B");
 
-    // Advance to localFraction=0.75 → crosses into the lead-in window
+    // B is a guide tone of the next chord and the countdown window covers the
+    // full 1-bar step — it must receive the guide-target ring immediately.
+    expect(bNote?.applyLensEmphasis.transitionRole).toBe("guide-target");
+    // Topology must be stable across renders
+    const initialTopology = result.current.topology;
+
+    // A frame advance within the same step must not change topology or notes
+    // that are already at their correct emphasis.
     act(() => {
       store.set(progressionVisualFrameAtom, {
         stepIndex: 0,
@@ -99,23 +106,15 @@ describe("useAnimatedFretboardView", () => {
         localFraction: 0.75,
         paused: false,
       });
-      store.set(progressionStepDeadlineAtom, Date.now() + 100);
     });
 
-    const updatedView = result.current.view;
-    const updatedBNote = result.current.view.renderedNotes.find((note) => note.noteName === "B");
-
-    // Topology must be stable — only emphasis changed
     expect(result.current.topology).toBe(initialTopology);
-    // noteData and renderedNotes must be new references (emphasis changed)
-    expect(updatedView.noteData).not.toBe(initialView.noteData);
-    expect(updatedView.renderedNotes).not.toBe(initialView.renderedNotes);
-    // B is the 3rd of V (G major) — an incoming tone the next chord introduces,
-    // so its emphasis must change once the lead-in window opens.
-    expect(updatedBNote?.applyLensEmphasis).not.toEqual(initialBNote?.applyLensEmphasis);
+    // B's guide-target emphasis stays the same — countdown is still open.
+    const updatedBNote = result.current.view.renderedNotes.find((note) => note.noteName === "B");
+    expect(updatedBNote?.applyLensEmphasis.transitionRole).toBe("guide-target");
     // Geometry must be unchanged
-    expect(updatedBNote?.cx).toBe(initialBNote?.cx);
-    expect(updatedBNote?.cy).toBe(initialBNote?.cy);
+    expect(updatedBNote?.cx).toBe(bNote?.cx);
+    expect(updatedBNote?.cy).toBe(bNote?.cy);
   });
 
   it("keeps noteData reference-stable when the frame advances within a step (below lead-in threshold)", () => {

--- a/src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts
+++ b/src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts
@@ -47,8 +47,7 @@ export function buildAnimatedFretboardNotes({
         nextChordTones: emphasisContext.nextChordTones,
         incomingTones: emphasisContext.incomingTones,
         departingTones: emphasisContext.departingTones,
-        leadInActive: emphasisContext.leadInActive,
-        planningActive: emphasisContext.planningActive,
+        guideCountdownActive: emphasisContext.guideCountdownActive,
       };
     }
 

--- a/src/components/FretboardSVG/hooks/useEmphasisContext.ts
+++ b/src/components/FretboardSVG/hooks/useEmphasisContext.ts
@@ -5,8 +5,6 @@ import {
   nextChordTonesAtom,
   incomingTonesAtom,
   departingTonesAtom,
-  leadInActiveAtom,
-  planningWindowActiveAtom,
   guideCountdownActiveAtom,
   guideCountdownTickFractionsAtom,
 } from "../../../store/practiceLensAtoms";
@@ -18,8 +16,6 @@ export interface EmphasisContext {
   nextChordTones: Set<string>;
   incomingTones: Set<string>;
   departingTones: Set<string>;
-  leadInActive: boolean;
-  planningActive: boolean;
   guideCountdownActive: boolean;
   countdownTicks: number[];
 }
@@ -31,8 +27,6 @@ export interface EmphasisContext {
  */
 export function useEmphasisContext(enabled: boolean): EmphasisContext | null {
   const playing = useAtomValue(progressionPlayingAtom);
-  const leadInActive = useAtomValue(leadInActiveAtom);
-  const planningActive = useAtomValue(planningWindowActiveAtom);
   const guideCountdownActive = useAtomValue(guideCountdownActiveAtom);
   const countdownTicks = useAtomValue(guideCountdownTickFractionsAtom);
   const nextGuideTones = useAtomValue(nextChordGuideTonesAtom);
@@ -47,8 +41,6 @@ export function useEmphasisContext(enabled: boolean): EmphasisContext | null {
     nextChordTones,
     incomingTones,
     departingTones,
-    leadInActive,
-    planningActive,
     guideCountdownActive,
     countdownTicks,
   };

--- a/src/components/FretboardSVG/hooks/useEmphasisContext.ts
+++ b/src/components/FretboardSVG/hooks/useEmphasisContext.ts
@@ -7,6 +7,8 @@ import {
   departingTonesAtom,
   leadInActiveAtom,
   planningWindowActiveAtom,
+  guideCountdownActiveAtom,
+  guideCountdownTickFractionsAtom,
 } from "../../../store/practiceLensAtoms";
 import { progressionPlayingAtom } from "../../../store/progressionAtoms";
 
@@ -18,6 +20,8 @@ export interface EmphasisContext {
   departingTones: Set<string>;
   leadInActive: boolean;
   planningActive: boolean;
+  guideCountdownActive: boolean;
+  countdownTicks: number[];
 }
 
 /**
@@ -29,6 +33,8 @@ export function useEmphasisContext(enabled: boolean): EmphasisContext | null {
   const playing = useAtomValue(progressionPlayingAtom);
   const leadInActive = useAtomValue(leadInActiveAtom);
   const planningActive = useAtomValue(planningWindowActiveAtom);
+  const guideCountdownActive = useAtomValue(guideCountdownActiveAtom);
+  const countdownTicks = useAtomValue(guideCountdownTickFractionsAtom);
   const nextGuideTones = useAtomValue(nextChordGuideTonesAtom);
   const nextGuideToneLabels = useAtomValue(nextChordGuideToneLabelsAtom);
   const nextChordTones = useAtomValue(nextChordTonesAtom);
@@ -43,5 +49,7 @@ export function useEmphasisContext(enabled: boolean): EmphasisContext | null {
     departingTones,
     leadInActive,
     planningActive,
+    guideCountdownActive,
+    countdownTicks,
   };
 }

--- a/src/components/FretboardSVG/utils/semantics.test.ts
+++ b/src/components/FretboardSVG/utils/semantics.test.ts
@@ -384,8 +384,7 @@ describe("getEmphasis - voice-leading emphasis", () => {
     nextChordTones: new Set<string>(),
     incomingTones: new Set<string>(),
     departingTones: new Set<string>(),
-    leadInActive: true,
-    planningActive: false,
+    guideCountdownActive: true,
   };
 
   it("falls back to tones-base when leadContext is undefined", () => {
@@ -451,7 +450,7 @@ describe("getEmphasis - voice-leading emphasis", () => {
 
   it("outside the lead-in window, a held common tone is NOT enlarged (no role)", () => {
     const ctx: LeadLensContext = {
-      ...baseLeadContext, notePc: "A", leadInActive: false,
+      ...baseLeadContext, notePc: "A", guideCountdownActive: false,
     };
     expect(getEmphasis("chord-tone-in-scale", false, ctx)).toEqual({
       radiusBoost: 1, opacityBoost: 1,
@@ -460,38 +459,41 @@ describe("getEmphasis - voice-leading emphasis", () => {
 
   it("outside the lead-in window, a guide tone produces no role", () => {
     const ctx: LeadLensContext = {
-      ...baseLeadContext, notePc: "B", nextGuideTones: new Set(["B"]), leadInActive: false,
+      ...baseLeadContext, notePc: "B", nextGuideTones: new Set(["B"]), guideCountdownActive: false,
     };
     expect(getEmphasis("note-inactive", false, ctx).transitionRole).toBeUndefined();
   });
 
-  it("marks a next-chord guide tone as 'guide-preview' during the planning window", () => {
-    const ctx: LeadLensContext = {
-      ...baseLeadContext, notePc: "B", leadInActive: false, planningActive: true,
+  it("marks a next-chord guide tone as 'guide-target' during the countdown window", () => {
+    const e = getEmphasis("chord-tone-in-scale", true, {
+      notePc: "B",
       nextGuideTones: new Set(["B"]),
       nextGuideToneLabels: new Map([["B", "3"]]),
-    };
-    // Planning preview: resting size, full opacity, the preview role + label,
-    // and NO glow (the ring carries it).
-    const e = getEmphasis("scale-only", false, ctx);
-    expect(e.transitionRole).toBe("guide-preview");
+      nextChordTones: new Set(["B", "D", "G"]),
+      incomingTones: new Set(["B"]),
+      departingTones: new Set(),
+      guideCountdownActive: true,
+    });
+    expect(e.transitionRole).toBe("guide-target");
     expect(e.guideTargetLabel).toBe("3");
-    expect(e.opacityBoost).toBe(1);
-    expect(e.radiusBoost).toBe(0.85);
   });
 
-  it("landing (guide-target) takes precedence over planning when both flags are set", () => {
-    const ctx: LeadLensContext = {
-      ...baseLeadContext, notePc: "B", leadInActive: true, planningActive: true,
+  it("returns the resting emphasis when the countdown window is inactive", () => {
+    const e = getEmphasis("chord-tone-in-scale", true, {
+      notePc: "B",
       nextGuideTones: new Set(["B"]),
       nextGuideToneLabels: new Map([["B", "3"]]),
-    };
-    expect(getEmphasis("scale-only", false, ctx).transitionRole).toBe("guide-target");
+      nextChordTones: new Set(["B", "D", "G"]),
+      incomingTones: new Set(["B"]),
+      departingTones: new Set(),
+      guideCountdownActive: false,
+    });
+    expect(e.transitionRole).toBeUndefined();
   });
 
-  it("produces no role when neither planning nor lead-in is active", () => {
+  it("produces no role when the countdown is inactive", () => {
     const ctx: LeadLensContext = {
-      ...baseLeadContext, notePc: "B", leadInActive: false, planningActive: false,
+      ...baseLeadContext, notePc: "B", guideCountdownActive: false,
       nextGuideTones: new Set(["B"]),
     };
     expect(getEmphasis("note-inactive", false, ctx).transitionRole).toBeUndefined();

--- a/src/components/FretboardSVG/utils/semantics.ts
+++ b/src/components/FretboardSVG/utils/semantics.ts
@@ -6,7 +6,7 @@ import {
 
 export type BoxBound = { minFret: number; maxFret: number };
 
-export type TransitionRole = "guide-target" | "guide-preview";
+export type TransitionRole = "guide-target";
 
 export type LensEmphasis = {
   radiusBoost: number;

--- a/src/components/FretboardSVG/utils/semantics.ts
+++ b/src/components/FretboardSVG/utils/semantics.ts
@@ -36,10 +36,8 @@ export type LeadLensContext = {
   incomingTones: Set<string>;
   /** Pitch classes the active chord drops on the change (`current − next`). */
   departingTones: Set<string>;
-  /** True only during the lead-in (landing) preview window. */
-  leadInActive: boolean;
-  /** True only during the earlier planning runway (mutually exclusive with leadInActive). */
-  planningActive: boolean;
+  /** True while the single continuous countdown window is open. */
+  guideCountdownActive: boolean;
 };
 
 /**
@@ -68,28 +66,17 @@ export function getEmphasis(
     return applyTonesBase(noteClass);
   }
 
-  const { notePc, nextGuideTones, nextGuideToneLabels, leadInActive, planningActive } = leadContext;
+  const { notePc, nextGuideTones, nextGuideToneLabels, guideCountdownActive } = leadContext;
 
   // The note's resting emphasis when not actively targeted — the base model.
-  // This is the size/shape a note shows OUTSIDE the lead-in window.
   const resting: LensEmphasis = applyTonesBase(noteClass);
 
-  // Landing: the next chord's guide tones get the urgent contracting ring.
-  if (leadInActive && nextGuideTones.has(notePc)) {
+  // Countdown: the next chord's guide tones get the single continuous ring.
+  if (guideCountdownActive && nextGuideTones.has(notePc)) {
     return {
       radiusBoost: resting.radiusBoost,
       opacityBoost: 1,
       transitionRole: "guide-target",
-      guideTargetLabel: nextGuideToneLabels.get(notePc),
-    };
-  }
-  // Planning: the same guide tones get a calm static preview (no glow — the
-  // dashed ring carries it). Brought to full opacity so the target reads.
-  if (planningActive && nextGuideTones.has(notePc)) {
-    return {
-      radiusBoost: resting.radiusBoost,
-      opacityBoost: 1,
-      transitionRole: "guide-preview",
       guideTargetLabel: nextGuideToneLabels.get(notePc),
     };
   }

--- a/src/store/practiceLensAtoms.test.ts
+++ b/src/store/practiceLensAtoms.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./chordOverlayAtoms";
 import { fingeringPatternAtom } from "./fingeringAtoms";
 import { makeAtomStore } from "../test-utils/renderWithAtoms";
-import { practiceCuesAtom, noteSemanticMapAtom, nextChordTonesAtom, commonTonesWithNextAtom, nextChordGuideTonesAtom, nextChordGuideToneLabelsAtom, beatPositionAtom, activeStepDurationBeatsAtom, computeLeadInWindowMs, isInLeadInWindow, isInPlanningWindow, activeChordTonesAtom, incomingTonesAtom, departingTonesAtom, leadInActiveAtom, leadInDurationMsAtom, stepRelativeFraction, planningWindowActiveAtom } from "./practiceLensAtoms";
+import { practiceCuesAtom, noteSemanticMapAtom, nextChordTonesAtom, commonTonesWithNextAtom, nextChordGuideTonesAtom, nextChordGuideToneLabelsAtom, beatPositionAtom, activeStepDurationBeatsAtom, computeLeadInWindowMs, isInLeadInWindow, isInPlanningWindow, activeChordTonesAtom, incomingTonesAtom, departingTonesAtom, leadInActiveAtom, leadInDurationMsAtom, stepRelativeFraction, planningWindowActiveAtom, isInCountdownWindow, computeCountdownTickFractions } from "./practiceLensAtoms";
 import { progressionStepsAtom, activeProgressionStepIndexAtom, progressionTempoBpmAtom, progressionStepDeadlineAtom, beatsPerBarAtom, activeResolvedProgressionStepAtom, displayedStepIndexPrimitiveAtom, setProgressionActiveStepIndexAtom, setProgressionPlayingAtom, progressionLoopEnabledAtom, progressionPlayingStateAtom, progressionStepDurationMsAtom, progressionBarDurationMsAtom } from "./progressionAtoms";
 import { progressionVisualFrameAtom } from "./progressionVisualAtoms";
 import { rootNoteAtom, scaleNameAtom, scaleVisibleAtom, colorNotesAtom, effectiveColorNotesAtom, toggleScaleVisibleAtom } from "./scaleAtoms";
@@ -730,6 +730,65 @@ describe("isInPlanningWindow", () => {
   it("returns false for a non-positive step duration", () => {
     expect(isInPlanningWindow(0.5, 0, 2000)).toBe(false);
     expect(isInPlanningWindow(0.5, -100, 2000)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isInCountdownWindow — single continuous countdown window
+// ---------------------------------------------------------------------------
+
+describe("isInCountdownWindow", () => {
+  it("is active across the whole step when step <= 2 bars", () => {
+    // step 2000, bar 2000: window = min(2000, 4000) = 2000 -> start fraction 0
+    expect(isInCountdownWindow(0, 2000, 2000)).toBe(true);
+    expect(isInCountdownWindow(0.99, 2000, 2000)).toBe(true);
+  });
+
+  it("caps the window at 2 bars for long chords", () => {
+    // step 8000, bar 2000: window = min(8000, 4000) = 4000 -> start fraction 0.5
+    expect(isInCountdownWindow(0.49, 8000, 2000)).toBe(false);
+    expect(isInCountdownWindow(0.5, 8000, 2000)).toBe(true);
+  });
+
+  it("returns false for a non-positive step duration", () => {
+    expect(isInCountdownWindow(0.5, 0, 2000)).toBe(false);
+    expect(isInCountdownWindow(0.5, -100, 2000)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeCountdownTickFractions — beat/bar boundary notches, capped at 4
+// ---------------------------------------------------------------------------
+
+describe("computeCountdownTickFractions", () => {
+  it("one tick per beat boundary when <= 4 beats", () => {
+    // 4 beats -> 4 segments -> interior ticks at 1/4, 2/4, 3/4
+    expect(computeCountdownTickFractions(4000, 1000, 4000)).toEqual([0.25, 0.5, 0.75]);
+  });
+
+  it("two beats yields a single midpoint tick", () => {
+    expect(computeCountdownTickFractions(2000, 1000, 4000)).toEqual([0.5]);
+  });
+
+  it("suppresses ticks below 2 beats", () => {
+    expect(computeCountdownTickFractions(1000, 1000, 4000)).toEqual([]);
+  });
+
+  it("collapses to bar boundaries when > 4 beats and bars in 2..4", () => {
+    // 8 beats, 2 bars -> segment by bar -> one tick at 0.5
+    expect(computeCountdownTickFractions(8000, 1000, 4000)).toEqual([0.5]);
+    // 12 beats, 3 bars -> ticks at 1/3, 2/3
+    expect(computeCountdownTickFractions(12000, 1000, 4000)).toEqual([1 / 3, 2 / 3]);
+  });
+
+  it("falls back to 4 even segments when bars also exceed 4", () => {
+    // 20 beats, 5 bars -> 4 even segments -> 0.25, 0.5, 0.75
+    expect(computeCountdownTickFractions(20000, 1000, 4000)).toEqual([0.25, 0.5, 0.75]);
+  });
+
+  it("returns [] for non-positive window or beat length", () => {
+    expect(computeCountdownTickFractions(0, 1000, 4000)).toEqual([]);
+    expect(computeCountdownTickFractions(4000, 0, 4000)).toEqual([]);
   });
 });
 

--- a/src/store/practiceLensAtoms.test.ts
+++ b/src/store/practiceLensAtoms.test.ts
@@ -761,13 +761,13 @@ describe("isInCountdownWindow", () => {
 // ---------------------------------------------------------------------------
 
 describe("computeCountdownTickFractions", () => {
-  it("one tick per beat boundary when <= 4 beats", () => {
-    // 4 beats -> 4 segments -> interior ticks at 1/4, 2/4, 3/4
-    expect(computeCountdownTickFractions(4000, 1000, 4000)).toEqual([0.25, 0.5, 0.75]);
+  it("anchor tick at 0 plus one per beat boundary when <= 4 beats", () => {
+    // 4 beats -> 4 segments -> anchor 0 + interior ticks at 1/4, 2/4, 3/4
+    expect(computeCountdownTickFractions(4000, 1000, 4000)).toEqual([0, 0.25, 0.5, 0.75]);
   });
 
-  it("two beats yields a single midpoint tick", () => {
-    expect(computeCountdownTickFractions(2000, 1000, 4000)).toEqual([0.5]);
+  it("two beats yields the anchor plus a single midpoint tick", () => {
+    expect(computeCountdownTickFractions(2000, 1000, 4000)).toEqual([0, 0.5]);
   });
 
   it("suppresses ticks below 2 beats", () => {
@@ -775,15 +775,15 @@ describe("computeCountdownTickFractions", () => {
   });
 
   it("collapses to bar boundaries when > 4 beats and bars in 2..4", () => {
-    // 8 beats, 2 bars -> segment by bar -> one tick at 0.5
-    expect(computeCountdownTickFractions(8000, 1000, 4000)).toEqual([0.5]);
-    // 12 beats, 3 bars -> ticks at 1/3, 2/3
-    expect(computeCountdownTickFractions(12000, 1000, 4000)).toEqual([1 / 3, 2 / 3]);
+    // 8 beats, 2 bars -> segment by bar -> anchor 0 + tick at 0.5
+    expect(computeCountdownTickFractions(8000, 1000, 4000)).toEqual([0, 0.5]);
+    // 12 beats, 3 bars -> anchor 0 + ticks at 1/3, 2/3
+    expect(computeCountdownTickFractions(12000, 1000, 4000)).toEqual([0, 1 / 3, 2 / 3]);
   });
 
   it("falls back to 4 even segments when bars also exceed 4", () => {
-    // 20 beats, 5 bars -> 4 even segments -> 0.25, 0.5, 0.75
-    expect(computeCountdownTickFractions(20000, 1000, 4000)).toEqual([0.25, 0.5, 0.75]);
+    // 20 beats, 5 bars -> 4 even segments -> anchor 0 + 0.25, 0.5, 0.75
+    expect(computeCountdownTickFractions(20000, 1000, 4000)).toEqual([0, 0.25, 0.5, 0.75]);
   });
 
   it("returns [] for non-positive window or beat length", () => {

--- a/src/store/practiceLensAtoms.test.ts
+++ b/src/store/practiceLensAtoms.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./chordOverlayAtoms";
 import { fingeringPatternAtom } from "./fingeringAtoms";
 import { makeAtomStore } from "../test-utils/renderWithAtoms";
-import { practiceCuesAtom, noteSemanticMapAtom, nextChordTonesAtom, commonTonesWithNextAtom, nextChordGuideTonesAtom, nextChordGuideToneLabelsAtom, beatPositionAtom, activeStepDurationBeatsAtom, computeLeadInWindowMs, isInLeadInWindow, isInPlanningWindow, activeChordTonesAtom, incomingTonesAtom, departingTonesAtom, leadInActiveAtom, leadInDurationMsAtom, stepRelativeFraction, planningWindowActiveAtom, isInCountdownWindow, computeCountdownTickFractions } from "./practiceLensAtoms";
+import { practiceCuesAtom, noteSemanticMapAtom, nextChordTonesAtom, commonTonesWithNextAtom, nextChordGuideTonesAtom, nextChordGuideToneLabelsAtom, beatPositionAtom, activeStepDurationBeatsAtom, computeLeadInWindowMs, isInLeadInWindow, isInPlanningWindow, activeChordTonesAtom, incomingTonesAtom, departingTonesAtom, leadInActiveAtom, leadInDurationMsAtom, stepRelativeFraction, planningWindowActiveAtom, isInCountdownWindow, computeCountdownTickFractions, guideCountdownWindowMsAtom, guideCountdownActiveAtom, guideCountdownTickFractionsAtom } from "./practiceLensAtoms";
 import { progressionStepsAtom, activeProgressionStepIndexAtom, progressionTempoBpmAtom, progressionStepDeadlineAtom, beatsPerBarAtom, activeResolvedProgressionStepAtom, displayedStepIndexPrimitiveAtom, setProgressionActiveStepIndexAtom, setProgressionPlayingAtom, progressionLoopEnabledAtom, progressionPlayingStateAtom, progressionStepDurationMsAtom, progressionBarDurationMsAtom } from "./progressionAtoms";
 import { progressionVisualFrameAtom } from "./progressionVisualAtoms";
 import { rootNoteAtom, scaleNameAtom, scaleVisibleAtom, colorNotesAtom, effectiveColorNotesAtom, toggleScaleVisibleAtom } from "./scaleAtoms";
@@ -1123,5 +1123,62 @@ describe("planningWindowActiveAtom", () => {
     store.set(progressionVisualFrameAtom, { stepIndex: 1, globalFraction: 0, localFraction: 0, paused: false });
     expect(store.get(planningWindowActiveAtom)).toBe(false);
     expect(store.get(leadInActiveAtom)).toBe(true);
+  });
+});
+
+describe("guide countdown atoms", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  function makePlayingStore() {
+    const store = createStore();
+    const unsub = store.sub(progressionStepsAtom, () => {});
+    unsub();
+    store.set(progressionPlayingStateAtom, true);
+    return store;
+  }
+
+  it("guideCountdownWindowMsAtom = min(step, 2·bar)", () => {
+    const store = makePlayingStore();
+    const step = store.get(progressionStepDurationMsAtom);
+    const bar = store.get(progressionBarDurationMsAtom);
+    expect(store.get(guideCountdownWindowMsAtom)).toBe(Math.min(step, 2 * bar));
+  });
+
+  it("guideCountdownTickFractionsAtom matches the pure helper for the active step", () => {
+    const store = makePlayingStore();
+    const windowMs = store.get(guideCountdownWindowMsAtom);
+    const bar = store.get(progressionBarDurationMsAtom);
+    const beatsPerBar = store.get(beatsPerBarAtom);
+    const beatMs = beatsPerBar > 0 ? bar / beatsPerBar : 0;
+    expect(store.get(guideCountdownTickFractionsAtom)).toEqual(
+      computeCountdownTickFractions(windowMs, beatMs, bar),
+    );
+  });
+
+  it("guideCountdownActiveAtom is false outside the window and true inside", () => {
+    const store = makePlayingStore();
+    store.set(displayedStepIndexPrimitiveAtom, 0);
+    const stepMs = store.get(progressionStepDurationMsAtom);
+    const bar = store.get(progressionBarDurationMsAtom);
+    const windowMs = Math.min(stepMs, 2 * bar);
+    store.set(progressionVisualFrameAtom, { stepIndex: 0, globalFraction: 0.1, localFraction: 0.1, paused: false });
+
+    // Deadline far in the future → step barely started → outside the window.
+    store.set(progressionStepDeadlineAtom, Date.now() + windowMs + 1000);
+    expect(store.get(guideCountdownActiveAtom)).toBe(false);
+
+    // Deadline inside the window → active.
+    store.set(progressionStepDeadlineAtom, Date.now() + windowMs - 50);
+    expect(store.get(guideCountdownActiveAtom)).toBe(true);
+  });
+
+  it("guideCountdownActiveAtom holds across the boundary gap (audio ahead of displayed)", () => {
+    const store = makePlayingStore();
+    store.set(displayedStepIndexPrimitiveAtom, 0);
+    // Audio frame already on the next step while the fretboard still shows step 0.
+    store.set(progressionVisualFrameAtom, { stepIndex: 1, globalFraction: 0.0, localFraction: 0.0, paused: false });
+    expect(store.get(guideCountdownActiveAtom)).toBe(true);
   });
 });

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -197,11 +197,15 @@ const MIN_TICK_BEATS = 2;
 const MAX_TICK_SEGMENTS = 4;
 
 /**
- * Window-fractions in (0,1) at which to draw static beat/bar boundary notches.
+ * Window-fractions in [0,1) at which to draw static beat/bar boundary notches.
+ * Includes an anchor tick at fraction 0 — the start/beat line (the full-circle
+ * drain's start and end coincide, so this single mark anchors both the launch
+ * and the landing point) — followed by one tick per interior segment boundary.
  *
  * - ≤ 4 beats → one segment per beat (subitizable at a glance).
  * - > 4 beats → collapse to bar lines when there are 2–4 bars, else 4 even
- *   segments (caps interior ticks at 3 — the ~4-object subitizing limit).
+ *   segments (caps interior ticks at 3 + the anchor → ≤ 4 marks, the ~4-object
+ *   subitizing limit).
  * - < 2 beats → no ticks.
  *
  * Pure so it is unit-testable. `windowMs`/`beatMs`/`barMs` are all in ms.
@@ -223,7 +227,7 @@ export function computeCountdownTickFractions(
     segments = bars >= 2 && bars <= MAX_TICK_SEGMENTS ? bars : MAX_TICK_SEGMENTS;
   }
 
-  const ticks: number[] = [];
+  const ticks: number[] = [0];
   for (let i = 1; i < segments; i++) ticks.push(i / segments);
   return ticks;
 }

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -174,6 +174,61 @@ export function isInPlanningWindow(
 }
 
 /**
+ * True when the playhead is inside the single continuous countdown window — the
+ * union of the old planning + landing windows. The window spans the final
+ * `min(step, PLANNING_RUNWAY_BARS · bar)` of the step and ends exactly on the
+ * beat. Pure so it is unit-testable without atom plumbing.
+ */
+export function isInCountdownWindow(
+  stepFraction: number,
+  stepDurationMs: number,
+  barDurationMs = Infinity,
+): boolean {
+  if (stepDurationMs <= 0) return false;
+  const windowMs = Math.min(stepDurationMs, PLANNING_RUNWAY_BARS * barDurationMs);
+  if (windowMs <= 0) return false;
+  const startFraction = 1 - windowMs / stepDurationMs;
+  return stepFraction >= startFraction;
+}
+
+/** Lowest beat count that shows interior ticks (a lone tick is noise). */
+const MIN_TICK_BEATS = 2;
+/** Subitizing cap — at most this many segments (≤ 3 interior ticks). */
+const MAX_TICK_SEGMENTS = 4;
+
+/**
+ * Window-fractions in (0,1) at which to draw static beat/bar boundary notches.
+ *
+ * - ≤ 4 beats → one segment per beat (subitizable at a glance).
+ * - > 4 beats → collapse to bar lines when there are 2–4 bars, else 4 even
+ *   segments (caps interior ticks at 3 — the ~4-object subitizing limit).
+ * - < 2 beats → no ticks.
+ *
+ * Pure so it is unit-testable. `windowMs`/`beatMs`/`barMs` are all in ms.
+ */
+export function computeCountdownTickFractions(
+  windowMs: number,
+  beatMs: number,
+  barMs: number,
+): number[] {
+  if (windowMs <= 0 || beatMs <= 0) return [];
+  const beats = Math.round(windowMs / beatMs);
+  if (beats < MIN_TICK_BEATS) return [];
+
+  let segments: number;
+  if (beats <= MAX_TICK_SEGMENTS) {
+    segments = beats;
+  } else {
+    const bars = barMs > 0 ? Math.round(windowMs / barMs) : 0;
+    segments = bars >= 2 && bars <= MAX_TICK_SEGMENTS ? bars : MAX_TICK_SEGMENTS;
+  }
+
+  const ticks: number[] = [];
+  for (let i = 1; i < segments; i++) ticks.push(i / segments);
+  return ticks;
+}
+
+/**
  * Fraction [0,1] of the active STEP elapsed, derived from the per-step deadline
  * (`Date.now() + stepDurationMs`, set on each step advance) rather than the
  * visual frame's `localFraction` — which the timeline resets every BAR, so a

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -720,6 +720,61 @@ export const planningWindowActiveAtom = atom((get): boolean => {
 });
 
 /**
+ * Length of the single continuous countdown window, in ms — `min(step, 2·bar)`.
+ * Written to the `--guide-duration` CSS custom property so the drain lasts
+ * exactly the window. Changes only when the active step / tempo changes.
+ */
+export const guideCountdownWindowMsAtom = atom((get): number => {
+  const step = get(progressionStepDurationMsAtom);
+  const bar = get(progressionBarDurationMsAtom);
+  return Math.min(step, PLANNING_RUNWAY_BARS * bar);
+});
+
+/**
+ * Window-fractions for the static beat-tick notches on the countdown ring.
+ * Derived from the countdown window and meter via
+ * {@link computeCountdownTickFractions}. Recomputes only on step/tempo/meter
+ * change — never per frame.
+ */
+export const guideCountdownTickFractionsAtom = atom((get): number[] => {
+  const windowMs = get(guideCountdownWindowMsAtom);
+  const bar = get(progressionBarDurationMsAtom);
+  const beatsPerBar = get(beatsPerBarAtom);
+  const beatMs = beatsPerBar > 0 ? bar / beatsPerBar : 0;
+  return computeCountdownTickFractions(windowMs, beatMs, bar);
+});
+
+/**
+ * Single continuous countdown phase — the union of the old planning + landing
+ * windows. True whenever the playhead is inside {@link isInCountdownWindow} for
+ * the active step, AND (like {@link leadInActiveAtom}) held true across the
+ * boundary-gap where the audio frame leads the displayed step. Reads the
+ * per-frame visual frame, but its VALUE only flips at the window threshold, so
+ * subscribers re-render at most twice per step.
+ */
+export const guideCountdownActiveAtom = atom((get): boolean => {
+  if (!get(progressionPlayingAtom)) return false;
+  const frame = get(progressionVisualFrameAtom);
+  if (!frame || frame.paused) return false;
+  const displayed = get(displayedProgressionStepIndexAtom);
+  // Boundary gap: audio has crossed into a later step than the fretboard shows —
+  // hold the ring on until the displayed shape catches up (same as lead-in).
+  if (frame.stepIndex !== displayed) return true;
+  // Only trust the step fraction when the deadline's step matches displayed.
+  if (get(activeProgressionStepIndexAtom) !== displayed) return false;
+  const deadline = get(progressionStepDeadlineAtom);
+  if (deadline == null) return false;
+  const stepMs = get(progressionStepDurationMsAtom);
+  const now = Date.now();
+  // Guard: step must have actually started (deadline within one step from now).
+  // Prevents the ring from firing when the countdown window spans the full step
+  // (short chords) and the deadline is still in the future beyond the step start.
+  if (deadline - now > stepMs) return false;
+  const stepFraction = stepRelativeFraction(deadline, now, stepMs);
+  return isInCountdownWindow(stepFraction, stepMs, get(progressionBarDurationMsAtom));
+});
+
+/**
  * Current beat position within the active progression step, derived from
  * the step deadline and tempo. Beat 0 = just started; `stepDurationBeats` = step ended.
  *

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -617,9 +617,11 @@ export const activeStepDurationBeatsAtom = atom((get): number => {
 });
 
 /**
- * Length of the active step's lead-in preview window, in milliseconds. Written
- * to the `--lead-in-duration` CSS custom property so the ghost ramp animation
- * lasts exactly the window. Changes only when the active step / tempo changes.
+ * Length of the active step's lead-in window, in milliseconds. Retained as a
+ * derived selector — it has no current production consumer (the countdown ring
+ * now drives its CSS from {@link guideCountdownWindowMsAtom}), but it keeps its
+ * own tests and is the natural input for any future lead-in-only cue. Changes
+ * only when the active step / tempo changes.
  */
 export const leadInDurationMsAtom = atom((get): number =>
   computeLeadInWindowMs(
@@ -630,11 +632,11 @@ export const leadInDurationMsAtom = atom((get): number =>
 
 /**
  * Length of the active step's PLANNING window, in milliseconds — the runway
- * before the lead-in/landing window. Written to the `--planning-duration` CSS
- * custom property so the preview "breathe" runs exactly once over the planning
- * phase and resolves to full brightness right as the landing drain begins (a
- * seamless brightness handoff). Mirrors {@link isInPlanningWindow}'s span:
- * `min(step, 2·bar) − landingWindow`, floored at 0.
+ * before the lead-in window. Retained as a derived selector with no current
+ * production consumer (the single continuous countdown ring replaced the
+ * separate planning "breathe" phase); kept with its own tests. Mirrors
+ * {@link isInPlanningWindow}'s span: `min(step, 2·bar) − landingWindow`,
+ * floored at 0.
  */
 export const planningDurationMsAtom = atom((get): number => {
   const step = get(progressionStepDurationMsAtom);


### PR DESCRIPTION
## Summary

Replaces the two-phase guide-tone hint (a breathing "preview" ring → a draining "landing" ring over the final ~50% of a chord) with **one continuous clockwise drain** over a single countdown window (`min(step, 2·bar)`, ending on the beat), plus **static beat-tick notches** on the ring's dark halo track so the player can read how much chord time remains and count beats at a glance.

- **Single window/flag** — `guideCountdownWindowMsAtom` + `guideCountdownActiveAtom` collapse the old planning + lead-in atoms for the animated ring; `guideCountdownTickFractionsAtom` drives the notches.
- **Beat-tick notches** — drawn with the same `pathLength=100` dash parametrization as the drain (so they align without trig), capped at ≤3 interior ticks (subitizing limit), suppressed below 2 beats, collapsing beat→bar boundaries for long chords.
- **Escalating salience** — core brightness ramp + a gentle GPU-composited looming scale toward the beat; the on-beat flash is retained as the climax.
- **Secondary (out-of-region) targets** unchanged (quiet static rings, no drain/ticks). **Reduced-motion** shows a static ring + static ticks, no animation.
- Per-frame cost ≈ one drain (notches are static, loom is composited).

Design + research basis: `docs/superpowers/specs/2026-06-07-guide-tone-countdown-ring-design.md`. Plan: `docs/superpowers/plans/2026-06-07-guide-tone-countdown-ring.md`.

**Note:** the spec's "stroke-width ramp" is implemented as brightness + looming scale — the core's `stroke-width` is `!important`-locked (to beat note-role rules) and CSS can't animate over `!important`. Same escalating-salience intent.

## Test Plan

- [x] `pnpm run lint` (0 errors)
- [x] `pnpm run test` (2426 passed)
- [x] `pnpm run build`
- [x] `pnpm exec tsc -b`
- [ ] **Manual playback check** (not covered by the static visual-regression suite, which doesn't capture the playback-active ring): start a progression, confirm the next chord's guide tones show a single green drain over the whole chord, dark tick notches divide the ring at beat boundaries, and the on-beat flash fires. Verify notch positions align with the drain hand — if mirrored, flip the `strokeDashoffset` sign at `FretboardNote.tsx` (the inline NOTE comment flags this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Countdown window support with static beat-tick notches on primary guide rings; countdown state drives ring timing.

* **Visual Improvements**
  * Unified countdown/landing behavior (preview role removed); refined ring animations (drain, opacity ramp, loom) and retimed on‑beat flash.
  * Backing visuals simplified; guide-target label anchored to ring radius; reduced‑motion handling adjusted.

* **Tests**
  * Tests updated to validate countdown-driven emphasis, tick rendering, and revised guide-phase expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->