### PR TITLE
fix(audio): handle Safari AudioContext suspension after extended idle

### DIFF
--- a/src/core/toneInit.test.ts
+++ b/src/core/toneInit.test.ts
@@ -43,6 +43,18 @@ describe("ensureToneStarted", () => {
     expect(mocks.startMock).toHaveBeenCalledTimes(1);
   });
 
+  it("re-invokes Tone.start() when the context has been re-suspended after initial start (Safari idle)", async () => {
+    await ensureToneStarted();
+    expect(mocks.startMock).toHaveBeenCalledTimes(1);
+
+    // Simulate Safari re-suspending the context after extended idle.
+    mocks.state.contextState = "suspended";
+
+    await ensureToneStarted();
+    expect(mocks.startMock).toHaveBeenCalledTimes(2);
+    expect(Tone.getContext().state).toBe("running");
+  });
+
   it("does not re-invoke Tone.start() once initialization has settled", async () => {
     await Promise.all([ensureToneStarted(), ensureToneStarted()]);
     // Concurrent callers may both miss the gate on their first turn, so

--- a/src/core/toneInit.ts
+++ b/src/core/toneInit.ts
@@ -7,8 +7,9 @@ let started = false;
  * gesture handler (click, keypress, etc.) so the underlying AudioContext
  * is allowed to resume in browsers that block autoplay.
  *
- * Subsequent calls are no-ops, regardless of how many times this is
- * invoked across the app lifecycle.
+ * Subsequent calls are no-ops while the AudioContext remains running.
+ * If the context is re-suspended (e.g. Safari idle suspension), this
+ * will re-attempt Tone.start() on a later user gesture.
  */
 export async function ensureToneStarted(): Promise<void> {
   if (started) {

--- a/src/core/toneInit.ts
+++ b/src/core/toneInit.ts
@@ -11,7 +11,15 @@ let started = false;
  * invoked across the app lifecycle.
  */
 export async function ensureToneStarted(): Promise<void> {
-  if (started) return;
+  if (started) {
+    // Safari re-suspends AudioContext after extended idle. Detect and
+    // re-call Tone.start() on the next user gesture so audio resumes.
+    try {
+      if (Tone.getContext().state === "running") return;
+    } catch {
+      // Context unavailable; fall through to Tone.start().
+    }
+  }
   await Tone.start();
   started = true;
 }

--- a/src/hooks/useProgressionAudioPlayback.test.tsx
+++ b/src/hooks/useProgressionAudioPlayback.test.tsx
@@ -13,6 +13,7 @@ import {
   progressionLoopEnabledAtom,
   progressionMetronomeEnabledAtom,
   progressionPlaybackLoadingAtom,
+  progressionPlayingAtom,
   progressionStepsAtom,
   progressionTempoBpmAtom,
   setProgressionPlayingAtom,
@@ -702,6 +703,54 @@ describe("useProgressionAudioPlayback (tone-native orchestrator)", () => {
     renderWithStore(<Harness />, store);
     expect(toneMocks.parts).toHaveLength(0);
     expect(toneMocks.loops).toHaveLength(0);
+  });
+
+  it("tears down and resets playing when AudioContext stays suspended after resume (Safari idle)", async () => {
+    _resetProgressionAudioForTests();
+    const resumeMock = vi.fn().mockResolvedValue(undefined);
+    const suspendedContext = {
+      currentTime: 0,
+      sampleRate: 44100,
+      state: "suspended" as AudioContextState,
+      createGain: () => ({
+        gain: {
+          value: 1,
+          cancelScheduledValues: vi.fn(),
+          setValueAtTime: vi.fn(),
+          linearRampToValueAtTime: vi.fn(),
+          exponentialRampToValueAtTime: vi.fn(),
+          setTargetAtTime: vi.fn(),
+        },
+        connect: vi.fn().mockReturnThis(),
+        disconnect: vi.fn(),
+      }),
+      destination: {} as AudioDestinationNode,
+      resume: resumeMock,
+    };
+    (window as unknown as { AudioContext: unknown }).AudioContext =
+      vi.fn(function () {
+        return suspendedContext;
+      }) as unknown as typeof AudioContext;
+
+    const store = makeAtomStore([
+      [rootNoteAtom, "C"],
+      [scaleNameAtom, "major"],
+      [progressionStepsAtom, threeBars],
+      [progressionTempoBpmAtom, 60],
+      [beatsPerBarAtom, 4],
+    ]);
+    store.set(setProgressionPlayingAtom, true);
+    renderWithStore(<Harness />, store);
+
+    await vi.waitFor(() => {
+      expect(resumeMock).toHaveBeenCalled();
+    });
+
+    // No parts — playback tore down before scheduling.
+    expect(toneMocks.parts).toHaveLength(0);
+    expect(store.get(progressionPlaybackLoadingAtom)).toBe(false);
+    // Playing reset to false so the UI reflects the failed start.
+    expect(store.get(progressionPlayingAtom)).toBe(false);
   });
 
   describe("error handling", () => {

--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -393,7 +393,18 @@ export function useProgressionAudioPlayback() {
       if (gen !== genRef.current) return;
       const audio = eng.ensureProgressionAudio();
       if (!audio) { tearDownAndStop(); return; }
-      eng.resumeProgressionAudio();
+      await eng.resumeProgressionAudio();
+      if (gen !== genRef.current) return;
+      // Safari can fail to resume AudioContext after extended idle.
+      // Bail before scheduling audio on a suspended context (no sound,
+      // but the visual clock would still advance — causing a fast,
+      // silent playhead).
+      if (audio.ctx.state !== "running") {
+        clearTimeout(loadingTimer);
+        tearDownAndStop();
+        setPlaying(false);
+        return;
+      }
       eng.restoreProgressionBus();
       eng.setLayerGain(audio.layers, "chord", store.get(progressionChordEnabledAtom));
       eng.setLayerGain(audio.layers, "bass", store.get(progressionBassEnabledAtom));


### PR DESCRIPTION
## Summary

- **Await `resumeProgressionAudio()` before starting the Transport** — previously fire-and-forget, which let Tone.js schedule audio on a suspended context (no sound, but the visual clock still advanced → fast, silent playhead)
- **Verify `ctx.state === "running"` after resume** — if Safari fails to resume, tear down cleanly and reset the playing atom so the UI doesn't show a stuck play state
- **Check context state in `ensureToneStarted()`** — the one-shot `started` flag never reset after Safari re-suspended the context, so `Tone.start()` was never re-called on the next user gesture

## Context

Safari aggressively suspends `AudioContext` after ~30 seconds of page inactivity. When the user returned and hit play, two things broke simultaneously:

1. **No sound** — `resumeProgressionAudio()` was not awaited, so the Transport started and scheduled audio events before the context had actually resumed
2. **Fast playhead** — the Tone.js Transport Worker fired chord-onset callbacks in a burst (all events "past due" against the frozen clock), advancing `setActiveStep` rapidly through every chord

## Test plan

- [x] New test: `toneInit` re-invokes `Tone.start()` when context is re-suspended after initial start
- [x] New test: playback hook tears down and resets playing when `AudioContext` stays suspended after resume
- [x] All 2534 existing tests pass
- [x] Lint clean, production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio playback resumption on Safari after app idle periods—audio context now properly re-initializes when needed.
  * Prevented silent playback where UI advances without actual audio playing.

* **Tests**
  * Added test coverage for audio context re-suspension scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->