### PR TITLE
fix(practice): hold held guide tones and fixed 4-segment drain ticks

### DIFF
--- a/src/components/FretboardSVG/FretboardNote.tsx
+++ b/src/components/FretboardSVG/FretboardNote.tsx
@@ -81,10 +81,13 @@ export const FretboardNote = memo(function FretboardNote({
 
   const prefersReducedMotion = useReducedMotion();
   const guideFade = { duration: prefersReducedMotion ? 0 : 0.18, ease: "easeOut" as const };
+  // "hold-guide" and "hold-common" both render the calm static "hold" ring:
+  // drain/loom/flash/tick keyframes are gated to the "landing" phase, so a held
+  // guide tone shows a steady ring with no countdown animation or ticks.
   const guidePhase =
     transitionRole === "guide-target"
       ? "landing"
-      : transitionRole === "hold-common"
+      : transitionRole === "hold-common" || transitionRole === "hold-guide"
         ? "hold"
         : undefined;
 

--- a/src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts
+++ b/src/components/FretboardSVG/hooks/useAnimatedFretboardView.test.ts
@@ -311,6 +311,7 @@ function makeLensEmphasisContext(
     countdownTicks: [],
     lens: "guide",
     commonTones: new Set(),
+    heldTargetTones: new Set(),
     ...overrides,
   };
 }
@@ -328,6 +329,21 @@ describe("buildAnimatedFretboardNotes — Field lens wiring", () => {
     });
     expect(notes[0].transitionRole).toBe("hold-common");
     expect(notes[0].applyLensEmphasis.radiusBoost).toBeGreaterThan(1);
+  });
+
+  it("emits hold-guide on a held guide tone under the guide lens during the countdown", () => {
+    const notes = buildAnimatedFretboardNotes({
+      topology: [makeLensTopologyNote({ noteName: "D" })],
+      hasChordOverlay: true,
+      emphasisContext: makeLensEmphasisContext({
+        lens: "guide",
+        nextGuideTones: new Set(["D"]),
+        nextGuideToneLabels: new Map([["D", "b3"]]),
+        heldTargetTones: new Set(["D"]),
+        guideCountdownActive: true,
+      }),
+    });
+    expect(notes[0].transitionRole).toBe("hold-guide");
   });
 });
 

--- a/src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts
+++ b/src/components/FretboardSVG/hooks/useAnimatedFretboardView.ts
@@ -50,6 +50,7 @@ export function buildAnimatedFretboardNotes({
         guideCountdownActive: emphasisContext.guideCountdownActive,
         lens: emphasisContext.lens,
         commonTones: emphasisContext.commonTones,
+        heldTargetTones: emphasisContext.heldTargetTones,
       };
     }
 

--- a/src/components/FretboardSVG/hooks/useEmphasisContext.ts
+++ b/src/components/FretboardSVG/hooks/useEmphasisContext.ts
@@ -8,6 +8,7 @@ import {
   guideCountdownActiveAtom,
   guideCountdownTickFractionsAtom,
   commonTonesWithNextAtom,
+  heldTargetTonesAtom,
   practiceLensAtom,
   type PracticeLens,
 } from "../../../store/practiceLensAtoms";
