### PR TITLE
fix(progression): resolve blues IV chord to F7, not F#7

### DIFF
--- a/src/progressions/progressionDomain.test.ts
+++ b/src/progressions/progressionDomain.test.ts
@@ -590,6 +590,14 @@ describe("resolveProgressionStep — quality pin", () => {
     const r = resolveProgressionStep(step("VII", "7"), "major pentatonic", "C");
     expect(r.unavailable).toBe(true);
   });
+
+  it("pins the override root to the harmony parent, not the blues overlay", () => {
+    // Regression: a "minor blues" overlay (C Eb F Gb G Bb) must not pin IV to
+    // its own ordinal-3 note (Gb/F#). IV:7 over C minor blues is F7, V:7 is G7,
+    // resolved against the minor harmony parent (C D Eb F G Ab Bb).
+    expect(resolveProgressionStep(step("IV", "7"), "minor blues", "C").root).toBe("F");
+    expect(resolveProgressionStep(step("V", "7"), "minor blues", "C").root).toBe("G");
+  });
 });
 
 const PRESET_HOME_SCALE: Record<string, string> = {

--- a/src/progressions/progressionDomain.ts
+++ b/src/progressions/progressionDomain.ts
@@ -470,14 +470,18 @@ export function resolveProgressionStep(
 
   // Quality pin: a valid override resolves a non-diatonic degree on its
   // scale-position root (e.g. a dominant V in natural minor). Relative to the
-  // scale degree, so it transposes with the root. Resolved against the active
-  // scale (not the harmony parent) so a degree whose ordinal exceeds the
-  // scale length (e.g. VII in a 5-note pentatonic) stays unavailable.
+  // scale degree, so it transposes with the root. The root note is taken from
+  // the harmony parent scale (consistent with remapDegreeByOrdinal) so blues /
+  // pentatonic overlays pin to the same roots as their parent — e.g. IV over a
+  // C "minor blues" overlay is F (minor parent ordinal 3), not Gb (the overlay's
+  // own ordinal 3). Availability is still gated by the active overlay scale's
+  // length, so a degree whose ordinal exceeds it (e.g. VII in a 5-note
+  // pentatonic) stays unavailable.
   let pinnedRoot: string | null = null;
   if (!diatonic && !usingManualRoot && overrideValid) {
     const ordinal = getDegreeOrdinal(step.degree);
-    if (ordinal !== null) {
-      pinnedRoot = getScaleNotes(rootNote, scaleName)[ordinal] ?? null;
+    if (ordinal !== null && ordinal < getScaleNotes(rootNote, scaleName).length) {
+      pinnedRoot = getScaleNotes(rootNote, harmonyScale)[ordinal] ?? null;
     }
   }
 


### PR DESCRIPTION
## Summary

The blues progression presets resolved the **IV** chord to **F#7 instead of F7** (in C). Commit `04de138f` switched the blues presets' overlay scale to `"minor blues"` on the premise that chord resolution routes through the `"minor blues" → "minor"` harmony-parent mapping. That mapping exists, but one resolution path bypassed it.

## Root cause

In `resolveProgressionStep` (`src/progressions/progressionDomain.ts`):

- `getDiatonicChord("IV", "minor", "C")` returns `undefined` — uppercase `IV` requests a *major*-quality degree, but minor's IV is minor (`iv`), so the case-mismatched lookup fails.
- With `diatonic` null and a valid `:7` override, resolution fell to the quality-pin fallback, which indexed `getScaleNotes(rootNote, scaleName)` using the raw **overlay** scale. For a C `minor blues` overlay (`C Eb F Gb G Bb`), ordinal 3 is `Gb` = **F#** → F#7.
- The old `"major"` overlay (`C D E F G A B`) had F at ordinal 3, which masked this latent bug.

## Fix

Source the pinned root from the **harmony parent** scale (consistent with `remapDegreeByOrdinal`), while keeping the availability gate on the active overlay scale's length so out-of-range degrees (e.g. `VII` in a 5-note pentatonic) stay unavailable.

```ts
if (ordinal !== null && ordinal < getScaleNotes(rootNote, scaleName).length) {
  pinnedRoot = getScaleNotes(rootNote, harmonyScale)[ordinal] ?? null;
}
```

IV:7 → F7, V:7 → G7.

## Scope (verified)

Diffed old-vs-new resolution across **every preset × every scale**. Only 16 differences, all in two overlays:

- **`minor blues`** — `IV:7` F# → F (the three blues presets; the reported bug).
- **`minor pentatonic`** — `IV:7` G → F, `V:7` A# → G (only surfaces under *manual* overlay selection with a preset loaded).

Every diff replaces a musically-wrong overlay-ordinal root with the correct harmony-parent root. **Zero changes** to all 7-note scales (harmony parent == scale) and to `major pentatonic` / `major blues` (uppercase degrees are diatonic in the major parent, so the pin branch never runs).

## Test plan

- [x] Added a regression test asserting `IV:7`/`V:7` over a C `minor blues` overlay resolve to F/G.
- [x] `pnpm test` — full suite passes (2525 passed, 1 skipped, 1 todo).
- [x] `pnpm run lint` — clean (1 pre-existing unrelated warning).
- [x] `pnpm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chord root resolution when applying quality overrides to non-diatonic degrees in harmony progressions, ensuring roots are correctly pinned to the parent scale.

* **Tests**
  * Added regression test to verify quality override chord root pinning behavior in harmony progressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->