### PR TITLE
feat(progression): add strum directions to shuffle/skank/jazz comps

### DIFF
--- a/docs/superpowers/plans/2026-06-09-strum-pattern-directions.md
+++ b/docs/superpowers/plans/2026-06-09-strum-pattern-directions.md
@@ -1,0 +1,140 @@
+# Strum Pattern Directions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Annotate three existing chord patterns with strum `direction` so the strum voice plays idiomatic up/down strokes.
+
+**Architecture:** Data-only change. `ChordHit.direction` already exists and the strum voice (`strumVoice.ts:12`) already reverses voicing order on `direction: "up"`. We add the field to hits in `shuffle-comp`, `offbeat-skank`, and `jazz-comp` in `patterns.ts`, following the constant-hand-motion convention (down on-beat, up on "&"), with reggae skank as all-up. `straight-quarters` is intentionally left unchanged — its all-down feel is already the default.
+
+**Tech Stack:** TypeScript, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-strum-pattern-directions-design.md`
+
+---
+
+### Task 1: Add strum directions to the three patterns (TDD)
+
+**Files:**
+- Modify: `src/progressions/audio/patterns.ts` (the `shuffle-comp`, `offbeat-skank`, and `jazz-comp` entries inside `CHORD_PATTERNS`)
+- Test: `src/progressions/audio/patterns.test.ts`
+
+The current hits (no `direction`) are:
+
+```ts
+// shuffle-comp
+{ beat: 0, velocity: 0.9 },
+{ beat: 1.5, velocity: 0.6 },
+
+// offbeat-skank
+{ beat: 0.5, velocity: 0.7 },
+{ beat: 1.5, velocity: 0.7 },
+{ beat: 2.5, velocity: 0.7 },
+{ beat: 3.5, velocity: 0.7 },
+
+// jazz-comp
+{ beat: 0, velocity: 0.75, style: "staccato" },
+{ beat: 1.5, velocity: 0.6, style: "staccato" },
+{ beat: 3.5, velocity: 0.7, style: "staccato" },
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this block to `src/progressions/audio/patterns.test.ts` (after the existing `jazz-comp chord pattern` describe block). It references `getChordPattern`, already imported at the top of the file.
+
+```ts
+describe("strum directions", () => {
+  it("shuffle-comp anchors a downstroke on the one and an upstroke pickup", () => {
+    const p = getChordPattern("shuffle-comp")!;
+    const byBeat = new Map(p.hits.map((h) => [h.beat, h.direction]));
+    expect(byBeat.get(0)).toBe("down");
+    expect(byBeat.get(1.5)).toBe("up");
+  });
+
+  it("offbeat-skank plays every hit as a reggae upstroke", () => {
+    const p = getChordPattern("offbeat-skank")!;
+    expect(p.hits.every((h) => h.direction === "up")).toBe(true);
+  });
+
+  it("jazz-comp strums down on the downbeat and up on the off-beat pickups", () => {
+    const p = getChordPattern("jazz-comp")!;
+    const byBeat = new Map(p.hits.map((h) => [h.beat, h.direction]));
+    expect(byBeat.get(0)).toBe("down");
+    expect(byBeat.get(1.5)).toBe("up");
+    expect(byBeat.get(3.5)).toBe("up");
+  });
+
+  it("leaves straight-quarters all-down (default) — no annotations", () => {
+    const p = getChordPattern("straight-quarters")!;
+    expect(p.hits.every((h) => h.direction === undefined)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm run test -- src/progressions/audio/patterns.test.ts -t "strum directions"`
+Expected: FAIL — `shuffle-comp` / `offbeat-skank` / `jazz-comp` assertions fail because `direction` is `undefined` (the `straight-quarters` test already passes).
+
+- [ ] **Step 3: Add the `direction` fields in `patterns.ts`**
+
+Replace the `shuffle-comp` hits with:
+
+```ts
+    hits: [
+      { beat: 0, velocity: 0.9, direction: "down" },
+      { beat: 1.5, velocity: 0.6, direction: "up" },
+    ],
+```
+
+Replace the `offbeat-skank` hits with:
+
+```ts
+    hits: [
+      { beat: 0.5, velocity: 0.7, direction: "up" },
+      { beat: 1.5, velocity: 0.7, direction: "up" },
+      { beat: 2.5, velocity: 0.7, direction: "up" },
+      { beat: 3.5, velocity: 0.7, direction: "up" },
+    ],
+```
+
+Replace the `jazz-comp` hits with:
+
+```ts
+    hits: [
+      { beat: 0, velocity: 0.75, style: "staccato", direction: "down" },
+      { beat: 1.5, velocity: 0.6, style: "staccato", direction: "up" },
+      { beat: 3.5, velocity: 0.7, style: "staccato", direction: "up" },
+    ],
+```
+
+Leave `straight-quarters` untouched.
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `pnpm run test -- src/progressions/audio/patterns.test.ts -t "strum directions"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Run the full patterns suite to confirm no regression**
+
+Run: `pnpm run test -- src/progressions/audio/patterns.test.ts`
+Expected: PASS — the existing `jazz-comp chord pattern` block (beats, staccato, velocity) is unaffected by adding `direction`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/progressions/audio/patterns.ts src/progressions/audio/patterns.test.ts
+git commit -m "feat(progression): add strum directions to shuffle/skank/jazz comps"
+```
+
+---
+
+### Task 2: Full verification
+
+- [ ] **Step 1: Lint, test, build**
+
+Run: `pnpm run lint && pnpm run test && pnpm run build`
+Expected: all pass. (AGENTS.md requires lint + test + build locally before a PR.)
+
+- [ ] **Step 2: Manual audio check (optional but recommended)**
+
+Run: `pnpm run dev`. Select the strum instrument, load each of `shuffle-comp`, `offbeat-skank`, `jazz-comp`, and confirm the up-strokes read as reversed note order — most audible on `offbeat-skank` (all four hits become up-strokes).

