### PR TITLE
fix(audio): recover progression audio after Safari long-idle suspension

### DIFF
--- a/src/components/HeaderTransportCluster/HeaderTransportCluster.test.tsx
+++ b/src/components/HeaderTransportCluster/HeaderTransportCluster.test.tsx
@@ -83,6 +83,7 @@ describe("HeaderTransportCluster", () => {
         connect: vi.fn(),
       }),
       destination: {},
+      addEventListener: vi.fn(),
     };
 
     (window as unknown as { AudioContext: unknown }).AudioContext =

--- a/src/components/HeaderTransportCluster/ProgressionPositionReadout.test.tsx
+++ b/src/components/HeaderTransportCluster/ProgressionPositionReadout.test.tsx
@@ -27,6 +27,7 @@ describe("ProgressionPositionReadout", () => {
         connect: vi.fn(),
       }),
       destination: {},
+      addEventListener: vi.fn(),
     };
 
     (window as unknown as { AudioContext: unknown }).AudioContext =
@@ -77,6 +78,7 @@ describe("ProgressionPositionReadout", () => {
         connect: vi.fn(),
       }),
       destination: {},
+      addEventListener: vi.fn(),
     };
 
     (window as unknown as { AudioContext: unknown }).AudioContext =
@@ -143,6 +145,7 @@ describe("ProgressionPositionReadout", () => {
         connect: vi.fn(),
       }),
       destination: {},
+      addEventListener: vi.fn(),
     };
 
     (window as unknown as { AudioContext: unknown }).AudioContext =
@@ -205,6 +208,7 @@ describe("ProgressionPositionReadout", () => {
         connect: vi.fn(),
       }),
       destination: {},
+      addEventListener: vi.fn(),
     };
 
     (window as unknown as { AudioContext: unknown }).AudioContext =

--- a/src/components/ProgressionTrack/ProgressionPlayhead.test.tsx
+++ b/src/components/ProgressionTrack/ProgressionPlayhead.test.tsx
@@ -69,6 +69,7 @@ describe("ProgressionPlayhead", () => {
         connect: vi.fn(),
       }),
       destination: {},
+      addEventListener: vi.fn(),
     };
 
     (window as unknown as { AudioContext: unknown }).AudioContext =
@@ -113,6 +114,7 @@ describe("ProgressionPlayhead", () => {
         connect: vi.fn(),
       }),
       destination: {},
+      addEventListener: vi.fn(),
     };
 
     (window as unknown as { AudioContext: unknown }).AudioContext =
@@ -180,6 +182,7 @@ describe("ProgressionPlayhead", () => {
         connect: vi.fn(),
       }),
       destination: {},
+      addEventListener: vi.fn(),
     };
 
     (window as unknown as { AudioContext: unknown }).AudioContext =

--- a/src/hooks/useProgressionAudioPlayback.test.tsx
+++ b/src/hooks/useProgressionAudioPlayback.test.tsx
@@ -30,6 +30,13 @@ vi.mock("../progressions/audio/visualClock", () => ({
   stopVisualClock: visualClockMocks.stopVisualClock,
 }));
 
