### PR TITLE
feat(fretboard-pkg): M3 progression + chord-card embed contract

### DIFF
--- a/packages/fretboard/src/contract/FretboardEmbed.test.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.test.tsx
@@ -320,6 +320,61 @@ describe("FretboardEmbed — progression playback runner mount", () => {
   });
 });
 
+describe("FretboardEmbed — M3 chord card hydration", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("hydrates voicing, practice lens, and the active chord quality override", async () => {
+    const [
+      { useAtomValue },
+      { voicingAtom },
+      { practiceLensAtom },
+      { activeChordQualityAtom },
+    ] = await Promise.all([
+      import("jotai"),
+      import("../store/chordOverlayAtoms"),
+      import("../store/practiceLensAtoms"),
+      import("../store/songStateAtoms"),
+    ]);
+    vi.doMock("../hooks/useProgressionAudioPlayback", () => ({
+      useProgressionAudioPlayback: () => {},
+      __resetProgressionAudioPlaybackForTests: () => {},
+    }));
+    vi.doMock("../components/Fretboard/Fretboard", () => ({
+      Fretboard: () => (
+        <div
+          data-testid="chord-probe"
+          data-voicing={String(useAtomValue(voicingAtom))}
+          data-lens={String(useAtomValue(practiceLensAtom))}
+          data-quality={String(useAtomValue(activeChordQualityAtom))}
+        />
+      ),
+    }));
+    const { FretboardEmbed: Fresh } = await import("./FretboardEmbed");
+    render(
+      <Fresh
+        config={{
+          progressionEnabled: true,
+          progressionPreset: "one-five-six-four",
+          root: "C",
+          scale: "major",
+          chordVoicing: "close",
+          chordPracticeLens: "root",
+          activeChordQuality: "maj7",
+        }}
+      />,
+    );
+    await act(async () => { await Promise.resolve(); });
+    const probe = screen.getByTestId("chord-probe");
+    expect(probe.getAttribute("data-voicing")).toBe("close");
+    expect(probe.getAttribute("data-lens")).toBe("root");
+    expect(probe.getAttribute("data-quality")).toBe("maj7");
+  });
+});
+
 describe("FretboardEmbed — M3 events-out", () => {
   beforeEach(() => {
     localStorage.clear();

--- a/packages/fretboard/src/contract/FretboardEmbed.test.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FretboardEmbed } from "./FretboardEmbed";
+import type { FretboardEventSink } from "./events";
 // Prime the lazy chunk so React.lazy() resolves on first microtask in jsdom.
 import "../components/FretboardSVG/FretboardSVG";
 
@@ -326,14 +327,14 @@ describe("FretboardEmbed — M3 events-out", () => {
     vi.resetModules();
   });
 
-  async function renderForEvents(config: Parameters<typeof FretboardEmbed>[0]["config"], onEvent: (e: unknown) => void) {
+  async function renderForEvents(config: Parameters<typeof FretboardEmbed>[0]["config"], onEvent: FretboardEventSink) {
     vi.doMock("../hooks/useProgressionAudioPlayback", () => ({
       useProgressionAudioPlayback: () => {},
       __resetProgressionAudioPlaybackForTests: () => {},
     }));
     vi.doMock("../components/Fretboard/Fretboard", () => ({ Fretboard: () => null }));
     const { FretboardEmbed: Fresh } = await import("./FretboardEmbed");
-    render(<Fresh config={config} onEvent={onEvent as never} />);
+    render(<Fresh config={config} onEvent={onEvent} />);
     await act(async () => { await Promise.resolve(); });
     // Second flush: preset effect may run after the initial events-out effect.
     // The subscription catches the subsequent resolvedProgressionStepsAtom change,
@@ -342,19 +343,18 @@ describe("FretboardEmbed — M3 events-out", () => {
   }
 
   it("emits progressionResolved with resolved chord labels and an initial playbackStateChanged", async () => {
-    const events: { type: string }[] = [];
+    const events: Parameters<FretboardEventSink>[0][] = [];
     await renderForEvents(
       { progressionEnabled: true, progressionPreset: "one-five-six-four", root: "C", scale: "major" },
-      (e) => events.push(e as { type: string }),
+      (e) => events.push(e),
     );
     // Multiple progressionResolved events may fire (initial empty + post-preset).
     // Assert on the LAST one, which reflects the fully-resolved preset steps.
-    const resolved = [...events].reverse().find((e) => e.type === "progressionResolved") as
-      | { type: "progressionResolved"; steps: { index: number; label: string }[] }
-      | undefined;
+    const resolved = [...events].reverse().find((e) => e.type === "progressionResolved");
     expect(resolved).toBeDefined();
-    expect(resolved!.steps.length).toBe(4);
-    expect(resolved!.steps[0].label).toBe("C");
+    expect(resolved!.type === "progressionResolved" && resolved!.steps.length).toBe(4);
+    expect(resolved!.type === "progressionResolved" && resolved!.steps[0].label).toBe("C");
     expect(events.some((e) => e.type === "playbackStateChanged")).toBe(true);
+    expect(events.some((e) => e.type === "activeStepChanged")).toBe(true);
   });
 });

--- a/packages/fretboard/src/contract/FretboardEmbed.test.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.test.tsx
@@ -202,6 +202,75 @@ describe("FretboardEmbed — M2 fingering/scale hydration", () => {
   });
 });
 
+describe("FretboardEmbed — M3 progression hydration", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  async function renderWithSongProbe(config: Parameters<typeof FretboardEmbed>[0]["config"]) {
+    const [
+      { useAtomValue: u },
+      {
+        currentProgressionPresetIdAtom: presetIdAtom,
+        progressionLoopEnabledAtom: loopAtom,
+        progressionTempoBpmAtom: tempoAtom,
+        progressionGenreStyleAtom: genreAtom,
+        progressionDrumsEnabledAtom: drumsAtom,
+        progressionBassEnabledAtom: bassAtom,
+        progressionChordEnabledAtom: chordsAtom,
+        progressionMetronomeEnabledAtom: metroAtom,
+      },
+    ] = await Promise.all([import("jotai"), import("../store/progressionAtoms")]);
+    vi.doMock("../hooks/useProgressionAudioPlayback", () => ({
+      useProgressionAudioPlayback: () => {},
+      __resetProgressionAudioPlaybackForTests: () => {},
+    }));
+    vi.doMock("../components/Fretboard/Fretboard", () => ({
+      Fretboard: () => (
+        <div
+          data-testid="song-probe"
+          data-preset={String(u(presetIdAtom))}
+          data-loop={String(u(loopAtom))}
+          data-tempo={String(u(tempoAtom))}
+          data-genre={String(u(genreAtom))}
+          data-drums={String(u(drumsAtom))}
+          data-bass={String(u(bassAtom))}
+          data-chords={String(u(chordsAtom))}
+          data-metro={String(u(metroAtom))}
+        />
+      ),
+    }));
+    const { FretboardEmbed: Fresh } = await import("./FretboardEmbed");
+    render(<Fresh config={config} />);
+    await act(async () => { await Promise.resolve(); });
+    return screen.getByTestId("song-probe");
+  }
+
+  it("hydrates preset, loop, tempo, genre and the four layer toggles", async () => {
+    const probe = await renderWithSongProbe({
+      progressionEnabled: true,
+      progressionPreset: "two-five-one",
+      progressionLoop: false,
+      progressionTempoBpm: 120,
+      progressionGenre: "jazz",
+      drumsEnabled: false,
+      bassEnabled: false,
+      chordsEnabled: true,
+      metronomeEnabled: true,
+    });
+    expect(probe.getAttribute("data-preset")).toBe("two-five-one");
+    expect(probe.getAttribute("data-loop")).toBe("false");
+    expect(probe.getAttribute("data-tempo")).toBe("120");
+    expect(probe.getAttribute("data-genre")).toBe("jazz");
+    expect(probe.getAttribute("data-drums")).toBe("false");
+    expect(probe.getAttribute("data-bass")).toBe("false");
+    expect(probe.getAttribute("data-chords")).toBe("true");
+    expect(probe.getAttribute("data-metro")).toBe("true");
+  });
+});
+
 describe("FretboardEmbed — progression playback runner mount", () => {
   beforeEach(() => {
     localStorage.clear();

--- a/packages/fretboard/src/contract/FretboardEmbed.test.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.test.tsx
@@ -201,3 +201,35 @@ describe("FretboardEmbed — M2 fingering/scale hydration", () => {
     expect(probe.getAttribute("data-scale-visible")).toBe("false");
   });
 });
+
+describe("FretboardEmbed — progression playback runner mount", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  async function renderEmbed(config: Parameters<typeof FretboardEmbed>[0]["config"]) {
+    const hookSpy = vi.fn();
+    vi.doMock("../hooks/useProgressionAudioPlayback", () => ({
+      useProgressionAudioPlayback: hookSpy,
+      __resetProgressionAudioPlaybackForTests: () => {},
+    }));
+    // Mock the heavy child so the test stays in jsdom without SVG/audio.
+    vi.doMock("../components/Fretboard/Fretboard", () => ({ Fretboard: () => null }));
+    const { FretboardEmbed: Fresh } = await import("./FretboardEmbed");
+    render(<Fresh config={config} />);
+    await act(async () => { await Promise.resolve(); });
+    return hookSpy;
+  }
+
+  it("mounts the playback hook when progressionEnabled is true", async () => {
+    const spy = await renderEmbed({ progressionEnabled: true });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("does NOT mount the playback hook by default", async () => {
+    const spy = await renderEmbed({});
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fretboard/src/contract/FretboardEmbed.test.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.test.tsx
@@ -318,3 +318,43 @@ describe("FretboardEmbed — progression playback runner mount", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 });
+
+describe("FretboardEmbed — M3 events-out", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  async function renderForEvents(config: Parameters<typeof FretboardEmbed>[0]["config"], onEvent: (e: unknown) => void) {
+    vi.doMock("../hooks/useProgressionAudioPlayback", () => ({
+      useProgressionAudioPlayback: () => {},
+      __resetProgressionAudioPlaybackForTests: () => {},
+    }));
+    vi.doMock("../components/Fretboard/Fretboard", () => ({ Fretboard: () => null }));
+    const { FretboardEmbed: Fresh } = await import("./FretboardEmbed");
+    render(<Fresh config={config} onEvent={onEvent as never} />);
+    await act(async () => { await Promise.resolve(); });
+    // Second flush: preset effect may run after the initial events-out effect.
+    // The subscription catches the subsequent resolvedProgressionStepsAtom change,
+    // but we need another microtask tick for it to propagate to our collector.
+    await act(async () => { await Promise.resolve(); });
+  }
+
+  it("emits progressionResolved with resolved chord labels and an initial playbackStateChanged", async () => {
+    const events: { type: string }[] = [];
+    await renderForEvents(
+      { progressionEnabled: true, progressionPreset: "one-five-six-four", root: "C", scale: "major" },
+      (e) => events.push(e as { type: string }),
+    );
+    // Multiple progressionResolved events may fire (initial empty + post-preset).
+    // Assert on the LAST one, which reflects the fully-resolved preset steps.
+    const resolved = [...events].reverse().find((e) => e.type === "progressionResolved") as
+      | { type: "progressionResolved"; steps: { index: number; label: string }[] }
+      | undefined;
+    expect(resolved).toBeDefined();
+    expect(resolved!.steps.length).toBe(4);
+    expect(resolved!.steps[0].label).toBe("C");
+    expect(events.some((e) => e.type === "playbackStateChanged")).toBe(true);
+  });
+});

--- a/packages/fretboard/src/contract/FretboardEmbed.test.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.test.tsx
@@ -332,7 +332,7 @@ describe("FretboardEmbed — M3 chord card hydration", () => {
       { useAtomValue },
       { voicingAtom },
       { practiceLensAtom },
-      { activeChordQualityAtom },
+      { activeChordQualityAtom, activeChordRootAtom },
     ] = await Promise.all([
       import("jotai"),
       import("../store/chordOverlayAtoms"),
@@ -350,6 +350,7 @@ describe("FretboardEmbed — M3 chord card hydration", () => {
           data-voicing={String(useAtomValue(voicingAtom))}
           data-lens={String(useAtomValue(practiceLensAtom))}
           data-quality={String(useAtomValue(activeChordQualityAtom))}
+          data-root={String(useAtomValue(activeChordRootAtom))}
         />
       ),
     }));
@@ -364,6 +365,7 @@ describe("FretboardEmbed — M3 chord card hydration", () => {
           chordVoicing: "close",
           chordPracticeLens: "root",
           activeChordQuality: "maj7",
+          activeChordManualRoot: "F#",
         }}
       />,
     );
@@ -372,6 +374,7 @@ describe("FretboardEmbed — M3 chord card hydration", () => {
     expect(probe.getAttribute("data-voicing")).toBe("close");
     expect(probe.getAttribute("data-lens")).toBe("root");
     expect(probe.getAttribute("data-quality")).toBe("maj7");
+    expect(probe.getAttribute("data-root")).toBe("F#");
   });
 });
 

--- a/packages/fretboard/src/contract/FretboardEmbed.test.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.test.tsx
@@ -211,7 +211,7 @@ describe("FretboardEmbed — M3 progression hydration", () => {
 
   async function renderWithSongProbe(config: Parameters<typeof FretboardEmbed>[0]["config"]) {
     const [
-      { useAtomValue: u },
+      { useAtomValue },
       {
         currentProgressionPresetIdAtom: presetIdAtom,
         progressionLoopEnabledAtom: loopAtom,
@@ -221,6 +221,7 @@ describe("FretboardEmbed — M3 progression hydration", () => {
         progressionBassEnabledAtom: bassAtom,
         progressionChordEnabledAtom: chordsAtom,
         progressionMetronomeEnabledAtom: metroAtom,
+        progressionPlayingAtom: playingAtom,
       },
     ] = await Promise.all([import("jotai"), import("../store/progressionAtoms")]);
     vi.doMock("../hooks/useProgressionAudioPlayback", () => ({
@@ -231,14 +232,15 @@ describe("FretboardEmbed — M3 progression hydration", () => {
       Fretboard: () => (
         <div
           data-testid="song-probe"
-          data-preset={String(u(presetIdAtom))}
-          data-loop={String(u(loopAtom))}
-          data-tempo={String(u(tempoAtom))}
-          data-genre={String(u(genreAtom))}
-          data-drums={String(u(drumsAtom))}
-          data-bass={String(u(bassAtom))}
-          data-chords={String(u(chordsAtom))}
-          data-metro={String(u(metroAtom))}
+          data-preset={String(useAtomValue(presetIdAtom))}
+          data-loop={String(useAtomValue(loopAtom))}
+          data-tempo={String(useAtomValue(tempoAtom))}
+          data-genre={String(useAtomValue(genreAtom))}
+          data-drums={String(useAtomValue(drumsAtom))}
+          data-bass={String(useAtomValue(bassAtom))}
+          data-chords={String(useAtomValue(chordsAtom))}
+          data-metro={String(useAtomValue(metroAtom))}
+          data-playing={String(useAtomValue(playingAtom))}
         />
       ),
     }));
@@ -268,6 +270,20 @@ describe("FretboardEmbed — M3 progression hydration", () => {
     expect(probe.getAttribute("data-bass")).toBe("false");
     expect(probe.getAttribute("data-chords")).toBe("true");
     expect(probe.getAttribute("data-metro")).toBe("true");
+  });
+
+  it("hydrates progressionPlaying after the preset load (transport effect wins ordering)", async () => {
+    // Loading the preset resets playing→false; the transport effect is declared
+    // AFTER the preset effect, so on mount it must re-set playing→true. This
+    // proves both that the transport effect runs and that its declaration order
+    // wins over the preset's reset.
+    const probe = await renderWithSongProbe({
+      progressionEnabled: true,
+      progressionPreset: "two-five-one",
+      progressionPlaying: true,
+    });
+    expect(probe.getAttribute("data-preset")).toBe("two-five-one");
+    expect(probe.getAttribute("data-playing")).toBe("true");
   });
 });
 

--- a/packages/fretboard/src/contract/FretboardEmbed.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.tsx
@@ -17,6 +17,9 @@ import {
   twoStringsPairAtom,
   twoStringsIntervalAtom,
 } from "../store/fingeringAtoms";
+import { voicingAtom } from "../store/chordOverlayAtoms";
+import { practiceLensAtom } from "../store/practiceLensAtoms";
+import { updateActiveChordAtom } from "../store/songStateAtoms";
 import {
   loadProgressionPresetAtom,
   progressionLoopEnabledAtom,
@@ -89,6 +92,16 @@ export interface FretboardConfig {
   bassEnabled?: boolean;
   chordsEnabled?: boolean;
   metronomeEnabled?: boolean;
+
+  // --- M3: chord card (acts on the active progression step + board overlay) ---
+  /** Quality override for the active chord (one of the CHORD_DEFINITIONS keys), or null to clear. */
+  activeChordQuality?: string | null;
+  /** Manual root for the active chord (sharp name), or null to clear. */
+  activeChordManualRoot?: string | null;
+  /** Board voicing overlay. */
+  chordVoicing?: "off" | "full" | "close";
+  /** Practice lens overlay. */
+  chordPracticeLens?: "guide" | "root" | "common";
 }
 
 export interface FretboardEmbedProps {
@@ -191,6 +204,21 @@ export function FretboardEmbed({ config, onEvent }: FretboardEmbedProps) {
       store.set(setProgressionPlayingAtom, config.progressionPlaying);
     }
   }, [store, config.progressionPlaying]);
+
+  // M3: chord card. Voicing/lens are board overlays; quality/manualRoot write to
+  // the active progression step via updateActiveChordAtom (no-op if no active
+  // step). null is a meaningful value here (clears the override), so guard only
+  // against undefined.
+  useEffect(() => {
+    if (config.chordVoicing !== undefined) store.set(voicingAtom, config.chordVoicing);
+    if (config.chordPracticeLens !== undefined) store.set(practiceLensAtom, config.chordPracticeLens);
+    if (config.activeChordQuality !== undefined) {
+      store.set(updateActiveChordAtom, { quality: config.activeChordQuality });
+    }
+    if (config.activeChordManualRoot !== undefined) {
+      store.set(updateActiveChordAtom, { root: config.activeChordManualRoot });
+    }
+  }, [store, config.chordVoicing, config.chordPracticeLens, config.activeChordQuality, config.activeChordManualRoot]);
 
   // Keep the latest onEvent without making the subscription effect depend on its
   // identity — hosts often pass an inline arrow, which would otherwise re-subscribe

--- a/packages/fretboard/src/contract/FretboardEmbed.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.tsx
@@ -27,6 +27,11 @@ import {
   progressionChordEnabledAtom,
   progressionMetronomeEnabledAtom,
   setProgressionPlayingAtom,
+  resolvedProgressionStepsAtom,
+  displayedProgressionStepIndexAtom,
+  progressionPlayingAtom,
+  progressionPlaybackLoadingAtom,
+  progressionPlaybackBlockedReasonAtom,
 } from "../store/progressionAtoms";
 
 /**
@@ -186,6 +191,56 @@ export function FretboardEmbed({ config, onEvent }: FretboardEmbedProps) {
       store.set(setProgressionPlayingAtom, config.progressionPlaying);
     }
   }, [store, config.progressionPlaying]);
+
+  // M3: events-out. Subscribe to the isolated store and push coarse, human-speed
+  // events to the host. `displayedProgressionStepIndexAtom` already debounces
+  // RAF→React via startTransition, so this fires at step boundaries, not per frame.
+  useEffect(() => {
+    if (!config.progressionEnabled || !onEvent) return;
+
+    const labelOf = (s: { shortChordLabel: string | null; label: string }) =>
+      s.shortChordLabel ?? s.label;
+
+    const emitResolved = () => {
+      const steps = store.get(resolvedProgressionStepsAtom);
+      onEvent({
+        type: "progressionResolved",
+        steps: steps.map((s) => ({
+          index: s.index,
+          degree: String(s.degree),
+          label: labelOf(s),
+          unavailable: s.unavailable,
+        })),
+      });
+    };
+    const emitActive = () => {
+      const idx = store.get(displayedProgressionStepIndexAtom);
+      const steps = store.get(resolvedProgressionStepsAtom);
+      const s = steps[idx];
+      onEvent({ type: "activeStepChanged", index: idx, label: s ? labelOf(s) : "" });
+    };
+    const emitPlayback = () => {
+      onEvent({
+        type: "playbackStateChanged",
+        playing: store.get(progressionPlayingAtom),
+        loading: store.get(progressionPlaybackLoadingAtom),
+        blockedReason: store.get(progressionPlaybackBlockedReasonAtom),
+      });
+    };
+
+    const unsubs = [
+      store.sub(resolvedProgressionStepsAtom, emitResolved),
+      store.sub(displayedProgressionStepIndexAtom, emitActive),
+      store.sub(progressionPlayingAtom, emitPlayback),
+      store.sub(progressionPlaybackLoadingAtom, emitPlayback),
+      store.sub(progressionPlaybackBlockedReasonAtom, emitPlayback),
+    ];
+    // Initial snapshot so the host renders correct state before the first change.
+    emitResolved();
+    emitActive();
+    emitPlayback();
+    return () => unsubs.forEach((u) => u());
+  }, [store, onEvent, config.progressionEnabled]);
 
   useEffect(() => {
     // Jotai's primitive `set` treats a function value as an updater

--- a/packages/fretboard/src/contract/FretboardEmbed.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.tsx
@@ -6,6 +6,7 @@ import { themeAtom, displayFormatAtom, type ThemePreference } from "../store/uiA
 import { audioModeAtom, fretboardEventSinkAtom } from "./embedAtoms";
 import type { FretboardEventSink } from "./events";
 import { prefetchAudioModule, resumeGuitarAudio } from "../core/lazyGuitarAudio";
+import { ProgressionPlaybackRunner } from "./ProgressionPlaybackRunner";
 import {
   fingeringPatternAtom,
   selectSingleCagedShapeAtom,
@@ -53,6 +54,10 @@ export interface FretboardConfig {
   twoStringsPair?: number;
   /** Interval (0 = Off, 1 = 3rds, 2 = 4ths, 3 = 6ths) when fingeringPattern === "two-strings". */
   twoStringsInterval?: number;
+
+  // --- M3: in-webview progression playback (opt-in) ---
+  /** Mount the Tone.js progression engine for this embed. Default false (M2 embeds unchanged). */
+  progressionEnabled?: boolean;
 }
 
 export interface FretboardEmbedProps {
@@ -144,6 +149,7 @@ export function FretboardEmbed({ config, onEvent }: FretboardEmbedProps) {
 
   return (
     <Provider store={store}>
+      {config.progressionEnabled ? <ProgressionPlaybackRunner /> : null}
       <Fretboard stringRowPx={config.stringRowPx} />
     </Provider>
   );

--- a/packages/fretboard/src/contract/FretboardEmbed.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Provider, createStore } from "jotai";
 import { Fretboard } from "../components/Fretboard/Fretboard";
 import { baseRootNoteAtom, baseScaleNameAtom, scaleVisibleAtom } from "../store/scaleAtoms";
@@ -192,18 +192,26 @@ export function FretboardEmbed({ config, onEvent }: FretboardEmbedProps) {
     }
   }, [store, config.progressionPlaying]);
 
+  // Keep the latest onEvent without making the subscription effect depend on its
+  // identity — hosts often pass an inline arrow, which would otherwise re-subscribe
+  // and re-emit the initial snapshot on every host render.
+  const onEventRef = useRef(onEvent);
+  useEffect(() => { onEventRef.current = onEvent; }, [onEvent]);
+
   // M3: events-out. Subscribe to the isolated store and push coarse, human-speed
   // events to the host. `displayedProgressionStepIndexAtom` already debounces
   // RAF→React via startTransition, so this fires at step boundaries, not per frame.
   useEffect(() => {
-    if (!config.progressionEnabled || !onEvent) return;
+    if (!config.progressionEnabled) return;
 
     const labelOf = (s: { shortChordLabel: string | null; label: string }) =>
       s.shortChordLabel ?? s.label;
 
     const emitResolved = () => {
+      const sink = onEventRef.current;
+      if (!sink) return;
       const steps = store.get(resolvedProgressionStepsAtom);
-      onEvent({
+      sink({
         type: "progressionResolved",
         steps: steps.map((s) => ({
           index: s.index,
@@ -214,13 +222,17 @@ export function FretboardEmbed({ config, onEvent }: FretboardEmbedProps) {
       });
     };
     const emitActive = () => {
+      const sink = onEventRef.current;
+      if (!sink) return;
       const idx = store.get(displayedProgressionStepIndexAtom);
       const steps = store.get(resolvedProgressionStepsAtom);
       const s = steps[idx];
-      onEvent({ type: "activeStepChanged", index: idx, label: s ? labelOf(s) : "" });
+      sink({ type: "activeStepChanged", index: idx, label: s ? labelOf(s) : "" });
     };
     const emitPlayback = () => {
-      onEvent({
+      const sink = onEventRef.current;
+      if (!sink) return;
+      sink({
         type: "playbackStateChanged",
         playing: store.get(progressionPlayingAtom),
         loading: store.get(progressionPlaybackLoadingAtom),
@@ -233,6 +245,7 @@ export function FretboardEmbed({ config, onEvent }: FretboardEmbedProps) {
       store.sub(displayedProgressionStepIndexAtom, emitActive),
       store.sub(progressionPlayingAtom, emitPlayback),
       store.sub(progressionPlaybackLoadingAtom, emitPlayback),
+      // blockedReason derives from resolvedProgressionStepsAtom, so a preset load fires emitPlayback alongside emitResolved — intentional.
       store.sub(progressionPlaybackBlockedReasonAtom, emitPlayback),
     ];
     // Initial snapshot so the host renders correct state before the first change.
@@ -240,7 +253,7 @@ export function FretboardEmbed({ config, onEvent }: FretboardEmbedProps) {
     emitActive();
     emitPlayback();
     return () => unsubs.forEach((u) => u());
-  }, [store, onEvent, config.progressionEnabled]);
+  }, [store, config.progressionEnabled]);
 
   useEffect(() => {
     // Jotai's primitive `set` treats a function value as an updater

--- a/packages/fretboard/src/contract/FretboardEmbed.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.tsx
@@ -209,6 +209,7 @@ export function FretboardEmbed({ config, onEvent }: FretboardEmbedProps) {
   // the active progression step via updateActiveChordAtom (no-op if no active
   // step). null is a meaningful value here (clears the override), so guard only
   // against undefined.
+  // Declared AFTER the preset effect so on mount the preset populates steps first; otherwise the quality/manualRoot writes find no active step and no-op.
   useEffect(() => {
     if (config.chordVoicing !== undefined) store.set(voicingAtom, config.chordVoicing);
     if (config.chordPracticeLens !== undefined) store.set(practiceLensAtom, config.chordPracticeLens);

--- a/packages/fretboard/src/contract/FretboardEmbed.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.tsx
@@ -17,6 +17,17 @@ import {
   twoStringsPairAtom,
   twoStringsIntervalAtom,
 } from "../store/fingeringAtoms";
+import {
+  loadProgressionPresetAtom,
+  progressionLoopEnabledAtom,
+  progressionTempoBpmAtom,
+  progressionGenreStyleAtom,
+  progressionDrumsEnabledAtom,
+  progressionBassEnabledAtom,
+  progressionChordEnabledAtom,
+  progressionMetronomeEnabledAtom,
+  setProgressionPlayingAtom,
+} from "../store/progressionAtoms";
 
 /**
  * Serializable configuration for an embedded fretboard. Every field crosses
@@ -58,6 +69,21 @@ export interface FretboardConfig {
   // --- M3: in-webview progression playback (opt-in) ---
   /** Mount the Tone.js progression engine for this embed. Default false (M2 embeds unchanged). */
   progressionEnabled?: boolean;
+  /** Progression preset id (e.g. "one-five-six-four"). Loading resets playback + applies the preset's scale/genre. */
+  progressionPreset?: string;
+  /** Transport: play/pause. */
+  progressionPlaying?: boolean;
+  /** Loop the progression. */
+  progressionLoop?: boolean;
+  /** Tempo in BPM (engine clamps to 40..240). */
+  progressionTempoBpm?: number;
+  /** Genre style: "pop"|"rock"|"blues"|"jazz"|"ballad"|"funk"|"bossa-nova". */
+  progressionGenre?: string;
+  /** Layer toggles. */
+  drumsEnabled?: boolean;
+  bassEnabled?: boolean;
+  chordsEnabled?: boolean;
+  metronomeEnabled?: boolean;
 }
 
 export interface FretboardEmbedProps {
@@ -120,6 +146,46 @@ export function FretboardEmbed({ config, onEvent }: FretboardEmbedProps) {
     config.twoStringsPair,
     config.twoStringsInterval,
   ]);
+
+  // M3: preset load — its OWN effect, keyed only on the preset id. Loading a
+  // preset resets playing→false and applies the preset's scale + category genre,
+  // so it must NOT re-run when unrelated song fields change (e.g. a tempo tweak
+  // would otherwise reload the preset and stop playback).
+  useEffect(() => {
+    if (config.progressionPreset !== undefined) {
+      store.set(loadProgressionPresetAtom, config.progressionPreset);
+    }
+  }, [store, config.progressionPreset]);
+
+  // M3: song feel — loop / tempo / genre / layers. Declared AFTER the preset
+  // effect so on mount these override the preset's category defaults. Keyed
+  // narrowly so a feel change never reloads the preset.
+  useEffect(() => {
+    if (config.progressionLoop !== undefined) store.set(progressionLoopEnabledAtom, config.progressionLoop);
+    if (config.progressionTempoBpm !== undefined) store.set(progressionTempoBpmAtom, config.progressionTempoBpm);
+    if (config.progressionGenre !== undefined) store.set(progressionGenreStyleAtom, config.progressionGenre);
+    if (config.drumsEnabled !== undefined) store.set(progressionDrumsEnabledAtom, config.drumsEnabled);
+    if (config.bassEnabled !== undefined) store.set(progressionBassEnabledAtom, config.bassEnabled);
+    if (config.chordsEnabled !== undefined) store.set(progressionChordEnabledAtom, config.chordsEnabled);
+    if (config.metronomeEnabled !== undefined) store.set(progressionMetronomeEnabledAtom, config.metronomeEnabled);
+  }, [
+    store,
+    config.progressionLoop,
+    config.progressionTempoBpm,
+    config.progressionGenre,
+    config.drumsEnabled,
+    config.bassEnabled,
+    config.chordsEnabled,
+    config.metronomeEnabled,
+  ]);
+
+  // M3: transport — playing in its OWN effect so toggling play never reloads the
+  // preset or re-applies the feel.
+  useEffect(() => {
+    if (config.progressionPlaying !== undefined) {
+      store.set(setProgressionPlayingAtom, config.progressionPlaying);
+    }
+  }, [store, config.progressionPlaying]);
 
   useEffect(() => {
     // Jotai's primitive `set` treats a function value as an updater

--- a/packages/fretboard/src/contract/ProgressionPlaybackRunner.tsx
+++ b/packages/fretboard/src/contract/ProgressionPlaybackRunner.tsx
@@ -1,0 +1,13 @@
+import { useProgressionAudioPlayback } from "../hooks/useProgressionAudioPlayback";
+
+/**
+ * Mounts the Tone.js progression playback engine against the embed's isolated
+ * Jotai store. The web app mounts `useProgressionAudioPlayback` in its own
+ * Inspector shell; the embed renders a bare `<Fretboard/>` that does NOT, so
+ * without this runner an embedded host gets a silent progression. Rendered only
+ * when the host opts in via `config.progressionEnabled`. Renders nothing.
+ */
+export function ProgressionPlaybackRunner() {
+  useProgressionAudioPlayback();
+  return null;
+}

--- a/packages/fretboard/src/contract/events.test.ts
+++ b/packages/fretboard/src/contract/events.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import type { FretboardEvent } from "./events";
+
+// Type-level smoke: each member is assignable to FretboardEvent and discriminates on `type`.
+describe("FretboardEvent union", () => {
+  it("accepts all four event members", () => {
+    const events: FretboardEvent[] = [
+      { type: "noteActivated", frequency: 440, note: "A4", string: 0, fret: 5 },
+      { type: "progressionResolved", steps: [{ index: 0, degree: "I", label: "C", unavailable: false }] },
+      { type: "activeStepChanged", index: 2, label: "Am" },
+      { type: "playbackStateChanged", playing: true, loading: false, blockedReason: null },
+    ];
+    const types = events.map((e) => e.type).sort();
+    expect(types).toEqual(["activeStepChanged", "noteActivated", "playbackStateChanged", "progressionResolved"]);
+  });
+});

--- a/packages/fretboard/src/contract/events.ts
+++ b/packages/fretboard/src/contract/events.ts
@@ -1,14 +1,33 @@
 /** Serializable events emitted across the embed boundary. Grows with consumers. */
-export type FretboardEvent = {
-  type: "noteActivated";
-  /** Frequency in Hz of the activated note (what the builtin synth would play). */
-  frequency: number;
-  /** Scientific-pitch note name including octave, e.g. "C#4". */
-  note: string;
-  /** String index that was tapped; 0 = highest-pitched string. */
-  string: number;
-  /** Fret number that was tapped; 0 = open string. */
-  fret: number;
-};
+export type FretboardEvent =
+  | {
+      type: "noteActivated";
+      /** Frequency in Hz of the activated note (what the builtin synth would play). */
+      frequency: number;
+      /** Scientific-pitch note name including octave, e.g. "C#4". */
+      note: string;
+      /** String index that was tapped; 0 = highest-pitched string. */
+      string: number;
+      /** Fret number that was tapped; 0 = open string. */
+      fret: number;
+    }
+  | {
+      // Emitted on preset/root/scale change so a host can render the chord sequence.
+      type: "progressionResolved";
+      steps: { index: number; degree: string; label: string; unavailable: boolean }[];
+    }
+  | {
+      // Emitted when the visual clock advances the active step during playback.
+      type: "activeStepChanged";
+      index: number;
+      label: string;
+    }
+  | {
+      // Emitted when play/pause/loading/blocked state changes.
+      type: "playbackStateChanged";
+      playing: boolean;
+      loading: boolean;
+      blockedReason: string | null;
+    };
 
 export type FretboardEventSink = (event: FretboardEvent) => void;


### PR DESCRIPTION
## What

Expands the `FretboardEmbed` contract so a native host can drive the in-webview Tone.js progression engine and the chord overlay. Additive only — the web app (which renders `<Fretboard/>` directly) is unaffected.

### Mount the playback engine inside the embed
The bare `<Fretboard/>` the embed renders does **not** mount `useProgressionAudioPlayback` (the web app mounts it in its own Inspector shell), so an embedded host got a silent progression. A new `ProgressionPlaybackRunner` mounts the hook inside the embed's isolated store, gated by `progressionEnabled` (default false → existing tap-only embeds unchanged).

### New `config`-in fields (each undefined-guarded hydration write)
- `progressionEnabled`, `progressionPreset`, `progressionPlaying`, `progressionLoop`, `progressionTempoBpm`, `progressionGenre`, `drumsEnabled`, `bassEnabled`, `chordsEnabled`, `metronomeEnabled`
- Chord card: `activeChordQuality` / `activeChordManualRoot` (via `updateActiveChordAtom`; `null` clears), `chordVoicing`, `chordPracticeLens`
- Effect split for correctness: preset load is isolated (it resets playback + applies the preset's scale/genre), feel writes override it, transport is isolated, chord writes run after preset so an active step exists.

### New events-out channel
`FretboardEvent` is now a discriminated union. The embed subscribes to the isolated store and emits `progressionResolved` / `activeStepChanged` / `playbackStateChanged` through the `onEvent` prop. `onEvent` is held in a ref so an inline-arrow host callback doesn't cause re-subscribe/re-emit churn.

## Tests
`packages/fretboard/src/contract/` — 17 tests pass (events union, runner mount gating, progression hydration incl. preset-reload ordering, events-out emission, chord hydration incl. manualRoot path). `tsc --noEmit` clean.

## Context
Consumed by the FretFlow mobile M3 Song tab + Chord card. Spec/plan: `docs/superpowers/specs/2026-06-13-m3-...` and `docs/superpowers/plans/2026-06-13-m3-...` in the mobile repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progression playback controls with preset selection, playback/loop transport, tempo/genre configuration, and instrument layer toggles (drums, bass, chords, metronome).
  * Added chord card overlay controls for voicing and practice lens options.
  * New event types for progression changes, active step updates, and playback state notifications.

* **Tests**
  * Extended test coverage for progression configuration hydration and chord overlay state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->