### PR TITLE
feat: backing-track variation (structural variations + safe humanizer)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-backing-track-variation.md
+++ b/docs/superpowers/plans/2026-06-08-backing-track-variation.md
@@ -1,0 +1,1023 @@
+# Backing Track Variation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Break the monotony of static 1–2 bar backing-track loops by adding chord/bass structural variations (genre-coupled turnaround fills) and extending the existing per-hit humanizer with groove-lock and probabilistic ghost-dropping.
+
+**Architecture:** Three independent tiers built on existing infrastructure. (A) The **Safe Humanizer** extends `humanize.ts` with two pure helpers (`shouldDropHit`, `grooveLockTimeAmount`) wired into the three humanized layers in `buildAllLayers.ts`. (B) **Variation Events** mirror the existing `DrumVariation` model with `ChordVariation`/`BassVariation` (substitutive, not additive), plumbed through `BuildAllLayersInput` → playback hook → Jotai atoms → `GenreStyle` (the coupling guarantee). (C) **Extended base patterns** are catalog-only and already supported by `sliceCellToBar`. Each phase ships independently.
+
+**Tech Stack:** React 19 + TypeScript, Vitest + Testing Library, Jotai (`atomWithStorage`), Tone.js playback. Package manager **pnpm**.
+
+**Source spec:** [docs/superpowers/specs/2026-06-08-backing-track-variation-design.md](../specs/2026-06-08-backing-track-variation-design.md)
+
+**Resolved design decisions (from spec):**
+- Loop variety: **per-bar only** (build-once-replay retained; no per-pass seed).
+- Groove lock: integer beats get **~40%** timing jitter; off-beats full. Velocity jitter unaffected.
+- Ghost drop: velocity **< 0.4 → flat ~12%** drop; **≥ 0.4 → never**.
+- Chord/bass variations are **substitutive** (replace the bar's base hits); drums stay **additive** (unchanged). At most one substitutive variation per bar — **first in catalog order wins**.
+- Humanizer **never** touches `metronome` or `chordOnsets`; only `chordStrums`, `bass`, `drums`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `src/progressions/audio/humanize.ts` | Pure per-hit jitter + new drop/groove helpers | Add `shouldDropHit`, `grooveLockTimeAmount` |
+| `src/progressions/audio/humanize.test.ts` | Humanizer unit tests | Add drop + groove-lock tests |
+| `src/progressions/audio/patterns.ts` | Pattern + variation catalogs and getters | Add `ChordVariation`/`BassVariation` types, catalogs, getters |
+| `src/progressions/audio/patterns.test.ts` | Catalog + gating tests | Add chord/bass variation tests |
+| `src/progressions/audio/buildAllLayers.ts` | Pure layer builder | Wire humanizer helpers; chord/bass variation substitution; new input fields |
+| `src/progressions/audio/buildAllLayers.test.ts` | Builder integration tests | Add substitution + humanizer-integration tests; extend `vi.mock` |
+| `src/progressions/audio/genres.ts` | Genre bundles (coupling) | Add `chordVariations`/`bassVariations` fields + data |
+| `src/progressions/audio/genres.test.ts` | Genre wiring tests | Add coupling tests |
+| `src/store/progressionAtoms.ts` | Jotai state | Add two atoms, wire `applyGenreStyleAtom` + reset |
+| `src/store/progressionAtoms.test.ts` | Atom tests | Add genre-apply + reset tests |
+| `src/hooks/useProgressionAudioPlayback.ts` | Reads atoms → calls builder | Read + thread two new atoms through all call sites + deps |
+
+**Pre-flight (run once before Task 1):**
+
+```bash
+cd /Users/isaaccocar/repos/fretboard-app.worktrees/backing-track-variation
+pnpm install
+pnpm run test -- src/progressions/audio
+```
+Expected: existing suite passes (green baseline).
+
+---
+
+## PHASE A — Safe Humanizer
+
+### Task 1: `shouldDropHit` predicate
+
+**Files:**
+- Modify: `src/progressions/audio/humanize.ts`
+- Test: `src/progressions/audio/humanize.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/progressions/audio/humanize.test.ts`:
+
+```typescript
+import { applyJitter, shouldDropHit } from "./humanize";
+
+describe("shouldDropHit", () => {
+  it("never drops hits with velocity >= 0.4", () => {
+    for (let seed = 0; seed < 200; seed++) {
+      expect(shouldDropHit(0.4, seed)).toBe(false);
+      expect(shouldDropHit(0.7, seed)).toBe(false);
+      expect(shouldDropHit(1, seed)).toBe(false);
+    }
+  });
+
+  it("drops a small fraction of sub-0.4 ghost hits (~12%)", () => {
+    let dropped = 0;
+    const N = 2000;
+    for (let seed = 0; seed < N; seed++) {
+      if (shouldDropHit(0.2, seed)) dropped++;
+    }
+    const rate = dropped / N;
+    expect(rate).toBeGreaterThan(0.07);
+    expect(rate).toBeLessThan(0.17);
+  });
+
+  it("is deterministic for a fixed velocity + seed", () => {
+    expect(shouldDropHit(0.2, 42)).toBe(shouldDropHit(0.2, 42));
+    expect(shouldDropHit(0.2, 42)).not.toBe(undefined);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test -- src/progressions/audio/humanize.test.ts`
+Expected: FAIL — `shouldDropHit is not a function` / not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/progressions/audio/humanize.ts`, after `applyJitter`, add (reuse the existing private `seededRandom`):
+
+```typescript
+/** Threshold below which a hit is a droppable "ghost". */
+const GHOST_VELOCITY_THRESHOLD = 0.4;
+/** Drop probability applied to sub-threshold ghosts. */
+const GHOST_DROP_CHANCE = 0.12;
+/** Seed offset so the drop roll is independent of the time/velocity rolls. */
+const DROP_SEED_OFFSET = 54321;
+
+/**
+ * Deterministic, seeded decision: should this hit be dropped entirely to
+ * simulate a player occasionally skipping a ghost stroke? Uses the hit's
+ * *authored* (pre-jitter) velocity so a ±10% velocity jitter can never flip a
+ * borderline ghost across the threshold. Structural hits (>= 0.4) never drop.
+ */
+export function shouldDropHit(velocity: number, seed: number): boolean {
+  if (velocity >= GHOST_VELOCITY_THRESHOLD) return false;
+  return seededRandom(seed + DROP_SEED_OFFSET) < GHOST_DROP_CHANCE;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test -- src/progressions/audio/humanize.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/progressions/audio/humanize.ts src/progressions/audio/humanize.test.ts
+git commit -m "feat(audio): add seeded shouldDropHit ghost-drop predicate"
+```
+
+---
+
+### Task 2: `grooveLockTimeAmount` helper
+
+**Files:**
+- Modify: `src/progressions/audio/humanize.ts`
+- Test: `src/progressions/audio/humanize.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/progressions/audio/humanize.test.ts` (extend the import to include `grooveLockTimeAmount`):
+
+```typescript
+import { applyJitter, shouldDropHit, grooveLockTimeAmount } from "./humanize";
+
+describe("grooveLockTimeAmount", () => {
+  it("reduces jitter on integer (anchor) beats to ~40%", () => {
+    expect(grooveLockTimeAmount(0, 0.015)).toBeCloseTo(0.006);
+    expect(grooveLockTimeAmount(2, 0.015)).toBeCloseTo(0.006);
+    expect(grooveLockTimeAmount(0, 0.005)).toBeCloseTo(0.002);
+  });
+
+  it("leaves off-beats at full jitter", () => {
+    expect(grooveLockTimeAmount(0.5, 0.015)).toBe(0.015);
+    expect(grooveLockTimeAmount(1.75, 0.015)).toBe(0.015);
+    expect(grooveLockTimeAmount(2.5, 0.005)).toBe(0.005);
+  });
+
+  it("is meter-agnostic (works for any integer beat)", () => {
+    expect(grooveLockTimeAmount(5, 0.015)).toBeCloseTo(0.006);
+    expect(grooveLockTimeAmount(6, 0.015)).toBeCloseTo(0.006);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test -- src/progressions/audio/humanize.test.ts`
+Expected: FAIL — `grooveLockTimeAmount is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/progressions/audio/humanize.ts`, add:
+
+```typescript
+/** Fraction of full timing jitter applied to anchor (integer) beats. */
+const ANCHOR_JITTER_FACTOR = 0.4;
+
+/**
+ * Groove lock: integer beats (the structural pulse) get reduced timing jitter;
+ * off-beat subdivisions keep the full amount. Meter-agnostic — keys off the
+ * bar-local beat value. Returns the `timeAmountSec` to feed `applyJitter`.
+ * (Velocity jitter is unaffected — only timing.)
+ */
+export function grooveLockTimeAmount(beat: number, fullAmountSec: number): number {
+  return Number.isInteger(beat) ? fullAmountSec * ANCHOR_JITTER_FACTOR : fullAmountSec;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test -- src/progressions/audio/humanize.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/progressions/audio/humanize.ts src/progressions/audio/humanize.test.ts
+git commit -m "feat(audio): add grooveLockTimeAmount for anchor-beat timing lock"
+```
+
+---
+
+### Task 3: Wire humanizer helpers into `buildAllLayers`
+
+**Files:**
+- Modify: `src/progressions/audio/buildAllLayers.ts:23` (import), `:294-343` (chord loop), `:373-408` (bass loop), `:419-435` (drum loop)
+- Test: `src/progressions/audio/buildAllLayers.test.ts`
+
+**Context:** `buildAllLayers.test.ts` mocks `./humanize` as a passthrough (line 13-15). The new helpers must be added to that mock or the builder crashes. The integration tests for drop/groove use the **real** module via `vi.importActual` in a separate `describe`.
+
+- [ ] **Step 1: Write the failing tests**
+
+First, extend the existing `vi.mock` at the top of `src/progressions/audio/buildAllLayers.test.ts` so the default-mocked suite keeps passing:
+
+```typescript
+vi.mock("./humanize", () => ({
+  applyJitter: (params: { time: number; velocity: number }) => ({ time: params.time, velocity: params.velocity }),
+  shouldDropHit: () => false,
+  grooveLockTimeAmount: (_beat: number, full: number) => full,
+}));
+```
+
+Then add a new test file `src/progressions/audio/buildAllLayers.humanize.test.ts` that uses the **real** humanizer (no mock):
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { buildAllLayersAsync } from "./buildAllLayers";
+import type { ResolvedProgressionStep } from "../progressionDomain";
+
+const step = (over: Partial<ResolvedProgressionStep> = {}): ResolvedProgressionStep => ({
+  id: "x", index: 0, degree: "I", duration: { value: 1, unit: "bar" },
+  qualityOverride: null, qualityOverrideApplied: false, invalidQualityOverride: false,
+  manualRoot: null, root: "C", quality: "M", diatonicQuality: "M",
+  label: "I", resolvedChordLabel: "C major", shortChordLabel: "C",
+  unavailable: false, unavailableReason: null, ...over,
+});
+
+const baseInput = {
+  tempoBpm: 60, beatsPerBar: 4, swing: 0,
+  chordPatternId: "ballad-whole", bassPatternId: "root-fifth",
+  drumPatternId: "rock", drumVariations: [] as string[], loop: true,
+};
+
+describe("buildAllLayers humanizer integration (real humanize)", () => {
+  it("never drops the metronome or shifts it off the grid", async () => {
+    const out = await buildAllLayersAsync({ ...baseInput, steps: [step(), step({ id: "b", index: 1, root: "G" })] });
+    // Metronome stays on exact beat boundaries (secondsPerBeat = 1 at 60bpm).
+    expect(out.metronome.every((m) => Number.isInteger(m.time))).toBe(true);
+    expect(out.metronome).toHaveLength(8);
+  });
+
+  it("keeps every chordOnset on its exact bar boundary (never humanized)", async () => {
+    const out = await buildAllLayersAsync({ ...baseInput, steps: [step(), step({ id: "b", index: 1, root: "G" })] });
+    expect(out.chordOnsets.map((o) => o.time)).toEqual([0, 4]);
+  });
+
+  it("never drops a high-velocity structural drum hit", async () => {
+    // rock kick on beat 0 has velocity 1 — must always survive.
+    const out = await buildAllLayersAsync({ ...baseInput, steps: Array.from({ length: 8 }, (_, i) => step({ id: `s${i}`, index: i })) });
+    const beatZeroKicks = out.drums.filter((d) => d.value.type === "kick" && d.value.velocity > 0.7);
+    expect(beatZeroKicks.length).toBeGreaterThanOrEqual(8); // one per bar, none dropped
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm run test -- src/progressions/audio/buildAllLayers.humanize.test.ts`
+Expected: FAIL — high-velocity kick count drops below 8 (real `shouldDropHit` not yet keyed to the structural hit) OR groove-lock import missing. (If they happen to pass because wiring is absent, the drop/groove behaviors aren't exercised — proceed to Step 3 to wire and re-confirm.)
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/progressions/audio/buildAllLayers.ts`, update the import (line 23):
+
+```typescript
+import { applyJitter, shouldDropHit, grooveLockTimeAmount } from "./humanize";
+```
+
+**Chord loop** — replace the `applyJitter` call (around line 298-305) so drop is checked first and timing uses groove lock (preserve the LH-bass grid-lock):
+
+```typescript
+          const chordSeed = stepIndex * 10000 + bar * 100 + hit.beat;
+          if (!isLhBass && shouldDropHit(hit.velocity, chordSeed)) continue;
+          const baseTime = barStart + swingBeat(hit.beat, input.swing) * secondsPerBeat;
+          const { time: hitTime, velocity } = applyJitter({
+            time: baseTime,
+            velocity: hit.velocity,
+            seed: chordSeed,
+            // LH bass doubles the upright an octave up — lock it to the grid.
+            timeAmountSec: isLhBass ? 0 : grooveLockTimeAmount(hit.beat, 0.015),
+          });
+```
+
+**Bass loop** — replace the `applyJitter` call (around line 391-399):
+
+```typescript
+          const bassSeed = stepIndex * 10000 + bar * 100 + hit.beat + 1;
+          if (!lockBassToGrid && shouldDropHit(hit.velocity, bassSeed)) continue;
+          const baseTime = barStart + swingBeat(hit.beat, input.swing) * secondsPerBeat;
+          const { time: hitTime, velocity } = applyJitter({
+            time: baseTime,
+            velocity: hit.velocity,
+            seed: bassSeed,
+            // Lock to the grid when the comp doubles this line (bossa LH).
+            timeAmountSec: lockBassToGrid ? 0 : grooveLockTimeAmount(hit.beat, 0.015),
+          });
+```
+
+**Drum loop** — replace the `applyJitter` call (around line 422-429):
+
+```typescript
+          const drumSeed = stepIndex * 10000 + bar * 100 + hit.beat + 2;
+          if (shouldDropHit(hit.velocity, drumSeed)) continue;
+          const baseTime = barStart + swingBeat(hit.beat, input.swing) * secondsPerBeat;
+          const { time: hitTime, velocity } = applyJitter({
+            time: baseTime,
+            velocity: hit.velocity,
+            seed: drumSeed,
+            timeAmountSec: grooveLockTimeAmount(hit.beat, 0.005), // tighter base for drums
+            velocityAmount: 0.05,
+          });
+```
+
+> Note: the chromatic-approach bass note carries `TURNAROUND_APPROACH_VELOCITY` (0.75) so it is never dropped — confirmed by the `>= 0.4` guard. The bass `chromatic-approach` synthetic hit has no `beat % 1` guarantee, but `grooveLockTimeAmount` handles any value.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm run test -- src/progressions/audio/buildAllLayers.test.ts src/progressions/audio/buildAllLayers.humanize.test.ts`
+Expected: PASS (both the mocked suite and the real-humanizer suite).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/progressions/audio/buildAllLayers.ts src/progressions/audio/buildAllLayers.test.ts src/progressions/audio/buildAllLayers.humanize.test.ts
+git commit -m "feat(audio): apply ghost-drop and groove-lock in buildAllLayers, exclude metronome/onsets"
+```
+
+---
+
+## PHASE B — Variation Events & Genre Coupling
+
+### Task 4: `ChordVariation` / `BassVariation` models + catalogs
+
+**Files:**
+- Modify: `src/progressions/audio/patterns.ts:99-107` (after `DrumVariation`), `:603-617` (getters)
+- Test: `src/progressions/audio/patterns.test.ts`
+
+**Context:** `variationFiresOnBar` already accepts any `{ barInterval, barPhase? }` — generalize its parameter type so chord/bass variations reuse it without duplication.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/progressions/audio/patterns.test.ts` (extend imports to include `CHORD_VARIATIONS`, `BASS_VARIATIONS`, `getChordVariation`, `getBassVariation`):
+
+```typescript
+describe("chord & bass variation catalogs", () => {
+  it("exposes chord and bass variation catalogs with unique IDs", () => {
+    const chordIds = CHORD_VARIATIONS.map((v) => v.id);
+    expect(new Set(chordIds).size).toBe(chordIds.length);
+    const bassIds = BASS_VARIATIONS.map((v) => v.id);
+    expect(new Set(bassIds).size).toBe(bassIds.length);
+  });
+
+  it("gates chord/bass variations through the shared variationFiresOnBar", () => {
+    const funkChord = getChordVariation("funk-turnaround-chord")!;
+    expect(funkChord.barInterval).toBe(4);
+    expect(funkChord.barPhase).toBe(3);
+    expect(variationFiresOnBar(funkChord, 3)).toBe(true);
+    expect(variationFiresOnBar(funkChord, 0)).toBe(false);
+
+    const funkBass = getBassVariation("funk-turnaround-bass")!;
+    expect(variationFiresOnBar(funkBass, 3)).toBe(true);
+    expect(variationFiresOnBar(funkBass, 7)).toBe(true);
+  });
+
+  it("keeps every variation's hits in bar-local range [0, 4)", () => {
+    for (const v of CHORD_VARIATIONS) {
+      for (const h of v.hits) expect(h.beat).toBeGreaterThanOrEqual(0), expect(h.beat).toBeLessThan(4);
+    }
+    for (const v of BASS_VARIATIONS) {
+      for (const h of v.hits) expect(h.beat).toBeGreaterThanOrEqual(0), expect(h.beat).toBeLessThan(4);
+    }
+  });
+
+  it("lookups return correct variations and undefined for misses", () => {
+    expect(getChordVariation("funk-turnaround-chord")).toBeDefined();
+    expect(getBassVariation("funk-turnaround-bass")).toBeDefined();
+    expect(getChordVariation("nope")).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm run test -- src/progressions/audio/patterns.test.ts`
+Expected: FAIL — `CHORD_VARIATIONS` / getters not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/progressions/audio/patterns.ts`, after the `DrumVariation` interface (line 107), add:
+
+```typescript
+/** A single-bar harmonic variation that *replaces* (not layers) the base
+ *  chord pattern's hits when it fires. Mirrors DrumVariation's gating fields. */
+export interface ChordVariation {
+  id: string;
+  label: string;
+  barInterval: number;
+  barPhase?: number;
+  hits: readonly ChordHit[];
+}
+
+/** A single-bar bass variation that *replaces* the base bass pattern's hits
+ *  when it fires (applied before the §3.4 turnaround tail-swap). */
+export interface BassVariation {
+  id: string;
+  label: string;
+  barInterval: number;
+  barPhase?: number;
+  hits: readonly CatalogBassHit[];
+}
+```
+
+Generalize the gating predicate signature (line 623) so it accepts any variation shape:
+
+```typescript
+export function variationFiresOnBar(
+  variation: { barInterval: number; barPhase?: number },
+  absoluteBar: number,
+): boolean {
+  if (variation.barInterval <= 0) return false;
+  return absoluteBar % variation.barInterval === (variation.barPhase ?? 0);
+}
+```
+
+Add the catalogs after `DRUM_VARIATIONS` (line 601). These are concrete starting points — tune musically later:
+
+```typescript
+export const CHORD_VARIATIONS: readonly ChordVariation[] = [
+  {
+    id: "funk-turnaround-chord",
+    label: "Funk Turnaround Comp",
+    barInterval: 4,
+    barPhase: 3,
+    // Pushed turnaround bar: a strong stab on the one, anticipated color stabs
+    // driving into the next chord.
+    hits: [
+      { beat: 0, velocity: 0.92, direction: "down", articulation: "stab" },
+      { beat: 1.5, velocity: 0.6, direction: "up", articulation: "muted" },
+      { beat: 2.5, velocity: 0.7, direction: "down", articulation: "color-stab" },
+      { beat: 3.5, velocity: 0.75, direction: "down", articulation: "color-stab" },
+    ],
+  },
+];
+
+export const BASS_VARIATIONS: readonly BassVariation[] = [
+  {
+    id: "funk-turnaround-bass",
+    label: "Funk Turnaround Walk",
+    barInterval: 4,
+    barPhase: 3,
+    // Walk-up turnaround: root anchor, octave pop, then a chromatic approach
+    // into the next chord on the last beat.
+    hits: [
+      { beat: 0, velocity: 1, note: "root", articulation: "staccato" },
+      { beat: 1.5, velocity: 0.7, note: "octave", articulation: "staccato" },
+      { beat: 2.5, velocity: 0.6, note: "fifth", articulation: "staccato" },
+      { beat: 3, velocity: 0.8, note: "chromatic-approach", articulation: "legato" },
+    ],
+  },
+];
+```
+
+Add getters after `getDrumVariation` (line 617):
+
+```typescript
+export function getChordVariation(id: string): ChordVariation | undefined {
+  return CHORD_VARIATIONS.find((v) => v.id === id);
+}
+
+export function getBassVariation(id: string): BassVariation | undefined {
+  return BASS_VARIATIONS.find((v) => v.id === id);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm run test -- src/progressions/audio/patterns.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/progressions/audio/patterns.ts src/progressions/audio/patterns.test.ts
+git commit -m "feat(audio): add ChordVariation/BassVariation models, catalogs, and getters"
+```
+
+---
+
+### Task 5: Chord-variation substitution in `buildAllLayers`
+
+**Files:**
+- Modify: `src/progressions/audio/buildAllLayers.ts:10-22` (imports), `:63-73` (input type), `:180-188` (resolve), `:289-293` (chord hit selection)
+- Test: `src/progressions/audio/buildAllLayers.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/progressions/audio/buildAllLayers.test.ts` (mocked-humanize suite):
+
+```typescript
+describe("chord variation substitution", () => {
+  it("replaces the base chord hits on a firing turnaround bar", async () => {
+    // pop-8ths base has 6 hits per bar; funk-turnaround-chord has 4. On bar 3
+    // (phase 3, interval 4) the comp must switch to the variation's hit count.
+    const steps = Array.from({ length: 8 }, (_, i) =>
+      step({ id: `s${i}`, index: i, root: i % 2 === 0 ? "C" : "G" }),
+    );
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      chordPatternId: "pop-8ths",
+      chordVariations: ["funk-turnaround-chord"],
+      bassPatternId: "root-fifth",
+      steps,
+    });
+    // Strums in bar index 3 (time window [12,16) at 60bpm).
+    const bar3 = out.chordStrums.filter((s) => s.time >= 12 && s.time < 16);
+    const bar0 = out.chordStrums.filter((s) => s.time >= 0 && s.time < 4);
+    expect(bar0).toHaveLength(6); // base pop-8ths
+    expect(bar3).toHaveLength(4); // variation
+  });
+
+  it("leaves non-firing bars on the base pattern", async () => {
+    const steps = Array.from({ length: 8 }, (_, i) => step({ id: `s${i}`, index: i }));
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      chordPatternId: "pop-8ths",
+      chordVariations: ["funk-turnaround-chord"],
+      steps,
+    });
+    const bar1 = out.chordStrums.filter((s) => s.time >= 4 && s.time < 8);
+    expect(bar1).toHaveLength(6); // base pop-8ths, untouched
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test -- src/progressions/audio/buildAllLayers.test.ts`
+Expected: FAIL — `chordVariations` not on input type / no substitution.
+
+- [ ] **Step 3: Write the implementation**
+
+Update imports (line 10-22) to add `getChordVariation`, `variationFiresOnBar` (already imported), and the `ChordVariation` type:
+
+```typescript
+import {
+  getBassPattern,
+  getChordPattern,
+  getDrumPattern,
+  getDrumVariation,
+  getChordVariation,
+  variationFiresOnBar,
+  repeatPatternToBeats,
+  sliceCellToBar,
+  type CatalogDrumPattern,
+  type DrumHit,
+  type DrumVariation,
+  type ChordVariation,
+  type BassArticulation,
+} from "./patterns";
+```
+
+Add to `BuildAllLayersInput` (after line 71):
+
+```typescript
+  drumVariations: readonly string[];
+  chordVariations: readonly string[];
+  bassVariations: readonly string[];
+  loop: boolean;
+```
+
+Resolve the chord variations once, near the drum-variation resolution (after line 187):
+
+```typescript
+  const chordVariationDefs: ChordVariation[] = input.chordVariations
+    .map((id) => getChordVariation(id))
+    .filter((v): v is ChordVariation => Boolean(v));
+```
+
+In the chord block, replace the hit selection (lines 290-293). The firing variation **replaces** the bar; first in catalog order wins:
+
+```typescript
+        const chordCellBars = chordPattern.bars ?? 1;
+        const firingChordVariation = chordVariationDefs.find((v) =>
+          variationFiresOnBar(v, absoluteBar),
+        );
+        const sourceHits = firingChordVariation
+          ? firingChordVariation.hits
+          : chordPattern.hits;
+        const hits = !firingChordVariation && isBarUnit && chordCellBars > 1
+          ? sliceCellToBar(sourceHits, absoluteBar % chordCellBars, input.beatsPerBar)
+          : repeatPatternToBeats(sourceHits, eventBeats, input.beatsPerBar);
+```
+
+> Variations are always 1 bar, so they take the `repeatPatternToBeats` path (the `sliceCellToBar` branch only applies to the multi-bar *base* cell when no variation fires).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test -- src/progressions/audio/buildAllLayers.test.ts`
+Expected: FAIL on unrelated existing tests — every existing `buildAllLayersAsync` call in the suite now needs `chordVariations`/`bassVariations`. Add `chordVariations: [], bassVariations: []` to the shared `baseInput` object (top of the file). Re-run.
+Expected after fix: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/progressions/audio/buildAllLayers.ts src/progressions/audio/buildAllLayers.test.ts
+git commit -m "feat(audio): substitute chord pattern with firing chord variation per bar"
+```
+
+---
+
+### Task 6: Bass-variation substitution (with §3.4 turnaround interaction)
+
+**Files:**
+- Modify: `src/progressions/audio/buildAllLayers.ts` (imports, resolve, bass block lines 346-372)
+- Test: `src/progressions/audio/buildAllLayers.test.ts`
+
+**Context — the interaction:** the bass block already has a §3.4 turnaround that drops the pattern tail and appends a chromatic approach when `bassPattern.turnaround === true`. Decision: a firing **bass variation replaces the base `patternHits` selection**; the §3.4 tail-swap then runs on that replaced set exactly as today (orthogonal — it leads into the next chord regardless of which groove plays). The variation chosen here (`funk-turnaround-bass`) already ends on a chromatic approach, and `funk-syncopated` has `turnaround` unset, so they do not double up.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/progressions/audio/buildAllLayers.test.ts`:
+
+```typescript
+describe("bass variation substitution", () => {
+  it("replaces the base bass hits on a firing turnaround bar", async () => {
+    // funk-syncopated has 5 hits/bar; funk-turnaround-bass has 4. Bar 3 fires.
+    const steps = Array.from({ length: 8 }, (_, i) =>
+      step({ id: `s${i}`, index: i, root: i % 2 === 0 ? "C" : "G" }),
+    );
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      bassPatternId: "funk-syncopated",
+      bassVariations: ["funk-turnaround-bass"],
+      chordPatternId: "ballad-whole",
+      steps,
+    });
+    const bar3 = out.bass.filter((b) => b.time >= 12 && b.time < 16);
+    const bar0 = out.bass.filter((b) => b.time >= 0 && b.time < 4);
+    expect(bar0).toHaveLength(5); // base funk-syncopated
+    expect(bar3).toHaveLength(4); // variation
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test -- src/progressions/audio/buildAllLayers.test.ts`
+Expected: FAIL — no bass substitution (bar 3 still has 5 hits).
+
+- [ ] **Step 3: Write the implementation**
+
+Add `getBassVariation` and `type BassVariation` to the patterns import. Resolve once near the chord-variation resolution:
+
+```typescript
+  const bassVariationDefs: BassVariation[] = input.bassVariations
+    .map((id) => getBassVariation(id))
+    .filter((v): v is BassVariation => Boolean(v));
+```
+
+In the bass block, replace the base-pattern selection (lines 347-350) so a firing variation supplies `patternHits` *before* the §3.4 logic:
+
+```typescript
+        const bassCellBars = bassPattern.bars ?? 1;
+        const firingBassVariation = bassVariationDefs.find((v) =>
+          variationFiresOnBar(v, absoluteBar),
+        );
+        const baseBassHits = firingBassVariation
+          ? firingBassVariation.hits
+          : bassPattern.hits;
+        const patternHits = !firingBassVariation && isBarUnit && bassCellBars > 1
+          ? sliceCellToBar(baseBassHits, absoluteBar % bassCellBars, input.beatsPerBar)
+          : repeatPatternToBeats(baseBassHits, eventBeats, input.beatsPerBar);
+```
+
+The existing `isTurnaroundBar` / tail-swap block (lines 355-372) is unchanged — it operates on `patternHits` as before.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test -- src/progressions/audio/buildAllLayers.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/progressions/audio/buildAllLayers.ts src/progressions/audio/buildAllLayers.test.ts
+git commit -m "feat(audio): substitute bass pattern with firing bass variation per bar"
+```
+
+---
+
+### Task 7: Plumb new input fields through the playback hook
+
+**Files:**
+- Modify: `src/hooks/useProgressionAudioPlayback.ts` (atom reads + every `buildAllLayersAsync` input + memo deps)
+
+**Context:** there is no unit test for this hook; correctness is verified by `tsc` (the new required `BuildAllLayersInput` fields make the build fail until every call site is updated). Grep `drumVariations` to find all sites (reads at ~133, input objects at ~158/176/219/253/434, deps arrays at ~163/201/291).
+
+- [ ] **Step 1: Verify the build currently fails (the failing "test")**
+
+Run: `pnpm run build`
+Expected: FAIL — `buildAllLayersAsync` calls in the hook are missing `chordVariations`/`bassVariations` (now required on `BuildAllLayersInput`).
+
+- [ ] **Step 2: Read the new atoms**
+
+In `src/hooks/useProgressionAudioPlayback.ts`, next to `const drumVariations = useAtomValue(progressionDrumVariationsAtom);` (line 133), add (import the atoms from `../store/progressionAtoms`):
+
+```typescript
+  const chordVariations = useAtomValue(progressionChordVariationsAtom);
+  const bassVariations = useAtomValue(progressionBassVariationsAtom);
+```
+
+- [ ] **Step 3: Thread through every call site + deps**
+
+For **each** object literal passed to `buildAllLayersAsync` (and the `inputs` memo it derives from), add the two fields next to `drumVariations`:
+
+```typescript
+        drumVariations,
+        chordVariations,
+        bassVariations,
+```
+
+And add `chordVariations, bassVariations` to **every** dependency array that already lists `drumVariations` (the `useMemo`/`useCallback` deps at ~163, ~201, ~291).
+
+- [ ] **Step 4: Verify the build passes**
+
+Run: `pnpm run build`
+Expected: PASS (tsc clean). Then:
+Run: `pnpm run test -- src/progressions/audio src/hooks`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useProgressionAudioPlayback.ts
+git commit -m "feat(audio): thread chord/bass variations through playback hook"
+```
+
+---
+
+### Task 8: State atoms + genre apply + reset
+
+**Files:**
+- Modify: `src/store/progressionAtoms.ts:262-287` (atoms + applyGenreStyle), `:733-738` (reset)
+- Test: `src/store/progressionAtoms.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/store/progressionAtoms.test.ts` (import the new atoms + `applyGenreStyleAtom`):
+
+```typescript
+describe("chord/bass variation atoms", () => {
+  it("applyGenreStyle populates chord and bass variations from the genre bundle", () => {
+    const store = createStore();
+    store.set(applyGenreStyleAtom, "funk");
+    expect(store.get(progressionChordVariationsAtom)).toContain("funk-turnaround-chord");
+    expect(store.get(progressionBassVariationsAtom)).toContain("funk-turnaround-bass");
+  });
+
+  it("reset returns chord/bass variations to empty defaults", () => {
+    const store = createStore();
+    store.set(progressionChordVariationsAtom, ["funk-turnaround-chord"]);
+    store.set(progressionBassVariationsAtom, ["funk-turnaround-bass"]);
+    store.set(resetProgressionAtomsAtom);
+    expect(store.get(progressionChordVariationsAtom)).toEqual([]);
+    expect(store.get(progressionBassVariationsAtom)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm run test -- src/store/progressionAtoms.test.ts`
+Expected: FAIL — atoms not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/store/progressionAtoms.ts`, after `progressionDrumVariationsAtom` (line 267), add:
+
+```typescript
+export const progressionChordVariationsAtom = atomWithStorage<string[]>(
+  k("progressionChordVariations"),
+  [],
+  stringArrayStorage,
+  GET_ON_INIT,
+);
+
+export const progressionBassVariationsAtom = atomWithStorage<string[]>(
+  k("progressionBassVariations"),
+  [],
+  stringArrayStorage,
+  GET_ON_INIT,
+);
+```
+
+In `applyGenreStyleAtom` (after line 284):
+
+```typescript
+  set(progressionDrumVariationsAtom, genre.drumVariations);
+  set(progressionChordVariationsAtom, genre.chordVariations);
+  set(progressionBassVariationsAtom, genre.bassVariations);
+```
+
+In the reset action (after line 738):
+
+```typescript
+  set(progressionDrumVariationsAtom, RESET);
+  set(progressionChordVariationsAtom, RESET);
+  set(progressionBassVariationsAtom, RESET);
+```
+
+> This depends on Task 9's `GenreStyle.chordVariations`/`bassVariations` fields. If executing Task 8 before Task 9, `tsc` will flag the missing fields — do Task 9 first or in the same batch.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm run test -- src/store/progressionAtoms.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/progressionAtoms.ts src/store/progressionAtoms.test.ts
+git commit -m "feat(progression): add chord/bass variation atoms with genre-apply and reset"
+```
+
+---
+
+### Task 9: Genre coupling — `GenreStyle` fields + matched-phase data
+
+**Files:**
+- Modify: `src/progressions/audio/genres.ts:3-14` (interface), `:16-59` (data)
+- Test: `src/progressions/audio/genres.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/progressions/audio/genres.test.ts` (import `getChordVariation`, `getBassVariation`):
+
+```typescript
+describe("genre chord/bass variation coupling", () => {
+  it("every genre declares chord and bass variation arrays", () => {
+    for (const g of GENRE_STYLES) {
+      expect(Array.isArray(g.chordVariations)).toBe(true);
+      expect(Array.isArray(g.bassVariations)).toBe(true);
+    }
+  });
+
+  it("keeps every referenced chord/bass variation id resolvable", () => {
+    for (const g of GENRE_STYLES) {
+      for (const id of g.chordVariations) expect(getChordVariation(id), `${g.id}:${id}`).toBeDefined();
+      for (const id of g.bassVariations) expect(getBassVariation(id), `${g.id}:${id}`).toBeDefined();
+    }
+  });
+
+  it("funk couples chord/bass/drum turnarounds on the same bar (interval 4, phase 3)", () => {
+    const funk = getGenreStyle("funk")!;
+    const chord = getChordVariation(funk.chordVariations[0])!;
+    const bass = getBassVariation(funk.bassVariations[0])!;
+    expect(chord.barInterval).toBe(4);
+    expect(chord.barPhase).toBe(3);
+    expect(bass.barInterval).toBe(4);
+    expect(bass.barPhase).toBe(3);
+    // Drum funk-fill-4 already fires on interval 4 / phase 3 — all three lock.
+    expect(funk.drumVariations).toContain("funk-fill-4");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm run test -- src/progressions/audio/genres.test.ts`
+Expected: FAIL — `chordVariations`/`bassVariations` not on `GenreStyle`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/progressions/audio/genres.ts`, add to the `GenreStyle` interface (after `drumVariations`):
+
+```typescript
+  drumVariations: string[];
+  chordVariations: string[];
+  bassVariations: string[];
+```
+
+Add both fields to **every** entry in `GENRE_STYLES`. Most are `[]`; funk carries the coupled pair:
+
+```typescript
+  // pop:        chordVariations: [], bassVariations: [],
+  // rock:       chordVariations: [], bassVariations: [],
+  // blues:      chordVariations: [], bassVariations: [],
+  // jazz:       chordVariations: [], bassVariations: [],
+  // ballad:     chordVariations: [], bassVariations: [],
+  // funk:       chordVariations: ["funk-turnaround-chord"], bassVariations: ["funk-turnaround-bass"],
+  // bossa-nova: chordVariations: [], bassVariations: [],
+```
+
+Apply each as a literal field on its genre object (the comment block above is the mapping, not the code — add `chordVariations: [...], bassVariations: [...]` to each of the 7 objects).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm run test -- src/progressions/audio/genres.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/progressions/audio/genres.ts src/progressions/audio/genres.test.ts
+git commit -m "feat(audio): couple chord/bass turnarounds to genres via GenreStyle bundle"
+```
+
+---
+
+## PHASE C — Extended Base Patterns (optional, catalog-only)
+
+### Task 10: Author a 4-bar extended pattern (representative)
+
+**Files:**
+- Modify: `src/progressions/audio/patterns.ts` (one new pattern in `CHORD_PATTERNS` or `BASS_PATTERNS`)
+- Test: `src/progressions/audio/buildAllLayers.test.ts`
+
+**Context:** no renderer change — `sliceCellToBar` + `absoluteBar % bars` already select the right bar of a `bars: N` cell on bar-unit steps. This task proves the path with a 4-bar cell and documents the beat-unit collapse caveat. Skip this task if no 4-bar pattern is desired yet.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/progressions/audio/buildAllLayers.test.ts`:
+
+```typescript
+describe("extended (4-bar) base pattern", () => {
+  it("plays a different bar of a 4-bar cell on each successive bar", async () => {
+    const steps = Array.from({ length: 4 }, (_, i) => step({ id: `s${i}`, index: i }));
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      chordPatternId: "extended-4bar-demo",
+      bassPatternId: "root-fifth",
+      steps,
+    });
+    // Bar 0 has 1 hit (beat 0); bar 3 has 2 hits (the authored turnaround bar).
+    const bar0 = out.chordStrums.filter((s) => s.time >= 0 && s.time < 4);
+    const bar3 = out.chordStrums.filter((s) => s.time >= 12 && s.time < 16);
+    expect(bar0).toHaveLength(1);
+    expect(bar3).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test -- src/progressions/audio/buildAllLayers.test.ts`
+Expected: FAIL — `extended-4bar-demo` pattern not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `CHORD_PATTERNS` in `src/progressions/audio/patterns.ts`:
+
+```typescript
+  {
+    id: "extended-4bar-demo",
+    label: "Extended 4-Bar Demo",
+    bars: 4,
+    // One sustained chord per bar for bars 0-2; bar 3 (beats 12-15) adds a
+    // second anticipation stab as a turnaround — proves multi-bar evolution
+    // without any variation event.
+    hits: [
+      { beat: 0, velocity: 0.8, style: "sustained" },
+      { beat: 4, velocity: 0.8, style: "sustained" },
+      { beat: 8, velocity: 0.8, style: "sustained" },
+      { beat: 12, velocity: 0.85, style: "sustained" },
+      { beat: 14.5, velocity: 0.7, direction: "up" },
+    ],
+  },
+```
+
+Update the catalog-count assertion in `patterns.test.ts` (`has 10 chord patterns` → `11`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test -- src/progressions/audio/patterns.test.ts src/progressions/audio/buildAllLayers.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/progressions/audio/patterns.ts src/progressions/audio/patterns.test.ts src/progressions/audio/buildAllLayers.test.ts
+git commit -m "feat(audio): add 4-bar extended chord pattern demonstrating multi-bar evolution"
+```
+
+---
+
+## Final Verification (run after all tasks)
+
+- [ ] **Lint, test, build (MANDATORY before PR):**
+
+```bash
+pnpm run lint
+pnpm run test
+pnpm run build
+```
+Expected: all green.
+
+- [ ] **Optional — audition in the dev server:**
+
+```bash
+pnpm run dev
+```
+Load the funk genre, set an 8+ bar progression, enable chords/bass/drums, play looped. Confirm: the turnaround bar (bar 4 of each group) audibly pushes chords + bass + drums together; repeats don't sound machine-gunned; the pulse stays tight on downbeats.
+
+---
+
+## Self-Review notes (author)
+
+- **Spec coverage:** Extended patterns → Task 10; ChordVariation/BassVariation → Tasks 4-6; substitution semantics (replace, first-wins) → Tasks 5-6; genre coupling → Task 9; humanizer groove-lock → Task 2; ghost-drop → Task 1; exclusions (metronome/onsets) → Task 3. Density Selection is intentionally **out of scope** per the spec.
+- **Type consistency:** `shouldDropHit(velocity, seed)`, `grooveLockTimeAmount(beat, fullAmountSec)`, `getChordVariation`/`getBassVariation`, `progressionChordVariationsAtom`/`progressionBassVariationsAtom`, `GenreStyle.chordVariations`/`bassVariations`, and `BuildAllLayersInput.chordVariations`/`bassVariations` are used identically across every task.
+- **Ordering dependency:** Task 8 (atoms) references `GenreStyle.chordVariations`/`bassVariations` from Task 9 — execute Task 9 before or with Task 8. Task 7's build only passes once Tasks 5-6 add the input fields.
+- **Known caveat (documented, not a bug):** extended patterns collapse to bar 0 on *beat-unit* steps (`repeatPatternToBeats` path) — acceptable; surfaced in the Task 10 context note.

--- a/docs/superpowers/specs/2026-06-08-backing-track-variation-design.md
+++ b/docs/superpowers/specs/2026-06-08-backing-track-variation-design.md
@@ -1,0 +1,41 @@
+# Backing Track Variation Design
+
+## Overview
+The backing tracks (drums, bass, chords) currently rely on 1-bar or 2-bar static loops. This creates a predictable and monotone feel over longer progressions. This design introduces a two-tiered system to break this monotony while preserving the strict genre-specific groove coupling (e.g., locking the bass and chords in funk or bossa nova).
+
+## Architecture & Components
+
+The solution is divided into two major components: Structural Phrasing and the Safe Humanizer.
+
+### 1. Structural Variation & Phrasing
+This layer handles the macro-phrasing of the backing track, ensuring patterns evolve naturally over 4-bar or 8-bar cycles.
+
+* **Extended Base Patterns:** Core static patterns can be authored as longer 4-bar or 8-bar phrases directly in the catalog, allowing the bass or chords to evolve without complex generation logic. The existing `absoluteBar % bars` modulo math in the audio renderer fully supports this.
+* **Variation Events:** We will introduce `ChordVariation` and `BassVariation` models, mirroring the existing `DRUM_VARIATIONS` system.
+  * These variations specify a `barInterval` (e.g., 4) and a `barPhase` (e.g., 3 for a turnaround bar).
+  * When `absoluteBar` aligns with the variation interval, the audio renderer will substitute the base pattern with the variation pattern for that bar.
+  * This allows tightly authored, genre-locked fills (e.g., a funk turnaround that pushes the bass and chords in sync).
+* **Density Selection:** The engine will accept a density tier (Sparse, Normal, Busy) as an optional parameter, allowing the variation system to swap to busier fills at the end of progressions, or sparse loops during intro sections.
+
+### 2. The Safe Humanizer Pass
+A post-processing filter applied within `buildAllLayers.ts` immediately before hits are returned to the scheduler. This pass guarantees no two loops sound identical without risking rhythm collapse.
+
+* **Velocity Jitter:** Every returned hit will have a randomized velocity offset (e.g., +/- 5-10%) to prevent "machine gun" repeating sample triggers.
+* **Micro-timing Jitter:** Hits will receive tiny timing offsets (e.g., +/- 10ms).
+  * **Groove Lock:** Anchor beats (such as beat 0 and beat 2 in 4/4) will receive zero or significantly less timing jitter to maintain the structural pulse. Off-beats (e.g., 16th note subdivisions) will receive more jitter.
+* **Probabilistic Ghost Dropping:** The humanizer calculates a drop chance based on velocity.
+  * Low-velocity hits (< 0.4 velocity) have a small probability (e.g., ~10-15%) of being completely removed from the output array.
+  * High-velocity structural hits (> 0.7 velocity) have a 0% drop chance.
+  * This simulates a player occasionally skipping a scratch or ghost strum naturally.
+
+## Data Flow
+1. `buildAllLayers.ts` iterates over the progression step and determines `absoluteBar`.
+2. For each instrument, it fetches the base pattern.
+3. It checks for applicable Variations (`DrumVariation`, `ChordVariation`, `BassVariation`) for the current `absoluteBar` and substitutes the hits if matched.
+4. It slices and repeats the pattern to fill the required beats for the step.
+5. It passes the final array of hits through the Safe Humanizer function.
+6. The humanized hits are returned to the playback scheduler.
+
+## Testing
+* **Variation Firing:** Unit tests will verify `variationFiresOnBar` for chords and bass, ensuring turnarounds trigger exactly when expected.
+* **Humanizer Bounds:** Tests will ensure that the humanizer never shifts a beat out of bounds (negative time or beyond the step length), never drops high-velocity notes, and keeps jitter within defined parameters.

--- a/docs/superpowers/specs/2026-06-08-backing-track-variation-design.md
+++ b/docs/superpowers/specs/2026-06-08-backing-track-variation-design.md
@@ -3,39 +3,99 @@
 ## Overview
 The backing tracks (drums, bass, chords) currently rely on 1-bar or 2-bar static loops. This creates a predictable and monotone feel over longer progressions. This design introduces a two-tiered system to break this monotony while preserving the strict genre-specific groove coupling (e.g., locking the bass and chords in funk or bossa nova).
 
+## Current State (what already exists — do not rebuild)
+
+This spec extends an existing system. Before authoring anything, read these and reuse them:
+
+* **The humanizer already exists.** `src/progressions/audio/humanize.ts` exports `applyJitter`, a **deterministic, seeded** (Mulberry32) per-hit jitter that already applies:
+  * **Velocity jitter** — default `velocityAmount = 0.1` (±10%); drums override to `0.05`.
+  * **Micro-timing jitter** — default `timeAmountSec = 0.015` (±15ms); drums override to `0.005`.
+  * It is already called inline in `buildAllLayers.ts` for chord strums, bass, and drums (lines ~299, ~392, ~423). It is **not** a single post-processing pass over the assembled arrays — it runs per-hit inside the bar loop.
+  * It already supports per-hit grid-locking (`timeAmountSec: 0`) — used today to lock the bossa LH bass to the grid so it doesn't flam against the upright.
+  * **Gaps in the existing humanizer (this is the actual new work):** there is **no groove-lock by beat position** (anchor beats are not de-jittered today) and **no probabilistic ghost dropping** (`applyJitter` always returns exactly one hit).
+* **The `DrumVariation` model already exists.** `patterns.ts` defines `DrumVariation { id, label, barInterval, barPhase?, pattern }`, the `DRUM_VARIATIONS` catalog (6 variations), `getDrumVariation`, and the pure gating predicate `variationFiresOnBar(variation, absoluteBar)`. **`variationFiresOnBar` is already generic** — it reads only `barInterval`/`barPhase`, so it can gate chord and bass variations without duplication.
+* **Drum variations are ADDITIVE, not substitutive.** In `buildAllLayers.ts` (line ~418) firing variation hits are *layered on top* of the base bar: `[...baseForBar, ...firingVariationHits]`. This contradicts the original draft's "substitute the base pattern" language — see §1 for the resolved semantics.
+* **Genre coupling already has a home: `GenreStyle` in `src/progressions/audio/genres.ts`.** Each genre bundles `chordPattern`, `bassPattern`, `drumPattern`, **`drumVariations: string[]`**, tempo, and swing. `applyGenreStyleAtom` (in `progressionAtoms.ts`) fans these into the per-instrument atoms. **This is the mechanism that guarantees genre lock** — see §3.
+* **Extended (4/8-bar) base patterns already work for bar-unit steps.** `sliceCellToBar(hits, absoluteBar % bars, beatsPerBar)` (used when `isBarUnit && cellBars > 1`) already selects the correct bar of a multi-bar cell. The 2-bar `bossa-comp` / `bossa` patterns prove the path. **Caveat:** for *beat-unit* steps (duration measured in beats, not bars) the code falls back to `repeatPatternToBeats`, which only emits bar 0 of the cell — extended patterns silently collapse there. Acceptable for now; call it out in tests.
+
 ## Architecture & Components
 
-The solution is divided into two major components: Structural Phrasing and the Safe Humanizer.
+The solution has two tiers: **Structural Variation** (macro-phrasing) and the **Safe Humanizer** (micro-variation). They are independent and can ship separately.
 
 ### 1. Structural Variation & Phrasing
-This layer handles the macro-phrasing of the backing track, ensuring patterns evolve naturally over 4-bar or 8-bar cycles.
+This layer handles macro-phrasing, ensuring patterns evolve naturally over 4-bar or 8-bar cycles.
 
-* **Extended Base Patterns:** Core static patterns can be authored as longer 4-bar or 8-bar phrases directly in the catalog, allowing the bass or chords to evolve without complex generation logic. The existing `absoluteBar % bars` modulo math in the audio renderer fully supports this.
-* **Variation Events:** We will introduce `ChordVariation` and `BassVariation` models, mirroring the existing `DRUM_VARIATIONS` system.
-  * These variations specify a `barInterval` (e.g., 4) and a `barPhase` (e.g., 3 for a turnaround bar).
-  * When `absoluteBar` aligns with the variation interval, the audio renderer will substitute the base pattern with the variation pattern for that bar.
-  * This allows tightly authored, genre-locked fills (e.g., a funk turnaround that pushes the bass and chords in sync).
-* **Density Selection:** The engine will accept a density tier (Sparse, Normal, Busy) as an optional parameter, allowing the variation system to swap to busier fills at the end of progressions, or sparse loops during intro sections.
+* **Extended Base Patterns:** Authored directly in the catalog as 4-bar or 8-bar `bars: N` cells. **No renderer change required** — the existing `sliceCellToBar` / `absoluteBar % bars` path supports them (see Current State caveat for beat-unit steps). This is purely catalog authoring + tests.
+
+* **Variation Events:** Introduce `ChordVariation` and `BassVariation` models mirroring `DrumVariation`. Each specifies a `barInterval` and optional `barPhase` (e.g. `barInterval: 4, barPhase: 3` for a turnaround bar). Reuse `variationFiresOnBar` for gating — do **not** duplicate the predicate.
+
+  * **Substitution semantics (must be decided, not left implicit):**
+    * **Drums** stay **additive** (unchanged) — a fill *adds* a crash/snare-roll over the base groove.
+    * **Chords and bass** are **substitutive** — when a chord/bass variation fires, its hits **replace** the base pattern's hits for that bar (a turnaround re-voices the whole bar; layering two harmonic patterns would collide). When **no** variation fires, the base pattern plays unchanged.
+    * **Multiple variations on the same bar:** at most one substitutive (chord/bass) variation may fire per bar. If two are configured to fire on the same `absoluteBar`, the **first in catalog order wins** (document this; tests must cover it). Additive drum variations may still stack (current behavior).
+  * This enables tightly authored, genre-locked fills (e.g. a funk turnaround that pushes bass and chords in sync — see §3 for how sync is guaranteed).
+
+* **Density Selection — DEFERRED (out of scope for this slice).** Sparse/Normal/Busy tiers, "intro" vs "end-of-progression" detection, and per-density pattern variants are a separate subsystem with no data model today (the catalog has no section/density tags, and nothing detects progression sections). Folding it in here would balloon scope and violate YAGNI. **Recommendation:** ship Extended Patterns + Variation Events + the Humanizer first; spec Density Selection separately once those land. If it must stay, it needs its own design covering: the density data model, how sections are detected, and how density maps to pattern selection.
 
 ### 2. The Safe Humanizer Pass
-A post-processing filter applied within `buildAllLayers.ts` immediately before hits are returned to the scheduler. This pass guarantees no two loops sound identical without risking rhythm collapse.
+Extends the existing `applyJitter` (do not replace it) with the two missing behaviors. The "no two loops sound identical" guarantee already holds *across bars* because the seed incorporates `stepIndex`/`bar`/`beat`; the new work prevents identical-sounding *repeats of the same pattern* and the machine-gun effect on repeated low-velocity samples.
 
-* **Velocity Jitter:** Every returned hit will have a randomized velocity offset (e.g., +/- 5-10%) to prevent "machine gun" repeating sample triggers.
-* **Micro-timing Jitter:** Hits will receive tiny timing offsets (e.g., +/- 10ms).
-  * **Groove Lock:** Anchor beats (such as beat 0 and beat 2 in 4/4) will receive zero or significantly less timing jitter to maintain the structural pulse. Off-beats (e.g., 16th note subdivisions) will receive more jitter.
-* **Probabilistic Ghost Dropping:** The humanizer calculates a drop chance based on velocity.
-  * Low-velocity hits (< 0.4 velocity) have a small probability (e.g., ~10-15%) of being completely removed from the output array.
-  * High-velocity structural hits (> 0.7 velocity) have a 0% drop chance.
-  * This simulates a player occasionally skipping a scratch or ghost strum naturally.
+* **Velocity Jitter:** Already implemented (±10% chords/bass, ±5% drums). **No change** unless tuning is desired — if so, state the new values explicitly rather than the draft's vague "±5-10%."
+* **Micro-timing Jitter:** Already implemented (±15ms chords/bass, ±5ms drums). The original draft's "±10ms" conflicts with the shipped defaults — **keep the existing values** unless a deliberate retune is intended, in which case name them.
+  * **Groove Lock (NEW):** Integer beats (`beat % 1 === 0` — meter-agnostic) receive **reduced** timing jitter (~40% of full, i.e. ~6ms when full is 15ms) to hold the structural pulse; off-beats (`.5`, `.25`, `.75` subdivisions) receive full jitter. **Not zero** on integers — zero-on-all-integers reads as machine-quantized and defeats humanization; reduced keeps the track alive while holding the pulse, and composes with the existing swing logic (which already offsets off-beats). Implement as a beat-position test feeding `timeAmountSec` (reuse the existing grid-lock plumbing). Velocity jitter is unaffected by groove lock — only timing.
+* **Probabilistic Ghost Dropping (NEW):** The humanizer may drop a hit entirely.
+  * Drop chance is computed from the **pre-jitter (authored) velocity**, not the post-jitter value — authored intent is deterministic and a ±10% jitter must not push a 0.45 ghost across the 0.4 threshold and change whether it drops.
+  * **Hard threshold (resolved):** velocity **< 0.4** has a flat **~12%** drop chance; velocity **≥ 0.4** is **never** dropped (this subsumes the original >0.7 safety rule). No interpolation — you skip ghost strokes, not real notes. Easy to test, deterministic, and keeps mid-range rhythmic content intact.
+  * **Determinism:** the drop decision must use the same seeded RNG keyed on the hit's existing seed, so playback is reproducible and the existing snapshot/unit tests stay stable.
+  * **Architecture note:** because dropping changes array length, `applyJitter`'s contract changes — it must be able to signal "drop." Options: (a) return `{ time, velocity } | null` and have each call site skip on `null`; or (b) add a separate `shouldDropHit(velocity, seed)` predicate the call sites check before pushing. Prefer (b) — it keeps `applyJitter`'s return type stable and the drop logic independently testable.
+  * **Exclusions (critical):** the humanizer must **never** drop or jitter:
+    * `metronome` events — they are the click reference and must stay on the grid.
+    * `chordOnsets` events — they drive React state writes (`isFirstBar`/`isLastBar`) and the §3.4 chromatic-approach gating; dropping or shifting them breaks UI sync and bass lead-ins.
+    * Only `chordStrums`, `bass`, and `drums` are humanized. (This matches today's behavior — preserve it.)
+
+### 3. Genre Coupling (how "locked in sync" is actually guaranteed)
+
+The original draft asserted genre-locked sync fills as a goal but never said what enforces them. Independent per-instrument variation events do **not** couple on their own. The coupling mechanism is **`GenreStyle`**:
+
+* Extend `GenreStyle` (in `genres.ts`) with **`chordVariations: string[]`** and **`bassVariations: string[]`**, alongside the existing `drumVariations`.
+* A genre author guarantees sync by selecting variations with **matching `barInterval` and `barPhase`** across the three instruments (e.g. funk: `funk-fill-4` drums + a `funk-turnaround-chord` + a `funk-turnaround-bass`, all `barInterval: 4, barPhase: 3`). Because the genre bundle ships them together, they always fire on the same bar.
+* This makes coupling a **data/authoring guarantee**, not a runtime coupling primitive — consistent with how `drumVariations` already works. No cross-instrument runtime wiring is added.
+
+## Plumbing / Files to touch
+
+The original draft listed only `buildAllLayers.ts`. The actual surface for Variation Events:
+
+1. **`src/progressions/audio/patterns.ts`** — add `ChordVariation` / `BassVariation` interfaces, `CHORD_VARIATIONS` / `BASS_VARIATIONS` catalogs, and `getChordVariation` / `getBassVariation`. Reuse `variationFiresOnBar`.
+2. **`src/progressions/audio/genres.ts`** — add `chordVariations` / `bassVariations` to `GenreStyle` and populate per genre (the coupling guarantee, §3).
+3. **`src/store/progressionAtoms.ts`** — add `progressionChordVariationsAtom` / `progressionBassVariationsAtom` (`atomWithStorage`, keyed via `k(...)`), wire them into `applyGenreStyleAtom`, and add both to the reset action (RESET).
+4. **`src/hooks/useProgressionAudioPlayback.ts`** — read the two new atoms and thread them through **every** `buildAllLayersAsync` input object and its dependency arrays (there are multiple call sites + memo deps — grep for `drumVariations` to find them all).
+5. **`src/progressions/audio/buildAllLayers.ts`** — add `chordVariations` / `bassVariations` to `BuildAllLayersInput`, resolve them like `drumVariations`, and apply substitutive selection in the chord and bass bar loops.
+6. **`src/progressions/audio/humanize.ts`** — add groove-lock (beat-position → reduced jitter) and `shouldDropHit` (§2).
+
+Density Selection plumbing is intentionally omitted (deferred, §1).
 
 ## Data Flow
-1. `buildAllLayers.ts` iterates over the progression step and determines `absoluteBar`.
-2. For each instrument, it fetches the base pattern.
-3. It checks for applicable Variations (`DrumVariation`, `ChordVariation`, `BassVariation`) for the current `absoluteBar` and substitutes the hits if matched.
-4. It slices and repeats the pattern to fill the required beats for the step.
-5. It passes the final array of hits through the Safe Humanizer function.
-6. The humanized hits are returned to the playback scheduler.
+1. `buildAllLayers.ts` iterates over each progression step and tracks `absoluteBar`.
+2. For each instrument, it fetches the base pattern (selecting the correct cell bar via `sliceCellToBar` for multi-bar patterns).
+3. It checks applicable variations via `variationFiresOnBar(v, absoluteBar)`:
+   * **Drums:** layer firing variation hits over the base (additive — unchanged).
+   * **Chords / Bass:** if a variation fires, **replace** the base bar's hits with the variation's; otherwise use the base. At most one substitutive variation per bar (catalog order wins).
+4. It slices/repeats to fill the step's beats.
+5. Each emitted hit passes through the humanizer per-hit: `shouldDropHit` (skip if dropped, never for velocity > 0.7), then `applyJitter` with groove-lock-adjusted `timeAmountSec`. **Metronome and chordOnsets bypass the humanizer.**
+6. The surviving, humanized hits are returned to the playback scheduler.
 
 ## Testing
-* **Variation Firing:** Unit tests will verify `variationFiresOnBar` for chords and bass, ensuring turnarounds trigger exactly when expected.
-* **Humanizer Bounds:** Tests will ensure that the humanizer never shifts a beat out of bounds (negative time or beyond the step length), never drops high-velocity notes, and keeps jitter within defined parameters.
+* **Variation firing:** `variationFiresOnBar` already has coverage; add cases proving chord and bass variations gate identically (turnarounds fire on exactly the expected `absoluteBar`).
+* **Substitution semantics:** a firing chord/bass variation **replaces** the base bar's hits (not layered); a non-firing bar plays the base unchanged; when two substitutive variations target the same bar, catalog order wins.
+* **Genre coupling:** for a genre whose chord/bass/drum variations share `barInterval`/`barPhase`, assert all three fire on the same `absoluteBar` (the sync guarantee).
+* **Humanizer bounds:** jitter never moves a hit to negative time or past the step length; jitter stays within the configured `timeAmountSec`/`velocityAmount`.
+* **Groove lock:** integer beats receive reduced (~40%) timing jitter; off-beats receive full jitter; velocity jitter is unaffected by beat position.
+* **Ghost dropping:** velocity ≥ 0.4 is **never** dropped; velocity < 0.4 drop rate sits near ~12% over a large sample; the drop decision is **deterministic** for a fixed seed (same input → same output across runs).
+* **Humanizer exclusions:** metronome and chordOnsets are never dropped or time-shifted.
+* **Regression:** with no variations configured and dropping disabled, output matches the pre-change build (guards the additive→substitutive split and the humanizer extension).
+* **Extended patterns:** a 4-bar `bars: 4` cell emits the correct bar per `absoluteBar` on bar-unit steps; document the beat-unit collapse caveat in a test.
+
+## Resolved Decisions
+1. **Loop variety — per-bar only.** Keep build-once-replay. Per-pass variety is **out of scope**: one pass already varies per bar (seed = `stepIndex`/`bar`/`beat`) and variations fire every 4 bars, which fixes the macro-monotony the project set out to solve. Adding a loop-pass seed would force a rebuild on every loop boundary and threaten gapless Tone.js looping — not worth it. The build stays single-pass and deterministic.
+2. **Groove lock — reduced on integers, full off-beats.** Integer beats get ~40% timing jitter (~6ms); off-beats get full (~15ms). Not zero on integers (avoids a robotic feel). Meter-agnostic via `beat % 1 === 0`. See §2 Groove Lock.
+3. **Ghost-drop curve — hard threshold, no interpolation.** Velocity < 0.4 → flat ~12% drop; velocity ≥ 0.4 → never dropped. See §2 Probabilistic Ghost Dropping.

--- a/src/components/Inspector/Inspector.module.css
+++ b/src/components/Inspector/Inspector.module.css
@@ -83,6 +83,14 @@
   padding: var(--space-3, 0.75rem) 0;
 }
 
+/* Keep-alive: visited tab panels are kept mounted via Radix `forceMount` so
+ * re-selecting a tab never remounts a heavy subtree (which would block the main
+ * thread and disturb playback). Radix does NOT auto-apply `hidden` to
+ * forceMounted inactive content, so hide it explicitly here. */
+.tabPanel[data-state="inactive"] {
+  display: none;
+}
+
 .tabBody {
   display: flex;
   flex-direction: column;

--- a/src/components/Inspector/Inspector.module.css.test.ts
+++ b/src/components/Inspector/Inspector.module.css.test.ts
@@ -11,6 +11,16 @@ describe("Inspector.module.css", () => {
     expect(css).not.toMatch(/composes:\s*faceplate/);
   });
 
+  it("hides inactive tab panels (forceMount keep-alive needs explicit hiding)", () => {
+    const css = readFileSync(
+      join(__dirname, "Inspector.module.css"),
+      "utf8",
+    );
+    expect(css).toMatch(
+      /\.tabPanel\[data-state="inactive"\]\s*\{[^}]*display:\s*none/s,
+    );
+  });
+
   it("defines mobile cardHeadActions order and flex behavior", () => {
     const css = readFileSync(
       join(__dirname, "InspectorCard.module.css"),

--- a/src/components/Inspector/Inspector.test.tsx
+++ b/src/components/Inspector/Inspector.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderWithAtoms } from "../../test-utils/renderWithAtoms";
 import { Inspector } from "./Inspector";
 
@@ -20,5 +21,35 @@ describe("Inspector v2.0", () => {
   it("defaults to the Overlay tab", () => {
     renderWithAtoms(<Inspector />);
     expect(screen.getByTestId("view-tab")).toBeVisible();
+  });
+
+  it("does not mount the Song body until the tab is first opened", () => {
+    const { container } = renderWithAtoms(<Inspector />);
+    // Overlay is the default tab — the heavy Song subtree should not mount yet
+    // (no app-startup cost for a tab the user hasn't visited).
+    expect(container.querySelector('[data-inspector-tab="song"]')).toBeNull();
+  });
+
+  it("keeps a visited tab body mounted after switching away (keep-alive)", async () => {
+    const user = userEvent.setup();
+    const { container } = renderWithAtoms(<Inspector />);
+
+    // Visit the Song tab — its body mounts.
+    await user.click(screen.getByRole("tab", { name: /song/i }));
+    expect(container.querySelector('[data-inspector-tab="song"]')).not.toBeNull();
+
+    // Switch back to Overlay. The Song body must STAY mounted, so returning to
+    // it is a cheap visibility toggle rather than a costly remount that blocks
+    // the main thread (which desyncs the playhead and glitches audio).
+    await user.click(screen.getByRole("tab", { name: /overlay/i }));
+    expect(container.querySelector('[data-inspector-tab="song"]')).not.toBeNull();
+
+    // ...and the now-inactive Song panel must be marked inactive so the CSS
+    // (.tabPanel[data-state="inactive"] { display: none }) hides it — Radix does
+    // NOT auto-hide forceMounted content, so both panels would otherwise show.
+    const songPanel = container.querySelector('[data-tab-id="song"]');
+    expect(songPanel?.getAttribute("data-state")).toBe("inactive");
+    const viewPanel = container.querySelector('[data-tab-id="view"]');
+    expect(viewPanel?.getAttribute("data-state")).toBe("active");
   });
 });

--- a/src/components/Inspector/Inspector.tsx
+++ b/src/components/Inspector/Inspector.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import * as RadixTabs from "@radix-ui/react-tabs";
 import { useAtom } from "jotai";
 import clsx from "clsx";
@@ -25,6 +25,19 @@ export interface InspectorProps {
 export function Inspector({ placement = "top" }: InspectorProps) {
   const { t } = useTranslation();
   const [active, setActive] = useAtom(inspectorActiveTabAtom);
+  // Keep-alive: once a tab has been opened, keep its body mounted (Radix hides
+  // it with the `hidden` attribute). Returning to a visited tab is then a cheap
+  // visibility toggle instead of remounting a heavy subtree (e.g. SongControls),
+  // whose synchronous mount blocks the main thread — that block stalls the rAF
+  // visual clock (snapping the WAAPI playhead) and starves Tone's lookahead
+  // scheduler (audio glitch). Unvisited tabs stay unmounted (no startup cost).
+  const [visited, setVisited] = useState<Set<InspectorTabId>>(() => new Set([active]));
+
+  const handleValueChange = (value: string) => {
+    const id = value as InspectorTabId;
+    setVisited((prev) => (prev.has(id) ? prev : new Set(prev).add(id)));
+    setActive(id);
+  };
 
   const tabList = (
     <RadixTabs.List className={styles.tabList} aria-label="Inspector">
@@ -44,7 +57,7 @@ export function Inspector({ placement = "top" }: InspectorProps) {
       className={clsx(styles.root, placement === "bottom" && styles.placementBottom)}
       data-placement={placement}
       value={active}
-      onValueChange={(value) => setActive(value as InspectorTabId)}
+      onValueChange={handleValueChange}
     >
       {placement === "top" ? <div className={styles.tabHeader}>{tabList}</div> : tabList}
       {INSPECTOR_TABS.map((tab) => (
@@ -53,6 +66,10 @@ export function Inspector({ placement = "top" }: InspectorProps) {
           value={tab.id}
           className={styles.tabPanel}
           data-tab-id={tab.id}
+          // Visited tabs stay mounted (Radix sets `hidden` when inactive) so
+          // re-selecting them never remounts the subtree. Unvisited tabs render
+          // lazily on first open.
+          forceMount={visited.has(tab.id) ? true : undefined}
         >
           {TAB_BODIES[tab.id]()}
         </RadixTabs.Content>

--- a/src/components/SongControls/SongControls.module.css
+++ b/src/components/SongControls/SongControls.module.css
@@ -588,7 +588,3 @@
   justify-content: center;
   margin-left: 0;
 }
-
-
-
-

--- a/src/components/SongControls/SongControls.module.css.test.ts
+++ b/src/components/SongControls/SongControls.module.css.test.ts
@@ -25,7 +25,6 @@ describe("SongControls button chrome", () => {
       /:global\(\.app-container\[data-layout-tier="mobile"\]\)\s+\.grouped-button\s*\{[^}]*height:\s*var\(--control-height\)/s,
     );
   });
-
   it("defines mobile root-quality flex row, lock-label sr-only, and lock-toggle size overrides", () => {
     expect(css).toMatch(
       /:global\(\.app-container\[data-layout-tier="mobile"\]\)\s+\.root-quality-row\s*\{[^}]*display:\s*flex/s,
@@ -53,6 +52,3 @@ describe("SongControls button chrome", () => {
     );
   });
 });
-
-
-

--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -12,6 +12,8 @@ import {
   progressionDrumPatternAtom,
   progressionDrumsEnabledAtom,
   progressionDrumVariationsAtom,
+  progressionChordVariationsAtom,
+  progressionBassVariationsAtom,
   progressionGenreStyleAtom,
   progressionLoopEnabledAtom,
   progressionMetronomeEnabledAtom,
@@ -131,6 +133,8 @@ export function useProgressionAudioPlayback() {
   const bassPatternId = useAtomValue(progressionBassPatternAtom);
   const drumPatternId = useAtomValue(progressionDrumPatternAtom);
   const drumVariations = useAtomValue(progressionDrumVariationsAtom);
+  const chordVariations = useAtomValue(progressionChordVariationsAtom);
+  const bassVariations = useAtomValue(progressionBassVariationsAtom);
 
   const chordOn = useAtomValue(progressionChordEnabledAtom);
   const bassOn = useAtomValue(progressionBassEnabledAtom);
@@ -159,8 +163,10 @@ export function useProgressionAudioPlayback() {
         bassPatternId,
         drumPatternId,
         drumVariations,
+        chordVariations,
+        bassVariations,
       }),
-    [beatsPerBar, steps, chordPatternId, bassPatternId, drumPatternId, drumVariations],
+    [beatsPerBar, steps, chordPatternId, bassPatternId, drumPatternId, drumVariations, chordVariations, bassVariations],
   );
   const cacheRef = useRef<{ key: string; value: BuiltLayers } | null>(null);
   const fullCacheKey = useMemo(
@@ -177,6 +183,8 @@ export function useProgressionAudioPlayback() {
         bassPatternId,
         drumPatternId,
         drumVariations,
+        chordVariations,
+        bassVariations,
         tempo,
         swing,
         loopEnabled,
@@ -188,6 +196,8 @@ export function useProgressionAudioPlayback() {
       bassPatternId,
       drumPatternId,
       drumVariations,
+      chordVariations,
+      bassVariations,
       tempo,
       swing,
       loopEnabled,
@@ -202,6 +212,8 @@ export function useProgressionAudioPlayback() {
     bassPatternId,
     drumPatternId,
     drumVariations,
+    chordVariations,
+    bassVariations,
     tempo,
     beatsPerBar,
     swing,
@@ -220,6 +232,8 @@ export function useProgressionAudioPlayback() {
       bassPatternId,
       drumPatternId,
       drumVariations,
+      chordVariations,
+      bassVariations,
       tempo,
       beatsPerBar,
       swing,
@@ -254,6 +268,8 @@ export function useProgressionAudioPlayback() {
             bassPatternId,
             drumPatternId,
             drumVariations,
+            chordVariations,
+            bassVariations,
             loop: loopEnabled,
           });
 
@@ -292,6 +308,8 @@ export function useProgressionAudioPlayback() {
     bassPatternId,
     drumPatternId,
     drumVariations,
+    chordVariations,
+    bassVariations,
     loopEnabled,
     store,
   ]);
@@ -417,6 +435,8 @@ export function useProgressionAudioPlayback() {
         bassPatternId: inputs.bassPatternId,
         drumPatternId: inputs.drumPatternId,
         drumVariations: inputs.drumVariations,
+        chordVariations: inputs.chordVariations,
+        bassVariations: inputs.bassVariations,
         tempo: inputs.tempo,
         swing: inputs.swing,
         loopEnabled: inputs.loopEnabled,
@@ -435,6 +455,8 @@ export function useProgressionAudioPlayback() {
             bassPatternId: inputs.bassPatternId,
             drumPatternId: inputs.drumPatternId,
             drumVariations: inputs.drumVariations,
+            chordVariations: inputs.chordVariations,
+            bassVariations: inputs.bassVariations,
             loop: inputs.loopEnabled,
           });
           cacheRef.current = {

--- a/src/progressions/audio/buildAllLayers.humanize.test.ts
+++ b/src/progressions/audio/buildAllLayers.humanize.test.ts
@@ -33,4 +33,39 @@ describe("buildAllLayers humanizer integration (real humanize)", () => {
     const beatZeroKicks = out.drums.filter((d) => d.value.type === "kick" && d.value.velocity > 0.7);
     expect(beatZeroKicks.length).toBeGreaterThanOrEqual(8);
   });
+
+  it("actually drops some ghost drum hits (real ghost-drop)", async () => {
+    // The `funk` pattern has many sub-0.4 ghost hits (ghost snares <=0.2,
+    // hats at 0.3/0.4) that are eligible to drop. Over 16 bars some must drop.
+    const bars = 16;
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      drumPatternId: "funk",
+      steps: Array.from({ length: bars }, (_, i) => step({ id: `s${i}`, index: i })),
+    });
+    // funk: 3 kicks + 5 snares + 16 hats = 24 hits/bar.
+    const hitsPerBar = 24;
+    const max = hitsPerBar * bars;
+    expect(out.drums.length).toBeGreaterThan(0);
+    expect(out.drums.length).toBeLessThan(max);
+  });
+
+  it("groove-locks on-beat strums tighter than off-beat strums", async () => {
+    // pop-8ths at 60bpm → secondsPerBeat = 1, so a strum's grid time equals
+    // its beat. On-beat hits use 40% of the 0.015 jitter (<=0.006); off-beat
+    // hits use the full 0.015.
+    const out = await buildAllLayersAsync({
+      ...baseInput,
+      chordPatternId: "pop-8ths",
+      steps: [step()],
+    });
+    const onBeat = out.chordStrums.find((s) => s.time < 0.5);
+    expect(onBeat).toBeDefined();
+    // Beat 0 → grid time 0; deviation bounded by the reduced on-beat amount.
+    expect(Math.abs(onBeat!.time - 0)).toBeLessThanOrEqual(0.006);
+    // Off-beat hit on beat 1.5 → grid time 1.5; deviation bounded by full amount.
+    const offBeat = out.chordStrums.find((s) => Math.abs(s.time - 1.5) <= 0.015);
+    expect(offBeat).toBeDefined();
+    expect(Math.abs(offBeat!.time - 1.5)).toBeLessThanOrEqual(0.015);
+  });
 });

--- a/src/progressions/audio/buildAllLayers.humanize.test.ts
+++ b/src/progressions/audio/buildAllLayers.humanize.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { buildAllLayersAsync } from "./buildAllLayers";
+import type { ResolvedProgressionStep } from "../progressionDomain";
+
+const step = (over: Partial<ResolvedProgressionStep> = {}): ResolvedProgressionStep => ({
+  id: "x", index: 0, degree: "I", duration: { value: 1, unit: "bar" },
+  qualityOverride: null, qualityOverrideApplied: false, invalidQualityOverride: false,
+  manualRoot: null, root: "C", quality: "M", diatonicQuality: "M",
+  label: "I", resolvedChordLabel: "C major", shortChordLabel: "C",
+  unavailable: false, unavailableReason: null, ...over,
+});
+
+const baseInput = {
+  tempoBpm: 60, beatsPerBar: 4, swing: 0,
+  chordPatternId: "ballad-whole", bassPatternId: "root-fifth",
+  drumPatternId: "rock", drumVariations: [] as string[], loop: true,
+};
+
+describe("buildAllLayers humanizer integration (real humanize)", () => {
+  it("never drops the metronome or shifts it off the grid", async () => {
+    const out = await buildAllLayersAsync({ ...baseInput, steps: [step(), step({ id: "b", index: 1, root: "G" })] });
+    expect(out.metronome.every((m) => Number.isInteger(m.time))).toBe(true);
+    expect(out.metronome).toHaveLength(8);
+  });
+
+  it("keeps every chordOnset on its exact bar boundary (never humanized)", async () => {
+    const out = await buildAllLayersAsync({ ...baseInput, steps: [step(), step({ id: "b", index: 1, root: "G" })] });
+    expect(out.chordOnsets.map((o) => o.time)).toEqual([0, 4]);
+  });
+
+  it("never drops a high-velocity structural drum hit", async () => {
+    const out = await buildAllLayersAsync({ ...baseInput, steps: Array.from({ length: 8 }, (_, i) => step({ id: `s${i}`, index: i })) });
+    const beatZeroKicks = out.drums.filter((d) => d.value.type === "kick" && d.value.velocity > 0.7);
+    expect(beatZeroKicks.length).toBeGreaterThanOrEqual(8);
+  });
+});

--- a/src/progressions/audio/buildAllLayers.humanize.test.ts
+++ b/src/progressions/audio/buildAllLayers.humanize.test.ts
@@ -13,7 +13,7 @@ const step = (over: Partial<ResolvedProgressionStep> = {}): ResolvedProgressionS
 const baseInput = {
   tempoBpm: 60, beatsPerBar: 4, swing: 0,
   chordPatternId: "ballad-whole", bassPatternId: "root-fifth",
-  drumPatternId: "rock", drumVariations: [] as string[], loop: true,
+  drumPatternId: "rock", drumVariations: [] as string[], chordVariations: [] as string[], bassVariations: [] as string[], loop: true,
 };
 
 describe("buildAllLayers humanizer integration (real humanize)", () => {

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -649,6 +649,39 @@ describe("buildAllLayers", () => {
     });
   });
 
+  describe("bass variation substitution", () => {
+    it("replaces the base bass hits on a firing turnaround bar", async () => {
+      // funk-syncopated has 5 hits/bar; funk-turnaround-bass has 4. Bar 3 fires.
+      const steps = Array.from({ length: 8 }, (_, i) =>
+        step({ id: `s${i}`, index: i, root: i % 2 === 0 ? "C" : "G" }),
+      );
+      const out = await buildAllLayersAsync({
+        ...baseInput,
+        bassPatternId: "funk-syncopated",
+        bassVariations: ["funk-turnaround-bass"],
+        chordPatternId: "ballad-whole",
+        steps,
+      });
+      const bar3 = out.bass.filter((b) => b.time >= 12 && b.time < 16);
+      const bar0 = out.bass.filter((b) => b.time >= 0 && b.time < 4);
+      expect(bar0).toHaveLength(5); // base funk-syncopated
+      expect(bar3).toHaveLength(4); // funk-turnaround-bass
+    });
+
+    it("leaves non-firing bass bars on the base pattern", async () => {
+      const steps = Array.from({ length: 8 }, (_, i) => step({ id: `s${i}`, index: i }));
+      const out = await buildAllLayersAsync({
+        ...baseInput,
+        bassPatternId: "funk-syncopated",
+        bassVariations: ["funk-turnaround-bass"],
+        chordPatternId: "ballad-whole",
+        steps,
+      });
+      const bar1 = out.bass.filter((b) => b.time >= 4 && b.time < 8);
+      expect(bar1).toHaveLength(5); // base funk-syncopated untouched
+    });
+  });
+
   describe("nextResolvableRoot", () => {
     it("returns the immediate next root", () => {
       const steps = [step({ root: "C" }), step({ id: "g", index: 1, root: "G" })];

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -680,6 +680,32 @@ describe("buildAllLayers", () => {
       const bar1 = out.bass.filter((b) => b.time >= 4 && b.time < 8);
       expect(bar1).toHaveLength(5); // base funk-syncopated untouched
     });
+
+    it("variation + base-turnaround: no double fill (variation replaces base, §3.4 swap operates on variation hits only)", async () => {
+      // root-fifth has turnaround:true (2 hits/bar normally). funk-turnaround-bass fires on
+      // absolute bar 3 (barInterval=4, barPhase=3). With loop:true over [C,G,C,G], bar 3
+      // is G with turnaround target C (loop-wrap) — so BOTH the variation fires AND the §3.4
+      // turnaround is active simultaneously.
+      //
+      // Correct behavior: variation substitutes base first (patternHits = 4 variation hits),
+      // then §3.4 tail-swaps: keeps beats < 3 (beats 0, 1.5, 2.5 = 3 hits) + adds one approach
+      // note on beat 3 = 4 total. No double fill.
+      // Bug indicator: if we saw 2 (base only) + 4 (variation) = 6, the base wasn't replaced.
+      const steps = Array.from({ length: 4 }, (_, i) =>
+        step({ id: `s${i}`, index: i, root: i % 2 === 0 ? "C" : "G" }),
+      );
+      const out = await buildAllLayersAsync({
+        ...baseInput,
+        bassPatternId: "root-fifth",
+        bassVariations: ["funk-turnaround-bass"],
+        chordPatternId: "ballad-whole",
+        steps,
+        loop: true,
+      });
+      const bar3 = out.bass.filter((b) => b.time >= 12 && b.time < 16);
+      // §3.4 tail-swaps the variation's beat-3 hit for one approach note: 3 pre-tail hits + 1 = 4.
+      expect(bar3).toHaveLength(4); // clean substitution — variation replaced base, no double fill
+    });
   });
 
   describe("nextResolvableRoot", () => {

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -12,7 +12,9 @@ import { buildVoicing, STRUM_PRESET } from "../voicingEngine";
 import type { ResolvedProgressionStep } from "../progressionDomain";
 
 vi.mock("./humanize", () => ({
-  applyJitter: (params: { time: number; velocity: number }) => ({ time: params.time, velocity: params.velocity })
+  applyJitter: (params: { time: number; velocity: number }) => ({ time: params.time, velocity: params.velocity }),
+  shouldDropHit: () => false,
+  grooveLockTimeAmount: (_beat: number, full: number) => full,
 }));
 
 const step = (over: Partial<ResolvedProgressionStep> = {}): ResolvedProgressionStep => ({

--- a/src/progressions/audio/buildAllLayers.test.ts
+++ b/src/progressions/audio/buildAllLayers.test.ts
@@ -46,6 +46,8 @@ describe("buildAllLayers", () => {
     bassPatternId: "root-fifth",
     drumPatternId: "rock",
     drumVariations: [] as string[],
+    chordVariations: [] as string[],
+    bassVariations: [] as string[],
     loop: true,
   };
 
@@ -274,7 +276,7 @@ describe("buildAllLayers", () => {
         steps: [step({ id: "a", duration: { value: 1, unit: "bar" } })],
         tempoBpm: 120, beatsPerBar: 4, swing: 0,
         chordPatternId: "pop-8ths", bassPatternId: "root-fifth",
-        drumPatternId: "pop", drumVariations: [], loop: false,
+        drumPatternId: "pop", drumVariations: [], chordVariations: [], bassVariations: [], loop: false,
       });
       expect(layers.chordStrums.length).toBeGreaterThan(0);
       for (const s of layers.chordStrums) {
@@ -613,6 +615,37 @@ describe("buildAllLayers", () => {
       expect(pitchClass(bassAt(out, 3)!.value.note)).toBe("F#");
       // G bar ([8,12)s): loop-wraps to C → B approach at 11s.
       expect(pitchClass(bassAt(out, 11)!.value.note)).toBe("B");
+    });
+  });
+
+  describe("chord variation substitution", () => {
+    it("replaces the base chord hits on a firing turnaround bar", async () => {
+      const steps = Array.from({ length: 8 }, (_, i) =>
+        step({ id: `s${i}`, index: i, root: i % 2 === 0 ? "C" : "G" }),
+      );
+      const out = await buildAllLayersAsync({
+        ...baseInput,
+        chordPatternId: "pop-8ths",
+        chordVariations: ["funk-turnaround-chord"],
+        bassPatternId: "root-fifth",
+        steps,
+      });
+      const bar3 = out.chordStrums.filter((s) => s.time >= 12 && s.time < 16);
+      const bar0 = out.chordStrums.filter((s) => s.time >= 0 && s.time < 4);
+      expect(bar0).toHaveLength(6); // base pop-8ths
+      expect(bar3).toHaveLength(4); // funk-turnaround-chord
+    });
+
+    it("leaves non-firing bars on the base pattern", async () => {
+      const steps = Array.from({ length: 8 }, (_, i) => step({ id: `s${i}`, index: i }));
+      const out = await buildAllLayersAsync({
+        ...baseInput,
+        chordPatternId: "pop-8ths",
+        chordVariations: ["funk-turnaround-chord"],
+        steps,
+      });
+      const bar1 = out.chordStrums.filter((s) => s.time >= 4 && s.time < 8);
+      expect(bar1).toHaveLength(6); // base pop-8ths, untouched
     });
   });
 

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -13,6 +13,7 @@ import {
   getDrumPattern,
   getDrumVariation,
   getChordVariation,
+  getBassVariation,
   variationFiresOnBar,
   repeatPatternToBeats,
   sliceCellToBar,
@@ -20,6 +21,7 @@ import {
   type DrumHit,
   type DrumVariation,
   type ChordVariation,
+  type BassVariation,
   type BassArticulation,
 } from "./patterns";
 import { applyJitter, shouldDropHit, grooveLockTimeAmount } from "./humanize";
@@ -192,6 +194,9 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
   const chordVariationDefs: ChordVariation[] = (input.chordVariations ?? [])
     .map((id) => getChordVariation(id))
     .filter((v): v is ChordVariation => Boolean(v));
+  const bassVariationDefs: BassVariation[] = (input.bassVariations ?? [])
+    .map((id) => getBassVariation(id))
+    .filter((v): v is BassVariation => Boolean(v));
 
   const chordOnsets: Array<{ time: number; value: ChordOnsetEvent }> = [];
   const chordStrums: Array<{ time: number; value: ChordStrumEvent }> = [];
@@ -362,9 +367,15 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
 
       if (bassPattern && bassLineNotes.length > 0) {
         const bassCellBars = bassPattern.bars ?? 1;
-        const patternHits = isBarUnit && bassCellBars > 1
-          ? sliceCellToBar(bassPattern.hits, absoluteBar % bassCellBars, input.beatsPerBar)
-          : repeatPatternToBeats(bassPattern.hits, eventBeats, input.beatsPerBar);
+        const firingBassVariation = bassVariationDefs.find((v) =>
+          variationFiresOnBar(v, absoluteBar),
+        );
+        const baseBassHits = firingBassVariation
+          ? firingBassVariation.hits
+          : bassPattern.hits;
+        const patternHits = !firingBassVariation && isBarUnit && bassCellBars > 1
+          ? sliceCellToBar(baseBassHits, absoluteBar % bassCellBars, input.beatsPerBar)
+          : repeatPatternToBeats(baseBassHits, eventBeats, input.beatsPerBar);
         // §3.4 end-of-phrase walk: on a step's last bar that precedes a real
         // chord change, opted-in patterns drop their tail (any hit on/after the
         // bar's last beat) and lead into the next root with one chromatic

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -20,7 +20,7 @@ import {
   type DrumVariation,
   type BassArticulation,
 } from "./patterns";
-import { applyJitter } from "./humanize";
+import { applyJitter, shouldDropHit, grooveLockTimeAmount } from "./humanize";
 
 type DrumVoice = "kick" | "snare" | "hihat" | "openHat" | "ride" | "crossStick";
 type StrumStyle = "staccato" | "sustained";
@@ -295,13 +295,15 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
           const hit = hits[hitIndex];
           const isLhBass =
             hit.voiceRole === "bass-root" || hit.voiceRole === "bass-fifth";
+          const chordSeed = stepIndex * 10000 + bar * 100 + hit.beat;
+          if (!isLhBass && shouldDropHit(hit.velocity, chordSeed)) continue;
           const baseTime = barStart + swingBeat(hit.beat, input.swing) * secondsPerBeat;
           const { time: hitTime, velocity } = applyJitter({
             time: baseTime,
             velocity: hit.velocity,
-            seed: stepIndex * 10000 + bar * 100 + hit.beat,
+            seed: chordSeed,
             // LH bass doubles the upright an octave up — lock it to the grid.
-            ...(isLhBass ? { timeAmountSec: 0 } : {}),
+            timeAmountSec: isLhBass ? 0 : grooveLockTimeAmount(hit.beat, 0.015),
           });
           // A sustained chord rings until the next hit in the bar, or to the bar
           // end when it is the last hit — a true whole note for ballad-whole,
@@ -371,6 +373,8 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
             ]
           : patternHits;
         for (const hit of hits) {
+          const bassSeed = stepIndex * 10000 + bar * 100 + hit.beat + 1;
+          if (!lockBassToGrid && shouldDropHit(hit.velocity, bassSeed)) continue;
           // The synthetic approach note targets the next chord (loop-aware);
           // every other hit keeps today's behavior exactly.
           const approachTarget =
@@ -392,10 +396,10 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
           const { time: hitTime, velocity } = applyJitter({
             time: baseTime,
             velocity: hit.velocity,
-            seed: stepIndex * 10000 + bar * 100 + hit.beat + 1, // slight offset for bass
+            seed: bassSeed,
             // Lock to the grid when the comp doubles this line (bossa LH), so
             // the two voices attack in perfect unison instead of flamming.
-            ...(lockBassToGrid ? { timeAmountSec: 0 } : {}),
+            timeAmountSec: lockBassToGrid ? 0 : grooveLockTimeAmount(hit.beat, 0.015),
           });
           bass.push({
             time: hitTime,
@@ -419,12 +423,14 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
       if (drumHitsForBar.length > 0) {
         const hits = repeatPatternToBeats(drumHitsForBar, eventBeats, input.beatsPerBar);
         for (const hit of hits) {
+          const drumSeed = stepIndex * 10000 + bar * 100 + hit.beat + 2;
+          if (shouldDropHit(hit.velocity, drumSeed)) continue;
           const baseTime = barStart + swingBeat(hit.beat, input.swing) * secondsPerBeat;
           const { time: hitTime, velocity } = applyJitter({
             time: baseTime,
             velocity: hit.velocity,
-            seed: stepIndex * 10000 + bar * 100 + hit.beat + 2, // offset for drums
-            timeAmountSec: 0.005, // tighter timing jitter for drums
+            seed: drumSeed,
+            timeAmountSec: grooveLockTimeAmount(hit.beat, 0.005),
             velocityAmount: 0.05,
           });
           drums.push({

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -12,12 +12,14 @@ import {
   getChordPattern,
   getDrumPattern,
   getDrumVariation,
+  getChordVariation,
   variationFiresOnBar,
   repeatPatternToBeats,
   sliceCellToBar,
   type CatalogDrumPattern,
   type DrumHit,
   type DrumVariation,
+  type ChordVariation,
   type BassArticulation,
 } from "./patterns";
 import { applyJitter, shouldDropHit, grooveLockTimeAmount } from "./humanize";
@@ -69,6 +71,8 @@ export interface BuildAllLayersInput {
   bassPatternId: string;
   drumPatternId: string;
   drumVariations: readonly string[];
+  chordVariations?: readonly string[];
+  bassVariations?: readonly string[];
   loop: boolean;
 }
 
@@ -185,6 +189,9 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
   const variations: DrumVariation[] = input.drumVariations
     .map((id) => getDrumVariation(id))
     .filter((v): v is DrumVariation => Boolean(v));
+  const chordVariationDefs: ChordVariation[] = (input.chordVariations ?? [])
+    .map((id) => getChordVariation(id))
+    .filter((v): v is ChordVariation => Boolean(v));
 
   const chordOnsets: Array<{ time: number; value: ChordOnsetEvent }> = [];
   const chordStrums: Array<{ time: number; value: ChordStrumEvent }> = [];
@@ -288,9 +295,15 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
 
       if (chordPattern && voicing.length > 0) {
         const chordCellBars = chordPattern.bars ?? 1;
-        const hits = isBarUnit && chordCellBars > 1
-          ? sliceCellToBar(chordPattern.hits, absoluteBar % chordCellBars, input.beatsPerBar)
-          : repeatPatternToBeats(chordPattern.hits, eventBeats, input.beatsPerBar);
+        const firingChordVariation = chordVariationDefs.find((v) =>
+          variationFiresOnBar(v, absoluteBar),
+        );
+        const sourceHits = firingChordVariation
+          ? firingChordVariation.hits
+          : chordPattern.hits;
+        const hits = !firingChordVariation && isBarUnit && chordCellBars > 1
+          ? sliceCellToBar(sourceHits, absoluteBar % chordCellBars, input.beatsPerBar)
+          : repeatPatternToBeats(sourceHits, eventBeats, input.beatsPerBar);
         for (let hitIndex = 0; hitIndex < hits.length; hitIndex++) {
           const hit = hits[hitIndex];
           const isLhBass =

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -296,7 +296,9 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
           const isLhBass =
             hit.voiceRole === "bass-root" || hit.voiceRole === "bass-fifth";
           const chordSeed = stepIndex * 10000 + bar * 100 + hit.beat;
-          if (!isLhBass && shouldDropHit(hit.velocity, chordSeed)) continue;
+          // Sustained chords aren't ghost strokes — never drop them (also keeps
+          // the sustain ring boundary, which reads hits[hitIndex + 1], intact).
+          if (!isLhBass && hit.style !== "sustained" && shouldDropHit(hit.velocity, chordSeed)) continue;
           const baseTime = barStart + swingBeat(hit.beat, input.swing) * secondsPerBeat;
           const { time: hitTime, velocity } = applyJitter({
             time: baseTime,

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -191,10 +191,10 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
   const variations: DrumVariation[] = input.drumVariations
     .map((id) => getDrumVariation(id))
     .filter((v): v is DrumVariation => Boolean(v));
-  const chordVariationDefs: ChordVariation[] = (input.chordVariations ?? [])
+  const chordVariationDefs: ChordVariation[] = input.chordVariations
     .map((id) => getChordVariation(id))
     .filter((v): v is ChordVariation => Boolean(v));
-  const bassVariationDefs: BassVariation[] = (input.bassVariations ?? [])
+  const bassVariationDefs: BassVariation[] = input.bassVariations
     .map((id) => getBassVariation(id))
     .filter((v): v is BassVariation => Boolean(v));
 
@@ -247,6 +247,9 @@ export async function buildAllLayersAsync(input: BuildAllLayersInput): Promise<B
     // Split the funk voicing intents: the "root" anchor needs the plain triad's
     // root note; the "color-stab" needs a voice-led rootless funk grip in the
     // current chord's register. Computed only when the pattern uses each hit.
+    // NOTE: these flags derive from the BASE pattern only. A chord variation that
+    // introduces a "root"/"color-stab" articulation the base lacks will fall back to
+    // the default voicing. Keep variation articulations a subset of their genre's base comp.
     const needsRootAnchor = !!chordPattern?.hits.some((h) => h.articulation === "root");
     const needsColor = !!chordPattern?.hits.some((h) => h.articulation === "color-stab");
     const plainVoicing = needsRootAnchor ? resolveChordVoicing(root, quality) : voicing;

--- a/src/progressions/audio/buildAllLayers.ts
+++ b/src/progressions/audio/buildAllLayers.ts
@@ -73,8 +73,8 @@ export interface BuildAllLayersInput {
   bassPatternId: string;
   drumPatternId: string;
   drumVariations: readonly string[];
-  chordVariations?: readonly string[];
-  bassVariations?: readonly string[];
+  chordVariations: readonly string[];
+  bassVariations: readonly string[];
   loop: boolean;
 }
 

--- a/src/progressions/audio/genres.test.ts
+++ b/src/progressions/audio/genres.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { GENRE_STYLES, getGenreStyle } from "./genres";
-import { getChordPattern, getBassPattern, getDrumPattern, getDrumVariation } from "./patterns";
+import { getChordPattern, getBassPattern, getDrumPattern, getDrumVariation, getChordVariation, getBassVariation } from "./patterns";
 
 describe("genre styles", () => {
   it("has 7 genre presets", () => {
@@ -98,5 +98,32 @@ describe("genre drum variations", () => {
         expect(getDrumVariation(id), `genre ${g.id} variation ${id}`).toBeDefined();
       }
     }
+  });
+});
+
+describe("genre chord/bass variation coupling", () => {
+  it("every genre declares chord and bass variation arrays", () => {
+    for (const g of GENRE_STYLES) {
+      expect(Array.isArray(g.chordVariations)).toBe(true);
+      expect(Array.isArray(g.bassVariations)).toBe(true);
+    }
+  });
+
+  it("keeps every referenced chord/bass variation id resolvable", () => {
+    for (const g of GENRE_STYLES) {
+      for (const id of g.chordVariations) expect(getChordVariation(id), `${g.id}:${id}`).toBeDefined();
+      for (const id of g.bassVariations) expect(getBassVariation(id), `${g.id}:${id}`).toBeDefined();
+    }
+  });
+
+  it("funk couples chord/bass/drum turnarounds on the same bar (interval 4, phase 3)", () => {
+    const funk = getGenreStyle("funk")!;
+    const chord = getChordVariation(funk.chordVariations[0])!;
+    const bass = getBassVariation(funk.bassVariations[0])!;
+    expect(chord.barInterval).toBe(4);
+    expect(chord.barPhase).toBe(3);
+    expect(bass.barInterval).toBe(4);
+    expect(bass.barPhase).toBe(3);
+    expect(funk.drumVariations).toContain("funk-fill-4");
   });
 });

--- a/src/progressions/audio/genres.ts
+++ b/src/progressions/audio/genres.ts
@@ -8,6 +8,8 @@ export interface GenreStyle {
   bassPattern: string;
   drumPattern: string;
   drumVariations: string[];
+  chordVariations: string[];
+  bassVariations: string[];
   tempoRange: [number, number];
   suggestedTempo: number;
   swing: number;
@@ -17,43 +19,43 @@ export const GENRE_STYLES: readonly GenreStyle[] = [
   {
     id: "pop", label: "Pop", chordInstrument: "piano",
     chordPattern: "straight-quarters", bassPattern: "root-fifth",
-    drumPattern: "pop", drumVariations: ["open-hat-and-of-4", "fill-every-4"],
+    drumPattern: "pop", drumVariations: ["open-hat-and-of-4", "fill-every-4"], chordVariations: [], bassVariations: [],
     tempoRange: [100, 130], suggestedTempo: 115, swing: 0,
   },
   {
     id: "rock", label: "Rock", chordInstrument: "strum",
     chordPattern: "pop-8ths", bassPattern: "pedal",
-    drumPattern: "rock", drumVariations: ["open-hat-and-of-4", "crash-bar-1", "fill-every-4"],
+    drumPattern: "rock", drumVariations: ["open-hat-and-of-4", "crash-bar-1", "fill-every-4"], chordVariations: [], bassVariations: [],
     tempoRange: [110, 140], suggestedTempo: 120, swing: 0,
   },
   {
     id: "blues", label: "Blues", chordInstrument: "organ",
     chordPattern: "shuffle-comp", bassPattern: "shuffle",
-    drumPattern: "blues-shuffle", drumVariations: ["blues-fill-4"],
+    drumPattern: "blues-shuffle", drumVariations: ["blues-fill-4"], chordVariations: [], bassVariations: [],
     tempoRange: [70, 110], suggestedTempo: 85, swing: 0.33,
   },
   {
     id: "jazz", label: "Jazz", chordInstrument: "piano",
     chordPattern: "jazz-comp", bassPattern: "walking",
-    drumPattern: "jazz-ride", drumVariations: ["jazz-turnaround-4"],
+    drumPattern: "jazz-ride", drumVariations: ["jazz-turnaround-4"], chordVariations: [], bassVariations: [],
     tempoRange: [100, 160], suggestedTempo: 130, swing: 0.33,
   },
   {
     id: "ballad", label: "Ballad", chordInstrument: "piano",
     chordPattern: "ballad-whole", bassPattern: "arpeggiated",
-    drumPattern: "ballad", drumVariations: [],
+    drumPattern: "ballad", drumVariations: [], chordVariations: [], bassVariations: [],
     tempoRange: [60, 80], suggestedTempo: 70, swing: 0,
   },
   {
     id: "funk", label: "Funk", chordInstrument: "strum",
     chordPattern: "funk-scratch", bassPattern: "funk-syncopated",
-    drumPattern: "funk", drumVariations: ["open-hat-and-of-4", "funk-fill-4"],
+    drumPattern: "funk", drumVariations: ["open-hat-and-of-4", "funk-fill-4"], chordVariations: ["funk-turnaround-chord"], bassVariations: ["funk-turnaround-bass"],
     tempoRange: [96, 120], suggestedTempo: 110, swing: 0,
   },
   {
     id: "bossa-nova", label: "Bossa Nova", chordInstrument: "piano",
     chordPattern: "bossa-comp", bassPattern: "bossa",
-    drumPattern: "bossa", drumVariations: [],
+    drumPattern: "bossa", drumVariations: [], chordVariations: [], bassVariations: [],
     tempoRange: [120, 140], suggestedTempo: 130, swing: 0,
   },
 ];

--- a/src/progressions/audio/humanize.test.ts
+++ b/src/progressions/audio/humanize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { applyJitter, shouldDropHit } from "./humanize";
+import { applyJitter, shouldDropHit, grooveLockTimeAmount } from "./humanize";
 
 describe("applyJitter", () => {
   it("returns a new object with jittered time and velocity", () => {
@@ -67,5 +67,24 @@ describe("shouldDropHit", () => {
   it("is deterministic for a fixed velocity + seed", () => {
     expect(shouldDropHit(0.2, 42)).toBe(shouldDropHit(0.2, 42));
     expect(shouldDropHit(0.2, 42)).not.toBe(undefined);
+  });
+});
+
+describe("grooveLockTimeAmount", () => {
+  it("reduces jitter on integer (anchor) beats to ~40%", () => {
+    expect(grooveLockTimeAmount(0, 0.015)).toBeCloseTo(0.006);
+    expect(grooveLockTimeAmount(2, 0.015)).toBeCloseTo(0.006);
+    expect(grooveLockTimeAmount(0, 0.005)).toBeCloseTo(0.002);
+  });
+
+  it("leaves off-beats at full jitter", () => {
+    expect(grooveLockTimeAmount(0.5, 0.015)).toBe(0.015);
+    expect(grooveLockTimeAmount(1.75, 0.015)).toBe(0.015);
+    expect(grooveLockTimeAmount(2.5, 0.005)).toBe(0.005);
+  });
+
+  it("is meter-agnostic (works for any integer beat)", () => {
+    expect(grooveLockTimeAmount(5, 0.015)).toBeCloseTo(0.006);
+    expect(grooveLockTimeAmount(6, 0.015)).toBeCloseTo(0.006);
   });
 });

--- a/src/progressions/audio/humanize.test.ts
+++ b/src/progressions/audio/humanize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { applyJitter } from "./humanize";
+import { applyJitter, shouldDropHit } from "./humanize";
 
 describe("applyJitter", () => {
   it("returns a new object with jittered time and velocity", () => {
@@ -41,5 +41,31 @@ describe("applyJitter", () => {
       const result0 = applyJitter({ time: 0, velocity: 0, seed: i });
       expect(result0.velocity).toBeGreaterThanOrEqual(0);
     }
+  });
+});
+
+describe("shouldDropHit", () => {
+  it("never drops hits with velocity >= 0.4", () => {
+    for (let seed = 0; seed < 200; seed++) {
+      expect(shouldDropHit(0.4, seed)).toBe(false);
+      expect(shouldDropHit(0.7, seed)).toBe(false);
+      expect(shouldDropHit(1, seed)).toBe(false);
+    }
+  });
+
+  it("drops a small fraction of sub-0.4 ghost hits (~12%)", () => {
+    let dropped = 0;
+    const N = 2000;
+    for (let seed = 0; seed < N; seed++) {
+      if (shouldDropHit(0.2, seed)) dropped++;
+    }
+    const rate = dropped / N;
+    expect(rate).toBeGreaterThan(0.07);
+    expect(rate).toBeLessThan(0.17);
+  });
+
+  it("is deterministic for a fixed velocity + seed", () => {
+    expect(shouldDropHit(0.2, 42)).toBe(shouldDropHit(0.2, 42));
+    expect(shouldDropHit(0.2, 42)).not.toBe(undefined);
   });
 });

--- a/src/progressions/audio/humanize.ts
+++ b/src/progressions/audio/humanize.ts
@@ -58,3 +58,16 @@ export function shouldDropHit(velocity: number, seed: number): boolean {
   if (velocity >= GHOST_VELOCITY_THRESHOLD) return false;
   return seededRandom(seed + DROP_SEED_OFFSET) < GHOST_DROP_CHANCE;
 }
+
+/** Fraction of full timing jitter applied to anchor (integer) beats. */
+const ANCHOR_JITTER_FACTOR = 0.4;
+
+/**
+ * Groove lock: integer beats (the structural pulse) get reduced timing jitter;
+ * off-beat subdivisions keep the full amount. Meter-agnostic — keys off the
+ * bar-local beat value. Returns the `timeAmountSec` to feed `applyJitter`.
+ * (Velocity jitter is unaffected — only timing.)
+ */
+export function grooveLockTimeAmount(beat: number, fullAmountSec: number): number {
+  return Number.isInteger(beat) ? fullAmountSec * ANCHOR_JITTER_FACTOR : fullAmountSec;
+}

--- a/src/progressions/audio/humanize.ts
+++ b/src/progressions/audio/humanize.ts
@@ -40,3 +40,21 @@ export function applyJitter({
 
   return { time: newTime, velocity: newVelocity };
 }
+
+/** Threshold below which a hit is a droppable "ghost". */
+const GHOST_VELOCITY_THRESHOLD = 0.4;
+/** Drop probability applied to sub-threshold ghosts. */
+const GHOST_DROP_CHANCE = 0.12;
+/** Seed offset so the drop roll is independent of the time/velocity rolls. */
+const DROP_SEED_OFFSET = 54321;
+
+/**
+ * Deterministic, seeded decision: should this hit be dropped entirely to
+ * simulate a player occasionally skipping a ghost stroke? Uses the hit's
+ * *authored* (pre-jitter) velocity so a ±10% velocity jitter can never flip a
+ * borderline ghost across the threshold. Structural hits (>= 0.4) never drop.
+ */
+export function shouldDropHit(velocity: number, seed: number): boolean {
+  if (velocity >= GHOST_VELOCITY_THRESHOLD) return false;
+  return seededRandom(seed + DROP_SEED_OFFSET) < GHOST_DROP_CHANCE;
+}

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -8,9 +8,13 @@ import {
   BASS_PATTERNS,
   DRUM_PATTERNS,
   DRUM_VARIATIONS,
+  CHORD_VARIATIONS,
+  BASS_VARIATIONS,
   getChordPattern,
   getBassPattern,
   getDrumPattern,
+  getChordVariation,
+  getBassVariation,
   variationFiresOnBar,
   type DrumVariation,
 } from "./patterns";
@@ -522,6 +526,48 @@ describe("BASS_PATTERNS turnaround opt-in", () => {
     for (const id of ["walking", "pedal", "funk-syncopated"]) {
       expect(byId(id).turnaround).toBeUndefined();
     }
+  });
+});
+
+describe("chord & bass variation catalogs", () => {
+  it("exposes chord and bass variation catalogs with unique IDs", () => {
+    const chordIds = CHORD_VARIATIONS.map((v) => v.id);
+    expect(new Set(chordIds).size).toBe(chordIds.length);
+    const bassIds = BASS_VARIATIONS.map((v) => v.id);
+    expect(new Set(bassIds).size).toBe(bassIds.length);
+  });
+
+  it("gates chord/bass variations through the shared variationFiresOnBar", () => {
+    const funkChord = getChordVariation("funk-turnaround-chord")!;
+    expect(funkChord.barInterval).toBe(4);
+    expect(funkChord.barPhase).toBe(3);
+    expect(variationFiresOnBar(funkChord, 3)).toBe(true);
+    expect(variationFiresOnBar(funkChord, 0)).toBe(false);
+
+    const funkBass = getBassVariation("funk-turnaround-bass")!;
+    expect(variationFiresOnBar(funkBass, 3)).toBe(true);
+    expect(variationFiresOnBar(funkBass, 7)).toBe(true);
+  });
+
+  it("keeps every variation's hits in bar-local range [0, 4)", () => {
+    for (const v of CHORD_VARIATIONS) {
+      for (const h of v.hits) {
+        expect(h.beat).toBeGreaterThanOrEqual(0);
+        expect(h.beat).toBeLessThan(4);
+      }
+    }
+    for (const v of BASS_VARIATIONS) {
+      for (const h of v.hits) {
+        expect(h.beat).toBeGreaterThanOrEqual(0);
+        expect(h.beat).toBeLessThan(4);
+      }
+    }
+  });
+
+  it("lookups return correct variations and undefined for misses", () => {
+    expect(getChordVariation("funk-turnaround-chord")).toBeDefined();
+    expect(getBassVariation("funk-turnaround-bass")).toBeDefined();
+    expect(getChordVariation("nope")).toBeUndefined();
   });
 });
 

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -30,7 +30,7 @@ export type BassNoteRole =
 
 export type BassArticulation = "staccato" | "legato" | "normal";
 
-interface ChordHit {
+export interface ChordHit {
   beat: number;
   velocity: number;
   style?: "staccato" | "sustained";
@@ -59,7 +59,7 @@ export interface ChordPattern {
   voicing?: "rootless-jazz";
 }
 
-interface CatalogBassHit {
+export interface CatalogBassHit {
   beat: number;
   velocity: number;
   note: BassNoteRole;
@@ -94,6 +94,26 @@ export interface CatalogDrumPattern {
   crossStick?: readonly DrumHit[];
   /** Cell length in bars (default 1). See ChordPattern.bars. */
   bars?: number;
+}
+
+/** A single-bar harmonic variation that *replaces* (not layers) the base
+ *  chord pattern's hits when it fires. Mirrors DrumVariation's gating fields. */
+export interface ChordVariation {
+  id: string;
+  label: string;
+  barInterval: number;
+  barPhase?: number;
+  hits: readonly ChordHit[];
+}
+
+/** A single-bar bass variation that *replaces* the base bass pattern's hits
+ *  when it fires (applied before the §3.4 turnaround tail-swap). */
+export interface BassVariation {
+  id: string;
+  label: string;
+  barInterval: number;
+  barPhase?: number;
+  hits: readonly CatalogBassHit[];
 }
 
 export interface DrumVariation {
@@ -616,12 +636,54 @@ export function getDrumVariation(id: string): DrumVariation | undefined {
   return DRUM_VARIATIONS.find((v) => v.id === id);
 }
 
+export const CHORD_VARIATIONS: readonly ChordVariation[] = [
+  {
+    id: "funk-turnaround-chord",
+    label: "Funk Turnaround Comp",
+    barInterval: 4,
+    barPhase: 3,
+    // Pushed turnaround bar: a strong stab on the one, anticipated color stabs
+    // driving into the next chord.
+    hits: [
+      { beat: 0, velocity: 0.92, direction: "down", articulation: "stab" },
+      { beat: 1.5, velocity: 0.6, direction: "up", articulation: "muted" },
+      { beat: 2.5, velocity: 0.7, direction: "down", articulation: "color-stab" },
+      { beat: 3.5, velocity: 0.75, direction: "down", articulation: "color-stab" },
+    ],
+  },
+];
+
+export const BASS_VARIATIONS: readonly BassVariation[] = [
+  {
+    id: "funk-turnaround-bass",
+    label: "Funk Turnaround Walk",
+    barInterval: 4,
+    barPhase: 3,
+    // Walk-up turnaround: root anchor, octave pop, then a chromatic approach
+    // into the next chord on the last beat.
+    hits: [
+      { beat: 0, velocity: 1, note: "root", articulation: "staccato" },
+      { beat: 1.5, velocity: 0.7, note: "octave", articulation: "staccato" },
+      { beat: 2.5, velocity: 0.6, note: "fifth", articulation: "staccato" },
+      { beat: 3, velocity: 0.8, note: "chromatic-approach", articulation: "legato" },
+    ],
+  },
+];
+
+export function getChordVariation(id: string): ChordVariation | undefined {
+  return CHORD_VARIATIONS.find((v) => v.id === id);
+}
+
+export function getBassVariation(id: string): BassVariation | undefined {
+  return BASS_VARIATIONS.find((v) => v.id === id);
+}
+
 /**
  * Pure gating predicate: does `variation` fire on the given absolute bar index?
  * Total — a non-positive `barInterval` never fires (no divide-by-zero / nonsense).
  */
 export function variationFiresOnBar(
-  variation: DrumVariation,
+  variation: { barInterval: number; barPhase?: number },
   absoluteBar: number,
 ): boolean {
   if (variation.barInterval <= 0) return false;

--- a/src/store/progressionAtoms.test.ts
+++ b/src/store/progressionAtoms.test.ts
@@ -39,6 +39,9 @@ import {
   progressionPlaybackLoadingAtom,
   progressionPlayingStateAtom,
   progressionStepDeadlineAtom,
+  progressionChordVariationsAtom,
+  progressionBassVariationsAtom,
+  applyGenreStyleAtom,
 } from "./progressionAtoms";
 import { DEFAULT_BEATS_PER_BAR } from "../progressions/progressionDomain";
 import { rootNoteAtom, scaleNameAtom } from "./scaleAtoms";
@@ -746,5 +749,31 @@ describe("setProgressionActiveStepIndexAtom — deadline refresh during playback
 
     // Deadline must remain at the sentinel value.
     expect(store.get(progressionStepDeadlineAtom)).toBe(123456);
+  });
+});
+
+describe("chord/bass variation atoms", () => {
+  it("applyGenreStyle populates chord and bass variations from the genre bundle", () => {
+    const store = createStore();
+    store.set(applyGenreStyleAtom, "funk");
+    expect(store.get(progressionChordVariationsAtom)).toContain("funk-turnaround-chord");
+    expect(store.get(progressionBassVariationsAtom)).toContain("funk-turnaround-bass");
+  });
+
+  it("applyGenreStyle clears chord/bass variations for a genre with none", () => {
+    const store = createStore();
+    store.set(progressionChordVariationsAtom, ["funk-turnaround-chord"]);
+    store.set(applyGenreStyleAtom, "pop");
+    expect(store.get(progressionChordVariationsAtom)).toEqual([]);
+    expect(store.get(progressionBassVariationsAtom)).toEqual([]);
+  });
+
+  it("reset returns chord/bass variations to empty defaults", () => {
+    const store = createStore();
+    store.set(progressionChordVariationsAtom, ["funk-turnaround-chord"]);
+    store.set(progressionBassVariationsAtom, ["funk-turnaround-bass"]);
+    store.set(resetProgressionAtomsAtom);
+    expect(store.get(progressionChordVariationsAtom)).toEqual([]);
+    expect(store.get(progressionBassVariationsAtom)).toEqual([]);
   });
 });

--- a/src/store/progressionAtoms.ts
+++ b/src/store/progressionAtoms.ts
@@ -266,6 +266,20 @@ export const progressionDrumVariationsAtom = atomWithStorage<string[]>(
   GET_ON_INIT,
 );
 
+export const progressionChordVariationsAtom = atomWithStorage<string[]>(
+  k("progressionChordVariations"),
+  [],
+  stringArrayStorage,
+  GET_ON_INIT,
+);
+
+export const progressionBassVariationsAtom = atomWithStorage<string[]>(
+  k("progressionBassVariations"),
+  [],
+  stringArrayStorage,
+  GET_ON_INIT,
+);
+
 export const progressionSwingAtom = atomWithStorage<number>(
   k("progressionSwing"),
   0,
@@ -282,6 +296,8 @@ export const applyGenreStyleAtom = atom(null, (_get, set, genreId: string) => {
   set(progressionBassPatternAtom, genre.bassPattern);
   set(progressionDrumPatternAtom, genre.drumPattern);
   set(progressionDrumVariationsAtom, genre.drumVariations);
+  set(progressionChordVariationsAtom, genre.chordVariations);
+  set(progressionBassVariationsAtom, genre.bassVariations);
   set(progressionSwingAtom, genre.swing);
   set(progressionTempoBpmAtom, genre.suggestedTempo);
 });
@@ -736,6 +752,8 @@ export const resetProgressionAtomsAtom = atom(null, (_get, set) => {
   set(progressionBassPatternAtom, RESET);
   set(progressionDrumPatternAtom, RESET);
   set(progressionDrumVariationsAtom, RESET);
+  set(progressionChordVariationsAtom, RESET);
+  set(progressionBassVariationsAtom, RESET);
   set(progressionSwingAtom, RESET);
   set(loadedPresetIdAtom, RESET);
   set(activeProgressionStepIndexAtom, 0);


### PR DESCRIPTION
## Summary

Breaks the monotony of static 1–2 bar backing-track loops with two independent tiers, built on the existing Tone.js progression engine:

**Tier 1 — Safe Humanizer** (`humanize.ts` → `buildAllLayers.ts`)
- `shouldDropHit(velocity, seed)` — deterministic ~12% drop of sub-0.4 ghost strokes; structural hits (≥0.4) never drop. Keys off authored (pre-jitter) velocity so jitter can't flip a borderline ghost.
- `grooveLockTimeAmount(beat, full)` — integer (anchor) beats get 40% timing jitter; off-beats full. Holds the pulse without sounding quantized.
- Wired into chord/bass/drum layers. **Metronome and chordOnsets are excluded** (click reference + React/voice-leading gating).
- Sustained chords are exempt from dropping (not ghost strokes; also preserves the sustain ring boundary).

**Tier 2 — Structural Variations** (`patterns.ts`, `buildAllLayers.ts`, `genres.ts`, `progressionAtoms.ts`, `useProgressionAudioPlayback.ts`)
- New `ChordVariation` / `BassVariation` models + catalogs + getters, reusing the generalized `variationFiresOnBar` predicate.
- **Substitutive** per-bar replacement (first-in-catalog wins) for chords and bass; drums stay additive (unchanged). The §4 bass turnaround tail-swap coexists cleanly — no double fills.
- **Genre coupling** via `GenreStyle.chordVariations` / `bassVariations`: funk ships a chord+bass+drum turnaround all locked to interval 4 / phase 3, so loading funk yields synced turnarounds.
- New persisted atoms wired into genre-apply + reset, threaded through the playback hook (including the build cache key, so variation changes invalidate correctly).

Deferred by design: Density Selection (Sparse/Normal/Busy) and the demo extended-pattern (the extended-cell path is already proven by the 2-bar bossa patterns).

Design + plan: `docs/superpowers/specs/2026-06-08-backing-track-variation-design.md`, `docs/superpowers/plans/2026-06-08-backing-track-variation.md`.

## Test Plan
- [x] `pnpm run test` — 2521 passing (new unit + integration coverage for drop determinism, groove-lock, humanizer exclusions, chord/bass substitution, genre coupling, atom apply/reset, variation+turnaround coexistence)
- [x] `pnpm run lint` — clean (1 pre-existing unrelated warning)
- [x] `pnpm run build` — clean
- [ ] Manual audition: load **Funk**, set an 8+ bar progression, loop with chords/bass/drums on — confirm the turnaround bar pushes all three together and repeats don't sound machine-gunned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added chord and bass pattern variations for progression audio, enabling customizable pattern substitution on specific bars
* Implemented tab content persistence—previously opened tabs remain loaded while hidden, improving tab-switching experience
* Enhanced audio humanization with intelligent note drop-out effects and groove-lock timing for more natural playback

**Bug Fixes**
* Fixed visibility of inactive tab panels
* Corrected mobile layout alignment for the progression editor

**Tests**
* Added comprehensive test coverage for chord/bass variations, humanization behavior, and tab management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->