### PR TITLE
fix(status-bar): progressively hide low-priority fields on narrow viewports

### DIFF
--- a/src/components/StatusBar/StatusBar.module.css
+++ b/src/components/StatusBar/StatusBar.module.css
@@ -83,26 +83,26 @@
 
 /* stylelint-disable selector-pseudo-class-no-unknown */
 @container (max-width: 1099px) {
-  :global([data-field-id="version"]) { display: none; }
+  .status-bar :global([data-field-id="version"]) { display: none; }
 }
 
 @container (max-width: 899px) {
-  :global([data-field-id="progression"]) { display: none; }
+  .status-bar :global([data-field-id="progression"]) { display: none; }
 }
 
 @container (max-width: 799px) {
-  :global([data-field-id="tuning"]) { display: none; }
+  .status-bar :global([data-field-id="tuning"]) { display: none; }
 }
 
 @container (max-width: 699px) {
-  :global([data-field-id="frets"]) { display: none; }
+  .status-bar :global([data-field-id="frets"]) { display: none; }
 }
 
 @container (max-width: 599px) {
-  :global([data-field-id="tempo"]) { display: none; }
+  .status-bar :global([data-field-id="tempo"]) { display: none; }
 }
 
 @container (max-width: 499px) {
-  :global([data-field-id="pattern"]) { display: none; }
+  .status-bar :global([data-field-id="pattern"]) { display: none; }
 }
 /* stylelint-enable selector-pseudo-class-no-unknown */

--- a/src/components/StatusBar/StatusBar.module.css
+++ b/src/components/StatusBar/StatusBar.module.css
@@ -13,6 +13,7 @@
   border-top: 0.5px solid var(--dc-border);
   border-bottom: 0.5px solid var(--dc-border);
   overflow: hidden;
+  container-type: inline-size;
 }
 
 /* Light-mode: cream BG, warm hairline divider. Reference palette: BG #ebebdc, MUTE #857c6c. */
@@ -74,3 +75,34 @@
   letter-spacing: 0.04em;
   color: var(--dc-fg-muted);
 }
+
+/* Progressive field hiding via container queries — least important first.
+   Container width ≈ viewport width (status bar spans full-bleed). The bar
+   only renders at ≥ 768 px (tablet+), so the top three breakpoints cover all
+   real-world cases; the lower ones are defensive for unusual window sizes. */
+
+/* stylelint-disable selector-pseudo-class-no-unknown */
+@container (max-width: 1099px) {
+  :global([data-field-id="version"]) { display: none; }
+}
+
+@container (max-width: 899px) {
+  :global([data-field-id="progression"]) { display: none; }
+}
+
+@container (max-width: 799px) {
+  :global([data-field-id="tuning"]) { display: none; }
+}
+
+@container (max-width: 699px) {
+  :global([data-field-id="frets"]) { display: none; }
+}
+
+@container (max-width: 599px) {
+  :global([data-field-id="tempo"]) { display: none; }
+}
+
+@container (max-width: 499px) {
+  :global([data-field-id="pattern"]) { display: none; }
+}
+/* stylelint-enable selector-pseudo-class-no-unknown */

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -76,7 +76,7 @@ export function StatusBar() {
   ];
 
   const renderField = (f: StatusField) => (
-    <div key={f.id} className={styles.field}>
+    <div key={f.id} className={styles.field} data-field-id={f.id}>
       <span className={styles.label}>{f.label}</span>
       <span className={styles.value} data-testid={`status-${f.id}`}>
         {f.value}
@@ -89,7 +89,7 @@ export function StatusBar() {
       <div className={styles.group}>{leftFields.map(renderField)}</div>
       <div className={styles.group}>
         {rightFields.map(renderField)}
-        <span className={styles.field}>
+        <span className={styles.field} data-field-id="version">
           <span className={styles.version} data-testid="status-version">
             FretFlow Studio {__APP_VERSION__}
           </span>


### PR DESCRIPTION
## Summary

- The status bar was silently clipping content at narrow viewport widths because `overflow: hidden` + `white-space: nowrap` had no way to shed items.
- Added `container-type: inline-size` to the status bar and six `@container (max-width: …)` rules that progressively hide fields from least to most important.
- Added `data-field-id` attributes to each field element so container queries can target them without extra CSS module class names.

## Hiding order

| Container width | Newly hidden field |
|---|---|
| ≤ 1099px | version tag |
| ≤ 899px | progression |
| ≤ 799px | tuning |
| ≤ 699px | frets |
| ≤ 599px | tempo |
| ≤ 499px | pattern |

**Key** and **Chord** are always visible — they carry the most critical reading context.

The bar only renders at ≥ 768 px (tablet+), so the top three breakpoints cover all real-world window sizes; the lower ones are defensive for unusual configurations.

## Separator dots

The `·` separators remain correct: each field generates its own `::before` pseudo-element, and `display: none` hides the whole field including its pseudo-element. No orphan dots appear at any breakpoint.

## Test plan

- [ ] All existing unit tests pass (`pnpm run test`) — fields are still in the DOM (just CSS-hidden), so no test changes were needed.
- [ ] Lint clean (`pnpm run lint`).
- [ ] Resize the browser window from 1400px down to ~768px and confirm fields disappear in the priority order above without any content clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved status bar responsiveness by implementing container-based layout adjustments that intelligently hide status fields as the display width decreases, ensuring better usability on smaller screens and windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->