### PR TITLE
fix(progression): keep playhead smooth on live tempo change

### DIFF
--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -205,6 +205,11 @@ export function useProgressionAudioPlayback() {
   );
   const instrumentRef = useRef(chordInstrument);
   const genRef = useRef(0);
+  // Tempo the currently-live Tone Parts were baked at. The layer event timings
+  // are seconds-at-build-tempo; a live tempo change rescales the Transport but
+  // not those baked seconds, so the visual timeline needs this reference to
+  // mirror the rescale (see the tempo effect below + timeline.setTimelineScale).
+  const builtTempoRef = useRef(tempo);
 
   const buildInputsRef = useRef({
     steps,
@@ -421,6 +426,10 @@ export function useProgressionAudioPlayback() {
       eng.setPlaybackTempo(inputs.tempo);
       eng.setPlaybackSwing(inputs.swing);
       eng.setPlaybackTimeSignature(inputs.beatsPerBar);
+      // These Parts are baked at inputs.tempo. Record it so a later live tempo
+      // change can scale the visual timeline. clearTimeline() (fired up front in
+      // the restart-tier reset) already reset the scale to 1 for this build.
+      builtTempoRef.current = inputs.tempo;
 
       let built;
       const currentCacheKey = JSON.stringify({
@@ -612,6 +621,11 @@ export function useProgressionAudioPlayback() {
   useEffect(() => {
     if (!engine) return;
     engine.setPlaybackTempo(tempo);
+    // The Transport now runs at the new BPM, rescaling every scheduled event's
+    // wall-clock position. The baked timeline seconds don't change, so mirror
+    // the rescale into the visual timeline: scale = builtTempo / currentTempo.
+    // Without this the playhead snaps to the stale baked offset at every bar.
+    engine.setTimelineScale(builtTempoRef.current / Math.max(1, tempo));
   }, [tempo]);
 
   useEffect(() => {

--- a/src/progressions/audio/progressionAudioEngine.ts
+++ b/src/progressions/audio/progressionAudioEngine.ts
@@ -16,7 +16,7 @@ export { setLayerGain } from "./layerBuses";
 export { scheduleBassNote } from "./bass";
 export { scheduleCrossStick, scheduleHiHat, scheduleKick, scheduleRide, scheduleSnare } from "./drumKit";
 export { scheduleClick } from "./metronome";
-export { clearTimeline, pauseTimeline, setActiveStep } from "./timeline";
+export { clearTimeline, pauseTimeline, setActiveStep, setTimelineScale } from "./timeline";
 export { getDraw, getTransport };
 export type { ProgressionPartHandle };
 

--- a/src/progressions/audio/timeline.test.ts
+++ b/src/progressions/audio/timeline.test.ts
@@ -7,6 +7,7 @@ import {
   pauseTimeline,
   resumeTimelineAtCurrentTime,
   setActiveStep,
+  setTimelineScale,
 } from "./timeline";
 import { _resetProgressionAudioForTests } from "./bus";
 
@@ -183,6 +184,29 @@ describe("timeline", () => {
     mockNow = 11.0;
     // 1s elapsed since resume
     expect(getTimelinePosition()?.globalFraction).toBeCloseTo(0.3, 5); // (2+1)/10
+  });
+
+  it("scales reported durations by the live tempo factor", () => {
+    // Built at the original tempo: cumulativeStart 4s, total 16s, step 4s.
+    setActiveStep(1, 0, 4, 4, 16);
+    // Tempo halved during playback → real wall-clock durations double.
+    setTimelineScale(2);
+    mockNow = 2; // 2 real seconds elapsed into the step
+
+    const pos = getTimelinePosition();
+    // Real cumulative start = 8s, real total = 32s, real step duration = 8s.
+    expect(pos?.localFraction).toBeCloseTo(2 / 8, 5); // 0.25
+    expect(pos?.globalFraction).toBeCloseTo((8 + 2) / 32, 5); // 0.3125
+    expect(pos?.totalDurationSec).toBeCloseTo(32, 5);
+  });
+
+  it("resets the tempo scale to 1 when the timeline is cleared", () => {
+    setActiveStep(0, 0, 4, 0, 16);
+    setTimelineScale(2);
+    clearTimeline();
+    // A fresh step after clear should report unscaled durations.
+    setActiveStep(0, 0, 4, 0, 16);
+    expect(getTimelinePosition()?.totalDurationSec).toBe(16);
   });
 
   it("clearTimeline wipes the active step", () => {

--- a/src/progressions/audio/timeline.ts
+++ b/src/progressions/audio/timeline.ts
@@ -45,6 +45,23 @@ interface TimelineState {
 
 let state: TimelineState = { active: null, paused: false };
 
+/**
+ * Wall-clock scale factor applied to the baked step durations. The layer events
+ * (`durationSec`, `cumulativeStartSec`, `totalDurationSec`) are baked in seconds
+ * at the tempo present when `buildAllLayers` ran. When the user changes tempo
+ * during playback we deliberately do NOT rebuild the Tone Parts (see
+ * `useProgressionAudioPlayback`); instead the Tone Transport's BPM is updated,
+ * which rescales every scheduled event's real-time position uniformly. This
+ * scalar mirrors that rescale into the visual timeline so the playhead and
+ * position readout track the audio instead of snapping to the stale baked
+ * offsets at every bar boundary.
+ *
+ * `scale = buildTempoBpm / currentTempoBpm` — i.e. baked seconds × scale = real
+ * seconds. Reset to 1 on `clearTimeline()` (which fires on every Part rebuild),
+ * so a fresh build always starts unscaled.
+ */
+let scale = 1;
+
 export interface TimelinePosition {
   stepIndex: number;
   /** Position across total duration, 0..1. */
@@ -103,9 +120,20 @@ export function resumeTimelineAtCurrentTime(): void {
   };
 }
 
+/**
+ * Set the live wall-clock scale factor (`buildTempoBpm / currentTempoBpm`).
+ * Called from the playback hook's tempo effect so the visual timeline matches
+ * the Tone Transport's rescaled audio after a live tempo change. Ignores
+ * non-finite or non-positive values, falling back to 1 (unscaled).
+ */
+export function setTimelineScale(nextScale: number): void {
+  scale = Number.isFinite(nextScale) && nextScale > 0 ? nextScale : 1;
+}
+
 /** Forget the active step. Use on stop / blocked / progression-disabled. */
 export function clearTimeline(): void {
   state = { active: null, paused: false };
+  scale = 1;
 }
 
 /**
@@ -117,22 +145,26 @@ export function clearTimeline(): void {
  */
 export function getTimelinePosition(): TimelinePosition | null {
   if (!state.active) return null;
+  // Baked seconds (build tempo) → real wall-clock seconds (current tempo).
+  const durationSec = state.active.durationSec * scale;
+  const cumulativeStartSec = state.active.cumulativeStartSec * scale;
+  const totalDurationSec = state.active.totalDurationSec * scale;
   if (state.paused) {
     const localFraction = 0;
-    const globalFraction = state.active.cumulativeStartSec / Math.max(0.001, state.active.totalDurationSec);
-    return { stepIndex: state.active.stepIndex, globalFraction, localFraction, paused: true, totalDurationSec: state.active.totalDurationSec };
+    const globalFraction = cumulativeStartSec / Math.max(0.001, totalDurationSec);
+    return { stepIndex: state.active.stepIndex, globalFraction, localFraction, paused: true, totalDurationSec };
   }
   const audio = ensureProgressionAudio();
   if (!audio) {
-    const globalFraction = state.active.cumulativeStartSec / Math.max(0.001, state.active.totalDurationSec);
-    return { stepIndex: state.active.stepIndex, globalFraction, localFraction: 0, paused: false, totalDurationSec: state.active.totalDurationSec };
+    const globalFraction = cumulativeStartSec / Math.max(0.001, totalDurationSec);
+    return { stepIndex: state.active.stepIndex, globalFraction, localFraction: 0, paused: false, totalDurationSec };
   }
   const elapsed = audio.ctx.currentTime - state.active.audioStartTime;
-  const localFraction = elapsed / Math.max(0.001, state.active.durationSec);
-  const cumulativeElapsed = state.active.cumulativeStartSec + elapsed;
-  const globalFraction = cumulativeElapsed / Math.max(0.001, state.active.totalDurationSec);
-  
-  return { stepIndex: state.active.stepIndex, globalFraction, localFraction, paused: false, totalDurationSec: state.active.totalDurationSec };
+  const localFraction = elapsed / Math.max(0.001, durationSec);
+  const cumulativeElapsed = cumulativeStartSec + elapsed;
+  const globalFraction = cumulativeElapsed / Math.max(0.001, totalDurationSec);
+
+  return { stepIndex: state.active.stepIndex, globalFraction, localFraction, paused: false, totalDurationSec };
 }
 
 /**
@@ -146,7 +178,7 @@ export function isCurrentStepFinished(): boolean {
   if (!audio) return false;
   return (
     audio.ctx.currentTime
-      >= state.active.audioStartTime + state.active.durationSec
+      >= state.active.audioStartTime + state.active.durationSec * scale
   );
 }
 
@@ -160,12 +192,13 @@ export function getTimeUntilCurrentStepEndMs(): number | null {
   if (!audio) return null;
   return Math.max(
     0,
-    (state.active.audioStartTime + state.active.durationSec - audio.ctx.currentTime) * 1000,
+    (state.active.audioStartTime + state.active.durationSec * scale - audio.ctx.currentTime) * 1000,
   );
 }
 
 /** Test-only reset; vitest modules persist across tests in the same file. */
 export function _resetTimelineForTests(): void {
   state = { active: null, paused: false };
+  scale = 1;
 }
 


### PR DESCRIPTION
## What

Fixes the playhead snapping to position on every bar after the tempo is changed during playback. Now the playhead speed adjusts once, smoothly, when tempo changes.

## Why (root cause)

The playback engine changes tempo live by rescaling the Tone Transport BPM (`setPlaybackTempo`) **without rebuilding the layer parts** — tempo is deliberately excluded from `buildKey` to avoid a disruptive rebuild.

However, the layer event timings (`durationSec`, `cumulativeStartSec`, `totalDurationSec`) are baked in **seconds at build-time tempo** (`secondsPerBeat = 60 / tempoBpm` in `buildAllLayers.ts`). The visual timeline and WAAPI playhead consume those baked seconds. After a tempo change the audio runs at the new rate while the visual fractions are still computed against old-tempo seconds, so every chord onset re-anchored `cumulativeStartSec`/`audioStartTime` to a stale baked offset and the playhead's drift-correction yanked it there — once per bar.

## How

Mirror the Transport's uniform rescale into the visual timeline with a single scale factor `buildTempo / currentTempo`:

- `timeline.ts`: new `scale` applied to all reported durations; `setTimelineScale()` setter; reset to `1` on `clearTimeline()` (fires on every part rebuild) and test reset. `isCurrentStepFinished` / `getTimeUntilCurrentStepEndMs` scaled too for correctness.
- `progressionAudioEngine.ts`: re-export `setTimelineScale`.
- `useProgressionAudioPlayback.ts`: record `builtTempoRef` at build time; the tempo effect now calls `setTimelineScale(builtTempo / currentTempo)` alongside `setPlaybackTempo`.

`globalFraction` stays continuous across the tempo change, so the playhead no longer snaps per bar.

## Notes for reviewer

- Audio playback was already correct at the new tempo before this fix — only the visual layer was wrong.
- Followed systematic-debugging (root cause first) + TDD: added two failing-first cases in `timeline.test.ts` (scale math + clear-resets-scale).

## Verification

- `pnpm run lint` — clean (1 pre-existing unrelated warning)
- `pnpm run test` — 2526 passed, 1 skipped
- `pnpm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)