### PR TITLE
fix(audio): rebuild progression audio graph after tab suspension

### DIFF
--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -715,15 +715,24 @@ export function useProgressionAudioPlayback() {
       if (document.visibilityState !== "visible") return;
       if (!playing || blocked || muted) return;
 
-      getEngine().then((eng) => {
+      getEngine().then(async (eng) => {
         if (!eng) return;
         // Re-check that playback is still active by the time the engine resolves
         if (!store.get(progressionPlayingAtom)) return;
         if (store.get(progressionPlaybackBlockedReasonAtom)) return;
 
-        const needsRestart = eng.recoverProgressionContext();
-        if (needsRestart) {
+        const action = await eng.recoverProgressionContext();
+
+        // Re-check after the await in case playback was stopped
+        if (!store.get(progressionPlayingAtom)) return;
+        if (store.get(progressionPlaybackBlockedReasonAtom)) return;
+
+        if (action === "restart") {
           setTabRestartTick((t) => t + 1);
+        } else if (action === "rebuild") {
+          const mix = eng.getGenreMix(store.get(progressionGenreStyleAtom)) ?? eng.DEFAULT_GENRE_MIX;
+          const tier = resolveActiveTier(eng, store.get(audioQualityAtom));
+          eng.configureProgressionGraph(eng.planSignalGraph(eng.TIER_PROFILES[tier], mix));
         }
       });
     };

--- a/src/progressions/audio/bus.ts
+++ b/src/progressions/audio/bus.ts
@@ -339,8 +339,8 @@ export function configureProgressionGraph(plan: SignalGraphPlan): MaterializedGr
  * should restart playback. Returns `false` when the context was recovered
  * in-place (scenario 2) — the existing Parts are still valid.
  */
-export function recoverProgressionContext(): boolean {
-  if (!ctx) return false;
+export async function recoverProgressionContext(): Promise<"restart" | "rebuild" | "none"> {
+  if (!ctx) return "none";
 
   const wasZombie = contextMayBeZombie;
 
@@ -352,17 +352,19 @@ export function recoverProgressionContext(): boolean {
   if (wasZombie) {
     // Old AudioContext was closed — all Tone.Parts referencing it are dead.
     // The caller must tear down and rebuild playback from bar 1.
-    return true;
+    return "restart";
   }
 
-  // Same context, but may have been suspended by the browser. resume + graph
-  // rebuild restores the signal path. Fire-and-forget — the existing Parts
-  // continue firing after the Transport clock resumes.
+  let graphWasDisposed = false;
   if (ctx && (ctx.state === "suspended" || ctx.state === "interrupted")) {
-    resumeProgressionAudio();
+    const hadGraph = currentGraph !== null;
+    await resumeProgressionAudio();
+    if (hadGraph && currentGraph === null) {
+      graphWasDisposed = true;
+    }
   }
 
-  return false;
+  return graphWasDisposed ? "rebuild" : "none";
 }
 
 /** Test-only reset hook so the module behaves predictably across `vitest` runs. */


### PR DESCRIPTION
Resolves issue where returning to the tab playing a progression resulted in no audio output. When Chrome suspended the AudioContext, the audio graph was disposed for safety, but it was never rebuilt. Now, recoverProgressionContext correctly instructs the caller to rebuild the graph in-place without restarting from bar 1.