+// toneInit mock: the hook calls ensureToneStarted() for Safari idle recovery.
+// Its behavior is tested in toneInit.test.ts; here it's a no-op.
+vi.mock("../core/toneInit", () => ({
+  ensureToneStarted: vi.fn().mockResolvedValue(undefined),
+  __resetToneStartedForTests: vi.fn(),
+}));
+
 // Tone mocks: capture all Parts and Loops constructed; expose for assertions.
 const toneMocks = vi.hoisted(() => {
   const contextNowRef = { fn: () => 0 };
@@ -238,6 +245,7 @@ describe("useProgressionAudioPlayback (tone-native orchestrator)", () => {
       }),
       destination: {} as AudioDestinationNode,
       resume: vi.fn(),
+      addEventListener: vi.fn(),
     };
     toneMocks.contextNowRef.fn = () => audioContext.currentTime;
     (window as unknown as { AudioContext: unknown }).AudioContext =
@@ -726,6 +734,7 @@ describe("useProgressionAudioPlayback (tone-native orchestrator)", () => {
       }),
       destination: {} as AudioDestinationNode,
       resume: resumeMock,
+      addEventListener: vi.fn(),
     };
     (window as unknown as { AudioContext: unknown }).AudioContext =
       vi.fn(function () {
@@ -751,6 +760,27 @@ describe("useProgressionAudioPlayback (tone-native orchestrator)", () => {
     expect(store.get(progressionPlaybackLoadingAtom)).toBe(false);
     // Playing reset to false so the UI reflects the failed start.
     expect(store.get(progressionPlayingAtom)).toBe(false);
+  });
+
+  it("calls ensureToneStarted before scheduling audio (Safari idle re-unlock)", async () => {
+    const toneInitMod = await import("../core/toneInit");
+    const spy = vi.mocked(toneInitMod.ensureToneStarted);
+    spy.mockClear();
+
+    const store = makeAtomStore([
+      [rootNoteAtom, "C"],
+      [scaleNameAtom, "major"],
+      [progressionStepsAtom, threeBars],
+      [progressionTempoBpmAtom, 60],
+      [beatsPerBarAtom, 4],
+    ]);
+    store.set(setProgressionPlayingAtom, true);
+    renderWithStore(<Harness />, store);
+
+    await vi.waitFor(() => {
+      expect(toneMocks.parts).toHaveLength(5);
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   describe("error handling", () => {

--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -37,6 +37,7 @@ import type {
 } from "../progressions/audio/progressionAudioEngine";
 import type { BuiltLayers } from "../progressions/audio/buildAllLayers";
 import { startVisualClock, stopVisualClock } from "../progressions/audio/visualClock";
+import { ensureToneStarted } from "../core/toneInit";
 
 const SCHEDULE_LEAD_SECONDS = 0.05;
 
@@ -393,6 +394,16 @@ export function useProgressionAudioPlayback() {
       if (gen !== genRef.current) return;
       const audio = eng.ensureProgressionAudio();
       if (!audio) { tearDownAndStop(); return; }
+
+      // Call Tone.start() BEFORE resumeProgressionAudio(). When Safari
+      // re-suspends the AudioContext after extended idle, ctx.resume() alone
+      // restores the "running" state but may not re-establish the internal
+      // audio-output gate. Tone.start() plays a silent buffer that
+      // re-unlocks the output. Must run while the context is still
+      // "suspended" — once resumed, ensureToneStarted() short-circuits.
+      try { await ensureToneStarted(); } catch { /* best-effort */ }
+      if (gen !== genRef.current) return;
+
       await eng.resumeProgressionAudio();
       if (gen !== genRef.current) return;
       // Safari can fail to resume AudioContext after extended idle.

--- a/src/progressions/audio/bus.test.ts
+++ b/src/progressions/audio/bus.test.ts
@@ -1,6 +1,28 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { _resetProgressionAudioForTests, ensureProgressionAudio } from "./bus";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetProgressionAudioForTests,
+  ensureProgressionAudio,
+  resumeProgressionAudio,
+  configureProgressionGraph,
+} from "./bus";
+
+// Stub Tone so bus.ts can initialize without a real AudioContext.
+vi.mock("tone", () => ({
+  getDraw: () => ({ expiration: 0.25 }),
+  setContext: vi.fn(),
+  Channel: class { connect() { return this; } disconnect() {} dispose() {} },
+  Compressor: class { connect() { return this; } disconnect() {} dispose() {} },
+  Limiter: class { connect() { return this; } disconnect() {} dispose() {} },
+  Gain: class { connect() { return this; } disconnect() {} dispose() {} },
+  EQ3: class { connect() { return this; } disconnect() {} dispose() {} },
+  Chebyshev: class { connect() { return this; } disconnect() {} dispose() {} },
+  Distortion: class { connect() { return this; } disconnect() {} dispose() {} },
+  Reverb: class { connect() { return this; } disconnect() {} dispose() {} generate() { return Promise.resolve(this); } },
+  Freeverb: class { connect() { return this; } disconnect() {} dispose() {} },
+  JCReverb: class { connect() { return this; } disconnect() {} dispose() {} },
+  connect: () => {},
+}));
 
 describe("ensureProgressionAudio", () => {
   beforeEach(() => {
@@ -32,5 +54,87 @@ describe("ensureProgressionAudio", () => {
     warnSpy.mockRestore();
     (window as unknown as { AudioContext: unknown }).AudioContext = origCtor;
     _resetProgressionAudioForTests();
+  });
+});
+
+describe("resumeProgressionAudio – suspension recovery", () => {
+  let stateChangeHandler: (() => void) | null;
+  let mockCtx: Record<string, unknown>;
+
+  beforeEach(() => {
+    _resetProgressionAudioForTests();
+    stateChangeHandler = null;
+    mockCtx = {
+      currentTime: 0,
+      sampleRate: 44100,
+      state: "running" as AudioContextState,
+      createGain: () => ({
+        gain: { value: 0.55 },
+        connect: vi.fn().mockReturnThis(),
+        disconnect: vi.fn(),
+      }),
+      destination: {},
+      resume: vi.fn(),
+      addEventListener: vi.fn((_event: string, handler: () => void) => {
+        stateChangeHandler = handler;
+      }),
+    };
+    (window as unknown as { AudioContext: unknown }).AudioContext =
+      vi.fn(function () { return mockCtx; }) as unknown as typeof AudioContext;
+  });
+
+  afterEach(() => {
+    _resetProgressionAudioForTests();
+  });
+
+  it("invalidates the signal-graph cache after a suspend/resume cycle", async () => {
+    const audio = ensureProgressionAudio();
+    expect(audio).not.toBeNull();
+
+    // Build a graph (populates the cache).
+    const { planSignalGraph } = await import("./sound/buildSignalGraph");
+    const { TIER_PROFILES } = await import("./sound/qualityTiers");
+    const { DEFAULT_GENRE_MIX } = await import("./sound/genreMixPresets");
+    const plan = planSignalGraph(TIER_PROFILES.eco, DEFAULT_GENRE_MIX);
+
+    const g1 = configureProgressionGraph(plan);
+    expect(g1).not.toBeNull();
+
+    // Same plan → cache hit (same object returned).
+    const g2 = configureProgressionGraph(plan);
+    expect(g2).toBe(g1);
+
+    // Simulate Safari suspending the context.
+    mockCtx.state = "suspended";
+    stateChangeHandler?.();
+
+    // Resume.
+    mockCtx.state = "running";
+    await resumeProgressionAudio();
+
+    // Same plan → cache MISS (graph was invalidated by the recovery path).
+    const g3 = configureProgressionGraph(plan);
+    expect(g3).not.toBe(g1);
+    expect(g3).not.toBeNull();
+  });
+
+  it("reconnects bus → ctx.destination after suspension", async () => {
+    const audio = ensureProgressionAudio();
+    expect(audio).not.toBeNull();
+    const busConnectSpy = vi.fn();
+    const busDisconnectSpy = vi.fn();
+    // Replace the bus's connect/disconnect with spies.
+    const busRef = audio!.bus;
+    busRef.connect = busConnectSpy as unknown as typeof busRef.connect;
+    busRef.disconnect = busDisconnectSpy;
+
+    // Simulate suspend → resume.
+    mockCtx.state = "suspended";
+    stateChangeHandler?.();
+    mockCtx.state = "running";
+    await resumeProgressionAudio();
+
+    expect(busDisconnectSpy).toHaveBeenCalled();
+    expect(busConnectSpy).toHaveBeenCalledWith(audio!.ctx.destination);
   });
 });

--- a/src/progressions/audio/bus.ts
+++ b/src/progressions/audio/bus.ts
@@ -25,6 +25,16 @@ let bus: GainNode | null = null;
 let layers: LayerBuses | null = null;
 let unsupported = false;
 
+/**
+ * Set when Safari (or any browser) suspends the AudioContext after extended
+ * idle. The next `resumeProgressionAudio()` call uses this to force a fresh
+ * signal-graph rebuild — cached Tone.js nodes (Channel, Compressor, Limiter,
+ * Reverb) may be non-functional after a long suspension even though the
+ * context reports "running". The bus→destination native connection is also
+ * re-established.
+ */
+let needsGraphRebuild = false;
+
 function getAudioContextConstructor(): (new () => AudioContext) | undefined {
   const w = window as Window & {
     AudioContext?: new () => AudioContext;
@@ -58,6 +68,15 @@ export function ensureProgressionAudio(): ProgressionAudio | null {
 
   try {
     ctx = new Ctor();
+
+    // Track when Safari (or any browser) re-suspends the context after idle.
+    // The flag tells resumeProgressionAudio() to rebuild stale Tone.js nodes.
+    ctx.addEventListener("statechange", () => {
+      if (ctx?.state === "suspended" || ctx?.state === "interrupted") {
+        needsGraphRebuild = true;
+      }
+    });
+
     bus = ctx.createGain();
     bus.gain.value = BUS_GAIN;
     bus.connect(ctx.destination);
@@ -111,6 +130,25 @@ export async function resumeProgressionAudio(): Promise<void> {
     } catch {
       // best-effort
     }
+  }
+
+  // Post-suspension recovery: after Safari re-suspends the AudioContext during
+  // extended idle, ctx.resume() restores state to "running" but the cached
+  // Tone.js signal-graph nodes (Channel, Compressor, Limiter, Reverb) may be
+  // non-functional, and the bus→destination native connection may be broken.
+  // Dispose the stale graph and reconnect the bus so the next
+  // configureProgressionGraph() call builds fresh nodes.
+  if (needsGraphRebuild) {
+    if (currentGraph) {
+      currentGraph.dispose();
+      // dispose() already sets currentGraph = null and lastPlanKey = null
+      // when the disposed graph matches currentGraph.
+    }
+    // Re-establish the bus→destination link (Safari may drop native
+    // AudioNode connections during very long suspension).
+    try { audio.bus.disconnect(); } catch { /* not connected */ }
+    audio.bus.connect(audio.ctx.destination);
+    needsGraphRebuild = false;
   }
 }
 
@@ -218,6 +256,7 @@ export function _resetProgressionAudioForTests(): void {
   bus = null;
   layers = null;
   unsupported = false;
+  needsGraphRebuild = false;
   _resetToneBusForTests();
 }
 

--- a/src/progressions/audio/configureGraph.test.ts
+++ b/src/progressions/audio/configureGraph.test.ts
@@ -58,6 +58,7 @@ describe("configureProgressionGraph", () => {
         destination: {},
         currentTime: 0,
         state: "running",
+        addEventListener: vi.fn(),
       };
     }) as unknown as typeof AudioContext;
   });

--- a/src/progressions/audio/timeline.test.ts
+++ b/src/progressions/audio/timeline.test.ts
@@ -38,6 +38,7 @@ beforeEach(() => {
     }),
     destination: {} as AudioDestinationNode,
     resume: vi.fn(),
+    addEventListener: vi.fn(),
   };
 
   (window as unknown as { AudioContext: unknown }).AudioContext =

--- a/src/progressions/audio/toneBus.test.ts
+++ b/src/progressions/audio/toneBus.test.ts
@@ -31,6 +31,7 @@ describe("toneBus binding", () => {
         destination: {},
         currentTime: 0,
         state: "running",
+        addEventListener: vi.fn(),
       };
     }) as unknown as typeof AudioContext;
   });


### PR DESCRIPTION
## Summary

- **Call `ensureToneStarted()` in the progression play flow** — the progression path only called `ctx.resume()`, never `Tone.start()`. Safari may require Tone's silent-buffer "interaction" to re-unlock audio output after re-suspending the context during extended idle. This was the missing piece from #573 (which fixed the fast-playhead symptom but not the no-sound symptom).
- **Track suspension via `statechange` listener and invalidate the signal-graph cache** — after very long Safari idle, cached Tone.js nodes (Channel, Compressor, Limiter, Reverb) may be non-functional even though the context reports "running". On the next play after suspension, the stale graph is disposed and `configureProgressionGraph()` builds fresh nodes.
- **Reconnect `bus → ctx.destination`** after suspension — Safari may drop native AudioNode connections during aggressive resource reclamation on long-backgrounded tabs.

## Context

After the fix in #573 (commit 060388e3), the playhead timing was corrected (no longer fast/silent), but audio still produced no sound after leaving the app open for a long time on Safari. The root cause was a two-part gap:

1. `ensureToneStarted()` was only called from `GuitarSynth` (fretboard note taps), never from the progression playback path
2. The signal graph was cached across suspension cycles — stale Tone.js nodes from hours ago were reused without rebuilding

## Test plan

- [x] New test: `ensureToneStarted` is called before audio scheduling in the progression play flow
- [x] New test: signal-graph cache is invalidated after a suspend/resume cycle
- [x] New test: bus→destination is reconnected after suspension
- [x] All 2537 existing + new tests pass
- [x] Lint clean, production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)