### PR TITLE
refactor(fretboard-pkg): extract fretboard design tokens into the package

### DIFF
--- a/packages/fretboard/src/components/FretboardSVG/FretboardDefs.tsx
+++ b/packages/fretboard/src/components/FretboardSVG/FretboardDefs.tsx
@@ -205,7 +205,7 @@ export const FretboardDefs = memo(({
           dx="0"
           dy="0"
           stdDeviation="3"
-          floodColor="var(--neon-orange)"
+          floodColor="var(--neon-orange, #b1431b)"
           floodOpacity="var(--fretboard-glow-opacity)"
         />
       </filter>

--- a/packages/fretboard/src/components/FretboardSVG/FretboardSVG.module.css
+++ b/packages/fretboard/src/components/FretboardSVG/FretboardSVG.module.css
@@ -61,7 +61,7 @@
 }
 
 .fretboard-note:focus-visible :is(circle, path, polygon) {
-  stroke: var(--accent-primary) !important;
+  stroke: var(--accent-primary, #147088) !important;
   stroke-width: 3 !important;
 }
 
@@ -150,8 +150,8 @@
 :global([data-theme="modern-light"]) .fretboard-note.chord-tone-in-scale text,
 :global([data-theme="modern-light"]) .fretboard-note.note-diatonic-chord text,
 :global([data-theme="modern-light"]) .fretboard-note.note-active text {
-  stroke: var(--note-label-on-color-stroke);
-  fill: var(--note-label-on-color);
+  stroke: var(--note-label-on-color-stroke, rgba(246, 242, 233, 0.50));
+  fill: var(--note-label-on-color, #2a251d);
 }
 
 /* Dark-mode per-role label-fill overrides (audit rows 1, 2, 3).
@@ -175,8 +175,8 @@
 }
 
 :global([data-theme="modern-light"]) .fretboard-note:is(.chord-tone-outside-scale, .note-blue) text {
-  stroke: var(--note-label-on-color-stroke);
-  fill: var(--note-label-on-color);
+  stroke: var(--note-label-on-color-stroke, rgba(246, 242, 233, 0.50));
+  fill: var(--note-label-on-color, #2a251d);
 }
 
 /* Chromatic-diamond labels read crisply — subordination comes from SIZE, not a dim glyph. */
@@ -237,7 +237,7 @@
    so `!important` is the robust, intent-correct exemption — the same escape the
    former glow underlay used in this file. */
 .note-target-backing {
-  fill: var(--note-incoming) !important;
+  fill: var(--note-incoming, #0f9d72) !important;
   stroke: none !important;
   pointer-events: none;
 }
@@ -286,7 +286,7 @@
 }
 
 .note-guide-ring-core {
-  stroke: var(--note-incoming) !important;
+  stroke: var(--note-incoming, #0f9d72) !important;
 }
 
 /* Stroke weights are constant across phases (no scale animation, so the ring
@@ -344,7 +344,7 @@
    the countdown. */
 .note-guide-ring-flash {
   fill: none !important;
-  stroke: var(--note-incoming) !important;
+  stroke: var(--note-incoming, #0f9d72) !important;
   stroke-width: 3 !important;
   opacity: 0;
   transform-box: fill-box;
@@ -397,7 +397,7 @@
    without overlapping the main note glyph. */
 .note-guide-label {
   dominant-baseline: middle;
-  fill: var(--note-incoming);
+  fill: var(--note-incoming, #0f9d72);
   font-size: 9px;
   font-weight: 600;
   pointer-events: none;
@@ -431,9 +431,9 @@
 
 .note-bubble:focus-visible {
   opacity: 1 !important;
-  outline: var(--focus-ring);
-  outline-offset: var(--focus-ring-offset);
-  box-shadow: var(--focus-ring-glow);
+  outline: var(--focus-ring, 2px solid #147088);
+  outline-offset: var(--focus-ring-offset, 2px);
+  box-shadow: var(--focus-ring-glow, 0 0 0 3px rgb(20 112 136 / 0.20));
 }
 
 /* Fret numbers row */
@@ -443,7 +443,7 @@
 
 .fret-number {
   text-align: center;
-  font-family: var(--font-sans);
+  font-family: var(--font-sans, "Inter", system-ui, "Avenir", "Helvetica", "Arial", sans-serif);
   font-size: 0.9rem;
   font-weight: 500;
   color: rgb(191 204 216 / 0.72);

--- a/packages/fretboard/src/components/FretboardSVG/FretboardSVG.test.tsx
+++ b/packages/fretboard/src/components/FretboardSVG/FretboardSVG.test.tsx
@@ -3,6 +3,8 @@ import type { ComponentProps } from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
 import "../../../../../src/styles/index.css";
 import "../../../../../src/styles/themes.css";
+// Fretboard tokens now live in the package; themes.css no longer defines them.
+import "../../styles/fretboard-tokens.css";
 import { FretboardSVG } from "../FretboardSVG/FretboardSVG";
 import { getFretboardNotes } from "@fretflow/core";
 import type { CagedShape, ShapePolygon } from "@fretflow/core";

--- a/packages/fretboard/src/styles/fretboard-tokens.css
+++ b/packages/fretboard/src/styles/fretboard-tokens.css
@@ -1,0 +1,177 @@
+/*
+   @fretflow/fretboard — Fretboard Design Tokens (single source of truth)
+
+   These tokens are owned by the fretboard renderer. They were previously
+   interleaved with app-wide tokens in src/styles/{tokens,semantic,themes}.css;
+   they now live here so the package is self-contained for styling. The web app
+   re-imports this file (src/main.tsx) so its rendering is unchanged, and the
+   web app's HelpModal diagrams (src/components/HelpModal/diagrams/*) continue to
+   consume the --fb-* family through this re-import. External consumers import
+   only this file.
+
+   Cascade is deterministic because each property is defined exactly once (here),
+   so import order relative to the app stylesheets does not matter.
+
+   Three sections:
+     :root                          theme-independent primitives + dark-theme
+                                    defaults (the values that lived in
+                                    tokens.css / semantic.css :root)
+     [data-theme="modern-light"]    light-theme values
+     [data-theme="modern-dark"]     dark-theme overrides
+
+   Some tokens are intentionally light-theme-only (no :root/dark default):
+   --fret-wire-shadow, --fretboard-board-shadow, --fretboard-note-text-fill,
+   --fretboard-note-text-stroke, --fretboard-fret-number-color, --nut-stop-1..4.
+   This mirrors the original structure verbatim — do not invent dark values.
+*/
+
+:root {
+  /* Fretboard wood / fret wire / strings / inlays / edges — dark-theme defaults. */
+  --fretboard-wood-top: #160d07;
+  --fretboard-wood-mid: #0d0805;
+  --fretboard-wood-bottom: #080403;
+  --fret-wire-dark: #4a5058;
+  --fret-wire-medium: #a6afbc;
+  --fret-wire-bright: #ebeff5;
+  --string-wire: #e4e8ee;
+  --string-wire-bass: #c6ccd2;
+  --string-taper-1: 1px;
+  --string-taper-2: 1.25px;
+  --string-taper-3: 1.5px;
+  --string-taper-4: 2px;
+  --string-taper-5: 2.5px;
+  --string-taper-6: 3px;
+  --inlay-pearl-stop1: rgb(250 247 232);
+  --inlay-pearl-stop2: rgb(218 209 182);
+  --inlay-pearl-stop3: rgb(156 144 118);
+  --inlay-pearl-opacity1: 0.98;
+  --inlay-pearl-opacity2: 0.88;
+  --inlay-pearl-opacity3: 0.75;
+  --fretboard-top-edge-color: rgb(218 182 138 / 0.22);
+  --fretboard-bottom-edge-color: rgb(0 0 0 / 0.75);
+  --fretboard-nut-slot-color: rgb(12 8 4 / 0.55);
+  --fretboard-glow-opacity: 0.65;
+
+  /* Fretboard accessibility chrome — interactive UI layer, not SVG artwork. */
+  --fretboard-a11y-hover-bg: rgb(255 255 255 / 0.15);
+}
+
+[data-theme="modern-light"] {
+  /* Fretboard wood — warm maple */
+  --fretboard-wood-top: #fbe6c6;
+  --fretboard-wood-mid: #f1c38e;
+  --fretboard-wood-bottom: #e0ab68;
+  --fret-wire-dark: #5c4a3a;
+  --fret-wire-medium: #bbaa97;
+  --fret-wire-bright: #f3eee2;
+  --fret-wire-shadow: rgb(0 0 0 / 0.15);
+
+  /* String colors — warm metal on light maple (retoned from cool blue-gray) */
+  --string-wire: #d8cdb8;
+  --string-wire-bass: #b8a585;
+
+  /* Nut gradient — bone white */
+  --nut-stop-1: #ffffff;
+  --nut-stop-2: #fcfbf8;
+  --nut-stop-3: #f8f4e8;
+  --nut-stop-4: #f3ecd8;
+
+  /* Inlays — neutral cool-white pearl tuned for maple fretboard (#fbe6c6 → #f1c38e → #e0ab68).
+     Reference: real WP inlays on maple read as near-white pearl — luminance high, chroma < 3%.
+     Against warm maple (brighter/warmer than rosewood), pure cool-seafoam reads as chromatic
+     clash. Solution: collapse green-cyan delta, stay essentially achromatic with faint cool lean.
+     Color family: neutral gray-white, saturation < 3%. NOT teal, NOT seafoam.
+     Light mode overrides the pearl stops only; opacity inherits the :root defaults. */
+  --inlay-pearl-stop1: rgb(240, 242, 242);
+  --inlay-pearl-stop2: rgb(216, 218, 218);
+  --inlay-pearl-stop3: rgb(188, 192, 192);
+
+  --fretboard-top-edge-color: rgba(255, 255, 255, 0.4);
+  --fretboard-bottom-edge-color: rgba(0, 0, 0, 0.15);
+  --fretboard-nut-slot-color: rgba(0, 0, 0, 0.2);
+  /* Light-mode glow opacity. Consumed by the glow-orange SVG <feDropShadow>
+     filter in FretboardDefs.tsx — so this also affects the chord-tone role
+     glow in light mode, not just the lens-emphasis hold/anticipation glow.
+     0.45 is the soft-but-clear target against the cream PANEL. */
+  --fretboard-glow-opacity: 0.45;
+
+  /* Fretboard accessibility chrome — light-mode override */
+  --fretboard-a11y-hover-bg: rgb(0 0 0 / 0.1);
+
+  /* Fretboard SVG — light-mode board shadow, note text, fret number */
+  --fretboard-board-shadow: rgb(0 0 0 / 0.15);
+  --fretboard-note-text-fill: #2a251d;  /* INK — reference palette */
+  --fretboard-note-text-stroke: transparent;
+  --fretboard-fret-number-color: #475569;
+
+  /* Chord-overlay semantic colors (2026-06 redesign): amber=home, teal=guide, neutral=rest.
+     Single-source oklch() literals, equivalence-preserving (original hex in comments).
+     Hues differ per theme by design (warm maple here vs cool rosewood in dark) — there is
+     no shared hue, so each triplet is independent. Triplets from scripts/derive-fb-oklch.mjs. */
+  --fb-home-fill: oklch(0.5898 0.1342 60.9); /* was #b5670a */
+  --fb-home-stroke: oklch(0.5285 0.1524 38.7); /* was var(--note-ring-tonic) → #b1431b */
+  --fb-guide-fill: oklch(0.9307 0.0370 225.0); /* was #cfeefb */
+  --fb-guide-stroke: oklch(0.5695 0.1042 226.2); /* was #1583a6 */
+  --fb-neutral-fill: oklch(0.9009 0.0095 62.6); /* was #e3ddd8 */
+  --fb-neutral-stroke: oklch(0.4262 0.0246 74.3); /* was #574d40 */
+  --fb-region-tint: oklch(0.4878 0.0283 67.1 / 0.20); /* was rgba(107, 93, 79, 0.20) */
+  --fb-connector-halo: rgb(0 0 0 / 0.6); /* light wood: dark casing carves the line (APCA composited Lc ~57 vs maple) */
+
+  /* Chord-tone connector palette — canonical Okabe-Ito 8-color palette.
+     Identical across light and dark themes for consistent voicing identity.
+     Light mode: lower fill-opacity (0.22 vs dark 0.15) because the warm tan
+     maple wood (#fbe6c6–#e0ab68) provides less contrast than rosewood, so
+     a moderate alpha keeps the connector readable without over-saturating.
+     Halo: warmer, slightly higher opacity to lift off the maple background. */
+  --chord-connector-fill-opacity: 0.22;
+  --chord-connector-outline-width: 1.25px;
+  --chord-connector-outline-opacity: 0.80;
+  --chord-connector-halo-width: 2px;
+  --chord-connector-halo-color: rgba(255, 255, 255, 0.55);
+  --chord-connector-color-1: #E69F00; /* Okabe-Ito: orange */
+  --chord-connector-color-2: #D55E00; /* Okabe-Ito: vermillion */
+  --chord-connector-color-3: #999999; /* Okabe-Ito: gray */
+  --chord-connector-color-4: #009E73; /* Okabe-Ito: bluish green */
+  --chord-connector-color-5: #56B4E9; /* Okabe-Ito: sky blue */
+  --chord-connector-color-6: #0072B2; /* Okabe-Ito: blue */
+  --chord-connector-color-7: #CC79A7; /* Okabe-Ito: reddish purple */
+  --chord-connector-color-8: #F0E442; /* Okabe-Ito: yellow */
+}
+
+[data-theme="modern-dark"] {
+  /* Fretboard accessibility chrome — alpha parity with light-mode (0.1), white channel for dark surfaces */
+  --fretboard-a11y-hover-bg: rgb(255 255 255 / 0.1);
+
+  /* Chord-overlay semantic colors (2026-06 redesign): amber=home, teal=guide, neutral=rest.
+     Single-source oklch() literals, equivalence-preserving (original hex in comments).
+     Hues differ per theme by design (cool rosewood here vs warm maple in light) — there is
+     no shared hue, so each triplet is independent. Triplets from scripts/derive-fb-oklch.mjs.
+     Note: home-stroke here was originally var(--note-ring-tonic) resolving through :root's
+     --neon-orange (#FF9A4D), now baked to its equivalent oklch literal — preserved verbatim. */
+  --fb-home-fill: oklch(0.5898 0.1342 60.9); /* was #b5670a — identical to light by design */
+  --fb-home-stroke: oklch(0.7775 0.1512 55.4); /* was var(--note-ring-tonic) → #FF9A4D */
+  --fb-guide-fill: oklch(0.4375 0.0764 235.5); /* was #1f5876 */
+  --fb-guide-stroke: oklch(0.8837 0.1056 209.8); /* was #7cecff */
+  --fb-neutral-fill: oklch(0.2525 0.0206 251.6); /* was #1b232c */
+  --fb-neutral-stroke: oklch(0.7108 0.0155 244.8); /* was #9aa3ab */
+  --fb-region-tint: oklch(0.7108 0.0155 244.8 / 0.14); /* was rgba(154, 163, 171, 0.14) */
+  --fb-connector-halo: rgb(0 0 0 / 0.5); /* dark wood: shadow halo carves the line */
+
+  /* Chord-tone connector overrides for dark mode.
+     Same canonical Okabe-Ito palette as light mode. Lower fill opacity because
+     dark rosewood provides high contrast at lower alpha. Halo disabled —
+     all canonical Okabe-Ito colors pass WCAG 3:1 against rosewood. */
+  --chord-connector-fill-opacity: 0.15;
+  --chord-connector-outline-width: 1.25px;
+  --chord-connector-outline-opacity: 0.85;
+  --chord-connector-halo-width: 0;
+  --chord-connector-halo-color: transparent;
+  --chord-connector-color-1: #E69F00; /* Okabe-Ito: orange */
+  --chord-connector-color-2: #D55E00; /* Okabe-Ito: vermillion */
+  --chord-connector-color-3: #999999; /* Okabe-Ito: gray */
+  --chord-connector-color-4: #009E73; /* Okabe-Ito: bluish green */
+  --chord-connector-color-5: #56B4E9; /* Okabe-Ito: sky blue */
+  --chord-connector-color-6: #0072B2; /* Okabe-Ito: blue */
+  --chord-connector-color-7: #CC79A7; /* Okabe-Ito: reddish purple */
+  --chord-connector-color-8: #F0E442; /* Okabe-Ito: yellow */
+}

--- a/scripts/ui-tokens.mjs
+++ b/scripts/ui-tokens.mjs
@@ -137,12 +137,24 @@ export function collectReferences(files) {
 
 function main() {
   const srcDir = fileURLToPath(new URL("../src", import.meta.url));
+  // Fretboard tokens (--fb-*, --chord-connector-*, wood/wire/etc.) were
+  // extracted into @fretflow/fretboard so the package is self-contained for
+  // styling. The app's HelpModal diagrams still reference --fb-* from src/, so
+  // the package's stylesheets must be pooled into the DEFINITIONS scan or those
+  // references would be flagged undefined. References are still collected from
+  // src/ only — the package's own var() usage carries inline fallbacks and
+  // runtime-injected tokens the src-scoped checker is not designed to resolve.
+  const pkgFretboardDir = fileURLToPath(
+    new URL("../packages/fretboard/src", import.meta.url),
+  );
   const cssFiles = listFiles(srcDir, [".css"]);
   // Token definitions live in CSS *and* in React inline-style keys (.ts/.tsx);
   // references only live in CSS.
   const defined = collectDefinedTokens([
     ...cssFiles,
     ...listFiles(srcDir, [".ts", ".tsx"]),
+    ...listFiles(pkgFretboardDir, [".css"]),
+    ...listFiles(pkgFretboardDir, [".ts", ".tsx"]),
   ]);
   const refs = collectReferences(cssFiles);
   const undefinedRefs = findUndefined(defined, refs);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,10 @@ import './styles/tokens.css'
 import './styles/index.css'
 import './styles/semantic.css'
 import './styles/themes.css'
+// Fretboard design tokens — owned by @fretflow/fretboard, re-imported here so
+// the web app's rendering (and HelpModal --fb-* usage) is unchanged. Single
+// source of truth; defined once, so import order is not significant.
+import '@fretflow/fretboard/styles/fretboard-tokens.css'
 import './styles/controls.css'
 import App from './App.tsx'
 import { ErrorBoundary, ErrorFallback } from './components/ErrorBoundary/ErrorBoundary'

--- a/src/styles/__tests__/cssTokens.ts
+++ b/src/styles/__tests__/cssTokens.ts
@@ -2,14 +2,30 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { parse, converter } from "culori";
 
-const THEMES_CSS = fileURLToPath(new URL("../themes.css", import.meta.url));
+// Theme tokens are split across the app's themes.css and the fretboard
+// package's own token stylesheet (fretboard-specific tokens — --fb-*,
+// --chord-connector-*, wood/wire/etc. — were extracted into the package so it
+// is self-contained for styling). readThemeBlock() merges the `[data-theme]`
+// block from every source so every token resolves regardless of which file
+// owns it.
+const THEME_SOURCES = [
+  new URL("../themes.css", import.meta.url),
+  new URL(
+    "../../../packages/fretboard/src/styles/fretboard-tokens.css",
+    import.meta.url,
+  ),
+].map((u) => fileURLToPath(u));
 
-/** Parse `[data-theme="<theme>"] { ... }` into a {token: value} map. */
-export function readThemeBlock(theme: string): Record<string, string> {
-  const css = readFileSync(THEMES_CSS, "utf8");
+/** Parse the `[data-theme="<theme>"] { ... }` block from one CSS file into a
+ *  {token: value} map. Returns {} if the file has no such block. */
+function readThemeBlockFromFile(
+  file: string,
+  theme: string,
+): Record<string, string> {
+  const css = readFileSync(file, "utf8");
   const head = `[data-theme="${theme}"] {`;
   const start = css.indexOf(head);
-  if (start === -1) throw new Error(`theme block not found: ${theme}`);
+  if (start === -1) return {};
   // Match to the first top-level closing brace of this block.
   let depth = 0;
   let i = start + head.length - 1;
@@ -26,6 +42,21 @@ export function readThemeBlock(theme: string): Record<string, string> {
   for (const m of body.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
     out[m[1]] = m[2].trim();
   }
+  return out;
+}
+
+/** Merge the `[data-theme="<theme>"]` token maps across all theme sources
+ *  (app themes.css + the @fretflow/fretboard token file). Each token is defined
+ *  in exactly one source, so the merge is conflict-free. */
+export function readThemeBlock(theme: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  let found = false;
+  for (const file of THEME_SOURCES) {
+    const block = readThemeBlockFromFile(file, theme);
+    if (Object.keys(block).length > 0) found = true;
+    Object.assign(out, block);
+  }
+  if (!found) throw new Error(`theme block not found: ${theme}`);
   return out;
 }
 

--- a/src/styles/semantic.css
+++ b/src/styles/semantic.css
@@ -218,8 +218,7 @@
   --fretboard-note-fill-deemphasis-chord:  #141e28;
   --fretboard-note-fill-deemphasis-violet: #1e1237;
 
-  /* Fretboard accessibility chrome — interactive UI layer, not SVG artwork */
-  --fretboard-a11y-hover-bg: rgb(255 255 255 / 0.15);
+  /* --fretboard-a11y-hover-bg moved to @fretflow/fretboard/styles/fretboard-tokens.css */
 
   /* DAW faceplate surface — theme-adaptive panel chrome used by the Inspector
      and other faceplate consumers. :root carries the dark-mode values as a
@@ -359,8 +358,7 @@
   --control-focus-glow: 0 0 0 3px color-mix(in srgb, var(--neon-cyan) 25%, transparent);
   --control-focus-inset: inset 0 0 0 2px var(--neon-cyan);
 
-  /* Fretboard accessibility chrome — alpha parity with light-mode (0.1), white channel for dark surfaces */
-  --fretboard-a11y-hover-bg: rgb(255 255 255 / 0.1);
+  /* --fretboard-a11y-hover-bg moved to @fretflow/fretboard/styles/fretboard-tokens.css */
 
   /* DAW faceplate — dark mode: navy substrate, bright cyan accent, neon glow. */
   --faceplate-bg: #0a121d;

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -132,57 +132,21 @@
   /* Disabled state — clearly inactive */
   --disabled-opacity: 0.4;
 
-  /* Fretboard wood — warm maple */
-  --fretboard-wood-top: #fbe6c6;
-  --fretboard-wood-mid: #f1c38e;
-  --fretboard-wood-bottom: #e0ab68;
+  /* Fretboard renderer color/geometry tokens (wood, fret wire, strings, nut,
+     inlay pearls, edges, glow opacity) moved to
+     @fretflow/fretboard/styles/fretboard-tokens.css. The tokens kept here are
+     app-side fretboard chrome not referenced by the package renderer. */
   --fretboard-wood-grain: rgba(120, 70, 30, 0.15);
-  --fret-wire-dark: #5c4a3a;
-  --fret-wire-medium: #bbaa97;
-  --fret-wire-bright: #f3eee2;
   --fret-wire-highlight: rgb(255 255 255 / 0.25);
-  --fret-wire-shadow: rgb(0 0 0 / 0.15);
   --fret-marker: rgba(60, 30, 10, 0.15);
   --fret-nut-bg: #f8f4e8;
   --fret-nut-wire: #475569;
   --fretboard-border: #9e633e;
-
-  /* String colors — warm metal on light maple (retoned from cool blue-gray) */
-  --string-wire: #d8cdb8;
-  --string-wire-bass: #b8a585;
-
-  /* Nut gradient — bone white */
-  --nut-stop-1: #ffffff;
-  --nut-stop-2: #fcfbf8;
-  --nut-stop-3: #f8f4e8;
-  --nut-stop-4: #f3ecd8;
-
-  /* Inlays — neutral cool-white pearl tuned for maple fretboard (#fbe6c6 → #f1c38e → #e0ab68).
-     Reference: real WP inlays on maple read as near-white pearl — luminance high, chroma < 3%.
-     Against warm maple (brighter/warmer than rosewood), pure cool-seafoam reads as chromatic
-     clash. Solution: collapse green-cyan delta, stay essentially achromatic with faint cool lean.
-     Color family: neutral gray-white, saturation < 3%. NOT teal, NOT seafoam.
-     stop1 rgb(240,242,242): highlight near-white, Δ(G-B)=0, Δ(R-G)=2 — virtually achromatic.
-     stop2 rgb(216,218,218): mid neutral gray, achromatic.
-     stop3 rgb(188,192,192): slightly cool anchor, Δ(G-B)=0, Δ(R-G)=4 — minimal chroma.
-     No walnut rim; dots sit flush against the wood with no hard stroke. */
   --inlay-dot: rgba(60, 30, 10, 0.18);
   --inlay-dot-12: rgba(60, 30, 10, 0.40);
-  --inlay-pearl-stop1: rgb(240, 242, 242);
-  --inlay-pearl-stop2: rgb(216, 218, 218);
-  --inlay-pearl-stop3: rgb(188, 192, 192);
-
   --nut: #f8f4e8;
   --fretboard-edge-shadow: inset 0 0 15px rgba(0, 0, 0, 0.1);
-  --fretboard-top-edge-color: rgba(255, 255, 255, 0.4);
-  --fretboard-bottom-edge-color: rgba(0, 0, 0, 0.15);
-  --fretboard-nut-slot-color: rgba(0, 0, 0, 0.2);
   --fretboard-headstock-bg: var(--fretboard-wood-mid);
-  /* Light-mode glow opacity. Consumed by the glow-orange SVG <feDropShadow>
-     filter in FretboardDefs.tsx — so this also affects the chord-tone role
-     glow in light mode, not just the lens-emphasis hold/anticipation glow.
-     0.45 is the soft-but-clear target against the cream PANEL. */
-  --fretboard-glow-opacity: 0.45;
 
   /* CAGED shapes — light mode rebalance round 2.
      E lifts to its lighter sky-blue rgb so it visibly separates from A's deeper blue.
@@ -228,13 +192,9 @@
   --selected-chord-border: #d05620; /* ORANGE bright — reference palette */
   --selected-highlight: rgb(255 255 255 / 0.15); /* Backward compatibility alias */
 
-  /* Fretboard accessibility chrome — light-mode override */
-  --fretboard-a11y-hover-bg: rgb(0 0 0 / 0.1);
+  /* --fretboard-a11y-hover-bg, --fretboard-board-shadow, --fretboard-note-text-fill,
+     --fretboard-note-text-stroke moved to @fretflow/fretboard/styles/fretboard-tokens.css */
 
-  /* Fretboard SVG — light-mode rings, fills, and number color */
-  --fretboard-board-shadow: rgb(0 0 0 / 0.15);
-  --fretboard-note-text-fill: #2a251d;  /* INK — reference palette */
-  --fretboard-note-text-stroke: transparent;
   /* Note text — light mode, reference palette */
   --note-text-in-scale:  #2a251d;  /* INK — dark warm brown on cream fills */
   --note-text-tonic:     #2a251d;  /* INK — same; tonic fill is warm enough at 22% */
@@ -258,7 +218,7 @@
   --fretboard-tension-chord-tone-stroke: color-mix(in srgb, var(--note-ring-tonic) 40%, transparent);
   --fretboard-tension-color-tone-fill: color-mix(in srgb, var(--note-ring-color-tone) 15%, #ffffff);
   --fretboard-tension-color-tone-stroke: color-mix(in srgb, var(--note-ring-color-tone) 40%, transparent);
-  --fretboard-fret-number-color: #475569;
+  /* --fretboard-fret-number-color moved to @fretflow/fretboard/styles/fretboard-tokens.css */
 
   /* Fretboard note fill token overrides — light mode, reference palette.
      Tonic + chord-root in warm ORANGE family (rust tints into cream PANEL);
@@ -273,39 +233,11 @@
   --fretboard-note-fill-deemphasis-chord:  var(--fretboard-guide-tones-deemphasis-fill);
   --fretboard-note-fill-deemphasis-violet: var(--fretboard-guide-tones-color-tone-fill);
 
-  /* Chord-overlay semantic colors (2026-06 redesign): amber=home, teal=guide, neutral=rest.
-     Single-source oklch() literals, equivalence-preserving (original hex in comments).
-     Hues differ per theme by design (warm maple here vs cool rosewood in dark) — there is
-     no shared hue, so each triplet is independent. Triplets from scripts/derive-fb-oklch.mjs. */
-  --fb-home-fill: oklch(0.5898 0.1342 60.9); /* was #b5670a */
-  --fb-home-stroke: oklch(0.5285 0.1524 38.7); /* was var(--note-ring-tonic) → #b1431b */
-  --fb-guide-fill: oklch(0.9307 0.0370 225.0); /* was #cfeefb */
-  --fb-guide-stroke: oklch(0.5695 0.1042 226.2); /* was #1583a6 */
-  --fb-neutral-fill: oklch(0.9009 0.0095 62.6); /* was #e3ddd8 */
-  --fb-neutral-stroke: oklch(0.4262 0.0246 74.3); /* was #574d40 */
-  --fb-region-tint: oklch(0.4878 0.0283 67.1 / 0.20); /* was rgba(107, 93, 79, 0.20) */
+  /* Chord-overlay accent (vermillion) kept app-side; resolves through
+     --chord-connector-color-2, now defined in @fretflow/fretboard. The
+     home/guide/neutral/region/halo --fb-* tokens and the full --chord-connector-*
+     palette moved to @fretflow/fretboard/styles/fretboard-tokens.css. */
   --fb-connector-accent: var(--chord-connector-color-2); /* vermillion */
-  --fb-connector-halo: rgb(0 0 0 / 0.6); /* light wood: dark casing carves the line (APCA composited Lc ~57 vs maple) */
-
-  /* Chord-tone connector palette — canonical Okabe-Ito 8-color palette.
-     Identical across light and dark themes for consistent voicing identity.
-     Light mode: lower fill-opacity (0.22 vs dark 0.15) because the warm tan
-     maple wood (#fbe6c6–#e0ab68) provides less contrast than rosewood, so
-     a moderate alpha keeps the connector readable without over-saturating.
-     Halo: warmer, slightly higher opacity to lift off the maple background. */
-  --chord-connector-fill-opacity: 0.22;
-  --chord-connector-outline-width: 1.25px;
-  --chord-connector-outline-opacity: 0.80;
-  --chord-connector-halo-width: 2px;
-  --chord-connector-halo-color: rgba(255, 255, 255, 0.55);
-  --chord-connector-color-1: #E69F00; /* Okabe-Ito: orange */
-  --chord-connector-color-2: #D55E00; /* Okabe-Ito: vermillion */
-  --chord-connector-color-3: #999999; /* Okabe-Ito: gray */
-  --chord-connector-color-4: #009E73; /* Okabe-Ito: bluish green */
-  --chord-connector-color-5: #56B4E9; /* Okabe-Ito: sky blue */
-  --chord-connector-color-6: #0072B2; /* Okabe-Ito: blue */
-  --chord-connector-color-7: #CC79A7; /* Okabe-Ito: reddish purple */
-  --chord-connector-color-8: #F0E442; /* Okabe-Ito: yellow */
 }
 
 /* ==========================================================================
@@ -327,39 +259,11 @@
      which drifts away from the mirror-warm-amber palette anchor. */
   --fretboard-note-fill-scale-only: #3a2f28;
 
-  /* Chord-overlay semantic colors (2026-06 redesign): amber=home, teal=guide, neutral=rest.
-     Single-source oklch() literals, equivalence-preserving (original hex in comments).
-     Hues differ per theme by design (cool rosewood here vs warm maple in light) — there is
-     no shared hue, so each triplet is independent. Triplets from scripts/derive-fb-oklch.mjs.
-     Note: home-stroke here resolves through :root's --neon-orange (#FF9A4D), not light's
-     #b1431b, because dark does not redefine --note-ring-tonic — preserved verbatim. */
-  --fb-home-fill: oklch(0.5898 0.1342 60.9); /* was #b5670a — identical to light by design */
-  --fb-home-stroke: oklch(0.7775 0.1512 55.4); /* was var(--note-ring-tonic) → #FF9A4D */
-  --fb-guide-fill: oklch(0.4375 0.0764 235.5); /* was #1f5876 */
-  --fb-guide-stroke: oklch(0.8837 0.1056 209.8); /* was #7cecff */
-  --fb-neutral-fill: oklch(0.2525 0.0206 251.6); /* was #1b232c */
-  --fb-neutral-stroke: oklch(0.7108 0.0155 244.8); /* was #9aa3ab */
-  --fb-region-tint: oklch(0.7108 0.0155 244.8 / 0.14); /* was rgba(154, 163, 171, 0.14) */
+  /* Chord-overlay accent (orange) kept app-side; resolves through
+     --chord-connector-color-1, now defined in @fretflow/fretboard. The
+     home/guide/neutral/region/halo --fb-* tokens and the full --chord-connector-*
+     palette moved to @fretflow/fretboard/styles/fretboard-tokens.css. */
   --fb-connector-accent: var(--chord-connector-color-1); /* orange */
-  --fb-connector-halo: rgb(0 0 0 / 0.5); /* dark wood: shadow halo carves the line */
-
-  /* Chord-tone connector overrides for dark mode.
-     Same canonical Okabe-Ito palette as light mode. Lower fill opacity because
-     dark rosewood provides high contrast at lower alpha. Halo disabled —
-     all canonical Okabe-Ito colors pass WCAG 3:1 against rosewood. */
-  --chord-connector-fill-opacity: 0.15;
-  --chord-connector-outline-width: 1.25px;
-  --chord-connector-outline-opacity: 0.85;
-  --chord-connector-halo-width: 0;
-  --chord-connector-halo-color: transparent;
-  --chord-connector-color-1: #E69F00; /* Okabe-Ito: orange */
-  --chord-connector-color-2: #D55E00; /* Okabe-Ito: vermillion */
-  --chord-connector-color-3: #999999; /* Okabe-Ito: gray */
-  --chord-connector-color-4: #009E73; /* Okabe-Ito: bluish green */
-  --chord-connector-color-5: #56B4E9; /* Okabe-Ito: sky blue */
-  --chord-connector-color-6: #0072B2; /* Okabe-Ito: blue */
-  --chord-connector-color-7: #CC79A7; /* Okabe-Ito: reddish purple */
-  --chord-connector-color-8: #F0E442; /* Okabe-Ito: yellow */
 
   /* Chip tokens — dark mode chip border and note inner fill */
   --chip-border-muted: rgb(255 255 255 / 0.22);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -146,37 +146,17 @@
 }
 
 :root {
-  --fretboard-wood-top: #160d07;
-  --fretboard-wood-mid: #0d0805;
-  --fretboard-wood-bottom: #080403;
+  /* Fretboard wood/wire/string/inlay/edge color + geometry tokens moved to
+     @fretflow/fretboard/styles/fretboard-tokens.css (re-imported in main.tsx).
+     The tokens kept here are app-side fretboard chrome not referenced by the
+     package renderer. */
   --fretboard-wood-grain: rgb(255 255 255 / 0.02);
-  --fret-wire-dark: #4a5058;
-  --fret-wire-medium: #a6afbc;
-  --fret-wire-bright: #ebeff5;
   --fret-wire-highlight: rgb(255 255 255 / 0.25);
-  --string-wire: #e4e8ee;
-  --string-wire-bass: #c6ccd2;
-  --string-taper-1: 1px;
-  --string-taper-2: 1.25px;
-  --string-taper-3: 1.5px;
-  --string-taper-4: 2px;
-  --string-taper-5: 2.5px;
-  --string-taper-6: 3px;
   --inlay-dot: rgb(210 210 210 / 0.18);
   --inlay-dot-12: rgb(210 210 210 / 0.28);
-  --inlay-pearl-stop1: rgb(250 247 232);
-  --inlay-pearl-stop2: rgb(218 209 182);
-  --inlay-pearl-stop3: rgb(156 144 118);
-  --inlay-pearl-opacity1: 0.98;
-  --inlay-pearl-opacity2: 0.88;
-  --inlay-pearl-opacity3: 0.75;
   --nut: #e0d4a8;
   --fretboard-edge-shadow: 0 0 16px rgb(0 0 0 / 0.45) inset;
-  --fretboard-top-edge-color: rgb(218 182 138 / 0.22);
-  --fretboard-bottom-edge-color: rgb(0 0 0 / 0.75);
-  --fretboard-nut-slot-color: rgb(12 8 4 / 0.55);
   --fretboard-headstock-bg: #07050a;
-  --fretboard-glow-opacity: 0.65;
 }
 
 :root {


### PR DESCRIPTION
## What

Make `@fretflow/fretboard` **self-contained for styling**. Its CSS modules and inline SVG `var(--…)` references previously depended on ~45 design tokens defined in the web app stylesheets (`src/styles/{tokens,semantic,themes}.css`). The fretboard's tokens are now the package's own single source of truth.

- **New** [`packages/fretboard/src/styles/fretboard-tokens.css`](https://github.com/iecg/fretboard-app/blob/claude/clever-bhabha-db4c39/packages/fretboard/src/styles/fretboard-tokens.css) with `:root` + `[data-theme="modern-light"]` + `[data-theme="modern-dark"]` sections, populated **verbatim** with the moved Category-A declarations (wood/wire/strings/inlays/edges/glow, `--fb-*` note-role fills, the chord-connector palette, board shadow, note text, fret number, nut gradient, a11y hover). Light-theme-only tokens reproduce that structure exactly — no fabricated dark values.
- **Removed** those declarations from `src/styles/{tokens,semantic,themes}.css` — single definition only, deterministic cascade. App-side fretboard chrome the renderer doesn't reference, and the shared `--note-role-*` / `--note-label-on-color` contract, stay app-owned.
- `src/main.tsx` **re-imports** the package token file → the web app and its HelpModal `--fb-*` diagrams are unchanged.
- **Category-B fallbacks** (`var(--token, <modern-light value>)`) at the package's reference sites for the genuinely app-owned tokens it merely references (`--accent-primary`, `--focus-ring*`, `--font-sans`, `--neon-orange`, `--note-incoming`, `--note-label-on-color*`) so standalone consumers still render.
- **Repointed tooling/tests:** `cssTokens.ts` merge-reads `themes.css` + the package token file; `FretboardSVG.test.tsx` imports the package tokens; `ui-tokens.mjs` pools `packages/fretboard/src` into the definition scan so the app's HelpModal references resolve.

## Why

The M1 mobile spike (fretflow-mobile) renders the fretboard inside an Expo DOM island and surfaced that a standalone consumer not importing the app stylesheets gets fallback/black colors. External consumers can now import only the package; no duplication, no drift.

## Verification

| Check | Result |
|---|---|
| `lint` + fretboard boundary check | ✅ 0 errors |
| `test` (full suite) | ✅ 2678 passed, 1 skipped |
| fb contrast/APCA guards (`cssTokens`, `fbColorTokens`, `connectorLegibility`, `FretboardSVG`) | ✅ 91 passed — **byte-exact** pre-migration values |
| `ui:tokens` | ✅ 0 undefined |
| `build` | ✅ CSS subpath import resolves |
| `test:visual` | ⚠️ 5 failures — **pre-existing** (see below) |

**Visual gate note:** the 5 visual-regression failures fail **identically on a clean baseline tree** (verified via stash test) — they are environment/text-rendering drift between this machine and the committed darwin snapshots, not the token move. The diff confirmed only dynamic-text pixels differ; the fretboard renders pixel-identical, and the dedicated `fretboard-svg` specs pass. Snapshots were **not** updated.

## Reviewer notes

- Two source-plan miscategorizations were corrected after verification: `--string-taper-*` is statically referenced + defined in `tokens.css` → moved to package `:root`; `--caged-*` / `--fretboard-note-fill-*` are not statically referenced by the package → left app-owned.
- Follow-up (separate, in `fretflow-mobile`): replace the island's three `../../../fretboard-app/src/styles/*.css` imports with the single `@fretflow/fretboard/styles/fretboard-tokens.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced visual robustness by adding CSS variable fallbacks for colors and styling elements across the fretboard interface.

* **Style**
  * Improved font rendering with expanded system font fallback stack for better cross-platform consistency.

* **Refactor**
  * Consolidated and reorganized design tokens into centralized sources for improved maintainability and consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->