@@ -23,6 +24,7 @@ export interface EmphasisContext {
   countdownTicks: number[];
   lens: PracticeLens;
   commonTones: Set<string>;
+  heldTargetTones: Set<string>;
 }
 
 /**
@@ -41,6 +43,7 @@ export function useEmphasisContext(enabled: boolean): EmphasisContext | null {
   const departingTones = useAtomValue(departingTonesAtom);
   const lens = useAtomValue(practiceLensAtom);
   const commonTones = useAtomValue(commonTonesWithNextAtom);
+  const heldTargetTones = useAtomValue(heldTargetTonesAtom);
   if (!enabled || !playing) return null;
   return {
     nextGuideTones,
@@ -52,5 +55,6 @@ export function useEmphasisContext(enabled: boolean): EmphasisContext | null {
     countdownTicks,
     lens,
     commonTones,
+    heldTargetTones,
   };
 }

--- a/src/components/FretboardSVG/utils/semantics.test.ts
+++ b/src/components/FretboardSVG/utils/semantics.test.ts
@@ -388,6 +388,7 @@ describe("getEmphasis - voice-leading emphasis", () => {
     guideCountdownActive: true,
     lens: "guide",
     commonTones: new Set<string>(),
+    heldTargetTones: new Set<string>(),
   };
 
   it("falls back to tones-base when leadContext is undefined", () => {
@@ -478,6 +479,7 @@ describe("getEmphasis - voice-leading emphasis", () => {
       guideCountdownActive: true,
       lens: "guide",
       commonTones: new Set<string>(),
+      heldTargetTones: new Set<string>(),
     });
     expect(e.transitionRole).toBe("guide-target");
     expect(e.guideTargetLabel).toBe("3");
@@ -494,6 +496,7 @@ describe("getEmphasis - voice-leading emphasis", () => {
       guideCountdownActive: false,
       lens: "guide",
       commonTones: new Set<string>(),
+      heldTargetTones: new Set<string>(),
     });
     expect(e.transitionRole).toBeUndefined();
   });
@@ -519,6 +522,7 @@ function makeLeadContext(overrides: Partial<LeadLensContext> = {}): LeadLensCont
     guideCountdownActive: false,
     lens: "guide" as PracticeLens,
     commonTones: new Set(),
+    heldTargetTones: new Set(),
     ...overrides,
   };
 }
@@ -582,5 +586,42 @@ describe("getEmphasis — common-hold (Field lens)", () => {
       );
       expect(res.transitionRole).not.toBe("hold-common");
     }
+  });
+});
+
+describe("getEmphasis — held guide tone (hold-guide)", () => {
+  it("renders a held next-chord guide tone as 'hold-guide' (static ring), not a drain", () => {
+    const res = getEmphasis(
+      "chord-tone-in-scale",
+      true,
+      makeLeadContext({
+        notePc: "D",
+        lens: "guide",
+        nextGuideTones: new Set(["D"]),
+        nextGuideToneLabels: new Map([["D", "b3"]]),
+        heldTargetTones: new Set(["D"]),
+        guideCountdownActive: true,
+      }),
+    );
+    expect(res.transitionRole).toBe("hold-guide");
+    // Label is retained; only the drain/ticks are suppressed by the hold phase.
+    expect(res.guideTargetLabel).toBe("b3");
+    expect(res.opacityBoost).toBe(1);
+  });
+
+  it("still drains a next-chord guide tone that is NOT held (moves into the chord)", () => {
+    const res = getEmphasis(
+      "chord-tone-in-scale",
+      true,
+      makeLeadContext({
+        notePc: "B",
+        lens: "guide",
+        nextGuideTones: new Set(["B"]),
+        nextGuideToneLabels: new Map([["B", "3"]]),
+        heldTargetTones: new Set<string>(),
+        guideCountdownActive: true,
+      }),
+    );
+    expect(res.transitionRole).toBe("guide-target");
   });
 });

--- a/src/components/FretboardSVG/utils/semantics.ts
+++ b/src/components/FretboardSVG/utils/semantics.ts
@@ -10,7 +10,7 @@ export type BoxBound = { minFret: number; maxFret: number };
 /** Gentle size hold for pivot/common tones under the Field lens. */
 const COMMON_HOLD_RADIUS_BOOST = 1.15;
 