--- a/docs/superpowers/specs/2026-06-09-strum-pattern-directions-design.md
+++ b/docs/superpowers/specs/2026-06-09-strum-pattern-directions-design.md
@@ -4,11 +4,15 @@ Improve strum realism by adding `direction` fields to existing chord patterns th
 
 ## Motivation
 
-The strum voice (`strumVoice.ts`) reverses voicing order for `direction: "up"`, mimicking a real up-stroke (highest string first → lowest last). Several patterns omit `direction`, so all their hits play as down-strums regardless of musical convention. This makes the strum instrument sound mechanical and one-dimensional, especially in genres like blues and pop where alternating strums are fundamental to the feel.
+The strum voice (`strumVoice.ts`) reverses voicing order for `direction: "up"`, mimicking a real up-stroke (highest string first → lowest last). Several patterns omit `direction`, so all their hits play as down-strums regardless of musical convention. This makes the strum instrument sound mechanical and one-dimensional, especially in genres like blues and reggae where alternating or up-stroke strums are fundamental to the feel.
+
+## Convention
+
+`direction` defaults to `"down"` when omitted. The established model (already followed by `pop-8ths`) is **constant hand motion**: a strumming hand oscillating at eighth-note rate plays down-strokes on the on-beats (0, 1, 2, 3) and up-strokes on the "&" off-beats (.5). New annotations follow this model, except where a genre convention overrides it (reggae skank is all up-strokes).
 
 ## Approach
 
-Add `direction` to hits in four patterns where the strumming convention is clear. Polyphonic voices (piano/organ) ignore `direction`, so the change is invisible for non-strum instruments.
+Add `direction` to hits in three patterns where the strumming convention is clear and produces audibly different note order. Polyphonic voices (piano/organ) ignore `direction`, so the change is invisible for non-strum instruments.
 
 ### `shuffle-comp`
 Used by Blues genre (currently organ, but user-selectable for strum). Blues guitar rhythm: strong downbeat anchor, lighter up-stroke pickup.
