### PR TITLE
fix(playback): fix playhead not stopping and jumping to end

### DIFF
--- a/src/components/ProgressionTrack/ProgressionPlayhead.tsx
+++ b/src/components/ProgressionTrack/ProgressionPlayhead.tsx
@@ -125,6 +125,9 @@ export function ProgressionPlayhead({
       if (anim) {
         anim.cancel();
       }
+      if (el && typeof el.getAnimations === "function") {
+        el.getAnimations().forEach((a) => a.cancel());
+      }
     };
   }, [playing, totalBarsForDisplay, totalDurationBars]);
 

--- a/src/hooks/useProgressionAudioPlayback.ts
+++ b/src/hooks/useProgressionAudioPlayback.ts
@@ -657,11 +657,9 @@ export function useProgressionAudioPlayback() {
       // for lint's exhaustive-deps check (which would otherwise warn).
       genRefSnapshot.current++;
       
-      // Audio is NOT disposed here. The next effect run handles teardown: a
-      // restart-tier change disposes + rewinds up front (see the reset block at
-      // the top of this effect), and a stop (`playing` false) hits the
-      // `tearDownAndStop()` early-return branch. Cleanup's only job is bumping
-      // `genRef` to invalidate any in-flight build.
+      // Stop the visual clock explicitly so the RAF loop doesn't leak across
+      // effect restarts (e.g. tab recovery). The next run handles audio teardown.
+      stopVisualClock();
     };
   }, [
     playing,


### PR DESCRIPTION
- Fix: The playhead WAAPI animation was not being reliably cleared when playback stopped, causing the playhead to jump to the end instead of snapping back to 0. It is now forcefully cancelled using `el.getAnimations()`.
- Fix: The visual clock loop was not properly stopped when the main playback effect restarted (e.g. after tab recovery), causing ghost updates to leak.