-export type TransitionRole = "guide-target" | "hold-common";
+export type TransitionRole = "guide-target" | "hold-common" | "hold-guide";
 
 export type LensEmphasis = {
   radiusBoost: number;
@@ -46,6 +46,12 @@ export type LeadLensContext = {
   lens: PracticeLens;
   /** Pitch classes shared between the active chord and the next (`active ∩ next`). */
   commonTones: Set<string>;
+  /**
+   * Aim-target pitch classes held across the change (`active targets ∩ next
+   * targets`). A guide tone (or root) in this set survives the change unchanged,
+   * so it renders as a quiet static ring rather than a draining countdown.
+   */
+  heldTargetTones: Set<string>;
 };
 
 /**
@@ -74,17 +80,22 @@ export function getEmphasis(
     return applyTonesBase(noteClass);
   }
 
-  const { notePc, nextGuideTones, nextGuideToneLabels, guideCountdownActive, lens, commonTones } = leadContext;
+  const { notePc, nextGuideTones, nextGuideToneLabels, guideCountdownActive, lens, commonTones, heldTargetTones } = leadContext;
 
   // The note's resting emphasis when not actively targeted — the base model.
   const resting: LensEmphasis = applyTonesBase(noteClass);
 
   // Countdown: the next chord's guide tones get the single continuous ring.
   if (guideCountdownActive && nextGuideTones.has(notePc)) {
+    // Held target: this guide tone (or root) is shared with the active chord, so
+    // the voice does not move into the next chord — there is nothing to count
+    // down toward. Render a quiet STATIC ring (the "hold" phase suppresses the
+    // drain, loom, flash, and ticks) instead of the draining countdown.
+    const isHeld = heldTargetTones.has(notePc);
     return {
       radiusBoost: resting.radiusBoost,
       opacityBoost: 1,
-      transitionRole: "guide-target",
+      transitionRole: isHeld ? "hold-guide" : "guide-target",
       guideTargetLabel: nextGuideToneLabels.get(notePc),
     };
   }

--- a/src/store/practiceLensAtoms.test.ts
+++ b/src/store/practiceLensAtoms.test.ts
@@ -759,44 +759,45 @@ describe("isInCountdownWindow", () => {
 });
 
 // ---------------------------------------------------------------------------
-// computeCountdownTickFractions — beat/bar boundary notches, capped at 4
+// computeCountdownTickFractions — always 4 even segments above the threshold
 // ---------------------------------------------------------------------------
 
 describe("computeCountdownTickFractions", () => {
-  it("anchor tick at 0 plus one per beat boundary when <= 4 beats", () => {
-    // 4 beats -> 4 segments -> anchor 0 + interior ticks at 1/4, 2/4, 3/4
-    expect(computeCountdownTickFractions(4000, 1000, 4000)).toEqual([0, 0.25, 0.5, 0.75]);
+  it("gives 4 even segments for a 4-beat chord", () => {
+    // 4 beats -> anchor 0 + interior ticks at 1/4, 2/4, 3/4
+    expect(computeCountdownTickFractions(4000, 1000)).toEqual([0, 0.25, 0.5, 0.75]);
   });
 
-  it("two beats yields the anchor plus a single midpoint tick", () => {
-    expect(computeCountdownTickFractions(2000, 1000, 4000)).toEqual([0, 0.5]);
+  it("gives 4 even segments at the 2-beat threshold (no longer a single midpoint)", () => {
+    expect(computeCountdownTickFractions(2000, 1000)).toEqual([0, 0.25, 0.5, 0.75]);
   });
 
   it("suppresses ticks below 2 beats", () => {
-    expect(computeCountdownTickFractions(1000, 1000, 4000)).toEqual([]);
+    expect(computeCountdownTickFractions(1000, 1000)).toEqual([]);
   });
 
-  it("collapses to bar boundaries when > 4 beats and bars in 2..4", () => {
-    // 8 beats, 2 bars -> segment by bar -> anchor 0 + tick at 0.5
-    expect(computeCountdownTickFractions(8000, 1000, 4000)).toEqual([0, 0.5]);
-    // 12 beats, 3 bars -> anchor 0 + ticks at 1/3, 2/3
-    expect(computeCountdownTickFractions(12000, 1000, 4000)).toEqual([0, 1 / 3, 2 / 3]);
+  it("keeps 4 even segments for a 2-bar chord (regression: was only 2 ticks)", () => {
+    // 8 beats / 2 bars -> always 4 even segments, not collapsed to bar lines.
+    expect(computeCountdownTickFractions(8000, 1000)).toEqual([0, 0.25, 0.5, 0.75]);
   });
 
-  it("gives one tick per bar for a full 4-bar chord window (regression)", () => {
-    // 16 beats / 4 bars -> segment by bar -> anchor + a tick at each bar
-    // boundary. Guards the adaptive-ticks fix: a 4-bar chord shows 4 marks.
-    expect(computeCountdownTickFractions(16000, 1000, 4000)).toEqual([0, 0.25, 0.5, 0.75]);
+  it("keeps 4 even segments for a 3-bar chord", () => {
+    // 12 beats / 3 bars -> still 4 even segments.
+    expect(computeCountdownTickFractions(12000, 1000)).toEqual([0, 0.25, 0.5, 0.75]);
   });
 
-  it("falls back to 4 even segments when bars also exceed 4", () => {
-    // 20 beats, 5 bars -> 4 even segments -> anchor 0 + 0.25, 0.5, 0.75
-    expect(computeCountdownTickFractions(20000, 1000, 4000)).toEqual([0, 0.25, 0.5, 0.75]);
+  it("keeps 4 even segments for a full 4-bar chord window", () => {
+    expect(computeCountdownTickFractions(16000, 1000)).toEqual([0, 0.25, 0.5, 0.75]);
+  });
+
+  it("keeps 4 even segments when the chord spans more than 4 bars", () => {
+    // 20 beats / 5 bars -> still capped at 4 even segments.
+    expect(computeCountdownTickFractions(20000, 1000)).toEqual([0, 0.25, 0.5, 0.75]);
   });
 
   it("returns [] for non-positive window or beat length", () => {
-    expect(computeCountdownTickFractions(0, 1000, 4000)).toEqual([]);
-    expect(computeCountdownTickFractions(4000, 0, 4000)).toEqual([]);
+    expect(computeCountdownTickFractions(0, 1000)).toEqual([]);
+    expect(computeCountdownTickFractions(4000, 0)).toEqual([]);
   });
 });
 
@@ -1169,7 +1170,7 @@ describe("guide countdown atoms", () => {
     // Window spans the full 4 bars, not a capped 2-bar runway.
     expect(store.get(guideCountdownWindowMsAtom)).toBe(stepMs);
 
-    // One tick per bar boundary: anchor + 3 interior ticks.
+    // Always 4 even segments: anchor + 3 interior ticks.
     expect(store.get(guideCountdownTickFractionsAtom)).toEqual([0, 0.25, 0.5, 0.75]);
 
     // Active from the FIRST bar (deep in the chord, far from the change).
@@ -1185,7 +1186,7 @@ describe("guide countdown atoms", () => {
     const beatsPerBar = store.get(beatsPerBarAtom);
     const beatMs = beatsPerBar > 0 ? bar / beatsPerBar : 0;
     expect(store.get(guideCountdownTickFractionsAtom)).toEqual(
-      computeCountdownTickFractions(windowMs, beatMs, bar),
+      computeCountdownTickFractions(windowMs, beatMs),
     );
   });
 

--- a/src/store/practiceLensAtoms.ts
+++ b/src/store/practiceLensAtoms.ts
@@ -196,42 +196,36 @@ export function isInCountdownWindow(
 
 /** Lowest beat count that shows interior ticks (a lone tick is noise). */
 const MIN_TICK_BEATS = 2;
-/** Subitizing cap — at most this many segments (≤ 3 interior ticks). */
-const MAX_TICK_SEGMENTS = 4;
+/**
+ * Fixed segment count for the drain track. The countdown window always divides
+ * into exactly this many even segments (anchor + 3 interior ticks = 4 marks,
+ * the ~4-object subitizing limit), independent of the chord's bar/beat count —
+ * a multi-bar chord no longer collapses to a sparse per-bar reading.
+ */
+const TICK_SEGMENTS = 4;
 
 /**
- * Window-fractions in [0,1) at which to draw static beat/bar boundary notches.
- * Includes an anchor tick at fraction 0 — the start/beat line (the full-circle
- * drain's start and end coincide, so this single mark anchors both the launch
- * and the landing point) — followed by one tick per interior segment boundary.
+ * Window-fractions in [0,1) at which to draw static drain-track notches.
+ * Always {@link TICK_SEGMENTS} even segments whenever the window is long enough
+ * to warrant ticks: an anchor tick at fraction 0 — the start/landing line (the
+ * full-circle drain's start and end coincide, so this single mark anchors both)
+ * — followed by one tick per interior segment boundary.
  *
- * - ≤ 4 beats → one segment per beat (subitizable at a glance).
- * - > 4 beats → collapse to bar lines when there are 2–4 bars, else 4 even
- *   segments (caps interior ticks at 3 + the anchor → ≤ 4 marks, the ~4-object
- *   subitizing limit).
- * - < 2 beats → no ticks.
+ * - ≥ 2 beats → 4 even segments ([0, ¼, ½, ¾]), regardless of bar count.
+ * - < 2 beats → no ticks (a lone tick is noise).
  *
- * Pure so it is unit-testable. `windowMs`/`beatMs`/`barMs` are all in ms.
+ * Pure so it is unit-testable. `windowMs`/`beatMs` are both in ms.
  */
 export function computeCountdownTickFractions(
   windowMs: number,
   beatMs: number,
-  barMs: number,
 ): number[] {
   if (windowMs <= 0 || beatMs <= 0) return [];
   const beats = Math.round(windowMs / beatMs);
   if (beats < MIN_TICK_BEATS) return [];
 
-  let segments: number;
-  if (beats <= MAX_TICK_SEGMENTS) {
-    segments = beats;
-  } else {
-    const bars = barMs > 0 ? Math.round(windowMs / barMs) : 0;
-    segments = bars >= 2 && bars <= MAX_TICK_SEGMENTS ? bars : MAX_TICK_SEGMENTS;
-  }
-
   const ticks: number[] = [0];
-  for (let i = 1; i < segments; i++) ticks.push(i / segments);
+  for (let i = 1; i < TICK_SEGMENTS; i++) ticks.push(i / TICK_SEGMENTS);
   return ticks;
 }
 
@@ -654,6 +648,49 @@ export const nextChordGuideTonesAtom = atom((get): Set<string> =>
 );
 
 /**
+ * Pitch-class set of the active lens's aim targets for the *current* (active)
+ * progression step — the same member selection as {@link nextTargetToneLabelsAtom}
+ * but evaluated against the chord the playhead is on. Used to detect *held*
+ * targets: a guide tone (or root) that is shared by the active and next chord
+ * survives the change unchanged, so it is a held voice — not a tone the player
+ * must move to. Empty for the common lens and whenever the active step is
+ * unavailable / missing root or quality.
+ */
+export const activeTargetTonesAtom = atom((get): Set<string> => {
+  const lens = get(practiceLensAtom);
+  if (lens === "common") return new Set();
+  const members = TARGET_MEMBERS_BY_LENS[lens];
+  const step = get(activeResolvedProgressionStepAtom);
+  if (!step || step.unavailable || step.root === null || step.quality === null) {
+    return new Set();
+  }
+  const def = CHORD_DEFINITIONS[step.quality];
+  if (!def) return new Set();
+  const rootIndex = NOTES.indexOf(step.root);
+  if (rootIndex === -1) return new Set();
+  const tones = new Set<string>();
+  for (const member of def.members) {
+    if (members.has(member.name)) {
+      tones.add(NOTES[(rootIndex + member.semitone) % 12]);
+    }
+  }
+  return tones;
+});
+
+/**
+ * Aim targets that are *held* across the upcoming change — the active chord's
+ * targets that the next chord also carries (`active ∩ next`). A held guide tone
+ * renders as a quiet static ring (no drain, no ticks): there is nothing to
+ * count down to because the voice does not move. Derived, so it recomputes only
+ * when the active or next target set changes.
+ */
+export const heldTargetTonesAtom = atom((get): Set<string> => {
+  const active = get(activeTargetTonesAtom);
+  const next = get(nextChordGuideTonesAtom);
+  return new Set([...active].filter((n) => next.has(n)));
+});
+
+/**
  * Duration of the active progression step in beats. Derived from the active
  * step's `duration` and the current meter (`beatsPerBar`).
  */
@@ -791,7 +828,7 @@ export const guideCountdownTickFractionsAtom = atom((get): number[] => {
   const bar = get(progressionBarDurationMsAtom);
   const beatsPerBar = get(beatsPerBarAtom);
   const beatMs = beatsPerBar > 0 ? bar / beatsPerBar : 0;
-  return computeCountdownTickFractions(windowMs, beatMs, bar);
+  return computeCountdownTickFractions(windowMs, beatMs);
 });
 
 /**


### PR DESCRIPTION
## Summary
- A next-chord guide tone shared with the active chord (a **held voice**) was wrongly rendered as a draining countdown target. It doesn't move into the next chord, so there's nothing to count down toward. It now renders as a quiet **static ring** (no drain/loom/flash/ticks) via a new `hold-guide` transition role; the interval label is retained.
- Added `activeTargetTonesAtom` / `heldTargetTonesAtom` (`active ∩ next` lens targets), threaded through the emphasis context into `getEmphasis`.
- `computeCountdownTickFractions` now always produces **4 even segments** (`[0, ¼, ½, ¾]`) above the 2-beat threshold instead of collapsing multi-bar chords to sparse per-bar ticks — so a 2-bar chord shows 4 ticks, not 2. Dropped the now-unused `barMs` param.

## Test Plan
- [x] `pnpm run test` — 2483 passed (added `hold-guide` coverage in `semantics.test.ts` + `useAnimatedFretboardView.test.ts`; rewrote the tick-fraction suite to assert always-4)
- [x] `pnpm run lint` — clean (one pre-existing unrelated warning)
- [x] `pnpm run build` — green
- [ ] Manual: during progression playback, confirm a held guide tone (e.g. b3 carried across the change) shows a static ring with no ticks, while a moving guide tone still drains; confirm a 2-bar chord shows 4 ticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)