@@ -18,18 +22,8 @@ Used by Blues genre (currently organ, but user-selectable for strum). Blues guit
 | 0    | 0.9      | down      |
 | 1.5  | 0.6      | up        |
 
-### `straight-quarters`
-Used by Pop genre (currently piano). When played on strum, folk/pop strumming naturally alternates down/up per quarter note.
-
-| Beat | Velocity | Direction |
-|------|----------|-----------|
-| 0    | 0.8      | down      |
-| 1    | 0.6      | up        |
-| 2    | 0.7      | down      |
-| 3    | 0.6      | up        |
-
 ### `offbeat-skank`
-Not genre-assigned, available in pattern dropdown. Reggae/ska up-stroke convention — all hits are up-strums.
+Not genre-assigned, available in pattern dropdown. Reggae/ska up-stroke convention — all hits are up-strums. This is the one pattern with a real net change: every hit flips from the default down to up.
 
 | Beat | Velocity | Direction |
 |------|----------|-----------|
@@ -39,7 +33,7 @@ Not genre-assigned, available in pattern dropdown. Reggae/ska up-stroke conventi
 | 3.5  | 0.7      | up        |
 
 ### `jazz-comp`
-Used by Jazz genre (currently piano). Jazz guitar comping on the off-beats typically uses a down-up-down motion.
+Used by Jazz genre (currently piano). Jazz guitar comping: down on the downbeat anchor, up on the off-beat pickups.
 
 | Beat | Velocity | Direction | Style     |
 |------|----------|-----------|-----------|
@@ -47,19 +41,22 @@ Used by Jazz genre (currently piano). Jazz guitar comping on the off-beats typic
 | 1.5  | 0.6      | up        | staccato  |
 | 3.5  | 0.7      | up        | staccato  |
 
+`shuffle-comp` beat 0 and `jazz-comp` beat 0 are already the default `down`; they are written explicitly to document intent alongside the up-strokes in the same pattern.
+
 ### Unchanged
+- **`straight-quarters`**: Used by Pop genre (currently piano). On strum, the desired feel is a driving all-down-stroke quarter pulse — the hand resets in the air between hits. Since `direction` defaults to `"down"`, that feel is already the behavior; no annotation is needed. Left unchanged deliberately (not an oversight): alternating D-U-D-U on bare quarters would contradict the constant-hand-motion convention used elsewhere.
 - **`ballad-whole`**: Single sustained hit — direction is meaningless.
 - **`bossa-comp`**: Designed for rootless-jazz voicing engine with LH/RH split. Not a strum pattern.
 - **`pop-8ths`**, **`funk-16th`**, **`funk-scratch`**, **`pop-syncopated-push`**: Already have direction annotations.
 
 ## Files Changed
 
-- `src/progressions/audio/patterns.ts` — add `direction` to `shuffle-comp`, `straight-quarters`, `offbeat-skank`, `jazz-comp`
+- `src/progressions/audio/patterns.ts` — add `direction` to `shuffle-comp`, `offbeat-skank`, `jazz-comp`
 
 ## Testing
 
 - Existing strum direction tests in `strumVoice.test.ts` should continue passing
-- Manual: play each pattern with strum instrument, verify audible up/down alternation matches the table above
+- Manual: play each changed pattern with the strum instrument, verify audible up/down behavior matches the tables above (most audible on `offbeat-skank`, where all hits become up-strokes)
 - No new tests needed — this is data-only, the direction handling is already tested
 
 ## Future Considerations

--- a/src/progressions/audio/patterns.test.ts
+++ b/src/progressions/audio/patterns.test.ts
@@ -571,6 +571,33 @@ describe("chord & bass variation catalogs", () => {
   });
 });
 
