### PR TITLE
fix(progression): match grouped button size to standalone toolbar buttons

### DIFF
--- a/src/components/SongControls/SongControls.module.css
+++ b/src/components/SongControls/SongControls.module.css
@@ -172,8 +172,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: var(--control-height);
-  width: var(--control-height);
+  height: calc(var(--control-height) - 4px);
+  width: calc(var(--control-height) - 4px);
   background: transparent;
   border: none;
   border-radius: calc(var(--dc-radius) - 2px);


### PR DESCRIPTION
The `.button-group` wrapping move/duplicate buttons had `padding: 2px` but the inner `.grouped-button` used `height: var(--control-height)` without compensating, making the group 4px taller than adjacent Add and Delete buttons.

Root cause: `.button-group` padding (4px vertical) added to the `var(--control-height)` inner button made the group 38px vs the standalone buttons at 34px.

Fix: Changed `.grouped-button` height/width to `calc(var(--control-height) - 4px)`, compensating for the 2px padding on each side. This matches the established pattern used by StepperShell (`calc(var(--control-height) - 6px)`).