### PR TITLE
feat(fretboard-pkg): hydrate scale/fingering overlay fields in FretboardEmbed config

### DIFF
--- a/packages/fretboard/src/contract/FretboardEmbed.test.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.test.tsx
@@ -3,18 +3,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FretboardEmbed } from "./FretboardEmbed";
-import { useAtomValue } from "jotai";
-import {
-  fingeringPatternAtom,
-  cagedShapesAtom,
-  npsPositionAtom,
-  npsOctaveAtom,
-  oneStringIndexAtom,
-  oneStringIntervalAtom,
-  twoStringsPairAtom,
-  twoStringsIntervalAtom,
-} from "../store/fingeringAtoms";
-import { scaleVisibleAtom } from "../store/scaleAtoms";
 // Prime the lazy chunk so React.lazy() resolves on first microtask in jsdom.
 import "../components/FretboardSVG/FretboardSVG";
 
@@ -125,17 +113,37 @@ describe("FretboardEmbed — M2 fingering/scale hydration", () => {
   });
 
   async function renderWithProbe(config: Parameters<typeof FretboardEmbed>[0]["config"]) {
+    // All imports are deferred until after vi.doMock so that each call to
+    // renderWithProbe gets a fresh module graph (consistent atom instances).
+    const [
+      { useAtomValue: freshUseAtomValue },
+      {
+        fingeringPatternAtom: fpAtom,
+        cagedShapesAtom: csAtom,
+        npsPositionAtom: npsPosAtom,
+        npsOctaveAtom: npsOctAtom,
+        oneStringIndexAtom: osIdxAtom,
+        oneStringIntervalAtom: osIntAtom,
+        twoStringsPairAtom: tsPairAtom,
+        twoStringsIntervalAtom: tsIntAtom,
+      },
+      { scaleVisibleAtom: svAtom },
+    ] = await Promise.all([
+      import("jotai"),
+      import("../store/fingeringAtoms"),
+      import("../store/scaleAtoms"),
+    ]);
     vi.doMock("../components/Fretboard/Fretboard", () => ({
       Fretboard: () => {
-        const fingeringPattern = useAtomValue(fingeringPatternAtom);
-        const cagedShapes = useAtomValue(cagedShapesAtom);
-        const npsPosition = useAtomValue(npsPositionAtom);
-        const npsOctave = useAtomValue(npsOctaveAtom);
-        const oneStringIndex = useAtomValue(oneStringIndexAtom);
-        const oneStringInterval = useAtomValue(oneStringIntervalAtom);
-        const twoStringsPair = useAtomValue(twoStringsPairAtom);
-        const twoStringsInterval = useAtomValue(twoStringsIntervalAtom);
-        const scaleVisible = useAtomValue(scaleVisibleAtom);
+        const fingeringPattern = freshUseAtomValue(fpAtom);
+        const cagedShapes = freshUseAtomValue(csAtom);
+        const npsPosition = freshUseAtomValue(npsPosAtom);
+        const npsOctave = freshUseAtomValue(npsOctAtom);
+        const oneStringIndex = freshUseAtomValue(osIdxAtom);
+        const oneStringInterval = freshUseAtomValue(osIntAtom);
+        const twoStringsPair = freshUseAtomValue(tsPairAtom);
+        const twoStringsInterval = freshUseAtomValue(tsIntAtom);
+        const scaleVisible = freshUseAtomValue(svAtom);
         return (
           <div
             data-testid="probe"
@@ -159,6 +167,7 @@ describe("FretboardEmbed — M2 fingering/scale hydration", () => {
   it("hydrates the active fingering pattern + CAGED shape", async () => {
     await renderWithProbe({ fingeringPattern: "caged", cagedShape: "A" });
     await flushSuspense();
+    await act(async () => { await Promise.resolve(); });
     const probe = screen.getByTestId("probe");
     expect(probe.getAttribute("data-fingering")).toBe("caged");
     expect(probe.getAttribute("data-caged")).toBe("A");
@@ -167,6 +176,7 @@ describe("FretboardEmbed — M2 fingering/scale hydration", () => {
   it("hydrates 3NPS position + octave", async () => {
     await renderWithProbe({ fingeringPattern: "3nps", npsPosition: 4, npsOctave: 1 });
     await flushSuspense();
+    await act(async () => { await Promise.resolve(); });
     const probe = screen.getByTestId("probe");
     expect(probe.getAttribute("data-nps-pos")).toBe("4");
     expect(probe.getAttribute("data-nps-oct")).toBe("1");
@@ -182,6 +192,7 @@ describe("FretboardEmbed — M2 fingering/scale hydration", () => {
       scaleVisible: false,
     });
     await flushSuspense();
+    await act(async () => { await Promise.resolve(); });
     const probe = screen.getByTestId("probe");
     expect(probe.getAttribute("data-one-idx")).toBe("3");
     expect(probe.getAttribute("data-one-int")).toBe("1");

--- a/packages/fretboard/src/contract/FretboardEmbed.test.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.test.tsx
@@ -3,6 +3,18 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FretboardEmbed } from "./FretboardEmbed";
+import { useAtomValue } from "jotai";
+import {
+  fingeringPatternAtom,
+  cagedShapesAtom,
+  npsPositionAtom,
+  npsOctaveAtom,
+  oneStringIndexAtom,
+  oneStringIntervalAtom,
+  twoStringsPairAtom,
+  twoStringsIntervalAtom,
+} from "../store/fingeringAtoms";
+import { scaleVisibleAtom } from "../store/scaleAtoms";
 // Prime the lazy chunk so React.lazy() resolves on first microtask in jsdom.
 import "../components/FretboardSVG/FretboardSVG";
 
@@ -102,5 +114,79 @@ describe("FretboardEmbed", () => {
     render(<FretboardEmbed config={{ audio: "events" }} />);
     await flushSuspense();
     expect(prefetchAudioModule).not.toHaveBeenCalled();
+  });
+});
+
+describe("FretboardEmbed — M2 fingering/scale hydration", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  async function renderWithProbe(config: Parameters<typeof FretboardEmbed>[0]["config"]) {
+    vi.doMock("../components/Fretboard/Fretboard", () => ({
+      Fretboard: () => {
+        const fingeringPattern = useAtomValue(fingeringPatternAtom);
+        const cagedShapes = useAtomValue(cagedShapesAtom);
+        const npsPosition = useAtomValue(npsPositionAtom);
+        const npsOctave = useAtomValue(npsOctaveAtom);
+        const oneStringIndex = useAtomValue(oneStringIndexAtom);
+        const oneStringInterval = useAtomValue(oneStringIntervalAtom);
+        const twoStringsPair = useAtomValue(twoStringsPairAtom);
+        const twoStringsInterval = useAtomValue(twoStringsIntervalAtom);
+        const scaleVisible = useAtomValue(scaleVisibleAtom);
+        return (
+          <div
+            data-testid="probe"
+            data-fingering={fingeringPattern}
+            data-caged={Array.from(cagedShapes).join(",")}
+            data-nps-pos={String(npsPosition)}
+            data-nps-oct={String(npsOctave)}
+            data-one-idx={String(oneStringIndex)}
+            data-one-int={String(oneStringInterval)}
+            data-two-pair={String(twoStringsPair)}
+            data-two-int={String(twoStringsInterval)}
+            data-scale-visible={String(scaleVisible)}
+          />
+        );
+      },
+    }));
+    const { FretboardEmbed: FreshFretboardEmbed } = await import("./FretboardEmbed");
+    return render(<FreshFretboardEmbed config={config} />);
+  }
+
+  it("hydrates the active fingering pattern + CAGED shape", async () => {
+    await renderWithProbe({ fingeringPattern: "caged", cagedShape: "A" });
+    await flushSuspense();
+    const probe = screen.getByTestId("probe");
+    expect(probe.getAttribute("data-fingering")).toBe("caged");
+    expect(probe.getAttribute("data-caged")).toBe("A");
+  });
+
+  it("hydrates 3NPS position + octave", async () => {
+    await renderWithProbe({ fingeringPattern: "3nps", npsPosition: 4, npsOctave: 1 });
+    await flushSuspense();
+    const probe = screen.getByTestId("probe");
+    expect(probe.getAttribute("data-nps-pos")).toBe("4");
+    expect(probe.getAttribute("data-nps-oct")).toBe("1");
+  });
+
+  it("hydrates one-string + two-strings sub-params and scaleVisible", async () => {
+    await renderWithProbe({
+      fingeringPattern: "two-strings",
+      oneStringIndex: 3,
+      oneStringInterval: 1,
+      twoStringsPair: 2,
+      twoStringsInterval: 3,
+      scaleVisible: false,
+    });
+    await flushSuspense();
+    const probe = screen.getByTestId("probe");
+    expect(probe.getAttribute("data-one-idx")).toBe("3");
+    expect(probe.getAttribute("data-one-int")).toBe("1");
+    expect(probe.getAttribute("data-two-pair")).toBe("2");
+    expect(probe.getAttribute("data-two-int")).toBe("3");
+    expect(probe.getAttribute("data-scale-visible")).toBe("false");
   });
 });

--- a/packages/fretboard/src/contract/FretboardEmbed.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.tsx
@@ -15,7 +15,7 @@ import { prefetchAudioModule, resumeGuitarAudio } from "../core/lazyGuitarAudio"
 export interface FretboardConfig {
   /** Root note as a sharp name, e.g. "C", "F#". */
   root?: string;
-  /** Scale name as stored by the app's internal token (e.g. "major", "minorPentatonic"). */
+  /** Scale name as stored by the app's internal token (e.g. "major", "minor pentatonic"). */
   scale?: string;
   theme?: ThemePreference;
   displayFormat?: "notes" | "degrees" | "none";
@@ -23,6 +23,26 @@ export interface FretboardConfig {
   audio?: "builtin" | "events";
   /** Pixel height per string row (host-controlled sizing). */
   stringRowPx?: number;
+
+  // --- M2: scale/fingering overlay controls (all human-speed, serializable) ---
+  /** Whether the scale overlay is shown on the board. */
+  scaleVisible?: boolean;
+  /** Active fingering pattern. */
+  fingeringPattern?: "none" | "caged" | "3nps" | "one-string" | "two-strings";
+  /** CAGED shape when fingeringPattern === "caged". */
+  cagedShape?: "C" | "A" | "G" | "E" | "D";
+  /** 3NPS position (1–7) when fingeringPattern === "3nps". */
+  npsPosition?: number;
+  /** 3NPS octave (0 = Low, 1 = High) when fingeringPattern === "3nps". */
+  npsOctave?: number;
+  /** Active string index (0–5) when fingeringPattern === "one-string". */
+  oneStringIndex?: number;
+  /** Connector toggle (0 = Off, 1 = On) when fingeringPattern === "one-string". */
+  oneStringInterval?: number;
+  /** Active pair index (0–4) when fingeringPattern === "two-strings". */
+  twoStringsPair?: number;
+  /** Interval (0 = Off, 1 = 3rds, 2 = 4ths, 3 = 6ths) when fingeringPattern === "two-strings". */
+  twoStringsInterval?: number;
 }
 
 export interface FretboardEmbedProps {

--- a/packages/fretboard/src/contract/FretboardEmbed.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.tsx
@@ -1,11 +1,21 @@
 import { useEffect, useState } from "react";
 import { Provider, createStore } from "jotai";
 import { Fretboard } from "../components/Fretboard/Fretboard";
-import { baseRootNoteAtom, baseScaleNameAtom } from "../store/scaleAtoms";
+import { baseRootNoteAtom, baseScaleNameAtom, scaleVisibleAtom } from "../store/scaleAtoms";
 import { themeAtom, displayFormatAtom, type ThemePreference } from "../store/uiAtoms";
 import { audioModeAtom, fretboardEventSinkAtom } from "./embedAtoms";
 import type { FretboardEventSink } from "./events";
 import { prefetchAudioModule, resumeGuitarAudio } from "../core/lazyGuitarAudio";
+import {
+  fingeringPatternAtom,
+  selectSingleCagedShapeAtom,
+  npsPositionAtom,
+  npsOctaveAtom,
+  oneStringIndexAtom,
+  oneStringIntervalAtom,
+  twoStringsPairAtom,
+  twoStringsIntervalAtom,
+} from "../store/fingeringAtoms";
 
 /**
  * Serializable configuration for an embedded fretboard. Every field crosses
@@ -79,6 +89,32 @@ export function FretboardEmbed({ config, onEvent }: FretboardEmbedProps) {
       store.set(displayFormatAtom, config.displayFormat);
     store.set(audioModeAtom, config.audio ?? "builtin");
   }, [store, config.root, config.scale, config.theme, config.displayFormat, config.audio]);
+
+  // M2: scale/fingering overlay hydration. Same imperative-write pattern as the
+  // base config effect above — each field is optional, so only defined values
+  // are written (undefined leaves the atom at its persisted/default value).
+  useEffect(() => {
+    if (config.scaleVisible !== undefined) store.set(scaleVisibleAtom, config.scaleVisible);
+    if (config.fingeringPattern !== undefined) store.set(fingeringPatternAtom, config.fingeringPattern);
+    if (config.cagedShape !== undefined) store.set(selectSingleCagedShapeAtom, config.cagedShape);
+    if (config.npsPosition !== undefined) store.set(npsPositionAtom, config.npsPosition);
+    if (config.npsOctave !== undefined) store.set(npsOctaveAtom, config.npsOctave);
+    if (config.oneStringIndex !== undefined) store.set(oneStringIndexAtom, config.oneStringIndex);
+    if (config.oneStringInterval !== undefined) store.set(oneStringIntervalAtom, config.oneStringInterval);
+    if (config.twoStringsPair !== undefined) store.set(twoStringsPairAtom, config.twoStringsPair);
+    if (config.twoStringsInterval !== undefined) store.set(twoStringsIntervalAtom, config.twoStringsInterval);
+  }, [
+    store,
+    config.scaleVisible,
+    config.fingeringPattern,
+    config.cagedShape,
+    config.npsPosition,
+    config.npsOctave,
+    config.oneStringIndex,
+    config.oneStringInterval,
+    config.twoStringsPair,
+    config.twoStringsInterval,
+  ]);
 
   useEffect(() => {
     // Jotai's primitive `set` treats a function value as an updater


### PR DESCRIPTION
## What

Expands the `FretboardConfig` embed contract so an embedding host (the FretFlow Expo DOM island) can drive the **scale/fingering overlay**, and adds a hydration effect that writes those fields into the embed's isolated Jotai store. This is the package-side enabler for **M2** of the mobile app (native shell + native Overlay controls).

Purely **additive** — the web app renders `<Fretboard/>` directly and is unaffected; the base config path and audio path are byte-for-byte unchanged.

## Changes

`FretboardConfig` gains 9 optional, serializable fields:

| field | type | notes |
|---|---|---|
| `scaleVisible` | `boolean` | scale overlay master visibility |
| `fingeringPattern` | `"none"\|"caged"\|"3nps"\|"one-string"\|"two-strings"` | |
| `cagedShape` | `"C"\|"A"\|"G"\|"E"\|"D"` | written via `selectSingleCagedShapeAtom` (single-shape invariant) |
| `npsPosition` | `number` | 1–7 |
| `npsOctave` | `number` | 0 \| 1 |
| `oneStringIndex` | `number` | 0–5 |
| `oneStringInterval` | `number` | 0 \| 1 |
| `twoStringsPair` | `number` | 0–4 |
| `twoStringsInterval` | `number` | 0–3 |

A second hydration `useEffect` writes each field undefined-guarded (undefined = leave the atom at its persisted/default value), mirroring the existing base-config effect.

## Tests

Adds a store-probe test block (mocks the child `Fretboard` with a component that reads the atoms and renders them as `data-*` attributes) covering hydration of: fingering pattern + CAGED shape; 3NPS position + octave; one-string + two-strings sub-params + `scaleVisible`. Verified the assertions fail when the hydration writes are removed (not vacuous).

Full gate green: `lint` (0 errors), `test` (2683 passed), `build`, boundary check.

> Note for reviewers: run this package's tests from the repo root (`npx vitest run packages/fretboard/...`) — `pnpm --filter @fretflow/fretboard exec vitest` resolves the vitest `setupFiles` path against the repo root and fails (pre-existing, unrelated to this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Extended FretboardEmbed configuration with new optional parameters to control scale and fingering overlay visibility, pattern selection, CAGED shape, 3NPS positioning, and string-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->