### PR TITLE
fix(progression): correct scroll-blur overlay positioning

### DIFF
--- a/src/components/SongControls/ProgressionStepList.module.css
+++ b/src/components/SongControls/ProgressionStepList.module.css
@@ -45,8 +45,6 @@
    (the `@supports` block below never applies), which degrades gracefully. */
 .scroll {
   position: relative;
-  flex: 1 1 0;
-  min-height: 0;
 }
 
 .scroll::before,


### PR DESCRIPTION
## Summary

- **Root cause:** `.scroll` had `flex: 1 1 0 / min-height: 0` inside `.col`, an auto-sized column flex container (`.progression-master-detail` uses `align-items: flex-start`, so `.col` is never given a definite height). With `flex-basis: 0` and no free space to grow into, the browser computed `.scroll`'s height as **0**.
- **Consequence:** The `::after` pseudo-element (`bottom: 0` of a 0-height containing block) was positioned **1.4 rem above the list** — hidden behind the caption — so the bottom blur was never visible. The top blur was also broken for the same structural reason.
- **Fix:** Remove `flex: 1 1 0` and `min-height: 0` from `.scroll`. It now falls back to `flex: 0 1 auto` and sizes to its content (the `.list`), placing both `::before` and `::after` at the true top and bottom of the list. The CSS scroll-driven animation logic itself required no changes.

## Test Plan

- [ ] Load the app with a progression of 8+ chords so the chord list overflows
- [ ] Scroll the list: a fade should appear at the **top** once you scroll away from the first item
- [ ] The **bottom** fade should be visible whenever more items exist below the viewport, and disappear when scrolled to the end
- [ ] Verify no layout regressions in the progression editor (chord list still renders at its natural height, editor panel alongside it)