### PR TITLE
fix(progression): restore Root/Quality side-by-side row in chord editor

### DIFF
--- a/src/components/SongControls/SongControls.module.css
+++ b/src/components/SongControls/SongControls.module.css
@@ -373,6 +373,16 @@
   min-height: 1.25rem;
 }
 
+/* Root + Quality form one group inside the editor row. At desktop/tablet
+   tiers they sit side-by-side; the mobile tier re-tightens the gap. Without
+   this base rule the div defaults to display:block and Quality stacks under
+   Root even when all three fields fit on one line (#557 regression). */
+.root-quality-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 2.25rem;
+}
+
 /* Quality + its inline lock toggle form one unit on the editor row. */
 .quality-row {
   display: flex;

--- a/src/components/SongControls/SongControls.module.css.test.ts
+++ b/src/components/SongControls/SongControls.module.css.test.ts
@@ -25,6 +25,13 @@ describe("SongControls button chrome", () => {
       /:global\(\.app-container\[data-layout-tier="mobile"\]\)\s+\.grouped-button\s*\{[^}]*height:\s*var\(--control-height\)/s,
     );
   });
+  it("lays Root and Quality side-by-side at base (non-mobile) tier", () => {
+    // Regression guard (#557): the base .root-quality-row rule must set
+    // display:flex so Root and Quality sit on one row at desktop/tablet
+    // tiers. Without it the div defaults to display:block and Quality
+    // stacks under Root even when all three fields fit on one line.
+    expect(css).toMatch(/^\.root-quality-row\s*\{[^}]*display:\s*flex/m);
+  });
   it("defines mobile root-quality flex row, lock-label sr-only, and lock-toggle size overrides", () => {
     expect(css).toMatch(
       /:global\(\.app-container\[data-layout-tier="mobile"\]\)\s+\.root-quality-row\s*\{[^}]*display:\s*flex/s,


### PR DESCRIPTION
## Problem

On the progression card's chord editor panel, the **Quality** field wraps onto its own line below **Chord Root** even when Chord Root, Duration, and Quality all fit on one row (see the reported screenshot — Root + Duration on top, Quality stranded below).

## Root cause

Mobile responsiveness pass 3 (#557, "Issue 5: Root/Quality Row Collapse") wrapped the Chord Root and Quality fields in a new `.root-quality-row` div. It added `display: flex` for that div **only** inside the `data-layout-tier="mobile"` rule and never added a base rule. At desktop/tablet tiers the div therefore defaulted to `display: block`, stacking Quality under Root.

Before #557, Root / Quality / Duration were direct children of the flex `.editor-grid`, so they sat on one wrapping row.

## Fix

Add a base `.root-quality-row` rule:

```css
.root-quality-row {
  display: flex;
  align-items: flex-start;
  gap: 2.25rem; /* matches the editor-grid column gap */
}
```

This restores the pre-#557 single-row layout at non-mobile tiers. The mobile override (tighter gap, `align-items: center`) is unchanged, so mobile behaviour is unaffected.

## Tests

- Added a CSS-module regression assertion that the **base** `.root-quality-row` rule sets `display: flex` (TDD: written failing first, then made to pass).
- `pnpm run lint` clean (1 pre-existing unrelated warning).
- `pnpm run test` — 2525 passed.
- `pnpm run build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)