### PR TITLE
fix(fretboard): enable horizontal scroll on desktop overflow

### DIFF
--- a/src/components/Fretboard/Fretboard.module.css
+++ b/src/components/Fretboard/Fretboard.module.css
@@ -38,8 +38,11 @@
   display: none;
 }
 
-/* Tablet: enable native touch scroll on the fretboard (same as mobile). */
-:global(.app-container[data-layout-tier="tablet"]) .fretboard-wrapper {
+/* Tablet and desktop: enable native scroll on the fretboard (same as mobile)
+   so an overflowing board scrolls horizontally instead of being clipped by the
+   base `overflow: clip` rule. */
+:global(.app-container[data-layout-tier="tablet"]) .fretboard-wrapper,
+:global(.app-container[data-layout-tier="desktop"]) .fretboard-wrapper {
   overflow-x: auto;
   overflow-y: visible;
   -webkit-overflow-scrolling: touch;

--- a/src/components/Fretboard/Fretboard.module.css.test.ts
+++ b/src/components/Fretboard/Fretboard.module.css.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const css = readFileSync(join(__dirname, "Fretboard.module.css"), "utf8");
+
+describe("Fretboard.module.css scroll rules", () => {
+  it("clips the wrapper by default to contain sub-pixel paint bleed", () => {
+    expect(css).toMatch(/\.fretboard-wrapper\s*\{[^}]*overflow:\s*clip/);
+  });
+
+  // Regression: desktop was missing from the scroll override, so an
+  // overflowing board stayed `overflow: clip` and could not scroll, while
+  // tablet/mobile scrolled fine.
+  it("enables horizontal scroll on desktop when the board overflows", () => {
+    expect(css).toMatch(
+      /data-layout-tier="desktop"\]\)\s*\.fretboard-wrapper[\s\S]*?overflow-x:\s*auto/,
+    );
+  });
+
+  it("enables horizontal scroll on tablet", () => {
+    expect(css).toMatch(
+      /data-layout-tier="tablet"\]\)\s*\.fretboard-wrapper[\s\S]*?overflow-x:\s*auto/,
+    );
+  });
+
+  it("enables horizontal scroll on mobile", () => {
+    expect(css).toMatch(
+      /data-layout-tier="mobile"\]\)\s*\.fretboard-wrapper[\s\S]*?overflow-x:\s*auto/,
+    );
+  });
+});


### PR DESCRIPTION
## What

On the **desktop** layout tier, an overflowing fretboard could not be scrolled — it was clipped. Tablet and mobile scrolled fine.

## Root cause

`src/components/Fretboard/Fretboard.module.css` sets the base `.fretboard-wrapper` to `overflow: clip` (deliberate — it contains sub-pixel paint bleed from the SVG, see the in-file comment). The scroll override that swaps this for `overflow-x: auto` existed **only** for `data-layout-tier="tablet"` and `data-layout-tier="mobile"`. There was no `desktop` rule, so desktop fell through to the clipping base rule.

## Fix

Add `data-layout-tier="desktop"` to the existing scroll selector (Option A — minimal, matches the established tablet/mobile pattern). Desktop now scrolls horizontally on overflow.

## Tests

Adds `Fretboard.module.css.test.ts`, a CSS-string regression test (mirroring the existing `ProgressionStepList.module.css.test.ts` pattern) asserting:
- base wrapper still clips by default
- all three tiers (desktop/tablet/mobile) enable `overflow-x: auto`

## Verification

- New test: 4/4 pass
- Full suite: 2528 pass, 0 failures (type-check clean). Note: the pre-push hook's parallel test+build runs intermittently hit environmental flakes (15s timeouts under CPU contention, a transient `jsdom` worker-resolution error) unrelated to this CSS-only change; all affected tests pass in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)