### PR TITLE
chore(build): remove Capacitor-specific VITE_MOBILE build variant

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "scripts": {
     "dev": "vite",
     "build": "pnpm --filter @fretflow/core run build && tsc -b && vite build && cp dist/index.html dist/404.html",
-    "build:mobile": "VITE_MOBILE=true pnpm run build",
-    "build:types": "pnpm --filter @fretflow/core run build && tsc -b",
+"build:types": "pnpm --filter @fretflow/core run build && tsc -b",
     "lint": "eslint . && node scripts/check-fretboard-boundaries.mjs",
     "ui:tokens": "node scripts/ui-tokens.mjs",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "dev": "vite",
     "build": "pnpm --filter @fretflow/core run build && tsc -b && vite build && cp dist/index.html dist/404.html",
-"build:types": "pnpm --filter @fretflow/core run build && tsc -b",
+    "build:types": "pnpm --filter @fretflow/core run build && tsc -b",
     "lint": "eslint . && node scripts/check-fretboard-boundaries.mjs",
     "ui:tokens": "node scripts/ui-tokens.mjs",
     "preview": "vite preview",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ import { fileURLToPath, URL } from 'node:url'
 const { version } = JSON.parse(readFileSync('./package.json', 'utf-8')) as { version: string }
 
 export default defineConfig({
-  base: process.env.VITE_MOBILE === 'true' ? './' : '/fretboard-app/',
+  base: '/fretboard-app/',
   server: {
     watch: {
       ignored: ['**/.claude/**', '**/.worktrees/**'],


### PR DESCRIPTION
## Summary

- Removes the `build:mobile` script from `package.json` that set `VITE_MOBILE=true`
- Replaces the `VITE_MOBILE` ternary in `vite.config.ts` with the static `/fretboard-app/` base path

## Why

These two artifacts were introduced on the `capacitorjs` branch to support Capacitor WKWebView embedding, which requires relative (`./`) asset paths. The project has since pivoted away from Capacitor toward an Expo/React Native strategy, so the mobile build variant is dead code.

The safe-area CSS (`env(safe-area-inset-*)`) is standard browser CSS and is unaffected.

## Reviewer notes

Pure deletion of dead config — no logic changes. `pnpm run build`, `pnpm run lint`, and `pnpm run test` all pass locally.