### PR TITLE
docs(visual-language): resolve open questions in fretboard-visual-language.md

### DIFF
--- a/docs/design/fretboard-visual-language.md
+++ b/docs/design/fretboard-visual-language.md
@@ -244,6 +244,9 @@ overlay off — guide tones exist only in chord context. See §10 for the spec t
 - Don't recompute emphasis per animation frame; ≤2 discrete recomputes per chord step.
   **[internal]**
 - Don't let motion mean anything but voice leading. **[internal]**
+- Don't de-emphasize chord tones not in the active voicing; the connector polyline already
+  groups the voicing via Gestalt connectedness, and a second encoding would over-encode.
+  **[internal]**
 
 ---
 
@@ -269,11 +272,7 @@ overlay off — guide tones exist only in chord context. See §10 for the spec t
   neutral tint. A future option: a small, *restrained* ladder of neutral shades for active
   region(s) vs. inactive, staying within the no-rainbow discipline (§2). *(Deferred;
   migrated from the exploration draft.)*
-- **Non-voicing chord tones** — whether to slightly de-emphasize chord tones not in the
-  active voicing (a salience/opacity tweak, not a shape change). *(Likely YAGNI; connector
-  already groups the voicing.)*
-- **"Show all CAGED positions" overview** — the only place the 5-hue palette would survive,
-  behind a toggle. *(Deferred feature.)*
+
 
 ---
 
@@ -385,6 +384,13 @@ with `git show <sha>:<path>` (SHA = last commit before deletion):
 - `2026-06-04-fretboard-followups-exploration-draft.md` (`432e2651`) — the deferred
   exploration ideas now captured in §6 (modal characteristic-tone accent channel, new
   pattern overlays / diagonal boxes, neutral region-shade ladder).
+
+**Cleaned up in the 2026-06-08 open-questions triage.**
+- `2026-06-08-visual-language-open-questions-cleanup.md` — closed the non-voicing chord
+  tones item as YAGNI (connector already groups the voicing); dropped the "show all CAGED
+  positions" overview (no use case; single-shape invariant enforced in storage); §6 reduced
+  from five items to three. The modal characteristic-tone accent channel remains the top
+  candidate for the next design-resolution pass.
 
 **Pruned from `main`, recovered from history (chord-transition motion):**
 - `2026-05-27-connector-transition-playback-research.md` (from `490b46b2^`) — root-cause

--- a/docs/superpowers/specs/2026-06-08-visual-language-open-questions-cleanup.md
+++ b/docs/superpowers/specs/2026-06-08-visual-language-open-questions-cleanup.md
@@ -1,0 +1,29 @@
+# Fretboard Visual Language — Open Questions Cleanup
+
+## Problem
+
+`docs/design/fretboard-visual-language.md` §6 listed five open/deferred questions.
+Four were purely in design-doc limbo — defined but with no decision, priority, or
+implementation. This spec resolves or reprioritizes all five.
+
+## Outcome per item
+
+| # | Item | Resolution | Action |
+|---|------|-----------|--------|
+| 1 | **Modal characteristic-tone accent channel** | **Resolve next** — highest-impact open design decision. Recommended approach (Approach B from the brainstorming session): pick the visual cue (ring/notch/halo/salience) and implement. | Stay in §6 pending design; next implementation candidate. |
+| 2 | **New pattern overlays** (diagonal boxes, etc.) | **Deferred** — future exploration, not in current scope. | Stay in §6 as-is. |
+| 3 | **Neutral region-shade ladder** | **Deferred** — included in triage, lowest current priority. The single `--fb-region-tint` variable suffices; a ladder would be a nice-to-have polish pass. | Stay in §6. |
+| 4 | **Non-voicing chord tones** | **Closed as YAGNI** — the connector polyline already groups the active voicing via Gestalt connectedness. Marker-level de-emphasis would over-encode and violates "redundant to reinforce, not extend." | Removed from §6; added to §5 (Anti-patterns). |
+| 5 | **"Show all CAGED positions" overview** | **Dropped** — the single-shape invariant is enforced in storage (`collapseToSingleShape` in `fingeringAtoms.ts`), the 5-hue CAGED rainbow was already weakest-on-record from the original research, and no use case justifies re-introducing it. | Removed from §6; code comment in `FretboardShapeLayer.tsx` updated. |
+
+## Files changed
+
+- `docs/design/fretboard-visual-language.md` — §5 and §6 updated; §10 provenance added.
+- `src/components/FretboardSVG/FretboardShapeLayer.tsx` — comment updated to no longer reference the dropped feature.
+- This spec.
+
+## Next step
+
+Implement the modal characteristic-tone accent channel (item #1 above) — resolve
+the visual cue (ring / notch / halo / salience elevation) and the degree-detection
+mechanism, then build.

--- a/src/components/FretboardSVG/FretboardShapeLayer.tsx
+++ b/src/components/FretboardSVG/FretboardShapeLayer.tsx
@@ -44,7 +44,7 @@ export const FretboardShapeLayer = memo(({ svgPolygons, animationMode = "group" 
   // All active-shape region shading uses a single neutral tint so it never
   // competes with the role-based note colors (amber home / teal guide / rest).
   // The per-CAGED `color` is intentionally ignored here; the per-shape tokens
-  // stay defined for a future opt-in "show all positions" overview.
+  // stay defined in case a future feature restores per-shape coloring.
   const polygons = svgPolygons.map(({ points, key }) => (
     <polygon
       key={key}


### PR DESCRIPTION
## Summary

Resolves the five open questions in `docs/design/fretboard-visual-language.md` §6 based on the brainstorming triage:

| # | Item | Resolution |
|---|------|-----------|
| 4 | Non-voicing chord tones | **Closed as YAGNI** — connector already groups the voicing |
| 5 | Show all CAGED positions overview | **Dropped** — single-shape invariant enforced in storage; no use case |
| 1 | Modal characteristic-tone accent | **Remains open** — top candidate for next design pass |
| 2 | New pattern overlays | **Remains deferred** |
| 3 | Neutral region-shade ladder | **Remains deferred** |

## Changes

- **`docs/design/fretboard-visual-language.md`** — removed items #4/#5 from §6; added #4 as anti-pattern in §5; added provenance entry in §10
- **`src/components/FretboardSVG/FretboardShapeLayer.tsx`** — updated comment referencing the dropped feature
- **`docs/superpowers/specs/2026-06-08-visual-language-open-questions-cleanup.md`** — triage spec

Closes no issue — this is a design-doc hygiene pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified design guidelines for chord tone display in the fretboard visual language, specifically regarding voicing representation.
  * Resolved two previously deferred design questions, streamlining the open-items list.
  * Updated design provenance with latest decision outcomes and direction for future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->