### PR TITLE
feat(audio): separate guitar/progression AudioContexts + Safari energy/wedge fixes

### DIFF
--- a/docs/superpowers/plans/2026-06-09-separate-audio-contexts.md
+++ b/docs/superpowers/plans/2026-06-09-separate-audio-contexts.md
@@ -1,0 +1,842 @@
+# Separate Audio Contexts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the guitar synth off Tone's shared global `AudioContext` onto its own dedicated raw-Web-Audio context, fully decoupled from the progression engine.
+
+**Architecture:** The progression keeps Tone.js and the global context (it needs `Transport`/`Draw`/sequencer clock-sync). The guitar is reimplemented as a small raw-Web-Audio voice engine on a private `AudioContext` it owns — `Tone.setContext()` can never touch it, so the orphaning, per-tap lookahead delay, and post-progression silence cannot recur. `audio.ts`'s public API (`init`/`resume`/`setMute`/`playNote`/`onError`/`onOutputWedged`) stays byte-identical, so every caller is untouched.
+
+**Tech Stack:** TypeScript, Web Audio API (`AudioContext`, `OscillatorNode`, `GainNode`, `BiquadFilterNode`, `PeriodicWave`), Vitest, Jotai. Source spec: `docs/superpowers/specs/2026-06-09-separate-audio-contexts-design.md`.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/core/audio.ts` | The guitar synth — now raw Web Audio on its own context | Rewrite internals; public API unchanged |
+| `src/core/audio.test.ts` | Guitar synth unit tests | Rewrite (drop Tone mocks; add fake `AudioContext`) |
+| `src/core/audioOutputHealth.ts` | Safari dead-output wedge probe | Add optional `ctx` param |
+| `src/core/audioOutputHealth.test.ts` | Wedge probe tests | Add explicit-ctx case |
+| `src/core/audioIdleSuspend.ts` | Energy idle-suspend registry | Delete the "sticky progression role" branch |
+| `src/core/audioIdleSuspend.test.ts` | Idle-suspend tests | Remove the now-obsolete sticky test |
+
+Unchanged: `src/progressions/audio/bus.ts`, `toneBus.ts`, `src/core/toneInit.ts`, `src/store/audioAtoms.ts`, `src/App.tsx`, `src/core/lazyGuitarAudio.ts`.
+
+---
+
+## Task 1: `probeOutputHealth` accepts an explicit context
+
+So the guitar can probe its **own** output rather than only the Tone global. Backward-compatible: no arg → current behavior (Tone global).
+
+**Files:**
+- Modify: `src/core/audioOutputHealth.ts:66-93`
+- Test: `src/core/audioOutputHealth.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test inside the `describe("probeOutputHealth", ...)` block in `src/core/audioOutputHealth.test.ts`, after the existing tests (before the closing `});`):
+
+```ts
+  it("probes an explicitly-passed context instead of the Tone global", async () => {
+    // A standalone context whose hardware clock is frozen while currentTime
+    // advances → wedged. The Tone-global mock (h.*) stays healthy, proving the
+    // explicit arg is what's used.
+    let ct = 0;
+    const explicitCtx = {
+      state: "running" as AudioContextState,
+      get currentTime() {
+        return ct;
+      },
+      getOutputTimestamp: () => ({ contextTime: 0 }),
+    } as unknown as AudioContext;
+
+    const p = probeOutputHealth(explicitCtx);
+    ct = 0.25; // currentTime advanced; contextTime stayed 0
+    await vi.advanceTimersByTimeAsync(300);
+    expect(await p).toBe("wedged");
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run src/core/audioOutputHealth.test.ts -t "probes an explicitly-passed context"`
+Expected: FAIL — `probeOutputHealth` currently ignores any argument and reads the Tone-global mock (returns `"healthy"`), so the `toBe("wedged")` assertion fails.
+
+- [ ] **Step 3: Add the optional parameter**
+
+Replace the function signature and its first line in `src/core/audioOutputHealth.ts`. Change:
+
+```ts
+export async function probeOutputHealth(): Promise<OutputHealth> {
+  const ctx = getLiveRawContext();
+```
+
+to:
+
+```ts
+export async function probeOutputHealth(explicitCtx?: AudioContext): Promise<OutputHealth> {
+  const ctx = explicitCtx ?? getLiveRawContext();
+```
+
+Leave the rest of the function body unchanged.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm exec vitest run src/core/audioOutputHealth.test.ts`
+Expected: PASS — all 7 tests (6 existing + 1 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/audioOutputHealth.ts src/core/audioOutputHealth.test.ts
+git commit -m "refactor(audio): let probeOutputHealth target an explicit context"
+```
+
+---
+
+## Task 2: Drop the "sticky progression role" hack from idle-suspend
+
+With the guitar on its own context, the guitar and progression are **distinct map keys** — role collision on one shared key is impossible, so the sticky workaround is dead code. Removing it makes `registerAudioContext` a plain `set`.
+
+**Files:**
+- Modify: `src/core/audioIdleSuspend.ts:27-34`
+- Test: `src/core/audioIdleSuspend.test.ts:147-155` (remove)
+
+- [ ] **Step 1: Remove the obsolete sticky test**
+
+Delete this entire test from `src/core/audioIdleSuspend.test.ts` (lines 147–155):
+
+```ts
+    it("keeps the progression role sticky — guitar re-registration cannot downgrade it", () => {
+      // The shared AudioContext: progression tags it first, then a fret tap
+      // re-registers the same object as "guitar". The progression-scoped check
+      // must still recognize it.
+      const shared = makeMockContext("suspended");
+      registerAudioContext(shared, "progression");
+      registerAudioContext(shared, "guitar");
+      expect(isContextSuspended("progression")).toBe(true);
+    });
+```
+
+Keep the `"upgrades a guitar context to progression when re-registered"` test directly above it — that behavior (a plain re-`set` upgrades the role) still holds.
+
+- [ ] **Step 2: Run the suite to confirm the sticky test is the only failure source after the code change**
+
+(Sequencing note: we remove the test first so the suite reflects the new contract; the code change in Step 3 makes it green.)
+
+Run: `pnpm exec vitest run src/core/audioIdleSuspend.test.ts`
+Expected: PASS currently (sticky behavior still present in code, but its test is gone). This confirms removing the test didn't break the others.
+
+- [ ] **Step 3: Simplify `registerAudioContext`**
+
+In `src/core/audioIdleSuspend.ts`, replace the whole function (lines 27–34):
+
+```ts
+export function registerAudioContext(ctx: AudioContext, role?: AudioContextRole): void {
+  // The guitar synth and the progression engine share one AudioContext once
+  // Tone is rebound (Tone.setContext). "progression" is sticky so a later
+  // guitar registration of that shared context can't downgrade the role and
+  // break the progression-scoped suspended check. Both still get suspended.
+  if (contexts.get(ctx) === "progression") return;
+  contexts.set(ctx, role);
+}
+```
+
+with:
+
+```ts
+export function registerAudioContext(ctx: AudioContext, role?: AudioContextRole): void {
+  // The guitar and the progression each own a SEPARATE AudioContext, so they are
+  // distinct map keys — no role collision to guard against. A later call with the
+  // same key simply updates (e.g. upgrades) the role.
+  contexts.set(ctx, role);
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm exec vitest run src/core/audioIdleSuspend.test.ts`
+Expected: PASS — including `"upgrades a guitar context to progression when re-registered"`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/audioIdleSuspend.ts src/core/audioIdleSuspend.test.ts
+git commit -m "refactor(audio): drop sticky-role hack now contexts are separate"
+```
+
+---
+
+## Task 3: Rewrite the guitar synth as a raw-Web-Audio engine
+
+The core change. Replace the Tone-backed internals of `GuitarSynth` with a private `AudioContext` + shared `masterGain`/`filter`/`wave` + per-tap oscillator voices. Public API preserved.
+
+**Files:**
+- Rewrite: `src/core/audio.ts`
+- Rewrite: `src/core/audio.test.ts`
+
+- [ ] **Step 1: Replace the test file with the raw-Web-Audio test suite**
+
+Overwrite `src/core/audio.test.ts` entirely with:
+
+```ts
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// audio.ts no longer uses Tone — it owns a raw AudioContext. Mock the two side
+// modules so unit tests stay synchronous and timer-free, and install a fake
+// Web Audio API on window (jsdom has none).
+vi.mock("./audioIdleSuspend", () => ({
+  registerAudioContext: vi.fn(),
+  markAudioActivity: vi.fn(),
+}));
+vi.mock("./audioOutputHealth", () => ({
+  probeOutputHealth: vi.fn().mockResolvedValue("healthy"),
+}));
+
+class FakeAudioParam {
+  value = 0;
+  setValueAtTime = vi.fn((v: number) => {
+    this.value = v;
+    return this;
+  });
+  linearRampToValueAtTime = vi.fn((v: number) => {
+    this.value = v;
+    return this;
+  });
+  exponentialRampToValueAtTime = vi.fn((v: number) => {
+    this.value = v;
+    return this;
+  });
+  cancelScheduledValues = vi.fn(() => this);
+}
+
+const created: { gains: any[]; filters: any[]; oscillators: any[] } = {
+  gains: [],
+  filters: [],
+  oscillators: [],
+};
+let lastPeriodicWave: { real: Float32Array; imag: Float32Array } | null = null;
+
+class FakeGain {
+  gain = new FakeAudioParam();
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+class FakeFilter {
+  type = "";
+  frequency = new FakeAudioParam();
+  Q = new FakeAudioParam();
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+class FakeOscillator {
+  frequency = new FakeAudioParam();
+  setPeriodicWave = vi.fn();
+  connect = vi.fn();
+  disconnect = vi.fn();
+  start = vi.fn();
+  stop = vi.fn();
+  onended: (() => void) | null = null;
+}
+class FakeAudioContext {
+  state: AudioContextState = "running";
+  currentTime = 0;
+  destination = {};
+  resume = vi.fn(async () => {
+    this.state = "running";
+  });
+  createGain = vi.fn(() => {
+    const g = new FakeGain();
+    created.gains.push(g);
+    return g;
+  });
+  createBiquadFilter = vi.fn(() => {
+    const f = new FakeFilter();
+    created.filters.push(f);
+    return f;
+  });
+  createOscillator = vi.fn(() => {
+    const o = new FakeOscillator();
+    created.oscillators.push(o);
+    return o;
+  });
+  createPeriodicWave = vi.fn((real: Float32Array, imag: Float32Array) => {
+    lastPeriodicWave = { real, imag };
+    return { real, imag } as unknown as PeriodicWave;
+  });
+}
+
+let ctorState: AudioContextState = "running";
+let resumeRejects = false;
+
+import { __resetSynthForTests, synth } from "./audio";
+
+beforeEach(() => {
+  created.gains.length = 0;
+  created.filters.length = 0;
+  created.oscillators.length = 0;
+  lastPeriodicWave = null;
+  ctorState = "running";
+  resumeRejects = false;
+
+  (window as any).AudioContext = vi.fn(function FakeCtor() {
+    const ctx = new FakeAudioContext();
+    ctx.state = ctorState;
+    if (resumeRejects) {
+      ctx.resume = vi.fn(async () => {
+        throw new Error("blocked");
+      });
+    }
+    return ctx;
+  });
+  (window as any).webkitAudioContext = undefined;
+
+  __resetSynthForTests();
+});
+
+describe("GuitarSynth (raw Web Audio)", () => {
+  describe("init", () => {
+    it("builds master gain, lowpass filter, and the partials periodic wave", () => {
+      synth.init();
+      // master gain → destination; filter → master gain.
+      expect(created.gains.length).toBe(1);
+      expect(created.filters.length).toBe(1);
+      const filter = created.filters[0];
+      expect(filter.type).toBe("lowpass");
+      expect(filter.frequency.value).toBe(10000);
+      expect(filter.Q.value).toBeCloseTo(0.1);
+      // Periodic wave: DC term 0, then the six partials as sine (imag) coeffs.
+      expect(lastPeriodicWave).not.toBeNull();
+      expect(Array.from(lastPeriodicWave!.imag)).toEqual([0, 1, 0.8, 0.45, 0.22, 0.12, 0.05]);
+      expect(Array.from(lastPeriodicWave!.real)).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    });
+
+    it("is idempotent on subsequent calls", () => {
+      synth.init();
+      synth.init();
+      synth.init();
+      expect(created.filters.length).toBe(1);
+    });
+
+    it("initializes master gain at 0.5 when unmuted", () => {
+      synth.init();
+      expect(created.gains[0].gain.value).toBeCloseTo(0.5);
+    });
+  });
+
+  describe("playNote", () => {
+    it("creates an oscillator with the periodic wave at the requested frequency", async () => {
+      await synth.playNote(440);
+      expect(created.oscillators.length).toBe(1);
+      const osc = created.oscillators[0];
+      expect(osc.setPeriodicWave).toHaveBeenCalledTimes(1);
+      expect(osc.frequency.setValueAtTime).toHaveBeenCalledWith(440, expect.any(Number));
+      expect(osc.start).toHaveBeenCalledTimes(1);
+      expect(osc.stop).toHaveBeenCalledTimes(1);
+    });
+
+    it("schedules the attack ramp to full amplitude (no lookahead — uses currentTime)", async () => {
+      await synth.playNote(440);
+      // The newest gain is the per-note envelope (gains[0] is master).
+      const env = created.gains[created.gains.length - 1];
+      // attack ramps to 1.0.
+      expect(env.gain.linearRampToValueAtTime).toHaveBeenCalledWith(1, expect.any(Number));
+    });
+
+    it("auto-initializes if init() was not called first", async () => {
+      await synth.playNote(110);
+      expect(created.filters.length).toBe(1);
+      expect(created.oscillators.length).toBe(1);
+    });
+
+    it("caps concurrent voices at 12 (skips beyond the cap)", async () => {
+      // onended is never fired by the fake, so every voice stays "active".
+      for (let i = 0; i < 12; i++) await synth.playNote(220);
+      expect(created.oscillators.length).toBe(12);
+      await synth.playNote(220); // 13th — skipped
+      expect(created.oscillators.length).toBe(12);
+    });
+
+    it("frees a voice when its oscillator ends, allowing new notes", async () => {
+      for (let i = 0; i < 12; i++) await synth.playNote(220);
+      created.oscillators[0].onended?.(); // first voice finishes
+      await synth.playNote(220);
+      expect(created.oscillators.length).toBe(13);
+    });
+
+    it("resumes its own context before playing when not running", async () => {
+      ctorState = "suspended";
+      synth.init();
+      const ctx = (synth as any).ctx as FakeAudioContext;
+      await synth.playNote(440);
+      expect(ctx.resume).toHaveBeenCalled();
+      expect(created.oscillators.length).toBe(1);
+    });
+
+    it("invokes onError and plays nothing when resume rejects", async () => {
+      ctorState = "suspended";
+      resumeRejects = true;
+      const onError = vi.fn();
+      synth.onError = onError;
+
+      await synth.playNote(330);
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError.mock.calls[0][0]).toMatch(/audio could not be started/i);
+      expect(created.oscillators.length).toBe(0);
+      synth.onError = undefined;
+    });
+  });
+
+  describe("setMute", () => {
+    it("ramps master gain to 0 on mute", () => {
+      synth.init();
+      const master = created.gains[0];
+      master.gain.linearRampToValueAtTime.mockClear();
+      synth.setMute(true);
+      expect(master.gain.linearRampToValueAtTime).toHaveBeenCalledWith(0, expect.any(Number));
+    });
+
+    it("ramps master gain back to 0.5 on unmute", () => {
+      synth.init();
+      const master = created.gains[0];
+      synth.setMute(true);
+      master.gain.linearRampToValueAtTime.mockClear();
+      synth.setMute(false);
+      expect(master.gain.linearRampToValueAtTime).toHaveBeenCalledWith(0.5, expect.any(Number));
+    });
+
+    it("suppresses playNote while muted", async () => {
+      synth.init();
+      synth.setMute(true);
+      await synth.playNote(440);
+      expect(created.oscillators.length).toBe(0);
+    });
+
+    it("does NOT resume when unmuting before a user gesture (context suspended)", () => {
+      ctorState = "suspended";
+      synth.init();
+      const ctx = (synth as any).ctx as FakeAudioContext;
+      synth.setMute(false);
+      // The gesture-dependent resume is suppressed; the gain ramp still happens.
+      expect(ctx.resume).not.toHaveBeenCalled();
+      expect(created.gains[0].gain.linearRampToValueAtTime).toHaveBeenCalled();
+    });
+  });
+
+  describe("resume", () => {
+    it("initializes lazily and resumes its own context", async () => {
+      ctorState = "suspended";
+      await synth.resume();
+      const ctx = (synth as any).ctx as FakeAudioContext;
+      expect(created.filters.length).toBe(1);
+      expect(ctx.resume).toHaveBeenCalled();
+    });
+
+    it("forwards a resume failure via onError", async () => {
+      ctorState = "suspended";
+      resumeRejects = true;
+      const onError = vi.fn();
+      synth.onError = onError;
+      await synth.resume();
+      expect(onError).toHaveBeenCalledTimes(1);
+      synth.onError = undefined;
+    });
+  });
+
+  describe("graceful degradation", () => {
+    it("marks itself unsupported when no AudioContext constructor exists", async () => {
+      (window as any).AudioContext = undefined;
+      (window as any).webkitAudioContext = undefined;
+      __resetSynthForTests();
+
+      synth.init();
+      await synth.playNote(440);
+      expect(created.oscillators.length).toBe(0);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `pnpm exec vitest run src/core/audio.test.ts`
+Expected: FAIL — the current `audio.ts` still imports/mocks Tone and has no raw-Web-Audio engine; assertions like `lastPeriodicWave` and `created.oscillators` won't be satisfied.
+
+- [ ] **Step 3: Rewrite `src/core/audio.ts`**
+
+Overwrite `src/core/audio.ts` entirely with:
+
+```ts
+/**
+ * GuitarSynth: a small raw-Web-Audio plucked-string voice on its OWN
+ * AudioContext.
+ *
+ * The guitar is a fire-and-forget, tap-to-play instrument. It deliberately does
+ * NOT use Tone.js: Tone is a sequencing/transport framework whose single global
+ * context the progression engine rebinds via Tone.setContext(), which would
+ * orphan a Tone-based guitar on a stale context. Owning a private AudioContext
+ * keeps the guitar completely decoupled from the progression — there is no
+ * shared global to fight over.
+ *
+ * Signal graph:
+ *   [per-note] OscillatorNode(periodicWave) -> GainNode(ADSR envelope)
+ *                                                 |
+ *   [shared]   ------------------------------------+--> BiquadFilter(lowpass)
+ *                                                        -> GainNode(master) -> destination
+ *
+ * Public API (preserved verbatim so callers — lazyGuitarAudio.ts, App.tsx —
+ * keep working):
+ *   - init(): void
+ *   - resume(): Promise<void>
+ *   - setMute(mute: boolean): void
+ *   - playNote(frequency: number): Promise<void>
+ *   - onError?: (message: string) => void
+ *   - onOutputWedged?: () => void
+ */
+import { markAudioActivity, registerAudioContext } from "./audioIdleSuspend";
+import { probeOutputHealth } from "./audioOutputHealth";
+
+const AUDIO_CONFIG = {
+  /** Master volume in linear gain. */
+  MASTER_GAIN: 0.5,
+
+  /** Quick attack, fast decay for percussive picked-note feel. */
+  ATTACK_TIME: 0.006,
+  DECAY_TIME: 0.55,
+  SUSTAIN: 0.02,
+  RELEASE_TIME: 0.3,
+
+  /** Single-note duration before the release stage begins (seconds). */
+  NOTE_DURATION: 0.5,
+
+  /** Lowpass filter — high enough to stay transparent. */
+  FILTER_FREQ: 10000,
+  FILTER_Q: 0.1,
+
+  /** Glide time when ramping master volume to/from mute (seconds). */
+  MUTE_TRANSITION_TIME: 0.02,
+
+  /** Hard cap on concurrent voices. */
+  MAX_POLYPHONY: 12,
+} as const;
+
+/**
+ * Sine-harmonic amplitudes of the plucked-string timbre. Index i is the
+ * (i+1)th harmonic; element 0 of the periodic-wave imag array is the DC term
+ * and stays 0. Matches the prior Tone "custom" oscillator partials exactly.
+ */
+const PARTIALS = [1, 0.8, 0.45, 0.22, 0.12, 0.05] as const;
+
+/** Smallest gain value usable as an exponential-ramp target (0 is illegal). */
+const NEAR_ZERO = 0.0001;
+
+/** Single source of truth for the "audio blocked" toast copy. */
+const AUDIO_BLOCKED_MESSAGE =
+  "Audio could not be started. Try tapping the screen or interacting with the page.";
+
+function getAudioContextConstructor(): (new () => AudioContext) | undefined {
+  if (typeof window === "undefined") return undefined;
+  const w = window as Window & {
+    AudioContext?: new () => AudioContext;
+    webkitAudioContext?: new () => AudioContext;
+  };
+  return w.AudioContext ?? w.webkitAudioContext;
+}
+
+class GuitarSynth {
+  private ctx: AudioContext | null = null;
+  private masterGain: GainNode | null = null;
+  private filter: BiquadFilterNode | null = null;
+  private wave: PeriodicWave | null = null;
+  private activeVoices = 0;
+  private isMuted = false;
+  private unsupported = false;
+  private wedgeProbeInFlight = false;
+  onError?: (message: string) => void;
+  /** Called when a played note reveals the Safari dead-output wedge. */
+  onOutputWedged?: () => void;
+
+  init(): void {
+    if (this.unsupported || this.ctx) return;
+
+    const Ctor = getAudioContextConstructor();
+    if (!Ctor) {
+      this.unsupported = true;
+      return;
+    }
+
+    try {
+      this.ctx = new Ctor();
+
+      // Master volume — ramped to mute/unmute — straight to destination.
+      this.masterGain = this.ctx.createGain();
+      this.masterGain.gain.value = this.isMuted ? 0 : AUDIO_CONFIG.MASTER_GAIN;
+      this.masterGain.connect(this.ctx.destination);
+
+      // Fixed lowpass; a deliberate simplification of the old per-note sweep.
+      this.filter = this.ctx.createBiquadFilter();
+      this.filter.type = "lowpass";
+      this.filter.frequency.value = AUDIO_CONFIG.FILTER_FREQ;
+      this.filter.Q.value = AUDIO_CONFIG.FILTER_Q;
+      this.filter.connect(this.masterGain);
+
+      // Additive partials baked into one PeriodicWave reused by every voice.
+      const imag = new Float32Array([0, ...PARTIALS]);
+      const real = new Float32Array(imag.length);
+      this.wave = this.ctx.createPeriodicWave(real, imag);
+
+      // Track this context for energy idle-suspend (own key; role "guitar").
+      registerAudioContext(this.ctx, "guitar");
+    } catch (e) {
+      this.unsupported = true;
+      this.ctx = null;
+      this.masterGain = null;
+      this.filter = null;
+      this.wave = null;
+      console.warn("GuitarSynth init failed:", e);
+    }
+  }
+
+  async resume(): Promise<void> {
+    this.init();
+    if (this.unsupported || !this.ctx) return;
+    try {
+      if (this.ctx.state !== "running") await this.ctx.resume();
+    } catch (e) {
+      console.warn("Guitar context resume failed:", e);
+      this.onError?.(AUDIO_BLOCKED_MESSAGE);
+    }
+  }
+
+  setMute(mute: boolean): void {
+    this.isMuted = mute;
+    if (this.masterGain && this.ctx) {
+      const target = mute ? 0 : AUDIO_CONFIG.MASTER_GAIN;
+      const now = this.ctx.currentTime;
+      // Click-free transition equivalent to the old rampTo smoothing.
+      this.masterGain.gain.cancelScheduledValues(now);
+      this.masterGain.gain.setValueAtTime(this.masterGain.gain.value, now);
+      this.masterGain.gain.linearRampToValueAtTime(target, now + AUDIO_CONFIG.MUTE_TRANSITION_TIME);
+    }
+    // Unmute is *usually* a user gesture, but this effect also fires on initial
+    // mount (isMutedAtom defaults to false). Skip the opportunistic resume when
+    // the context hasn't been unlocked yet — otherwise resume() runs without a
+    // gesture and Safari/iOS rejects it. App.tsx's pointerdown handler performs
+    // the real first-gesture resume.
+    if (!mute && this.contextUnlocked()) {
+      void this.resume();
+    }
+  }
+
+  private contextUnlocked(): boolean {
+    return this.ctx != null && this.ctx.state !== "suspended";
+  }
+
+  async playNote(frequency: number): Promise<void> {
+    if (this.isMuted) return;
+    this.init();
+    if (this.unsupported || !this.ctx || !this.masterGain || !this.filter || !this.wave) return;
+
+    // Returning from idle-suspend: resume our OWN context. Active tapping keeps
+    // it running (markAudioActivity reschedules the idle timer), so this only
+    // pays latency on the first tap after a long idle.
+    if (this.ctx.state !== "running") {
+      try {
+        await this.ctx.resume();
+      } catch (e) {
+        console.warn("Guitar context resume failed in playNote:", e);
+        this.onError?.(AUDIO_BLOCKED_MESSAGE);
+        return;
+      }
+    }
+
+    markAudioActivity();
+
+    if (this.activeVoices >= AUDIO_CONFIG.MAX_POLYPHONY) {
+      // Matches the old PolySynth-throws-and-we-swallow behavior.
+      console.warn("GuitarSynth.playNote skipped: max polyphony reached");
+      return;
+    }
+
+    try {
+      const { ATTACK_TIME, DECAY_TIME, SUSTAIN, RELEASE_TIME, NOTE_DURATION } = AUDIO_CONFIG;
+      // Schedule from currentTime — zero lookahead, so a tap sounds instantly.
+      const t0 = this.ctx.currentTime;
+
+      const osc = this.ctx.createOscillator();
+      osc.setPeriodicWave(this.wave);
+      osc.frequency.setValueAtTime(frequency, t0);
+
+      const env = this.ctx.createGain();
+      // ADSR: attack → decay-to-sustain → release tail. Exponential ramps need
+      // a strictly-positive target, hence NEAR_ZERO.
+      env.gain.setValueAtTime(NEAR_ZERO, t0);
+      env.gain.linearRampToValueAtTime(1, t0 + ATTACK_TIME);
+      env.gain.exponentialRampToValueAtTime(
+        Math.max(SUSTAIN, NEAR_ZERO),
+        t0 + ATTACK_TIME + DECAY_TIME,
+      );
+      const releaseEnd = t0 + NOTE_DURATION + RELEASE_TIME;
+      env.gain.exponentialRampToValueAtTime(NEAR_ZERO, releaseEnd);
+      env.gain.setValueAtTime(0, releaseEnd + 0.001);
+
+      osc.connect(env);
+      env.connect(this.filter);
+
+      const stopAt = releaseEnd + 0.02;
+      osc.start(t0);
+      osc.stop(stopAt);
+
+      this.activeVoices += 1;
+      osc.onended = () => {
+        this.activeVoices = Math.max(0, this.activeVoices - 1);
+        try {
+          osc.disconnect();
+        } catch {
+          /* already disconnected */
+        }
+        try {
+          env.disconnect();
+        } catch {
+          /* already disconnected */
+        }
+      };
+
+      this.checkOutputAfterPlay();
+    } catch (e) {
+      console.warn("GuitarSynth.playNote failed:", e);
+    }
+  }
+
+  /**
+   * After a note is triggered, verify it actually reached the hardware. On
+   * Safari the context can report "running" while output is dead (see
+   * audioOutputHealth). Fire-and-forget, de-duped so rapid taps run one probe.
+   * Probes THIS synth's own context.
+   */
+  private checkOutputAfterPlay(): void {
+    if (this.wedgeProbeInFlight || !this.onOutputWedged || !this.ctx) return;
+    this.wedgeProbeInFlight = true;
+    void probeOutputHealth(this.ctx)
+      .then((health) => {
+        if (health === "wedged") this.onOutputWedged?.();
+      })
+      .catch(() => {})
+      .finally(() => {
+        this.wedgeProbeInFlight = false;
+      });
+  }
+}
+
+export const synth = new GuitarSynth();
+
+/**
+ * Test-only hook: reset internal state on the singleton so tests can
+ * re-exercise init/playNote/setMute paths. Not part of the public runtime API.
+ */
+export function __resetSynthForTests(): void {
+  const s = synth as unknown as {
+    ctx: unknown;
+    masterGain: unknown;
+    filter: unknown;
+    wave: unknown;
+    activeVoices: number;
+    isMuted: boolean;
+    unsupported: boolean;
+    wedgeProbeInFlight: boolean;
+    onError: undefined;
+    onOutputWedged: undefined;
+  };
+  s.ctx = null;
+  s.masterGain = null;
+  s.filter = null;
+  s.wave = null;
+  s.activeVoices = 0;
+  s.isMuted = false;
+  s.unsupported = false;
+  s.wedgeProbeInFlight = false;
+  s.onError = undefined;
+  s.onOutputWedged = undefined;
+}
+```
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `pnpm exec vitest run src/core/audio.test.ts`
+Expected: PASS — all tests in the rewritten suite.
+
+- [ ] **Step 5: Run the full audio-related suite to catch cross-module breakage**
+
+Run: `pnpm exec vitest run src/core/audio.test.ts src/core/audioIdleSuspend.test.ts src/core/audioOutputHealth.test.ts src/App.test.tsx src/integration.test.tsx`
+Expected: PASS. `App.test.tsx` and `integration.test.tsx` mock `./core/lazyGuitarAudio`, so they never load `audio.ts` and should be unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/audio.ts src/core/audio.test.ts
+git commit -m "feat(audio): run the guitar synth on its own raw-Web-Audio context
+
+The guitar no longer rides Tone's global context. Reimplemented as a small
+raw-Web-Audio voice engine (oscillator + ADSR gain + lowpass) on a private
+AudioContext, so Tone.setContext() from the progression engine can never orphan
+it. Public API unchanged."
+```
+
+---
+
+## Task 4: Full verification gate + manual timbre/recovery check
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm no other module imports the removed Tone surface from `audio.ts`**
+
+Run: `grep -rn "from \"\.\./core/audio\"\|from \"\./audio\"\|core/audio'" src --include="*.ts" --include="*.tsx" | grep -v "\.test\." | grep -v lazyGuitarAudio`
+Expected: no matches (only `lazyGuitarAudio.ts` consumes `audio.ts`). If anything else appears, inspect it — the public API is unchanged so it should still compile, but verify.
+
+- [ ] **Step 2: Lint**
+
+Run: `pnpm run lint`
+Expected: clean (one pre-existing unrelated warning in `useFretboardTopologyModel.ts` is acceptable; no new warnings in `src/core/audio*`).
+
+- [ ] **Step 3: Full test suite**
+
+Run: `pnpm run test`
+Expected: all green (the suite was at 2557 passing before this work).
+
+- [ ] **Step 4: Production build**
+
+Run: `pnpm run build`
+Expected: `tsc -b` + `vite build` succeed with no type errors.
+
+- [ ] **Step 5: Manual verification in production preview (by ear — the decisive test)**
+
+Run: `pnpm run preview:prod`, open the served URL, then verify:
+  1. **Timbre A/B:** tap fretboard notes; compare against deployed v2.6.4. If the decay/release sounds off (Tone used exponential envelope curves), the ramp targets in `playNote` are the tuning point — confirm the exponential ramps match the deployed feel.
+  2. **Core regression (the bug this fixes):** play a progression to the end (or stop it), then tap the fretboard → **guitar sound plays**. This is the post-progression silence that the context split eliminates.
+  3. **Idle resume:** leave the tab idle > 30s (idle-suspend fires), then tap → first tap resumes the guitar context and plays.
+  4. **Mute/unmute:** toggle mute; taps are silenced and restored without clicks.
+
+- [ ] **Step 6: Remove any temporary instrumentation**
+
+If any `console.log`/debug probes were added during tuning, remove them. Re-run `pnpm run lint && pnpm run test` to confirm still green.
+
+- [ ] **Step 7: Final commit (only if Step 5 required envelope tuning or Step 6 removed instrumentation)**
+
+```bash
+git add src/core/audio.ts
+git commit -m "fix(audio): tune guitar envelope curves to match v2.6.4 timbre"
+```
+
+(If no tuning or cleanup was needed, skip this commit.)
+
+---
+
+## Notes for the implementer
+
+- **Why no `toneInit`/`Tone.start()` in the guitar path anymore:** the guitar owns its context and resumes it directly (`ctx.resume()`). `Tone.start()` resumes the *global* (progression) context — irrelevant to the guitar now. The progression keeps using `ensureToneStarted()` unchanged.
+- **Voice cleanup depends on `onended`:** real browsers fire `OscillatorNode.onended` after `stop()`. The fake in the test never fires it automatically, which is why the polyphony-cap test can hold 12 live voices and the "frees a voice" test fires it manually.
+- **Exponential ramps cannot target 0** — that is why `NEAR_ZERO` (0.0001) is used and a final `setValueAtTime(0, ...)` snaps to true silence.
+- **`createPeriodicWave` normalization** is left at the browser default (enabled). `masterGain` (0.5) sets the operating level; adjust by ear in Task 4 Step 5 if needed.

--- a/docs/superpowers/specs/2026-06-09-separate-audio-contexts-design.md
+++ b/docs/superpowers/specs/2026-06-09-separate-audio-contexts-design.md
@@ -1,0 +1,193 @@
+# Separate the guitar and progression onto two independent AudioContexts
+
+> Status: approved design, pending implementation plan.
+> Date: 2026-06-09.
+
+## Problem
+
+Every guitar-audio bug investigated this session traces back to a single
+architectural flaw: **the guitar synth and the progression engine share Tone's
+one global `AudioContext`, and the progression hijacks it.**
+
+Current arrangement:
+
+- **Guitar** (`src/core/audio.ts`) builds a `Tone.PolySynth` with **no explicit
+  context**, so it binds to Tone's auto-created **global/default** context.
+- **Progression** (`src/progressions/audio/bus.ts`) creates its **own**
+  `new AudioContext()`, then `bindToneToProgressionContext()`
+  (`src/progressions/audio/toneBus.ts`) calls `Tone.setContext(progressionCtx)`.
+  This is a **process-wide** mutation so that Tone's sequencer, `Transport`,
+  `Draw`, and `Tone.now()` clock-sync with the progression's context — which the
+  progression genuinely needs.
+
+The flaw: `Tone.setContext()` swaps (and, per its `disposeOld` argument, can
+dispose) the **global** context out from under the guitar's already-constructed
+nodes. After a progression plays, the guitar is orphaned on a stale context.
+Observed symptoms across the session: a fixed ~100ms per-tap lookahead delay,
+post-progression fretboard silence, a clock mismatch between the synth's context
+and the global one, and a "sticky progression role" workaround in
+`audioIdleSuspend.ts` that exists only to paper over the shared-key collision.
+
+## Goal
+
+Give the guitar an `AudioContext` it **owns** and that `Tone.setContext()` can
+**never touch**, leaving the global Tone context entirely to the progression.
+Two genuinely independent contexts, neither aware of the other.
+
+## Chosen approach: guitar off Tone entirely (raw Web Audio)
+
+The guitar is a fire-and-forget, tap-to-play instrument: an oscillator, an
+amplitude envelope, a lowpass filter, `start`/`stop`. It needs none of Tone's
+sequencing/transport machinery. We reimplement its voice in **raw Web Audio on
+its own dedicated context**. The progression keeps Tone and the global context,
+unchanged.
+
+This was preferred over the lower-risk alternative (keep the existing
+`Tone.PolySynth` but bind it to a dedicated `Tone.Context` via the per-node
+`{ context }` option) because it is the better end-state regardless of risk:
+
+1. **The guitar does not need Tone.** Tone is a sequencing framework; the
+   guitar is a one-shot instrument that uses Tone only for voice allocation and
+   pays for it with global-context coupling.
+2. **It deletes the bug class rather than containing it.** With no shared global
+   context, the orphaning, lookahead delay, `setContext` hijack, sticky-role
+   hack, and post-progression silence cannot recur — there is no global to fight
+   over.
+3. **It is the right tool, and a return rather than an invention.** The guitar
+   was hand-rolled Web Audio before the Tone migration; raw Web Audio is the
+   lower-latency, fewer-moving-parts path for a tap instrument.
+
+The one real cost — reproducing the timbre — is bounded because the recipe is
+exact (see below), not guesswork.
+
+## Architecture
+
+| | Guitar | Progression |
+|---|---|---|
+| Context | own `AudioContext`, created + owned by `audio.ts` | own `AudioContext` (`bus.ts`), unchanged |
+| Framework | none — raw Web Audio | Tone.js (global context, unchanged) |
+| `Tone.setContext` | never touches it | still binds the progression context globally |
+| Scheduling | `ctx.currentTime` (zero lookahead) | Tone lookahead (unchanged) |
+
+`audio.ts`'s public API stays byte-identical — `init()`, `resume()`,
+`setMute()`, `playNote()`, `onError`, `onOutputWedged` — so `lazyGuitarAudio.ts`,
+`App.tsx`, and every caller are untouched. Only the internals change.
+
+## Voice engine (inside `audio.ts`)
+
+Persistent (shared) nodes built once in `init()`; transient (per-note) nodes
+created per tap.
+
+Signal graph:
+
+```
+[per-note] OscillatorNode(periodicWave) -> GainNode(envelope)
+                                              |
+[shared]   -----------------------------------+--> BiquadFilter(lowpass) -> GainNode(master) -> ctx.destination
+```
+
+Shared nodes (built once):
+
+- `masterGain`: `.gain = 0.5` (the old `MASTER_GAIN`). Mute ramps the gain to `0`
+  / `0.5` over `0.02s`.
+- `filter`: `BiquadFilterNode`, lowpass, `frequency 10000`, `Q 0.1`.
+- `wave`: `ctx.createPeriodicWave(real, imag)` once, where
+  `imag = [0, 1, 0.8, 0.45, 0.22, 0.12, 0.05]` and `real` is the same-length zero
+  array. DC term (index 0) is `0`; the partials become the sine-harmonic
+  amplitudes, matching Tone's `oscillator.type = "custom"` semantics.
+
+Per-note (`playNote(f)`): an `OscillatorNode` with `setPeriodicWave(wave)`,
+`frequency = f` at `t0 = ctx.currentTime` (zero lookahead → instant tap),
+feeding a fresh envelope `GainNode`. ADSR scheduled to match Tone's `Synth`
+envelope:
+
+- attack: `0 -> 1` over `0.006s`
+- decay: `1 -> 0.02` (sustain level) over `0.55s`
+- release: at `t0 + 0.5` (NOTE_DURATION), ramp toward `0` over `0.3s`
+- `osc.stop(t0 + 0.5 + 0.3 + epsilon)`; `onended` disconnects both transient
+  nodes.
+
+Polyphony: an active-voice counter capped at **12** (the old `MAX_POLYPHONY`).
+At the cap, skip the new note and `console.warn` — matching today's behavior
+where `PolySynth` throws past `maxPolyphony` and we swallow it.
+
+Lifecycle (public API preserved):
+
+- `init()`: lazily build the guitar `AudioContext` (`AudioContext ??
+  webkitAudioContext`) plus the shared nodes and wave, then
+  `registerAudioContext(guitarCtx, "guitar")`. Set `unsupported = true` on
+  failure.
+- `resume()`: `init()` then `guitarCtx.resume()` — its own context, no
+  `Tone.start()`.
+- `playNote(f)`: if `ctx.state !== "running"`, `await ctx.resume()` first (this
+  only pays latency when returning from idle-suspend; active tapping keeps the
+  context running via `markAudioActivity()`), then schedule. Keep
+  `markAudioActivity()` and `checkOutputAfterPlay()`.
+- `setMute(mute)`: ramp the master gain; keep the `audioContextUnlocked()` gate
+  on the opportunistic resume so a mount-time `setMute(false)` does not try to
+  resume before a user gesture.
+
+Timbre note: the partial and envelope numbers are exact, but Tone's default
+decay/release *curves* are exponential. Match by ear in `preview:prod` against
+deployed v2.6.4 and adjust the curve type (linear vs. exponential ramp) if it is
+audibly off. This is the one by-ear step in the implementation.
+
+## File-by-file changes
+
+Core:
+
+- `src/core/audio.ts` — replace the Tone-based internals with the raw Web Audio
+  voice engine above. Remove `import * as Tone` and the `ensureToneStarted`
+  import. Add the private `ctx`, shared nodes, and per-note scheduler. Keep the
+  `registerAudioContext` / `markAudioActivity` / `checkOutputAfterPlay` calls.
+  `audioContextUnlocked()` now reads the guitar context's state.
+
+Knock-on simplifications (net deletions):
+
+- `src/core/audioIdleSuspend.ts` — delete the "sticky progression role" branch
+  in `registerAudioContext` (it returns early when the existing role is
+  `"progression"`); replace with a plain `contexts.set(ctx, role)`. With two
+  distinct context keys, role collision is impossible. Update the comment.
+- `src/core/audioOutputHealth.ts` — `probeOutputHealth(ctx?: AudioContext)`:
+  default to the Tone global (progression) context; the guitar passes its own
+  context so its wedge check probes its actual output.
+
+Unchanged: `src/progressions/audio/bus.ts`, `src/progressions/audio/toneBus.ts`,
+`src/core/toneInit.ts` (progression keeps the global Tone context),
+`src/store/audioAtoms.ts`, `src/App.tsx`, `src/core/lazyGuitarAudio.ts`.
+
+Tests:
+
+- `src/core/audio.test.ts` — substantial rewrite. Drop `vi.mock("tone")` and
+  `vi.mock("./toneInit")`. Add a small fake `AudioContext` (jsdom has none)
+  exposing `createOscillator`, `createGain`, `createBiquadFilter`,
+  `createPeriodicWave`, `destination`, `currentTime`, `state`, `resume`. Assert:
+  shared-node construction; `createPeriodicWave` imag equals
+  `[0, 1, 0.8, 0.45, 0.22, 0.12, 0.05]`; per-tap oscillator gets the wave +
+  frequency + `start`/`stop`; envelope ramps; graph wiring; mute ramp; the
+  12-voice cap skips; the unsupported path; `resume()` calls `ctx.resume()`.
+- `src/core/audioIdleSuspend.test.ts` — remove the now-obsolete
+  sticky-progression test; keep the role and `IDLE_SUSPEND_MS` tests.
+- `src/core/audioOutputHealth.test.ts` — add an explicit-context case; keep the
+  default-global case.
+- `src/App.test.tsx` and `src/integration.test.tsx` — unchanged; they mock
+  `./core/lazyGuitarAudio` and never touch `audio.ts` internals.
+
+## Verification
+
+1. `pnpm run lint`, `pnpm run test`, `pnpm run build` all green.
+2. `preview:prod`, by ear:
+   - A/B the guitar timbre against deployed v2.6.4 (tune the envelope curve if
+     needed).
+   - Core regression: play a progression, then tap the fretboard — sound
+     recovers (this is the bug the split fixes).
+   - Idle 30s, then tap — the guitar context resumes and plays.
+   - Mute / unmute behaves as before.
+3. Remove any temporary instrumentation before finishing.
+
+## Non-goals
+
+- No change to the progression engine, its context, or its Tone usage.
+- No change to the guitar's public API or to any caller.
+- No new AudioContext-recreation "recovery" logic (the existing Safari
+  wedge-detection banner work is separate and unaffected).

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -65,6 +65,7 @@ vi.mock("./components/FingeringPatternControls/FingeringPatternControls", async 
 vi.mock("./core/lazyGuitarAudio", () => ({
   setGuitarMutePreference: vi.fn(),
   setGuitarAudioErrorHandler: vi.fn(),
+  setGuitarOutputWedgedHandler: vi.fn(),
   resumeGuitarAudio: vi.fn(),
   playGuitarNote: vi.fn(),
   prefetchAudioModule: vi.fn(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,9 +101,11 @@ function AppContent() {
     const onDeviceChange = () => {
       clearTimeout(settleTimer);
       settleTimer = setTimeout(() => {
-        void probeOutputHealth().then((health) => {
-          if (health === "wedged") setAudioOutputWedged(true);
-        });
+        void probeOutputHealth()
+          .then((health) => {
+            if (health === "wedged") setAudioOutputWedged(true);
+          })
+          .catch(() => {});
       }, 600);
     };
     md.addEventListener("devicechange", onDeviceChange);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,10 +7,12 @@ import { HelpCircle, Moon, Settings2, Sun, Volume2, VolumeX } from "lucide-react
 import {
   resumeGuitarAudio,
   setGuitarAudioErrorHandler,
+  setGuitarOutputWedgedHandler,
   setGuitarMutePreference,
   prefetchAudioModule,
 } from "./core/lazyGuitarAudio";
-import { isMutedAtom, toggleMuteAtom, audioErrorAtom } from "./store/audioAtoms";
+import { probeOutputHealth } from "./core/audioOutputHealth";
+import { isMutedAtom, toggleMuteAtom, audioErrorAtom, audioOutputWedgedAtom } from "./store/audioAtoms";
 import { chordTypeAtom } from "./store/chordOverlayAtoms";
 import { settingsOverlayOpenAtom, themeAtom } from "./store/uiAtoms";
 import audioErrorStyles from "./components/AudioErrorBanner/AudioErrorBanner.module.css";
@@ -54,6 +56,7 @@ function AppContent() {
   const setSettingsOverlayOpen = useSetAtom(settingsOverlayOpenAtom);
   const toggleMute = useSetAtom(toggleMuteAtom);
   const [audioError, setAudioError] = useAtom(audioErrorAtom);
+  const [audioOutputWedged, setAudioOutputWedged] = useAtom(audioOutputWedgedAtom);
   const setTheme = useSetAtom(themeAtom);
 
   const [showHelp, setShowHelp] = useState(false);
@@ -77,6 +80,38 @@ function AppContent() {
       setGuitarAudioErrorHandler(undefined);
     };
   }, [setAudioError]);
+
+  // Safari "dead Web Audio output" wedge: a played note can reveal that the
+  // context is running but no sound reaches the speakers (see
+  // core/audioOutputHealth). It survives reload — only a full browser restart
+  // recovers it — so we surface a guidance banner rather than fail silently.
+  useEffect(() => {
+    setGuitarOutputWedgedHandler(() => setAudioOutputWedged(true));
+    return () => {
+      setGuitarOutputWedgedHandler(undefined);
+    };
+  }, [setAudioOutputWedged]);
+
+  // An output-device change (e.g. AirPods handing off phone → Mac) is a prime
+  // trigger for the wedge. Probe after a settle delay; flag it if output is dead.
+  useEffect(() => {
+    const md = navigator.mediaDevices;
+    if (!md?.addEventListener) return;
+    let settleTimer: ReturnType<typeof setTimeout> | undefined;
+    const onDeviceChange = () => {
+      clearTimeout(settleTimer);
+      settleTimer = setTimeout(() => {
+        void probeOutputHealth().then((health) => {
+          if (health === "wedged") setAudioOutputWedged(true);
+        });
+      }, 600);
+    };
+    md.addEventListener("devicechange", onDeviceChange);
+    return () => {
+      clearTimeout(settleTimer);
+      md.removeEventListener("devicechange", onDeviceChange);
+    };
+  }, [setAudioOutputWedged]);
 
   useEffect(() => {
     const prefetchAll = () => {
@@ -250,6 +285,19 @@ function AppContent() {
           type="button"
           className={audioErrorStyles.dismiss}
           onClick={() => setAudioError(null)}
+          aria-label={t("common.dismiss")}
+        >
+          {t("common.dismiss")}
+        </button>
+      </div>
+    )}
+    {audioOutputWedged && (
+      <div role="alert" className={audioErrorStyles.banner}>
+        <span className={audioErrorStyles.message}>{t("common.audioOutputWedged")}</span>
+        <button
+          type="button"
+          className={audioErrorStyles.dismiss}
+          onClick={() => setAudioOutputWedged(false)}
           aria-label={t("common.dismiss")}
         >
           {t("common.dismiss")}

--- a/src/components/TransportBar/TransportBar.module.css
+++ b/src/components/TransportBar/TransportBar.module.css
@@ -95,6 +95,12 @@
   animation: transport-spin 0.7s linear infinite;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .spinIcon {
+    animation: none;
+  }
+}
+
 @keyframes transport-spin {
   to { transform: rotate(360deg); }
 }

--- a/src/components/TransportBar/TransportBar.module.css
+++ b/src/components/TransportBar/TransportBar.module.css
@@ -91,6 +91,14 @@
   color: var(--track-accent);
 }
 
+.spinIcon {
+  animation: transport-spin 0.7s linear infinite;
+}
+
+@keyframes transport-spin {
+  to { transform: rotate(360deg); }
+}
+
 /* Mobile tier: grow the transport / instrument touch targets up to the shared
    control-height token so the play, stop, loop and instrument buttons are
    comfortably tappable on phones. */

--- a/src/components/TransportBar/TransportBar.tsx
+++ b/src/components/TransportBar/TransportBar.tsx
@@ -3,6 +3,7 @@ import {
   AudioWaveform,
   Drum,
   Guitar,
+  LoaderCircle,
   Play,
   Repeat,
   Square,
@@ -85,7 +86,9 @@ export function TransportBar() {
           aria-label={playStopLabel}
           aria-busy={progressionPlaybackLoading || undefined}
         >
-          {playStopIsPlaying ? (
+          {progressionPlaybackLoading && playStopIsPlaying ? (
+            <LoaderCircle size={14} strokeWidth={2.4} aria-hidden="true" className={styles.spinIcon} />
+          ) : playStopIsPlaying ? (
             <Square size={14} strokeWidth={2.4} aria-hidden="true" fill="currentColor" />
           ) : (
             <Play size={14} strokeWidth={2.4} aria-hidden="true" fill="currentColor" />

--- a/src/core/audio.test.ts
+++ b/src/core/audio.test.ts
@@ -1,212 +1,195 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// jsdom has no real AudioContext, so mock the slice of `tone` we touch.
-// PolySynth/Filter/Volume are exposed as constructor spies whose instances
-// we can inspect after each call.
-const mocks = vi.hoisted(() => {
-  const ensureStartedMock = vi.fn(async () => {});
-
-  // Mirror the toneInit test's getContext stub so we can flip the
-  // AudioContext state from tests and exercise the suspended-vs-unlocked
-  // gate in setMute(false).
-  const contextState = {
-    value: "running" as "suspended" | "running" | "interrupted" | "closed",
-  };
-  const getContextMock = vi.fn(() => ({
-    get state() {
-      return contextState.value;
-    },
-    // `playNote` registers rawContext for idle-suspend and schedules notes
-    // at immediate() (== currentTime, no lookAhead) for zero-latency taps.
-    rawContext: {
-      get state() {
-        return contextState.value;
-      },
-    },
-    immediate: () => 0,
-  }));
-
-  const triggerAttackRelease = vi.fn();
-  const polySynthInstances: any[] = [];
-  // Use `function` (not arrow) so the mock is constructable via `new`.
-  const PolySynth = vi.fn(function PolySynthMock() {
-    const instance = {
-      triggerAttackRelease,
-      // Notes schedule at the synth's own context time (no lookAhead, correct
-      // timeline after Tone.setContext). Mock returns a fixed 0.
-      immediate: vi.fn(() => 0),
-      connect: vi.fn().mockReturnThis(),
-      toDestination: vi.fn().mockReturnThis(),
-      dispose: vi.fn(),
-    };
-    polySynthInstances.push(instance);
-    return instance;
-  });
-
-  const filterInstances: any[] = [];
-  const Filter = vi.fn(function FilterMock() {
-    const instance = {
-      connect: vi.fn().mockReturnThis(),
-      toDestination: vi.fn().mockReturnThis(),
-      dispose: vi.fn(),
-    };
-    filterInstances.push(instance);
-    return instance;
-  });
-
-  const volumeInstances: any[] = [];
-  const Volume = vi.fn(function VolumeMock(initialDb: number) {
-    const volumeParam = {
-      value: initialDb,
-      rampTo: vi.fn(),
-    };
-    const instance = {
-      volume: volumeParam,
-      connect: vi.fn().mockReturnThis(),
-      toDestination: vi.fn().mockReturnThis(),
-      dispose: vi.fn(),
-    };
-    volumeInstances.push(instance);
-    return instance;
-  });
-
-  // Synth is just a class token passed to PolySynth — no behavior needed.
-  const Synth = vi.fn(function SynthMock() {});
-
-  return {
-    ensureStartedMock,
-    PolySynth,
-    Filter,
-    Volume,
-    Synth,
-    polySynthInstances,
-    filterInstances,
-    volumeInstances,
-    triggerAttackRelease,
-    contextState,
-    getContextMock,
-  };
-});
-
-vi.mock("tone", () => ({
-  PolySynth: mocks.PolySynth,
-  Synth: mocks.Synth,
-  Filter: mocks.Filter,
-  Volume: mocks.Volume,
-  getContext: mocks.getContextMock,
+// audio.ts no longer uses Tone — it owns a raw AudioContext. Mock the two side
+// modules so unit tests stay synchronous and timer-free, and install a fake
+// Web Audio API on window (jsdom has none).
+vi.mock("./audioIdleSuspend", () => ({
+  registerAudioContext: vi.fn(),
+  markAudioActivity: vi.fn(),
+}));
+vi.mock("./audioOutputHealth", () => ({
+  probeOutputHealth: vi.fn().mockResolvedValue("healthy"),
 }));
 
-vi.mock("./toneInit", () => ({
-  ensureToneStarted: mocks.ensureStartedMock,
-}));
+class FakeAudioParam {
+  value = 0;
+  setValueAtTime = vi.fn((v: number) => {
+    this.value = v;
+    return this;
+  });
+  linearRampToValueAtTime = vi.fn((v: number) => {
+    this.value = v;
+    return this;
+  });
+  exponentialRampToValueAtTime = vi.fn((v: number) => {
+    this.value = v;
+    return this;
+  });
+  cancelScheduledValues = vi.fn(() => this);
+}
+
+const created: { gains: any[]; filters: any[]; oscillators: any[] } = {
+  gains: [],
+  filters: [],
+  oscillators: [],
+};
+let lastPeriodicWave: { real: Float32Array; imag: Float32Array } | null = null;
+
+class FakeGain {
+  gain = new FakeAudioParam();
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+class FakeFilter {
+  type = "";
+  frequency = new FakeAudioParam();
+  Q = new FakeAudioParam();
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+class FakeOscillator {
+  frequency = new FakeAudioParam();
+  setPeriodicWave = vi.fn();
+  connect = vi.fn();
+  disconnect = vi.fn();
+  start = vi.fn();
+  stop = vi.fn();
+  onended: (() => void) | null = null;
+}
+class FakeAudioContext {
+  state: AudioContextState = "running";
+  currentTime = 0;
+  destination = {};
+  resume = vi.fn(async () => {
+    this.state = "running";
+  });
+  createGain = vi.fn(() => {
+    const g = new FakeGain();
+    created.gains.push(g);
+    return g;
+  });
+  createBiquadFilter = vi.fn(() => {
+    const f = new FakeFilter();
+    created.filters.push(f);
+    return f;
+  });
+  createOscillator = vi.fn(() => {
+    const o = new FakeOscillator();
+    created.oscillators.push(o);
+    return o;
+  });
+  createPeriodicWave = vi.fn((real: Float32Array, imag: Float32Array) => {
+    lastPeriodicWave = { real, imag };
+    return { real, imag } as unknown as PeriodicWave;
+  });
+}
+
+let ctorState: AudioContextState = "running";
+let resumeRejects = false;
 
 import { __resetSynthForTests, synth } from "./audio";
 
 beforeEach(() => {
-  mocks.PolySynth.mockClear();
-  mocks.Filter.mockClear();
-  mocks.Volume.mockClear();
-  mocks.triggerAttackRelease.mockClear();
-  mocks.ensureStartedMock.mockClear();
-  mocks.getContextMock.mockClear();
-  mocks.polySynthInstances.length = 0;
-  mocks.filterInstances.length = 0;
-  mocks.volumeInstances.length = 0;
-  // Default to "running" so existing tests that don't care about the
-  // gesture gate keep the previous behavior; the regression test below
-  // flips this to "suspended" explicitly.
-  mocks.contextState.value = "running";
+  created.gains.length = 0;
+  created.filters.length = 0;
+  created.oscillators.length = 0;
+  lastPeriodicWave = null;
+  ctorState = "running";
+  resumeRejects = false;
+
+  (window as any).AudioContext = vi.fn(function FakeCtor() {
+    const ctx = new FakeAudioContext();
+    ctx.state = ctorState;
+    if (resumeRejects) {
+      ctx.resume = vi.fn(async () => {
+        throw new Error("blocked");
+      });
+    }
+    return ctx;
+  });
+  (window as any).webkitAudioContext = undefined;
+
   __resetSynthForTests();
 });
 
-describe("GuitarSynth (Tone-backed)", () => {
+describe("GuitarSynth (raw Web Audio)", () => {
   describe("init", () => {
-    it("constructs a PolySynth, Filter, and Volume on first call", () => {
+    it("builds master gain, lowpass filter, and the partials periodic wave", () => {
       synth.init();
-      expect(mocks.PolySynth).toHaveBeenCalledTimes(1);
-      expect(mocks.Filter).toHaveBeenCalledTimes(1);
-      expect(mocks.Volume).toHaveBeenCalledTimes(1);
+      expect(created.gains.length).toBe(1);
+      expect(created.filters.length).toBe(1);
+      const filter = created.filters[0];
+      expect(filter.type).toBe("lowpass");
+      expect(filter.frequency.value).toBe(10000);
+      expect(filter.Q.value).toBeCloseTo(0.1);
+      expect(lastPeriodicWave).not.toBeNull();
+      expect(Array.from(lastPeriodicWave!.imag)).toEqual([0, 1, 0.8, 0.45, 0.22, 0.12, 0.05]);
+      expect(Array.from(lastPeriodicWave!.real)).toEqual([0, 0, 0, 0, 0, 0, 0]);
     });
 
     it("is idempotent on subsequent calls", () => {
       synth.init();
       synth.init();
       synth.init();
-      expect(mocks.PolySynth).toHaveBeenCalledTimes(1);
-      expect(mocks.Filter).toHaveBeenCalledTimes(1);
-      expect(mocks.Volume).toHaveBeenCalledTimes(1);
+      expect(created.filters.length).toBe(1);
     });
 
-    it("routes PolySynth -> Filter -> Volume -> destination", () => {
+    it("initializes master gain at 0.5 when unmuted", () => {
       synth.init();
-      const polySynth = mocks.polySynthInstances[0];
-      const filter = mocks.filterInstances[0];
-      const volume = mocks.volumeInstances[0];
-
-      // Volume is connected straight to destination.
-      expect(volume.toDestination).toHaveBeenCalledTimes(1);
-      // Filter routes into Volume; PolySynth routes into Filter.
-      expect(filter.connect).toHaveBeenCalledWith(volume);
-      expect(polySynth.connect).toHaveBeenCalledWith(filter);
-    });
-
-    it("locks the PolySynth timbre contract (partials + envelope + polyphony)", () => {
-      synth.init();
-      const opts = (mocks.PolySynth.mock.calls[0] as unknown as [
-        {
-          maxPolyphony: number;
-          options: {
-            oscillator: { type: string; partials: number[] };
-            envelope: { attack: number; decay: number; sustain: number; release: number };
-          };
-        },
-      ])[0];
-      expect(opts.maxPolyphony).toBe(12);
-      expect(opts.options.oscillator.type).toBe("custom");
-      expect(opts.options.oscillator.partials).toEqual([1, 0.8, 0.45, 0.22, 0.12, 0.05]);
-      expect(opts.options.envelope.attack).toBeCloseTo(0.006);
-      expect(opts.options.envelope.decay).toBeCloseTo(0.55);
-      expect(opts.options.envelope.sustain).toBeCloseTo(0.02);
-      expect(opts.options.envelope.release).toBeCloseTo(0.3);
-    });
-
-    it("initializes Volume at the master-gain dB (≈ -6.02 dB for 0.5 gain)", () => {
-      synth.init();
-      const initialDb = (mocks.Volume.mock.calls[0] as unknown as [number])[0];
-      // gainToDb(0.5) === 20 * log10(0.5) ≈ -6.0206
-      expect(initialDb).toBeCloseTo(-6.0206, 2);
+      expect(created.gains[0].gain.value).toBeCloseTo(0.5);
     });
   });
 
   describe("playNote", () => {
-    it("triggers the PolySynth with the requested frequency", async () => {
+    it("creates an oscillator with the periodic wave at the requested frequency", async () => {
       await synth.playNote(440);
-      expect(mocks.triggerAttackRelease).toHaveBeenCalledTimes(1);
-      expect(mocks.triggerAttackRelease.mock.calls[0][0]).toBe(440);
+      expect(created.oscillators.length).toBe(1);
+      const osc = created.oscillators[0];
+      expect(osc.setPeriodicWave).toHaveBeenCalledTimes(1);
+      expect(osc.frequency.setValueAtTime).toHaveBeenCalledWith(440, expect.any(Number));
+      expect(osc.start).toHaveBeenCalledTimes(1);
+      expect(osc.stop).toHaveBeenCalledTimes(1);
     });
 
-    it("schedules the note at the context's immediate() time, not the lookahead-delayed now()", async () => {
-      // Regression guard: triggering with no explicit time uses Tone.now()
-      // (== currentTime + lookAhead, ~100ms), an audible per-tap delay. The
-      // 3rd arg must be the immediate() time (mock returns 0).
+    it("schedules the attack ramp to full amplitude (no lookahead — uses currentTime)", async () => {
       await synth.playNote(440);
-      expect(mocks.triggerAttackRelease.mock.calls[0][2]).toBe(0);
-    });
-
-    it("ensures Tone has started before triggering", async () => {
-      await synth.playNote(220);
-      expect(mocks.ensureStartedMock).toHaveBeenCalled();
+      const env = created.gains[created.gains.length - 1];
+      expect(env.gain.linearRampToValueAtTime).toHaveBeenCalledWith(1, expect.any(Number));
     });
 
     it("auto-initializes if init() was not called first", async () => {
       await synth.playNote(110);
-      expect(mocks.PolySynth).toHaveBeenCalledTimes(1);
-      expect(mocks.triggerAttackRelease).toHaveBeenCalledTimes(1);
+      expect(created.filters.length).toBe(1);
+      expect(created.oscillators.length).toBe(1);
     });
 
-    it("invokes onError when ensureToneStarted rejects", async () => {
-      mocks.ensureStartedMock.mockRejectedValueOnce(new Error("blocked"));
+    it("caps concurrent voices at 12 (skips beyond the cap)", async () => {
+      for (let i = 0; i < 12; i++) await synth.playNote(220);
+      expect(created.oscillators.length).toBe(12);
+      await synth.playNote(220);
+      expect(created.oscillators.length).toBe(12);
+    });
+
+    it("frees a voice when its oscillator ends, allowing new notes", async () => {
+      for (let i = 0; i < 12; i++) await synth.playNote(220);
+      created.oscillators[0].onended?.();
+      await synth.playNote(220);
+      expect(created.oscillators.length).toBe(13);
+    });
+
+    it("resumes its own context before playing when not running", async () => {
+      ctorState = "suspended";
+      synth.init();
+      const ctx = (synth as any).ctx as FakeAudioContext;
+      await synth.playNote(440);
+      expect(ctx.resume).toHaveBeenCalled();
+      expect(created.oscillators.length).toBe(1);
+    });
+
+    it("invokes onError and plays nothing when resume rejects", async () => {
+      ctorState = "suspended";
+      resumeRejects = true;
       const onError = vi.fn();
       synth.onError = onError;
 
@@ -214,129 +197,75 @@ describe("GuitarSynth (Tone-backed)", () => {
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError.mock.calls[0][0]).toMatch(/audio could not be started/i);
-      expect(mocks.triggerAttackRelease).not.toHaveBeenCalled();
-
+      expect(created.oscillators.length).toBe(0);
       synth.onError = undefined;
     });
   });
 
   describe("setMute", () => {
-    it("ramps master volume down on mute", () => {
+    it("ramps master gain to 0 on mute", () => {
       synth.init();
-      const volume = mocks.volumeInstances[0];
-      volume.volume.rampTo.mockClear();
-
+      const master = created.gains[0];
+      master.gain.linearRampToValueAtTime.mockClear();
       synth.setMute(true);
-
-      expect(volume.volume.rampTo).toHaveBeenCalledTimes(1);
-      const [target] = volume.volume.rampTo.mock.calls[0];
-      expect(target).toBe(-Infinity);
+      expect(master.gain.linearRampToValueAtTime).toHaveBeenCalledWith(0, expect.any(Number));
     });
 
-    it("ramps master volume back up on unmute", () => {
+    it("ramps master gain back to 0.5 on unmute", () => {
       synth.init();
-      const volume = mocks.volumeInstances[0];
+      const master = created.gains[0];
       synth.setMute(true);
-      volume.volume.rampTo.mockClear();
-
+      master.gain.linearRampToValueAtTime.mockClear();
       synth.setMute(false);
-
-      expect(volume.volume.rampTo).toHaveBeenCalledTimes(1);
-      const [target] = volume.volume.rampTo.mock.calls[0];
-      // gainToDb(0.5) ≈ -6.0206 dB
-      expect(target).toBeCloseTo(-6.0206, 2);
+      expect(master.gain.linearRampToValueAtTime).toHaveBeenCalledWith(0.5, expect.any(Number));
     });
 
-    it("suppresses subsequent playNote calls while muted", async () => {
+    it("suppresses playNote while muted", async () => {
       synth.init();
       synth.setMute(true);
-      mocks.triggerAttackRelease.mockClear();
-
       await synth.playNote(440);
-
-      expect(mocks.triggerAttackRelease).not.toHaveBeenCalled();
+      expect(created.oscillators.length).toBe(0);
     });
 
-    it("allows playback after unmute", async () => {
+    it("does NOT resume when unmuting before a user gesture (context suspended)", () => {
+      ctorState = "suspended";
       synth.init();
-      synth.setMute(true);
+      const ctx = (synth as any).ctx as FakeAudioContext;
       synth.setMute(false);
-      mocks.triggerAttackRelease.mockClear();
-
-      await synth.playNote(440);
-
-      expect(mocks.triggerAttackRelease).toHaveBeenCalledTimes(1);
-    });
-
-    // Regression: App.tsx runs `synth.setMute(isMuted)` in a mount effect
-    // and `isMutedAtom` defaults to `false`. Before this gate, the unmute
-    // branch unconditionally invoked `resume()` -> `ensureToneStarted()` ->
-    // `Tone.start()`, which rejects on Safari/iOS when no user gesture
-    // has occurred and surfaces the "audio blocked" toast on every fresh
-    // page load. setMute(false) must be a no-op for Tone.start while the
-    // AudioContext is still suspended.
-    it("does NOT call Tone.start when unmuting before a user gesture (context suspended)", () => {
-      mocks.contextState.value = "suspended";
-      synth.init();
-      const volume = mocks.volumeInstances[0];
-      volume.volume.rampTo.mockClear();
-      mocks.ensureStartedMock.mockClear();
-
-      synth.setMute(false);
-
-      expect(mocks.ensureStartedMock).not.toHaveBeenCalled();
-      // The volume ramp still happens — only the gesture-dependent
-      // resume is suppressed.
-      expect(volume.volume.rampTo).toHaveBeenCalledTimes(1);
+      expect(ctx.resume).not.toHaveBeenCalled();
+      expect(created.gains[0].gain.linearRampToValueAtTime).toHaveBeenCalled();
     });
   });
 
   describe("resume", () => {
-    it("delegates to ensureToneStarted", async () => {
+    it("initializes lazily and resumes its own context", async () => {
+      ctorState = "suspended";
       await synth.resume();
-      expect(mocks.ensureStartedMock).toHaveBeenCalled();
+      const ctx = (synth as any).ctx as FakeAudioContext;
+      expect(created.filters.length).toBe(1);
+      expect(ctx.resume).toHaveBeenCalled();
     });
 
-    it("initializes lazily before starting Tone", async () => {
-      await synth.resume();
-      expect(mocks.PolySynth).toHaveBeenCalledTimes(1);
-    });
-
-    it("forwards failures via onError", async () => {
-      mocks.ensureStartedMock.mockRejectedValueOnce(new Error("blocked"));
+    it("forwards a resume failure via onError", async () => {
+      ctorState = "suspended";
+      resumeRejects = true;
       const onError = vi.fn();
       synth.onError = onError;
-
       await synth.resume();
-
       expect(onError).toHaveBeenCalledTimes(1);
       synth.onError = undefined;
     });
   });
 
   describe("graceful degradation", () => {
-    it("marks itself unsupported if Tone construction throws", () => {
-      mocks.PolySynth.mockImplementationOnce(() => {
-        throw new Error("no audio");
-      });
+    it("marks itself unsupported when no AudioContext constructor exists", async () => {
+      (window as any).AudioContext = undefined;
+      (window as any).webkitAudioContext = undefined;
+      __resetSynthForTests();
 
       synth.init();
-
-      // No further init attempts after marking unsupported.
-      synth.init();
-      expect(mocks.PolySynth).toHaveBeenCalledTimes(1);
-    });
-
-    it("playNote becomes a no-op when unsupported", async () => {
-      mocks.PolySynth.mockImplementationOnce(() => {
-        throw new Error("no audio");
-      });
-      synth.init();
-      mocks.ensureStartedMock.mockClear();
-
       await synth.playNote(440);
-
-      expect(mocks.triggerAttackRelease).not.toHaveBeenCalled();
+      expect(created.oscillators.length).toBe(0);
     });
   });
 });

--- a/src/core/audio.test.ts
+++ b/src/core/audio.test.ts
@@ -89,6 +89,9 @@ let ctorState: AudioContextState = "running";
 let resumeRejects = false;
 
 import { __resetSynthForTests, synth } from "./audio";
+import { probeOutputHealth } from "./audioOutputHealth";
+
+const probeMock = probeOutputHealth as unknown as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   created.gains.length = 0;
@@ -97,6 +100,8 @@ beforeEach(() => {
   lastPeriodicWave = null;
   ctorState = "running";
   resumeRejects = false;
+  probeMock.mockClear();
+  probeMock.mockResolvedValue("healthy");
 
   (window as any).AudioContext = vi.fn(function FakeCtor() {
     const ctx = new FakeAudioContext();
@@ -199,6 +204,53 @@ describe("GuitarSynth (raw Web Audio)", () => {
       expect(onError.mock.calls[0][0]).toMatch(/audio could not be started/i);
       expect(created.oscillators.length).toBe(0);
       synth.onError = undefined;
+    });
+  });
+
+  describe("output-health probe (Safari wedge signal)", () => {
+    it("fires onOutputWedged when the post-play probe reports a wedged context", async () => {
+      probeMock.mockResolvedValueOnce("wedged");
+      const onWedged = vi.fn();
+      synth.onOutputWedged = onWedged;
+
+      await synth.playNote(440);
+      await vi.waitFor(() => expect(onWedged).toHaveBeenCalledTimes(1));
+
+      // The probe runs against the guitar's own context, not the Tone global.
+      expect(probeMock).toHaveBeenCalledWith((synth as any).ctx);
+      synth.onOutputWedged = undefined;
+    });
+
+    it("does not fire onOutputWedged when the probe reports healthy", async () => {
+      const onWedged = vi.fn();
+      synth.onOutputWedged = onWedged;
+
+      await synth.playNote(440);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(onWedged).not.toHaveBeenCalled();
+      synth.onOutputWedged = undefined;
+    });
+
+    it("de-dupes the probe while one is already in flight", async () => {
+      // Hold the first probe pending so the second tap sees it in-flight.
+      let release!: (h: string) => void;
+      probeMock.mockReturnValueOnce(new Promise<string>((r) => (release = r)));
+      synth.onOutputWedged = vi.fn();
+
+      await synth.playNote(440); // starts probe #1 (pending)
+      await synth.playNote(440); // in-flight → must NOT start probe #2
+
+      expect(probeMock).toHaveBeenCalledTimes(1);
+      release("healthy");
+      synth.onOutputWedged = undefined;
+    });
+
+    it("never probes when no onOutputWedged handler is set", async () => {
+      await synth.playNote(440);
+      await Promise.resolve();
+      expect(probeMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/core/audio.test.ts
+++ b/src/core/audio.test.ts
@@ -17,6 +17,14 @@ const mocks = vi.hoisted(() => {
     get state() {
       return contextState.value;
     },
+    // `playNote` registers rawContext for idle-suspend and schedules notes
+    // at immediate() (== currentTime, no lookAhead) for zero-latency taps.
+    rawContext: {
+      get state() {
+        return contextState.value;
+      },
+    },
+    immediate: () => 0,
   }));
 
   const triggerAttackRelease = vi.fn();
@@ -25,6 +33,9 @@ const mocks = vi.hoisted(() => {
   const PolySynth = vi.fn(function PolySynthMock() {
     const instance = {
       triggerAttackRelease,
+      // Notes schedule at the synth's own context time (no lookAhead, correct
+      // timeline after Tone.setContext). Mock returns a fixed 0.
+      immediate: vi.fn(() => 0),
       connect: vi.fn().mockReturnThis(),
       toDestination: vi.fn().mockReturnThis(),
       dispose: vi.fn(),
@@ -173,6 +184,14 @@ describe("GuitarSynth (Tone-backed)", () => {
       await synth.playNote(440);
       expect(mocks.triggerAttackRelease).toHaveBeenCalledTimes(1);
       expect(mocks.triggerAttackRelease.mock.calls[0][0]).toBe(440);
+    });
+
+    it("schedules the note at the context's immediate() time, not the lookahead-delayed now()", async () => {
+      // Regression guard: triggering with no explicit time uses Tone.now()
+      // (== currentTime + lookAhead, ~100ms), an audible per-tap delay. The
+      // 3rd arg must be the immediate() time (mock returns 0).
+      await synth.playNote(440);
+      expect(mocks.triggerAttackRelease.mock.calls[0][2]).toBe(0);
     });
 
     it("ensures Tone has started before triggering", async () => {

--- a/src/core/audio.ts
+++ b/src/core/audio.ts
@@ -16,6 +16,8 @@
 import * as Tone from "tone";
 
 import { ensureToneStarted } from "./toneInit";
+import { markAudioActivity, registerAudioContext } from "./audioIdleSuspend";
+import { probeOutputHealth } from "./audioOutputHealth";
 
 const AUDIO_CONFIG = {
   /** Master volume in linear gain (matches prior MASTER_GAIN = 0.5). */
@@ -82,7 +84,10 @@ class GuitarSynth {
   private volume: Tone.Volume | null = null;
   private isMuted = false;
   private unsupported = false;
+  private wedgeProbeInFlight = false;
   onError?: (message: string) => void;
+  /** Called when a played note reveals the Safari dead-output wedge. */
+  onOutputWedged?: () => void;
 
   init(): void {
     if (this.unsupported || this.polySynth) return;
@@ -164,6 +169,11 @@ class GuitarSynth {
     if (this.unsupported || !this.polySynth) return;
 
     try {
+      // ensureToneStarted() resumes/starts the LIVE Tone context (which may
+      // have been swapped via Tone.setContext when the progression engine
+      // bound its own context). Never cache a context reference for resume —
+      // a stale/orphaned context sits "suspended" forever and awaiting its
+      // resume on every note added a fixed per-note latency.
       await ensureToneStarted();
     } catch (e) {
       console.warn("Tone.start failed in playNote:", e);
@@ -171,13 +181,51 @@ class GuitarSynth {
       return;
     }
 
+    // Track whichever context is live right now for energy idle-suspend.
+    // Tagged "guitar"; if the progression engine already owns this (shared)
+    // context the "progression" role sticks — see registerAudioContext.
+    registerAudioContext(Tone.getContext().rawContext as AudioContext, "guitar");
+    markAudioActivity();
     try {
-      this.polySynth.triggerAttackRelease(frequency, AUDIO_CONFIG.NOTE_DURATION);
+      // Schedule at the context's immediate() time (== currentTime), NOT the
+      // default Tone.now() which adds the context lookAhead (0.1s). For a
+      // tap-to-play instrument that 100ms is an audible per-note delay; the
+      // progression sequencer keeps the lookAhead for glitch-free scheduling.
+      // Schedule at THIS synth's own context time, not Tone.now() (which adds
+      // the 0.1s lookAhead → audible per-tap delay) and not
+      // Tone.getContext().immediate() (the GLOBAL context — after a progression
+      // calls Tone.setContext() the synth is orphaned on its original context,
+      // so the global clock is the wrong timeline and notes schedule in the
+      // synth's past → silence). `polySynth.immediate()` is its own currentTime.
+      this.polySynth.triggerAttackRelease(
+        frequency,
+        AUDIO_CONFIG.NOTE_DURATION,
+        this.polySynth.immediate(),
+      );
+      this.checkOutputAfterPlay();
     } catch (e) {
       // PolySynth throws if maxPolyphony is exceeded; swallow and log
       // rather than surfacing — same UX as the old "skipping note" warn.
       console.warn("GuitarSynth.playNote failed:", e);
     }
+  }
+
+  /**
+   * After a note is triggered, verify it actually reached the hardware. On
+   * Safari the context can report "running" while output is dead (see
+   * audioOutputHealth). Fire-and-forget, de-duped so rapid taps run one probe.
+   */
+  private checkOutputAfterPlay(): void {
+    if (this.wedgeProbeInFlight || !this.onOutputWedged) return;
+    this.wedgeProbeInFlight = true;
+    void probeOutputHealth()
+      .then((health) => {
+        if (health === "wedged") this.onOutputWedged?.();
+      })
+      .catch(() => {})
+      .finally(() => {
+        this.wedgeProbeInFlight = false;
+      });
   }
 }
 
@@ -195,12 +243,16 @@ export function __resetSynthForTests(): void {
     volume: unknown;
     isMuted: boolean;
     unsupported: boolean;
+    wedgeProbeInFlight: boolean;
     onError: undefined;
+    onOutputWedged: undefined;
   };
   s.polySynth = null;
   s.filter = null;
   s.volume = null;
   s.isMuted = false;
   s.unsupported = false;
+  s.wedgeProbeInFlight = false;
   s.onError = undefined;
+  s.onOutputWedged = undefined;
 }

--- a/src/core/audio.ts
+++ b/src/core/audio.ts
@@ -1,26 +1,34 @@
 /**
- * GuitarSynth: Tone.js-backed polyphonic synth for guitar-like plucks.
+ * GuitarSynth: a small raw-Web-Audio plucked-string voice on its OWN
+ * AudioContext.
  *
- * Replaces the previous hand-rolled Web Audio implementation. Tone.PolySynth
- * handles voice allocation, while custom partials + envelope + a lowpass
- * Filter approximate the old plucked-string flavor.
+ * The guitar is a fire-and-forget, tap-to-play instrument. It deliberately does
+ * NOT use Tone.js: Tone is a sequencing/transport framework whose single global
+ * context the progression engine rebinds via Tone.setContext(), which would
+ * orphan a Tone-based guitar on a stale context. Owning a private AudioContext
+ * keeps the guitar completely decoupled from the progression — there is no
+ * shared global to fight over.
  *
- * Public API (preserved verbatim from the prior implementation so callers
- * — App.tsx, Fretboard.tsx, useResetConfirmation.ts — keep working):
+ * Signal graph:
+ *   [per-note] OscillatorNode(periodicWave) -> GainNode(ADSR envelope)
+ *                                                 |
+ *   [shared]   ------------------------------------+--> BiquadFilter(lowpass)
+ *                                                        -> GainNode(master) -> destination
+ *
+ * Public API (preserved verbatim so callers — lazyGuitarAudio.ts, App.tsx —
+ * keep working):
  *   - init(): void
  *   - resume(): Promise<void>
  *   - setMute(mute: boolean): void
  *   - playNote(frequency: number): Promise<void>
  *   - onError?: (message: string) => void
+ *   - onOutputWedged?: () => void
  */
-import * as Tone from "tone";
-
-import { ensureToneStarted } from "./toneInit";
 import { markAudioActivity, registerAudioContext } from "./audioIdleSuspend";
 import { probeOutputHealth } from "./audioOutputHealth";
 
 const AUDIO_CONFIG = {
-  /** Master volume in linear gain (matches prior MASTER_GAIN = 0.5). */
+  /** Master volume in linear gain. */
   MASTER_GAIN: 0.5,
 
   /** Quick attack, fast decay for percussive picked-note feel. */
@@ -29,59 +37,49 @@ const AUDIO_CONFIG = {
   SUSTAIN: 0.02,
   RELEASE_TIME: 0.3,
 
-  /** Single-note duration handed to triggerAttackRelease (seconds). */
+  /** Single-note duration before the release stage begins (seconds). */
   NOTE_DURATION: 0.5,
 
-  /** Filter set high enough to be transparent — strum voice has none. */
+  /** Lowpass filter — high enough to stay transparent. */
   FILTER_FREQ: 10000,
   FILTER_Q: 0.1,
 
   /** Glide time when ramping master volume to/from mute (seconds). */
   MUTE_TRANSITION_TIME: 0.02,
 
-  /**
-   * Hard cap on concurrent voices. The prior hand-rolled impl ran a
-   * pool of 8 with up to 4 temp voices only when the pool was exhausted;
-   * PolySynth treats this as a flat ceiling above which it throws.
-   */
+  /** Hard cap on concurrent voices. */
   MAX_POLYPHONY: 12,
 } as const;
+
+/**
+ * Sine-harmonic amplitudes of the plucked-string timbre. Index i is the
+ * (i+1)th harmonic; element 0 of the periodic-wave imag array is the DC term
+ * and stays 0. Matches the prior Tone "custom" oscillator partials exactly.
+ */
+const PARTIALS = [1, 0.8, 0.45, 0.22, 0.12, 0.05] as const;
+
+/** Smallest gain value usable as an exponential-ramp target (0 is illegal). */
+const NEAR_ZERO = 0.0001;
 
 /** Single source of truth for the "audio blocked" toast copy. */
 const AUDIO_BLOCKED_MESSAGE =
   "Audio could not be started. Try tapping the screen or interacting with the page.";
 
-/** Linear gain -> decibels; -Infinity for fully muted. */
-function gainToDb(gain: number): number {
-  if (gain <= 0) return -Infinity;
-  return 20 * Math.log10(gain);
-}
-
-/**
- * True once the underlying AudioContext has advanced past "suspended" —
- * i.e. a real user gesture has unlocked audio. Calling Tone.start() before
- * that point rejects on Safari/iOS (which surfaces an "audio blocked"
- * toast on plain page load), so callers like setMute(false) that fire on
- * mount must defer their resume until this returns true.
- *
- * The dedicated gesture handler in App.tsx still calls resume() directly
- * from a real `click` / `touchstart` and bypasses this gate, so first
- * audio still arrives the moment the user interacts.
- */
-function audioContextUnlocked(): boolean {
-  try {
-    return Tone.getContext().state !== "suspended";
-  } catch {
-    // jsdom / no-AudioContext environments — treat as not unlocked so
-    // we never accidentally fire Tone.start() in tests.
-    return false;
-  }
+function getAudioContextConstructor(): (new () => AudioContext) | undefined {
+  if (typeof window === "undefined") return undefined;
+  const w = window as Window & {
+    AudioContext?: new () => AudioContext;
+    webkitAudioContext?: new () => AudioContext;
+  };
+  return w.AudioContext ?? w.webkitAudioContext;
 }
 
 class GuitarSynth {
-  private polySynth: Tone.PolySynth<Tone.Synth> | null = null;
-  private filter: Tone.Filter | null = null;
-  private volume: Tone.Volume | null = null;
+  private ctx: AudioContext | null = null;
+  private masterGain: GainNode | null = null;
+  private filter: BiquadFilterNode | null = null;
+  private wave: PeriodicWave | null = null;
+  private activeVoices = 0;
   private isMuted = false;
   private unsupported = false;
   private wedgeProbeInFlight = false;
@@ -90,122 +88,156 @@ class GuitarSynth {
   onOutputWedged?: () => void;
 
   init(): void {
-    if (this.unsupported || this.polySynth) return;
+    if (this.unsupported || this.ctx) return;
+
+    const Ctor = getAudioContextConstructor();
+    if (!Ctor) {
+      this.unsupported = true;
+      return;
+    }
 
     try {
-      // Master volume node — ramped to mute/unmute.
-      this.volume = new Tone.Volume(gainToDb(AUDIO_CONFIG.MASTER_GAIN)).toDestination();
+      this.ctx = new Ctor();
 
-      // Lowpass filter approximates the prior dynamic filter-sweep color.
-      // A fixed cutoff is a deliberate simplification: the old impl swept
-      // the filter per-note for damping, but PolySynth voices are shared,
-      // so we trade that motion for predictability.
-      this.filter = new Tone.Filter({
-        type: "lowpass",
-        frequency: AUDIO_CONFIG.FILTER_FREQ,
-        Q: AUDIO_CONFIG.FILTER_Q,
-      }).connect(this.volume);
+      // Master volume — ramped to mute/unmute — straight to destination.
+      this.masterGain = this.ctx.createGain();
+      this.masterGain.gain.value = this.isMuted ? 0 : AUDIO_CONFIG.MASTER_GAIN;
+      this.masterGain.connect(this.ctx.destination);
 
-      // Custom partials match the strum voice for a warmer guitar-like
-      // timbre. Tone's "custom" partials omit the DC (index 0).
-      this.polySynth = new Tone.PolySynth({
-        voice: Tone.Synth,
-        maxPolyphony: AUDIO_CONFIG.MAX_POLYPHONY,
-        options: {
-          oscillator: {
-            type: "custom",
-            partials: [1, 0.8, 0.45, 0.22, 0.12, 0.05],
-          },
-          envelope: {
-            attack: AUDIO_CONFIG.ATTACK_TIME,
-            decay: AUDIO_CONFIG.DECAY_TIME,
-            sustain: AUDIO_CONFIG.SUSTAIN,
-            release: AUDIO_CONFIG.RELEASE_TIME,
-          },
-        },
-      }).connect(this.filter);
+      // Fixed lowpass; a deliberate simplification of the old per-note sweep.
+      this.filter = this.ctx.createBiquadFilter();
+      this.filter.type = "lowpass";
+      this.filter.frequency.value = AUDIO_CONFIG.FILTER_FREQ;
+      this.filter.Q.value = AUDIO_CONFIG.FILTER_Q;
+      this.filter.connect(this.masterGain);
+
+      // Additive partials baked into one PeriodicWave reused by every voice.
+      // Using number[] (not Float32Array) preserves float64 precision so that
+      // the values round-trip exactly through the fake in tests and match the
+      // PARTIALS constants without float32 rounding noise.
+      const imag: number[] = [0, ...PARTIALS];
+      const real: number[] = new Array(imag.length).fill(0);
+      this.wave = this.ctx.createPeriodicWave(real, imag);
+
+      // Track this context for energy idle-suspend (own key; role "guitar").
+      registerAudioContext(this.ctx, "guitar");
     } catch (e) {
       this.unsupported = true;
-      this.polySynth = null;
+      this.ctx = null;
+      this.masterGain = null;
       this.filter = null;
-      this.volume = null;
+      this.wave = null;
       console.warn("GuitarSynth init failed:", e);
     }
   }
 
   async resume(): Promise<void> {
     this.init();
-    if (this.unsupported) return;
+    if (this.unsupported || !this.ctx) return;
     try {
-      await ensureToneStarted();
+      if (this.ctx.state !== "running") await this.ctx.resume();
     } catch (e) {
-      console.warn("Tone.start failed:", e);
+      console.warn("Guitar context resume failed:", e);
       this.onError?.(AUDIO_BLOCKED_MESSAGE);
     }
   }
 
   setMute(mute: boolean): void {
     this.isMuted = mute;
-    if (this.volume) {
-      const targetDb = mute ? -Infinity : gainToDb(AUDIO_CONFIG.MASTER_GAIN);
-      // rampTo gives a click-free transition equivalent to the old
-      // setTargetAtTime smoothing.
-      this.volume.volume.rampTo(targetDb, AUDIO_CONFIG.MUTE_TRANSITION_TIME);
+    if (this.masterGain && this.ctx) {
+      const target = mute ? 0 : AUDIO_CONFIG.MASTER_GAIN;
+      const now = this.ctx.currentTime;
+      // Click-free transition equivalent to the old rampTo smoothing.
+      this.masterGain.gain.cancelScheduledValues(now);
+      this.masterGain.gain.setValueAtTime(this.masterGain.gain.value, now);
+      this.masterGain.gain.linearRampToValueAtTime(target, now + AUDIO_CONFIG.MUTE_TRANSITION_TIME);
     }
-    // Unmute is *usually* a user gesture, but this effect also fires on
-    // initial mount (isMutedAtom defaults to false). Skip the opportunistic
-    // resume when the AudioContext hasn't been unlocked yet — otherwise
-    // Tone.start() rejects on Safari/iOS without a gesture and fires the
-    // "audio blocked" toast on every fresh page load. App.tsx's dedicated
-    // pointerdown handler still performs the real first-gesture resume.
-    if (!mute && audioContextUnlocked()) {
+    // Unmute is *usually* a user gesture, but this effect also fires on initial
+    // mount (isMutedAtom defaults to false). Skip the opportunistic resume when
+    // the context hasn't been unlocked yet — otherwise resume() runs without a
+    // gesture and Safari/iOS rejects it. App.tsx's pointerdown handler performs
+    // the real first-gesture resume.
+    if (!mute && this.contextUnlocked()) {
       void this.resume();
     }
+  }
+
+  private contextUnlocked(): boolean {
+    return this.ctx != null && this.ctx.state !== "suspended";
   }
 
   async playNote(frequency: number): Promise<void> {
     if (this.isMuted) return;
     this.init();
-    if (this.unsupported || !this.polySynth) return;
+    if (this.unsupported || !this.ctx || !this.masterGain || !this.filter || !this.wave) return;
 
-    try {
-      // ensureToneStarted() resumes/starts the LIVE Tone context (which may
-      // have been swapped via Tone.setContext when the progression engine
-      // bound its own context). Never cache a context reference for resume —
-      // a stale/orphaned context sits "suspended" forever and awaiting its
-      // resume on every note added a fixed per-note latency.
-      await ensureToneStarted();
-    } catch (e) {
-      console.warn("Tone.start failed in playNote:", e);
-      this.onError?.(AUDIO_BLOCKED_MESSAGE);
+    // Returning from idle-suspend: resume our OWN context. Active tapping keeps
+    // it running (markAudioActivity reschedules the idle timer), so this only
+    // pays latency on the first tap after a long idle.
+    if (this.ctx.state !== "running") {
+      try {
+        await this.ctx.resume();
+      } catch (e) {
+        console.warn("Guitar context resume failed in playNote:", e);
+        this.onError?.(AUDIO_BLOCKED_MESSAGE);
+        return;
+      }
+    }
+
+    markAudioActivity();
+
+    if (this.activeVoices >= AUDIO_CONFIG.MAX_POLYPHONY) {
+      // Matches the old PolySynth-throws-and-we-swallow behavior.
+      console.warn("GuitarSynth.playNote skipped: max polyphony reached");
       return;
     }
 
-    // Track whichever context is live right now for energy idle-suspend.
-    // Tagged "guitar"; if the progression engine already owns this (shared)
-    // context the "progression" role sticks — see registerAudioContext.
-    registerAudioContext(Tone.getContext().rawContext as AudioContext, "guitar");
-    markAudioActivity();
     try {
-      // Schedule at the context's immediate() time (== currentTime), NOT the
-      // default Tone.now() which adds the context lookAhead (0.1s). For a
-      // tap-to-play instrument that 100ms is an audible per-note delay; the
-      // progression sequencer keeps the lookAhead for glitch-free scheduling.
-      // Schedule at THIS synth's own context time, not Tone.now() (which adds
-      // the 0.1s lookAhead → audible per-tap delay) and not
-      // Tone.getContext().immediate() (the GLOBAL context — after a progression
-      // calls Tone.setContext() the synth is orphaned on its original context,
-      // so the global clock is the wrong timeline and notes schedule in the
-      // synth's past → silence). `polySynth.immediate()` is its own currentTime.
-      this.polySynth.triggerAttackRelease(
-        frequency,
-        AUDIO_CONFIG.NOTE_DURATION,
-        this.polySynth.immediate(),
+      const { ATTACK_TIME, DECAY_TIME, SUSTAIN, RELEASE_TIME, NOTE_DURATION } = AUDIO_CONFIG;
+      // Schedule from currentTime — zero lookahead, so a tap sounds instantly.
+      const t0 = this.ctx.currentTime;
+
+      const osc = this.ctx.createOscillator();
+      osc.setPeriodicWave(this.wave);
+      osc.frequency.setValueAtTime(frequency, t0);
+
+      const env = this.ctx.createGain();
+      // ADSR: attack → decay-to-sustain → release tail. Exponential ramps need
+      // a strictly-positive target, hence NEAR_ZERO.
+      env.gain.setValueAtTime(NEAR_ZERO, t0);
+      env.gain.linearRampToValueAtTime(1, t0 + ATTACK_TIME);
+      env.gain.exponentialRampToValueAtTime(
+        Math.max(SUSTAIN, NEAR_ZERO),
+        t0 + ATTACK_TIME + DECAY_TIME,
       );
+      const releaseEnd = t0 + NOTE_DURATION + RELEASE_TIME;
+      env.gain.exponentialRampToValueAtTime(NEAR_ZERO, releaseEnd);
+      env.gain.setValueAtTime(0, releaseEnd + 0.001);
+
+      osc.connect(env);
+      env.connect(this.filter);
+
+      const stopAt = releaseEnd + 0.02;
+      osc.start(t0);
+      osc.stop(stopAt);
+
+      this.activeVoices += 1;
+      osc.onended = () => {
+        this.activeVoices = Math.max(0, this.activeVoices - 1);
+        try {
+          osc.disconnect();
+        } catch {
+          /* already disconnected */
+        }
+        try {
+          env.disconnect();
+        } catch {
+          /* already disconnected */
+        }
+      };
+
       this.checkOutputAfterPlay();
     } catch (e) {
-      // PolySynth throws if maxPolyphony is exceeded; swallow and log
-      // rather than surfacing — same UX as the old "skipping note" warn.
       console.warn("GuitarSynth.playNote failed:", e);
     }
   }
@@ -214,11 +246,12 @@ class GuitarSynth {
    * After a note is triggered, verify it actually reached the hardware. On
    * Safari the context can report "running" while output is dead (see
    * audioOutputHealth). Fire-and-forget, de-duped so rapid taps run one probe.
+   * Probes THIS synth's own context.
    */
   private checkOutputAfterPlay(): void {
-    if (this.wedgeProbeInFlight || !this.onOutputWedged) return;
+    if (this.wedgeProbeInFlight || !this.onOutputWedged || !this.ctx) return;
     this.wedgeProbeInFlight = true;
-    void probeOutputHealth()
+    void probeOutputHealth(this.ctx)
       .then((health) => {
         if (health === "wedged") this.onOutputWedged?.();
       })
@@ -233,23 +266,26 @@ export const synth = new GuitarSynth();
 
 /**
  * Test-only hook: reset internal state on the singleton so tests can
- * re-exercise init/playNote/setMute paths. Not part of the public runtime
- * API.
+ * re-exercise init/playNote/setMute paths. Not part of the public runtime API.
  */
 export function __resetSynthForTests(): void {
   const s = synth as unknown as {
-    polySynth: unknown;
+    ctx: unknown;
+    masterGain: unknown;
     filter: unknown;
-    volume: unknown;
+    wave: unknown;
+    activeVoices: number;
     isMuted: boolean;
     unsupported: boolean;
     wedgeProbeInFlight: boolean;
     onError: undefined;
     onOutputWedged: undefined;
   };
-  s.polySynth = null;
+  s.ctx = null;
+  s.masterGain = null;
   s.filter = null;
-  s.volume = null;
+  s.wave = null;
+  s.activeVoices = 0;
   s.isMuted = false;
   s.unsupported = false;
   s.wedgeProbeInFlight = false;

--- a/src/core/audioIdleSuspend.test.ts
+++ b/src/core/audioIdleSuspend.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  registerAudioContext,
+  unregisterAudioContext,
+  holdAudioActive,
+  releaseAudioActive,
+  markAudioActivity,
+  isContextSuspended,
+  _resetAudioIdleSuspendForTests,
+} from "./audioIdleSuspend";
+
+function makeMockContext(state = "running"): AudioContext {
+  return {
+    state,
+    suspend: vi.fn().mockResolvedValue(undefined),
+  } as unknown as AudioContext;
+}
+
+const IDLE_MS = 30_000;
+
+describe("audioIdleSuspend", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _resetAudioIdleSuspendForTests();
+  });
+
+  afterEach(() => {
+    _resetAudioIdleSuspendForTests();
+    vi.useRealTimers();
+  });
+
+  it("suspends a registered context after 30s of inactivity", () => {
+    const ctx = makeMockContext();
+    registerAudioContext(ctx);
+    markAudioActivity();
+
+    vi.advanceTimersByTime(IDLE_MS - 1);
+    expect(ctx.suspend).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(ctx.suspend).toHaveBeenCalledOnce();
+  });
+
+  it("resets the timer on each markAudioActivity call", () => {
+    const ctx = makeMockContext();
+    registerAudioContext(ctx);
+    markAudioActivity();
+
+    vi.advanceTimersByTime(20_000);
+    markAudioActivity();
+
+    vi.advanceTimersByTime(20_000);
+    expect(ctx.suspend).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(10_000);
+    expect(ctx.suspend).toHaveBeenCalledOnce();
+  });
+
+  it("does not suspend while held active", () => {
+    const ctx = makeMockContext();
+    registerAudioContext(ctx);
+    holdAudioActive();
+    markAudioActivity();
+
+    vi.advanceTimersByTime(IDLE_MS * 2);
+    expect(ctx.suspend).not.toHaveBeenCalled();
+  });
+
+  it("starts idle timer when released", () => {
+    const ctx = makeMockContext();
+    registerAudioContext(ctx);
+    holdAudioActive();
+
+    vi.advanceTimersByTime(IDLE_MS * 2);
+    expect(ctx.suspend).not.toHaveBeenCalled();
+
+    releaseAudioActive();
+    vi.advanceTimersByTime(IDLE_MS);
+    expect(ctx.suspend).toHaveBeenCalledOnce();
+  });
+
+  it("skips contexts that are already suspended", () => {
+    const ctx = makeMockContext("suspended");
+    registerAudioContext(ctx);
+    markAudioActivity();
+
+    vi.advanceTimersByTime(IDLE_MS);
+    expect(ctx.suspend).not.toHaveBeenCalled();
+  });
+
+  it("suspends multiple registered contexts", () => {
+    const ctx1 = makeMockContext();
+    const ctx2 = makeMockContext();
+    registerAudioContext(ctx1);
+    registerAudioContext(ctx2);
+    markAudioActivity();
+
+    vi.advanceTimersByTime(IDLE_MS);
+    expect(ctx1.suspend).toHaveBeenCalledOnce();
+    expect(ctx2.suspend).toHaveBeenCalledOnce();
+  });
+
+  it("does not suspend unregistered contexts", () => {
+    const ctx = makeMockContext();
+    registerAudioContext(ctx);
+    unregisterAudioContext(ctx);
+    markAudioActivity();
+
+    vi.advanceTimersByTime(IDLE_MS);
+    expect(ctx.suspend).not.toHaveBeenCalled();
+  });
+
+  describe("isContextSuspended", () => {
+    it("scopes to a role — ignores a suspended context of another role", () => {
+      const progression = makeMockContext("running");
+      const guitar = makeMockContext("suspended");
+      registerAudioContext(progression, "progression");
+      registerAudioContext(guitar, "guitar");
+
+      // An idle guitar context must not make the progression check report suspended.
+      expect(isContextSuspended("progression")).toBe(false);
+      expect(isContextSuspended("guitar")).toBe(true);
+    });
+
+    it("reports the progression context's own suspended state", () => {
+      const progression = makeMockContext("suspended");
+      registerAudioContext(progression, "progression");
+      expect(isContextSuspended("progression")).toBe(true);
+    });
+
+    it("with no role, checks every registered context", () => {
+      const a = makeMockContext("running");
+      const b = makeMockContext("suspended");
+      registerAudioContext(a, "progression");
+      registerAudioContext(b, "guitar");
+      expect(isContextSuspended()).toBe(true);
+    });
+
+    it("upgrades a guitar context to progression when re-registered", () => {
+      const ctx = makeMockContext("suspended");
+      registerAudioContext(ctx, "guitar");
+      expect(isContextSuspended("progression")).toBe(false);
+      registerAudioContext(ctx, "progression");
+      expect(isContextSuspended("progression")).toBe(true);
+    });
+
+
+  });
+});

--- a/src/core/audioIdleSuspend.ts
+++ b/src/core/audioIdleSuspend.ts
@@ -1,0 +1,91 @@
+/**
+ * Idle-suspend for AudioContexts.
+ *
+ * A running AudioContext keeps the browser's audio rendering thread alive
+ * (~44.1 kHz processing loop), which Safari flags as "significant energy"
+ * even when no audio is playing. This module suspends all registered
+ * contexts after a configurable idle period and lets callers resume them
+ * on demand.
+ *
+ * Integration points:
+ *   - GuitarSynth.playNote() → markAudioActivity()
+ *   - progression play/stop → holdAudioActive() / releaseAudioActive()
+ *   - bus.ts / audio.ts init → registerAudioContext()
+ */
+
+const IDLE_SUSPEND_MS = 30_000;
+
+/** Which subsystem owns a registered context. Lets callers query a single
+ *  role's suspended state instead of all contexts (e.g. the progression
+ *  spinner must not react to an idle guitar context). */
+export type AudioContextRole = "progression" | "guitar";
+
+const contexts = new Map<AudioContext, AudioContextRole | undefined>();
+let timer: ReturnType<typeof setTimeout> | null = null;
+let held = false;
+
+export function registerAudioContext(ctx: AudioContext, role?: AudioContextRole): void {
+  // The guitar and the progression each own a SEPARATE AudioContext, so they are
+  // distinct map keys — no role collision to guard against. A later call with the
+  // same key simply updates (e.g. upgrades) the role.
+  contexts.set(ctx, role);
+}
+
+export function unregisterAudioContext(ctx: AudioContext): void {
+  contexts.delete(ctx);
+}
+
+export function holdAudioActive(): void {
+  held = true;
+  clearIdleTimer();
+}
+
+export function releaseAudioActive(): void {
+  held = false;
+  scheduleIdleSuspend();
+}
+
+export function markAudioActivity(): void {
+  scheduleIdleSuspend();
+}
+
+function clearIdleTimer(): void {
+  if (timer !== null) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}
+
+function scheduleIdleSuspend(): void {
+  clearIdleTimer();
+  if (held) return;
+  timer = setTimeout(suspendAll, IDLE_SUSPEND_MS);
+}
+
+function suspendAll(): void {
+  timer = null;
+  if (held) return;
+  for (const ctx of contexts.keys()) {
+    if (ctx.state === "running") {
+      ctx.suspend().catch(() => {});
+    }
+  }
+}
+
+/** True if any registered context with the given role is not running.
+ *  Omit `role` to check every context. */
+export function isContextSuspended(role?: AudioContextRole): boolean {
+  for (const [ctx, ctxRole] of contexts) {
+    if (role !== undefined && ctxRole !== role) continue;
+    if (ctx.state !== "running") return true;
+  }
+  return false;
+}
+
+export function _resetAudioIdleSuspendForTests(): void {
+  clearIdleTimer();
+  contexts.clear();
+  held = false;
+}
+
+export { IDLE_SUSPEND_MS };

--- a/src/core/audioOutputHealth.test.ts
+++ b/src/core/audioOutputHealth.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mutable fake context state, driven per-test.
+const h = vi.hoisted(() => ({
+  state: "running" as AudioContextState,
+  currentTime: 0,
+  contextTime: 0 as number | undefined,
+  hasTimestamp: true,
+}));
+
+vi.mock("tone", () => ({
+  getContext: () => ({
+    rawContext: {
+      get state() {
+        return h.state;
+      },
+      get currentTime() {
+        return h.currentTime;
+      },
+      getOutputTimestamp: h.hasTimestamp
+        ? () => ({ contextTime: h.contextTime })
+        : undefined,
+    },
+  }),
+}));
+
+import { probeOutputHealth } from "./audioOutputHealth";
+
+/** Run the probe, advancing the fake 250ms window after applying the
+ *  "second sample" values supplied in `after`. */
+async function runProbe(after: { currentTime?: number; contextTime?: number }) {
+  const p = probeOutputHealth(); // first sample taken synchronously
+  if (after.currentTime !== undefined) h.currentTime = after.currentTime;
+  if (after.contextTime !== undefined) h.contextTime = after.contextTime;
+  await vi.advanceTimersByTimeAsync(300);
+  return p;
+}
+
+describe("probeOutputHealth", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    h.state = "running";
+    h.currentTime = 0;
+    h.contextTime = 0;
+    h.hasTimestamp = true;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports healthy when the hardware clock keeps pace with currentTime", async () => {
+    const result = await runProbe({ currentTime: 0.25, contextTime: 0.24 });
+    expect(result).toBe("healthy");
+  });
+
+  it("reports wedged when currentTime advances but the hardware clock is frozen", async () => {
+    const result = await runProbe({ currentTime: 0.25, contextTime: 0 });
+    expect(result).toBe("wedged");
+  });
+
+  it("reports unknown when getOutputTimestamp is unsupported", async () => {
+    h.hasTimestamp = false;
+    const result = await runProbe({ currentTime: 0.25 });
+    expect(result).toBe("unknown");
+  });
+
+  it("reports unknown when getOutputTimestamp returns no contextTime", async () => {
+    h.contextTime = undefined;
+    const result = await runProbe({ currentTime: 0.25, contextTime: undefined });
+    expect(result).toBe("unknown");
+  });
+
+  it("reports unknown when the context is suspended", async () => {
+    h.state = "suspended";
+    const result = await runProbe({ currentTime: 0.25, contextTime: 0 });
+    expect(result).toBe("unknown");
+  });
+
+  it("reports unknown when currentTime barely advanced (inconclusive)", async () => {
+    const result = await runProbe({ currentTime: 0.05, contextTime: 0 });
+    expect(result).toBe("unknown");
+  });
+
+  it("probes an explicitly-passed context instead of the Tone global", async () => {
+    // A standalone context whose hardware clock is frozen while currentTime
+    // advances → wedged. The Tone-global mock (h.*) stays healthy, proving the
+    // explicit arg is what's used.
+    let ct = 0;
+    const explicitCtx = {
+      state: "running" as AudioContextState,
+      get currentTime() {
+        return ct;
+      },
+      getOutputTimestamp: () => ({ contextTime: 0 }),
+    } as unknown as AudioContext;
+
+    const p = probeOutputHealth(explicitCtx);
+    ct = 0.25; // currentTime advanced; contextTime stayed 0
+    await vi.advanceTimersByTimeAsync(300);
+    expect(await p).toBe("wedged");
+  });
+});

--- a/src/core/audioOutputHealth.ts
+++ b/src/core/audioOutputHealth.ts
@@ -1,0 +1,93 @@
+/**
+ * Detect Safari's "dead Web Audio output" wedge.
+ *
+ * On Safari/macOS, after long idle or an output-device change (e.g. AirPods
+ * handing off phone → Mac), the AudioContext keeps reporting `state: "running"`
+ * and `currentTime` keeps advancing, but no audio reaches the speakers. It
+ * survives a full page reload (a fresh AudioContext lands in the same wedged
+ * per-process audio session), so recreating the context cannot fix it — only a
+ * full browser restart does. We therefore DETECT the condition and tell the
+ * user, rather than pretending to recover.
+ *
+ * Detection signal: `currentTime` advances regardless of real output, but
+ * `getOutputTimestamp().contextTime` reports the frame the HARDWARE is actually
+ * outputting — it freezes when nothing is being consumed. So:
+ *   currentTime advanced  AND  contextTime did not  →  output is wedged.
+ *
+ * `getOutputTimestamp` is feature-detected; when unavailable the probe returns
+ * "unknown" and we never raise a false alarm.
+ */
+
+import * as Tone from "tone";
+
+export type OutputHealth = "healthy" | "wedged" | "unknown";
+
+/** Gap between the two samples. Long enough that a healthy contextTime moves
+ *  well past timer/scheduling jitter, short enough to feel instant. */
+const PROBE_WINDOW_MS = 250;
+
+/** A healthy hardware clock should advance by at least this fraction of the
+ *  elapsed wall time across the window. Wedged output advances ~0. The slack
+ *  absorbs output latency and timer imprecision. */
+const MIN_ADVANCE_RATIO = 0.25;
+
+function getLiveRawContext(): AudioContext | null {
+  try {
+    const raw = Tone.getContext().rawContext as unknown as AudioContext | undefined;
+    return raw ?? null;
+  } catch {
+    return null;
+  }
+}
+
+interface OutputTimestampCapable {
+  getOutputTimestamp?: () => { contextTime?: number };
+}
+
+function readContextTime(ctx: AudioContext): number | null {
+  const fn = (ctx as unknown as OutputTimestampCapable).getOutputTimestamp;
+  if (typeof fn !== "function") return null;
+  try {
+    const ts = fn.call(ctx);
+    return typeof ts?.contextTime === "number" ? ts.contextTime : null;
+  } catch {
+    return null;
+  }
+}
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Sample the live context twice and classify output health. Only meaningful
+ * while audio is (or was just) playing — the caller is responsible for probing
+ * at a moment sound should be reaching the hardware.
+ */
+export async function probeOutputHealth(explicitCtx?: AudioContext): Promise<OutputHealth> {
+  const ctx = explicitCtx ?? getLiveRawContext();
+  // A suspended/closed context is a different (recoverable) condition handled
+  // elsewhere; only a "running" context can be a silent-output zombie.
+  if (!ctx || ctx.state !== "running") return "unknown";
+
+  const ct0 = readContextTime(ctx);
+  if (ct0 === null) return "unknown"; // getOutputTimestamp unsupported
+
+  const t0 = ctx.currentTime;
+  await wait(PROBE_WINDOW_MS);
+
+  if (ctx.state !== "running") return "unknown";
+  const ct1 = readContextTime(ctx);
+  if (ct1 === null) return "unknown";
+  const t1 = ctx.currentTime;
+
+  const currentAdvanced = t1 - t0;
+  const hardwareAdvanced = ct1 - ct0;
+
+  // currentTime barely moved (e.g. context paused under the hood) → inconclusive.
+  if (currentAdvanced < PROBE_WINDOW_MS / 1000 / 2) return "unknown";
+
+  // Hardware clock kept up → real output. Otherwise it's frozen → wedged.
+  return hardwareAdvanced >= currentAdvanced * MIN_ADVANCE_RATIO
+    ? "healthy"
+    : "wedged";
+}

--- a/src/core/lazyGuitarAudio.ts
+++ b/src/core/lazyGuitarAudio.ts
@@ -3,11 +3,13 @@ type GuitarSynthModule = typeof import("./audio");
 let modulePromise: Promise<GuitarSynthModule> | null = null;
 let desiredMute = false;
 let errorHandler: ((message: string) => void) | undefined;
+let outputWedgedHandler: (() => void) | undefined;
 
 async function loadAudioModule(): Promise<GuitarSynthModule> {
   if (!modulePromise) {
     modulePromise = import("./audio").then((mod) => {
       mod.synth.onError = errorHandler;
+      mod.synth.onOutputWedged = outputWedgedHandler;
       mod.synth.setMute(desiredMute);
       return mod;
     });
@@ -35,6 +37,15 @@ export function setGuitarAudioErrorHandler(
   });
 }
 
+export function setGuitarOutputWedgedHandler(
+  nextHandler: (() => void) | undefined,
+): void {
+  outputWedgedHandler = nextHandler;
+  void modulePromise?.then((mod) => {
+    mod.synth.onOutputWedged = nextHandler;
+  });
+}
+
 export async function resumeGuitarAudio(): Promise<void> {
   const mod = await loadAudioModule();
   await mod.synth.resume();
@@ -49,4 +60,5 @@ export function __resetLazyGuitarAudioForTests(): void {
   modulePromise = null;
   desiredMute = false;
   errorHandler = undefined;
+  outputWedgedHandler = undefined;
 }

--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import { useAtomValue, useSetAtom, useStore } from "jotai";
 import { getNoteFrequency } from "@fretflow/core";
-import { audioQualityAtom, isMutedAtom } from "../store/audioAtoms";
+import { audioOutputWedgedAtom, audioQualityAtom, isMutedAtom } from "../store/audioAtoms";
 import {
   beatsPerBarAtom,
   progressionBassEnabledAtom,
@@ -38,6 +38,8 @@ import type {
 import type { BuiltLayers } from "../progressions/audio/buildAllLayers";
 import { startVisualClock, stopVisualClock } from "../progressions/audio/visualClock";
 import { ensureToneStarted } from "../core/toneInit";
+import { holdAudioActive, isContextSuspended, releaseAudioActive } from "../core/audioIdleSuspend";
+import { probeOutputHealth } from "../core/audioOutputHealth";
 
 const SCHEDULE_LEAD_SECONDS = 0.05;
 
@@ -147,6 +149,7 @@ export function useProgressionAudioPlayback() {
   const setActiveStepIndex = useSetAtom(setProgressionActiveStepIndexAtom);
   const setPlaying = useSetAtom(setProgressionPlayingAtom);
   const setLoading = useSetAtom(progressionPlaybackLoadingAtom);
+  const setOutputWedged = useSetAtom(audioOutputWedgedAtom);
   const store = useStore();
 
   const primsRef = useRef<PlaybackPrimitives | null>(null);
@@ -325,6 +328,7 @@ export function useProgressionAudioPlayback() {
   useEffect(() => {
     return () => {
       stopVisualClock();
+      releaseAudioActive();
       if (engine) engine.getDraw().cancel?.();
       engine?.disposeAll(primsRef.current);
       primsRef.current = null;
@@ -333,9 +337,29 @@ export function useProgressionAudioPlayback() {
     };
   }, [setLoading]);
 
+  // While the progression is playing, periodically verify audio actually
+  // reaches the hardware. On Safari the context can report "running" while
+  // output is silently dead after idle / a device change (see
+  // core/audioOutputHealth); flag it so the recovery banner shows. Once per
+  // second — cheap, and only while playing.
+  useEffect(() => {
+    if (!playing || blocked || muted) return;
+    let cancelled = false;
+    const id = window.setInterval(() => {
+      void probeOutputHealth().then((health) => {
+        if (!cancelled && health === "wedged") setOutputWedged(true);
+      });
+    }, 1000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [playing, blocked, muted, setOutputWedged]);
+
   useEffect(() => {
     const tearDownAndStop = () => {
       stopVisualClock();
+      releaseAudioActive();
       engine?.disposeAll(primsRef.current);
       primsRef.current = null;
       if (engine) engine.silenceProgressionBus();
@@ -345,6 +369,7 @@ export function useProgressionAudioPlayback() {
 
     if (blocked || muted) { tearDownAndStop(); return; }
     if (!playing) { tearDownAndStop(); engine?.pauseTimeline(); return; }
+    holdAudioActive();
     startVisualClock(store);
 
     const gen = ++genRef.current;
@@ -378,10 +403,12 @@ export function useProgressionAudioPlayback() {
       engine.getTransport().stop();
     }
 
-    // Defer the loading spinner to prevent rapid UI flashing for fast rebuilds
-    // In test mode, we make it synchronous to satisfy strict test assertions.
+    // Show loading immediately when resuming from idle-suspended AudioContext
+    // (the ctx.resume() + Tone.start() round-trip is perceptible). Otherwise
+    // defer the spinner by 150ms to prevent rapid UI flashing on fast rebuilds.
     let loadingTimer: ReturnType<typeof setTimeout> | undefined;
-    if (import.meta.env.MODE === "test") {
+    const needsResume = isContextSuspended("progression");
+    if (import.meta.env.MODE === "test" || needsResume) {
       setLoading(true);
     } else {
       loadingTimer = setTimeout(() => {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -137,7 +137,7 @@ export const en: Dictionary = {
     dismiss: "Dismiss",
     rotateMessage: "Please rotate your device to portrait mode",
     audioOutputWedged:
-      "Audio output stopped — a Safari issue after the tab idles or the audio device changes. Fully quit Safari (⌘Q) and reopen to restore sound.",
+      "Audio output stopped — a Safari issue after the tab idles or the audio device changes. Fully quit and reopen Safari (⌘Q on Mac) to restore sound.",
   },
   help: {
     title: "Help",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -136,6 +136,8 @@ export const en: Dictionary = {
     themeToDark: "Switch to dark theme",
     dismiss: "Dismiss",
     rotateMessage: "Please rotate your device to portrait mode",
+    audioOutputWedged:
+      "Audio output stopped — a Safari issue after the tab idles or the audio device changes. Fully quit Safari (⌘Q) and reopen to restore sound.",
   },
   help: {
     title: "Help",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -137,7 +137,7 @@ export const es: Dictionary = {
     dismiss: "Cerrar",
     rotateMessage: "Por favor, gira tu dispositivo a modo vertical",
     audioOutputWedged:
-      "El audio se detuvo — un problema de Safari tras dejar la pestaña inactiva o cambiar el dispositivo de audio. Cierra Safari por completo (⌘Q) y vuelve a abrirlo para restaurar el sonido.",
+      "El audio se detuvo — un problema de Safari tras dejar la pestaña inactiva o cambiar el dispositivo de audio. Cierra Safari por completo y vuelve a abrirlo (⌘Q en Mac) para restaurar el sonido.",
   },
   help: {
     title: "Ayuda",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -136,6 +136,8 @@ export const es: Dictionary = {
     themeToDark: "Cambiar a tema oscuro",
     dismiss: "Cerrar",
     rotateMessage: "Por favor, gira tu dispositivo a modo vertical",
+    audioOutputWedged:
+      "El audio se detuvo — un problema de Safari tras dejar la pestaña inactiva o cambiar el dispositivo de audio. Cierra Safari por completo (⌘Q) y vuelve a abrirlo para restaurar el sonido.",
   },
   help: {
     title: "Ayuda",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -134,6 +134,7 @@ export interface Dictionary {
     themeToDark: string;
     dismiss: string;
     rotateMessage: string;
+    audioOutputWedged: string;
   };
   help: {
     title: string;

--- a/src/integration.test.tsx
+++ b/src/integration.test.tsx
@@ -14,6 +14,7 @@ const lazyAudio = vi.hoisted(() => ({
   playGuitarNote: vi.fn(),
   setGuitarMutePreference: vi.fn(),
   setGuitarAudioErrorHandler: vi.fn(),
+  setGuitarOutputWedgedHandler: vi.fn(),
   resumeGuitarAudio: vi.fn(),
   prefetchAudioModule: vi.fn(),
 }));

--- a/src/progressions/audio/bus.ts
+++ b/src/progressions/audio/bus.ts
@@ -12,6 +12,7 @@
  */
 
 import { getDraw } from "tone";
+import { registerAudioContext, unregisterAudioContext } from "../../core/audioIdleSuspend";
 import { buildLayerBuses, type LayerBuses } from "./layerBuses";
 import { _resetToneBusForTests, bindToneToProgressionContext, resetToneBusBinding } from "./toneBus";
 import { materializeSignalGraph, type MaterializedGraph, type SignalGraphPlan } from "./sound/buildSignalGraph";
@@ -78,6 +79,7 @@ function tearDownForContextReplacement(): void {
   }
   lastPlanKey = null;
   if (ctx) {
+    unregisterAudioContext(ctx);
     try { ctx.close(); } catch { /* already closed */ }
   }
   ctx = null;
@@ -151,6 +153,7 @@ export function ensureProgressionAudio(): ProgressionAudio | null {
     bus.connect(ctx.destination);
     layers = buildLayerBuses(ctx, bus);
     bindToneToProgressionContext({ ctx, bus, layers });
+    registerAudioContext(ctx, "progression");
   } catch (err) {
     // Dev-mode diagnostic — silent in production. The 2026-05-25 P2-T1
     // regression (Tone.Draw.expiration assignment on undefined) hid in

--- a/src/store/audioAtoms.ts
+++ b/src/store/audioAtoms.ts
@@ -5,6 +5,14 @@ import type { QualitySetting } from "../progressions/audio/sound/qualityTiers";
 
 export const audioErrorAtom = atom<string | null>(null);
 
+/**
+ * Set when Safari's Web Audio output session is detected as wedged (context
+ * reports "running" + currentTime advances, but the hardware clock is frozen —
+ * see `core/audioOutputHealth.ts`). Not persisted: a browser restart clears the
+ * condition, and so does a reload of this flag. Drives a guidance banner.
+ */
+export const audioOutputWedgedAtom = atom<boolean>(false);
+
 export const enharmonicDisplayAtom = atom<"auto" | "on" | "off">("auto");
 
 export const isMutedAtom = atomWithStorage(


### PR DESCRIPTION
## Summary

Audio reliability + energy work for Safari, **and** the architectural fix that
decouples the guitar synth from the progression engine by giving each its own
`AudioContext`.

This branch is the full audio-debugging arc from the session, landed as a clean
progression of commits.

## What's included

**`feat(audio)` — energy, wedge banner, latency fixes** (baseline)
- AudioContext idle-suspend after 30s of inactivity (fixes Safari's "significant
  energy" report while idle).
- Progression play/stop spinner on the transport.
- Safari **dead-output wedge** detection (`audioOutputHealth.ts`) + dismissible
  guidance banner (⌘Q + reopen) instead of failing silently. No
  context-recreation "recovery" — a full reload already maximally recreates the
  context and the wedge survives, so the dead layer is Safari's per-process
  audio session, below the AudioContext. en/es strings added.
- Fret-tap latency fix: schedule at the synth's own `immediate()` clock (zero
  lookahead) and own context time.

**`refactor(audio)` — groundwork**
- `probeOutputHealth(explicitCtx?)` can target a specific context.
- Dropped the now-needless "sticky progression role" hack in `audioIdleSuspend`.

**`feat(audio)` — guitar on its own raw-Web-Audio context (the architectural fix)**
- The guitar synth no longer uses Tone.js or rides Tone's single global context.
  It's reimplemented as a small raw-Web-Audio voice engine (oscillator with the
  same partials → ADSR gain → lowpass) on a **private AudioContext it owns**.
- The progression keeps Tone and the global context. Because the guitar shares
  no global, `Tone.setContext()` from the progression engine can never orphan
  it — eliminating the post-progression silence, the per-tap lookahead delay,
  and the stale-clock class of bugs at the root rather than patching symptoms.
- Public API of `audio.ts` is byte-identical, so no caller changed.

**`docs`** — design spec + implementation plan
(`docs/superpowers/specs/…-separate-audio-contexts-design.md`,
`docs/superpowers/plans/…-separate-audio-contexts.md`).

## Verification

- `pnpm run lint` — clean (one pre-existing unrelated warning in
  `useFretboardTopologyModel.ts`).
- `pnpm run test` — 2554 passed, 1 skipped, 1 todo. `audio.ts` unit suite
  rewritten against a fake Web Audio API; cross-module suites green.
- `pnpm run build` — succeeds, `tsc -b` clean.

### Reviewer note — remaining by-ear checks (real Safari)
Automated tests cover the synth logic against a fake context; these are the
human-in-the-loop confirmations on a real device:
- Timbre A/B vs. deployed v2.6.4 (the new envelope uses exponential decay/release
  ramps — tune if audibly off).
- Play a progression, then tap the fretboard → guitar sound recovers.
- Idle > 30s, then tap → context resumes.
- Safari wedged-state → banner appears only on a real wedge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
