### PR TITLE
fix(fretboard): eliminate chord-boundary highlight flash

### DIFF
--- a/src/components/Fretboard/Fretboard.tsx
+++ b/src/components/Fretboard/Fretboard.tsx
@@ -94,8 +94,16 @@ export function Fretboard(props: FretboardProps) {
   const highlightNotes = props.highlightNotes ?? state.highlightNotes;
   const rootNote = props.rootNote ?? state.rootNote;
   const displayFormat = props.displayFormat ?? state.displayFormat;
-  const chordTones = props.chordTones ?? state.chordTones;
-  const chordRoot = props.chordRoot ?? state.chordRoot;
+  // Chord-identity fields read from the UN-deferred `baseState` so they update
+  // in lockstep with the emphasis context (which subscribes to atoms directly,
+  // without a useDeferredValue wrapper). Reading these from the deferred `state`
+  // produced a 1-2 frame gap at chord boundaries where the chord-tone
+  // classification (deferred) still reflected chord A while the emphasis cues
+  // (urgent) already targeted chord B — visible as old chord-tone notes
+  // lingering "highlighted" for ~150-300ms after the boundary (combined with
+  // the 0.15s CSS fill transition).
+  const chordTones = props.chordTones ?? baseState.chordTones;
+  const chordRoot = props.chordRoot ?? baseState.chordRoot;
   const chordFretSpread = props.chordFretSpread ?? state.chordFretSpread;
   const chordBoxBounds = props.chordBoxBounds !== undefined ? props.chordBoxBounds : state.chordBoxBounds;
   const autoCenterTarget = props.autoCenterTarget ?? viewport.autoCenterTarget;
@@ -109,7 +117,9 @@ export function Fretboard(props: FretboardProps) {
   const activePattern = props.activePattern ?? state.activePattern;
   const activeShape = props.activeShape ?? state.activeShape;
   const shapeScope = props.shapeScope ?? state.shapeScope;
-  const noteSemantics = state.noteSemanticMap.size > 0 ? state.noteSemanticMap : undefined;
+  // Chord-identity (see chordTones/chordRoot above): use baseState so semantic
+  // classification flips on the same render as the emphasis context.
+  const noteSemantics = baseState.noteSemanticMap.size > 0 ? baseState.noteSemanticMap : undefined;
   const startFret = viewport.startFret;
   const endFret = viewport.endFret;
   const stringRowPx = props.stringRowPx ?? STRING_ROW_PX_DEFAULT;
@@ -118,21 +128,23 @@ export function Fretboard(props: FretboardProps) {
 
   const fretboardLayout = getCachedFretboardLayout(tuning, Math.max(endFret, maxFret));
 
-  // `state.fullChordPositions` is already a Set<string> sourced from
+  // `baseState.fullChordPositions` is already a Set<string> sourced from
   // chordHighlightPositionsAtom — pass it through directly. The note-highlight
   // set is the union of ALL fitting voicing candidates' positions, decoupled
-  // from `state.fullChordMatches` (the connector source).
-  const fullChordPositionKeys = state.fullChordPositions;
+  // from `baseState.fullChordMatches` (the connector source). Both are read
+  // from `baseState` (chord-identity) so they update in sync with the chord
+  // tones above and the emphasis context (see comment on `chordTones`).
+  const fullChordPositionKeys = baseState.fullChordPositions;
 
   const fullChordVoicings = useMemo(
     () =>
-      state.fullChordMatches.map((match) => ({
+      baseState.fullChordMatches.map((match) => ({
         shape: match.shape,
         voicingKey: match.positionKeys.map((key) => key.replace("-", ",")).join("|"),
         notes: match.notes,
         isFallback: match.isFallback,
       })),
-    [state.fullChordMatches],
+    [baseState.fullChordMatches],
   );
 
   const [containerWidth, setContainerWidth] = useState<number>(() => {


### PR DESCRIPTION
## Summary

Fixes the visual flash where notes that aren't part of the new chord briefly remain highlighted right at a chord boundary during progression playback.

## Root cause

There was a **priority asymmetry** in how chord-boundary data reached the fretboard. Two parallel paths feed `FretboardSVG` at different React priorities:

- **Chord identity** (`chordTones`, `chordRoot`, `noteSemanticMap`, `fullChordPositions`, `fullChordMatches`) flowed through **two** defer layers — `startTransition` in `src/progressions/audio/visualClock.ts:41` plus `useDeferredValue` in `src/components/Fretboard/Fretboard.tsx:87`.
- **Emphasis cues** (`useEmphasisContext` → next-chord guide tones, common tones, incoming/departing/held-target sets) went through **only one** defer layer (`startTransition`), with no `useDeferredValue` wrapper.

At every chord boundary the deferred-commit raced: the emphasis context already showed chord **B**'s cues while `noteSemanticMap` / `chordTones` / `chordRoot` still described chord **A**. `buildAnimatedFretboardNotes` consumed both together, so for one or more frames the rendered notes had chord A's semantic classification AND chord B's transition roles. The 0.15s CSS `fill` transition on `[data-motion="css"] .fretboard-note` then dragged this mismatch out visually for ~150–300 ms — exactly the "notes that shouldn't be highlighted are highlighted for a split second" symptom.

## Fix

In `src/components/Fretboard/Fretboard.tsx`, chord-identity fields now read from the un-deferred `baseState` while everything non-chord (scale, shapes, viewport, polygons, hidden notes, etc.) keeps the `useDeferredValue` jank protection.

| Field | Before | After |
|---|---|---|
| `chordTones` | `state.chordTones` | `baseState.chordTones` |
| `chordRoot` | `state.chordRoot` | `baseState.chordRoot` |
| `noteSemanticMap` | `state.noteSemanticMap` | `baseState.noteSemanticMap` |
| `fullChordPositions` | `state.fullChordPositions` | `baseState.fullChordPositions` |
| `fullChordMatches` | `state.fullChordMatches` | `baseState.fullChordMatches` |

Semantic classification and emphasis cues now flip on the same React commit, so the inconsistent-render window is closed.

## Why not just remove `useDeferredValue`?

That was the alternative. Keeping it on the non-chord surface preserves the original jank protection for keyboard/scroll/scale edits on non-playback paths, where the deferred commit isn't racing the emphasis context. Only the chord-identity subset needs lockstep timing, so this is the minimum change that fixes the race without giving up the original optimization.

## Verification

- [x] `pnpm run lint` — clean (only pre-existing warning in `useFretboardTopologyModel.ts`, unrelated)
- [x] `pnpm run build` — passes
- [x] `pnpm run test` — 2532 / 2532 passing, 1 skipped, 1 todo
- [x] Dev preview — progression playback runs without console errors; chord transitions visually clean

## Test plan

- [ ] Play a 4-chord progression (e.g., C–G–Am–F) and watch the fretboard at each chord change — notes belonging only to the *previous* chord should de-emphasize cleanly, without a brief flash of being highlighted alongside the new chord
- [ ] Same check with Voicing = `Full` and Voicing = `Close` (both go through the same chord-identity surface)
- [ ] Same check while editing a chord mid-playback (root/quality change) — should still feel smooth, not stutter
- [ ] Non-playback path: change scale root and scale type a few times — should still feel responsive (the `useDeferredValue` jank guard is still in place for everything except chord identity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)