### PR TITLE
fix(progression): recover audio on tab return while playing

### DIFF
--- a/docs/superpowers/specs/2026-06-09-strum-pattern-directions-design.md
+++ b/docs/superpowers/specs/2026-06-09-strum-pattern-directions-design.md
@@ -1,0 +1,67 @@
+# Strum Pattern Directions
+
+Improve strum realism by adding `direction` fields to existing chord patterns that lack them. No new patterns, no structural changes — just annotating hits with up/down strum direction so the strum voice alternates note order.
+
+## Motivation
+
+The strum voice (`strumVoice.ts`) reverses voicing order for `direction: "up"`, mimicking a real up-stroke (highest string first → lowest last). Several patterns omit `direction`, so all their hits play as down-strums regardless of musical convention. This makes the strum instrument sound mechanical and one-dimensional, especially in genres like blues and pop where alternating strums are fundamental to the feel.
+
+## Approach
+
+Add `direction` to hits in four patterns where the strumming convention is clear. Polyphonic voices (piano/organ) ignore `direction`, so the change is invisible for non-strum instruments.
+
+### `shuffle-comp`
+Used by Blues genre (currently organ, but user-selectable for strum). Blues guitar rhythm: strong downbeat anchor, lighter up-stroke pickup.
+
+| Beat | Velocity | Direction |
+|------|----------|-----------|
+| 0    | 0.9      | down      |
+| 1.5  | 0.6      | up        |
+
+### `straight-quarters`
+Used by Pop genre (currently piano). When played on strum, folk/pop strumming naturally alternates down/up per quarter note.
+
+| Beat | Velocity | Direction |
+|------|----------|-----------|
+| 0    | 0.8      | down      |
+| 1    | 0.6      | up        |
+| 2    | 0.7      | down      |
+| 3    | 0.6      | up        |
+
+### `offbeat-skank`
+Not genre-assigned, available in pattern dropdown. Reggae/ska up-stroke convention — all hits are up-strums.
+
+| Beat | Velocity | Direction |
+|------|----------|-----------|
+| 0.5  | 0.7      | up        |
+| 1.5  | 0.7      | up        |
+| 2.5  | 0.7      | up        |
+| 3.5  | 0.7      | up        |
+
+### `jazz-comp`
+Used by Jazz genre (currently piano). Jazz guitar comping on the off-beats typically uses a down-up-down motion.
+
+| Beat | Velocity | Direction | Style     |
+|------|----------|-----------|-----------|
+| 0    | 0.75     | down      | staccato  |
+| 1.5  | 0.6      | up        | staccato  |
+| 3.5  | 0.7      | up        | staccato  |
+
+### Unchanged
+- **`ballad-whole`**: Single sustained hit — direction is meaningless.
+- **`bossa-comp`**: Designed for rootless-jazz voicing engine with LH/RH split. Not a strum pattern.
+- **`pop-8ths`**, **`funk-16th`**, **`funk-scratch`**, **`pop-syncopated-push`**: Already have direction annotations.
+
+## Files Changed
+
+- `src/progressions/audio/patterns.ts` — add `direction` to `shuffle-comp`, `straight-quarters`, `offbeat-skank`, `jazz-comp`
+
+## Testing
+
+- Existing strum direction tests in `strumVoice.test.ts` should continue passing
+- Manual: play each pattern with strum instrument, verify audible up/down alternation matches the table above
+- No new tests needed — this is data-only, the direction handling is already tested
+
+## Future Considerations
+
+- Genre-to-pattern assignments could be revisited (e.g., Blues using strum instead of organ, with `shuffle-comp` as the pattern), but that's out of scope here.