+describe("strum directions", () => {
+  it("shuffle-comp anchors a downstroke on the one and an upstroke pickup", () => {
+    const p = getChordPattern("shuffle-comp")!;
+    const byBeat = new Map(p.hits.map((h) => [h.beat, h.direction]));
+    expect(byBeat.get(0)).toBe("down");
+    expect(byBeat.get(1.5)).toBe("up");
+  });
+
+  it("offbeat-skank plays every hit as a reggae upstroke", () => {
+    const p = getChordPattern("offbeat-skank")!;
+    expect(p.hits.every((h) => h.direction === "up")).toBe(true);
+  });
+
+  it("jazz-comp strums down on the downbeat and up on the off-beat pickups", () => {
+    const p = getChordPattern("jazz-comp")!;
+    const byBeat = new Map(p.hits.map((h) => [h.beat, h.direction]));
+    expect(byBeat.get(0)).toBe("down");
+    expect(byBeat.get(1.5)).toBe("up");
+    expect(byBeat.get(3.5)).toBe("up");
+  });
+
+  it("leaves straight-quarters all-down (default) — no annotations", () => {
+    const p = getChordPattern("straight-quarters")!;
+    expect(p.hits.every((h) => h.direction === undefined)).toBe(true);
+  });
+});
+
 describe("bossa patterns", () => {
   it("rewrites the bossa drum pattern as a 2-bar cell with a bossa-clave cross-stick", () => {
     const bossa = getDrumPattern("bossa")!;

--- a/src/progressions/audio/patterns.ts
+++ b/src/progressions/audio/patterns.ts
@@ -159,27 +159,27 @@ export const CHORD_PATTERNS: readonly ChordPattern[] = [
     id: "offbeat-skank",
     label: "Offbeat Skank",
     hits: [
-      { beat: 0.5, velocity: 0.7 },
-      { beat: 1.5, velocity: 0.7 },
-      { beat: 2.5, velocity: 0.7 },
-      { beat: 3.5, velocity: 0.7 },
+      { beat: 0.5, velocity: 0.7, direction: "up" },
+      { beat: 1.5, velocity: 0.7, direction: "up" },
+      { beat: 2.5, velocity: 0.7, direction: "up" },
+      { beat: 3.5, velocity: 0.7, direction: "up" },
     ],
   },
   {
     id: "shuffle-comp",
     label: "Shuffle Comp",
     hits: [
-      { beat: 0, velocity: 0.9 },
-      { beat: 1.5, velocity: 0.6 },
+      { beat: 0, velocity: 0.9, direction: "down" },
+      { beat: 1.5, velocity: 0.6, direction: "up" },
     ],
   },
   {
     id: "jazz-comp",
     label: "Jazz Comping",
     hits: [
-      { beat: 0, velocity: 0.75, style: "staccato" },
-      { beat: 1.5, velocity: 0.6, style: "staccato" },
-      { beat: 3.5, velocity: 0.7, style: "staccato" },
+      { beat: 0, velocity: 0.75, style: "staccato", direction: "down" },
+      { beat: 1.5, velocity: 0.6, style: "staccato", direction: "up" },
+      { beat: 3.5, velocity: 0.7, style: "staccato", direction: "up" },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Annotate three existing chord patterns in `patterns.ts` with idiomatic strum `direction`, so the strum voice plays realistic up/down note ordering.
  - `shuffle-comp`: down on the one, up pickup on the "&".
  - `offbeat-skank`: all reggae upstrokes.
  - `jazz-comp`: down on the downbeat, up on the off-beat pickups.
- `straight-quarters` left unannotated — its all-down feel already matches the `direction` default (`"down"`), per the spec's constant-hand-motion convention.
- Data-only change: `ChordHit.direction` and the strum-voice reversal already exist; polyphonic voices (piano/organ) ignore `direction`.

Spec: `docs/superpowers/specs/2026-06-09-strum-pattern-directions-design.md`
Plan: `docs/superpowers/plans/2026-06-09-strum-pattern-directions.md`

## Test Plan

- [x] `pnpm run test` — 2607 passed (added 4 `strum directions` cases incl. a `straight-quarters` regression guard)
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run build` — succeeds
- [ ] Manual: play `offbeat-skank` on the strum instrument and confirm all hits read as up-strokes

🤖 Generated with [Claude Code](https://claude.com/claude-code)