--- a/src/hooks/useProgressionAudioPlayback.test.tsx
+++ b/src/hooks/useProgressionAudioPlayback.test.tsx
@@ -120,6 +120,8 @@ const toneMocks = vi.hoisted(() => {
     cancel: vi.fn(),
     bpm: { value: 120 },
     seconds: 0,
+    ticks: 0,
+    PPQ: 192,
     swing: 0,
     timeSignature: 4,
   };
@@ -602,8 +604,8 @@ describe("useProgressionAudioPlayback (tone-native orchestrator)", () => {
     // Loop=true at build time: no end-event scheduled.
     expect(toneMocks.transport.scheduleOnce).not.toHaveBeenCalled();
 
-    // Simulate transport mid-loop (3s into a 12s loop → 9s remaining).
-    toneMocks.transport.seconds = 3;
+    // Simulate transport mid-loop (3s into a 12s loop at 60 BPM → 3 beats = 3 * 192 = 576 ticks).
+    toneMocks.transport.ticks = 576;
 
     act(() => {
       store.set(progressionLoopEnabledAtom, false);
@@ -613,11 +615,12 @@ describe("useProgressionAudioPlayback (tone-native orchestrator)", () => {
     expect(toneMocks.transport.scheduleOnce).toHaveBeenCalledTimes(1);
     const [, when] = toneMocks.transport.scheduleOnce.mock.calls[0];
     expect(typeof when).toBe("string");
-    // "+<positive number>" — 9s remaining + 0.05s lead = 9.05s.
-    expect(when).toMatch(/^\+\d+(\.\d+)?$/);
-    const seconds = Number(String(when).slice(1));
-    expect(seconds).toBeGreaterThan(0);
-    expect(seconds).toBeLessThanOrEqual(12 + 0.1);
+    // "+<ticks>i" — 9s remaining at 60BPM = 9 beats = 9 * 192 = 1728 ticks. + lead = 0.05 * 192 = 9.6 -> 10 ticks. Total ~ 1738i.
+    expect(when).toMatch(/^\+\d+i$/);
+    const ticks = Number(String(when).slice(1, -1));
+    expect(ticks).toBeGreaterThan(0);
+    // 12s loop at 60 BPM = 12 beats = 2304 ticks. Remaining + lead = 1728 + 9.6 = 1737.6 ticks.
+    expect(ticks).toBeLessThanOrEqual(2304 + 10);
   });
 
   it("toggling drums flips the layer gain without rebuilding primitives", async () => {

--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAtomValue, useSetAtom, useStore } from "jotai";
 import { getNoteFrequency } from "@fretflow/core";
 import { audioOutputWedgedAtom, audioQualityAtom, isMutedAtom } from "../store/audioAtoms";
@@ -151,6 +151,11 @@ export function useProgressionAudioPlayback() {
   const setLoading = useSetAtom(progressionPlaybackLoadingAtom);
   const setOutputWedged = useSetAtom(audioOutputWedgedAtom);
   const store = useStore();
+
+  // Incremented when the user returns to a visible tab with a playing
+  // progression and the AudioContext was replaced (Safari zombie recovery).
+  // Triggers the main playback effect to restart from bar 1.
+  const [tabRestartTick, setTabRestartTick] = useState(0);
 
   const primsRef = useRef<PlaybackPrimitives | null>(null);
   const buildKey = useMemo(
@@ -329,10 +334,12 @@ export function useProgressionAudioPlayback() {
     return () => {
       stopVisualClock();
       releaseAudioActive();
-      if (engine) engine.getDraw().cancel?.();
+      if (engine) {
+        engine.getDraw().cancel?.();
+        engine.silenceProgressionBus();
+      }
       engine?.disposeAll(primsRef.current);
       primsRef.current = null;
-      engine?.silenceProgressionBus();
       setLoading(false);
     };
   }, [setLoading]);
@@ -360,9 +367,9 @@ export function useProgressionAudioPlayback() {
     const tearDownAndStop = () => {
       stopVisualClock();
       releaseAudioActive();
+      if (engine) engine.silenceProgressionBus();
       engine?.disposeAll(primsRef.current);
       primsRef.current = null;
-      if (engine) engine.silenceProgressionBus();
       engine?.clearTimeline();
       setLoading(false);
     };
@@ -628,7 +635,7 @@ export function useProgressionAudioPlayback() {
       let endEventId: number | null = null;
       if (!inputs.loopEnabled) {
         endEventId = eng.getTransport().scheduleOnce(
-          () => setPlaying(false),
+          (audioTime) => eng.getDraw().schedule(() => setPlaying(false), audioTime),
           `+${totalDurationSec + SCHEDULE_LEAD_SECONDS}`,
         );
       }
@@ -661,6 +668,7 @@ export function useProgressionAudioPlayback() {
     blocked,
     muted,
     buildKey,
+    tabRestartTick,
     setActiveStepIndex,
     setPlaying,
     setLoading,
@@ -696,6 +704,33 @@ export function useProgressionAudioPlayback() {
     engine.setLayerGain(audio.layers, "metronome", metronomeOn);
   }, [chordOn, bassOn, drumsOn, metronomeOn]);
 
+  // Tab-return recovery: when the page becomes visible while a progression is
+  // playing, check if the AudioContext needs recovery (browser-suspended or
+  // Safari zombie). If the context was replaced (zombie), bump a tick counter
+  // to force the main playback effect to restart from bar 1. If just suspended,
+  // recoverProgressionContext handles the resume + graph rebuild in-place.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== "visible") return;
+      if (!playing || blocked || muted) return;
+
+      getEngine().then((eng) => {
+        if (!eng) return;
+        // Re-check that playback is still active by the time the engine resolves
+        if (!store.get(progressionPlayingAtom)) return;
+        if (store.get(progressionPlaybackBlockedReasonAtom)) return;
+
+        const needsRestart = eng.recoverProgressionContext();
+        if (needsRestart) {
+          setTabRestartTick((t) => t + 1);
+        }
+      });
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, [playing, blocked, muted, store]);
+
   useEffect(() => {
     if (!engine) return;
     const prims = primsRef.current;
@@ -709,12 +744,16 @@ export function useProgressionAudioPlayback() {
       }
     } else {
       if (prims.endEventId === null && totalDurationSec > 0) {
-        const transport = engine.getTransport() as unknown as { seconds: number };
-        const elapsedInLoop = transport.seconds % totalDurationSec;
-        const remaining = totalDurationSec - elapsedInLoop;
+        const transport = engine.getTransport() as unknown as { ticks: number, PPQ: number };
+        const ticksPerSecondAtBuild = (builtTempoRef.current / 60) * transport.PPQ;
+        const totalTicks = totalDurationSec * ticksPerSecondAtBuild;
+        const leadTicks = SCHEDULE_LEAD_SECONDS * ticksPerSecondAtBuild;
+        
+        const elapsedTicksInLoop = transport.ticks % totalTicks;
+        const remainingTicks = totalTicks - elapsedTicksInLoop;
         prims.endEventId = engine.getTransport().scheduleOnce(
-          () => setPlaying(false),
-          `+${remaining + SCHEDULE_LEAD_SECONDS}`,
+          (audioTime) => engine!.getDraw().schedule(() => setPlaying(false), audioTime),
+          `+${Math.round(remainingTicks + leadTicks)}i`,
         );
       }
     }

--- a/src/progressions/audio/bus.ts
+++ b/src/progressions/audio/bus.ts
@@ -321,6 +321,50 @@ export function configureProgressionGraph(plan: SignalGraphPlan): MaterializedGr
   return graph;
 }
 
+/**
+ * Called when the page becomes visible after being hidden while a progression
+ * was playing. Handles two scenarios:
+ *
+ * 1. **Zombie context** (Safari) — AudioContext reports "running" but produces
+ *    no audio after extended idle. `ensureProgressionAudio()` tears down the
+ *    dead context and creates a fresh one. Old Tone.Parts are dead → caller
+ *    must restart playback from bar 1.
+ *
+ * 2. **Suspended context** (Chrome/Firefox) — AudioContext was suspended when
+ *    the tab went to background. `ctx.resume()` + `needsGraphRebuild` recovery
+ *    restores the existing signal graph. Existing Tone.Parts continue after
+ *    resume → no restart needed.
+ *
+ * Returns `true` when the context was replaced (scenario 1) — the caller
+ * should restart playback. Returns `false` when the context was recovered
+ * in-place (scenario 2) — the existing Parts are still valid.
+ */
+export function recoverProgressionContext(): boolean {
+  if (!ctx) return false;
+
+  const wasZombie = contextMayBeZombie;
+
+  // ensureProgressionAudio detects zombie → tears down dead context and
+  // creates a fresh one. After this call, contextMayBeZombie is cleared and
+  // ctx points at the replacement (or the same healthy context).
+  ensureProgressionAudio();
+
+  if (wasZombie) {
+    // Old AudioContext was closed — all Tone.Parts referencing it are dead.
+    // The caller must tear down and rebuild playback from bar 1.
+    return true;
+  }
+
+  // Same context, but may have been suspended by the browser. resume + graph
+  // rebuild restores the signal path. Fire-and-forget — the existing Parts
+  // continue firing after the Transport clock resumes.
+  if (ctx && (ctx.state === "suspended" || ctx.state === "interrupted")) {
+    resumeProgressionAudio();
+  }
+
+  return false;
+}
+
 /** Test-only reset hook so the module behaves predictably across `vitest` runs. */
 export function _resetProgressionAudioForTests(): void {
   if (currentGraph) { try { currentGraph.dispose(); } catch { /* */ } currentGraph = null; }

--- a/src/progressions/audio/progressionAudioEngine.ts
+++ b/src/progressions/audio/progressionAudioEngine.ts
@@ -1,7 +1,7 @@
 import { getDraw, getTransport } from "tone";
 import type { ProgressionPartHandle } from "./progressionPart";
 
-export { ensureProgressionAudio, resumeProgressionAudio, restoreProgressionBus, silenceProgressionBus, configureProgressionGraph } from "./bus";
+export { ensureProgressionAudio, recoverProgressionContext, resumeProgressionAudio, restoreProgressionBus, silenceProgressionBus, configureProgressionGraph } from "./bus";
 export { planSignalGraph } from "./sound/buildSignalGraph";
 export type { SignalGraphPlan, MaterializedGraph } from "./sound/buildSignalGraph";
 export { TIER_PROFILES, resolveTier, detectDefaultTier } from "./sound/qualityTiers";


### PR DESCRIPTION
## Summary
- Progression audio would stop when returning to a tab that was playing — browser suspends AudioContext in background tabs, and zombie contexts (Safari) were undetected during active playback
- Added `recoverProgressionContext()` in `bus.ts` that handles zombie teardown/recreate and suspended-context resume with graph rebuild
- Added `visibilitychange` handler in `useProgressionAudioPlayback.ts` that detects tab-return while playing, applies recovery, and bumps a restart trigger when zombie recovery requires full playback restart from bar 1

## Test Plan
- [ ] Lint, test, and build all pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audio playback recovery when returning to the app after switching tabs.
  * Improved audio teardown sequencing to ensure reliable playback transitions.
  * Refined end-of-playback behavior for more accurate timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->