### PR TITLE
feat(fretboard-pkg): native-audio support (logic export + active step)

### DIFF
--- a/packages/fretboard/src/contract/FretboardEmbed.test.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.test.tsx
@@ -378,6 +378,27 @@ describe("FretboardEmbed — M3 chord card hydration", () => {
   });
 });
 
+describe("FretboardEmbed — M3 native active-step hydration", () => {
+  beforeEach(() => { localStorage.clear(); vi.clearAllMocks(); vi.resetModules(); });
+
+  it("hydrates activeProgressionStepIndex into the displayed step", async () => {
+    const [{ useAtomValue }, { displayedProgressionStepIndexAtom }] = await Promise.all([
+      import("jotai"),
+      import("../store/progressionAtoms"),
+    ]);
+    vi.doMock("../hooks/useProgressionAudioPlayback", () => ({
+      useProgressionAudioPlayback: () => {}, __resetProgressionAudioPlaybackForTests: () => {},
+    }));
+    vi.doMock("../components/Fretboard/Fretboard", () => ({
+      Fretboard: () => <div data-testid="probe" data-step={String(useAtomValue(displayedProgressionStepIndexAtom))} />,
+    }));
+    const { FretboardEmbed: Fresh } = await import("./FretboardEmbed");
+    render(<Fresh config={{ progressionPreset: "one-five-six-four", root: "C", scale: "major", activeProgressionStepIndex: 2 }} />);
+    await act(async () => { await Promise.resolve(); });
+    expect(screen.getByTestId("probe").getAttribute("data-step")).toBe("2");
+  });
+});
+
 describe("FretboardEmbed — M3 events-out", () => {
   beforeEach(() => {
     localStorage.clear();

--- a/packages/fretboard/src/contract/FretboardEmbed.tsx
+++ b/packages/fretboard/src/contract/FretboardEmbed.tsx
@@ -30,6 +30,7 @@ import {
   progressionChordEnabledAtom,
   progressionMetronomeEnabledAtom,
   setProgressionPlayingAtom,
+  setProgressionActiveStepIndexAtom,
   resolvedProgressionStepsAtom,
   displayedProgressionStepIndexAtom,
   progressionPlayingAtom,
@@ -102,6 +103,10 @@ export interface FretboardConfig {
   chordVoicing?: "off" | "full" | "close";
   /** Practice lens overlay. */
   chordPracticeLens?: "guide" | "root" | "common";
+
+  // --- M3: native-audio step highlight (native engine owns the clock) ---
+  /** Host-driven active progression step (native audio owns the clock). Highlights the board's current chord. */
+  activeProgressionStepIndex?: number;
 }
 
 export interface FretboardEmbedProps {
@@ -220,6 +225,15 @@ export function FretboardEmbed({ config, onEvent }: FretboardEmbedProps) {
       store.set(updateActiveChordAtom, { root: config.activeChordManualRoot });
     }
   }, [store, config.chordVoicing, config.chordPracticeLens, config.activeChordQuality, config.activeChordManualRoot]);
+
+  // M3-native: the native engine owns the clock and pushes the active step in so
+  // the board highlights the current chord (the in-webview visual clock does not
+  // run here — progressionEnabled stays false on mobile).
+  useEffect(() => {
+    if (config.activeProgressionStepIndex !== undefined) {
+      store.set(setProgressionActiveStepIndexAtom, config.activeProgressionStepIndex);
+    }
+  }, [store, config.activeProgressionStepIndex]);
 
   // Keep the latest onEvent without making the subscription effect depend on its
   // identity — hosts often pass an inline arrow, which would otherwise re-subscribe

--- a/packages/fretboard/src/progression-logic.test.ts
+++ b/packages/fretboard/src/progression-logic.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildAllLayersAsync,
+  getGenreStyle,
+  getGenreMix,
+  PROGRESSION_PRESETS,
+  resolveProgressionStep,
+} from "./progression-logic";
+
+describe("progression-logic entry (Tone-free native surface)", () => {
+  it("re-exports the musical-logic API", () => {
+    expect(typeof buildAllLayersAsync).toBe("function");
+    expect(typeof getGenreStyle).toBe("function");
+    expect(typeof getGenreMix).toBe("function");
+    expect(typeof resolveProgressionStep).toBe("function");
+    expect(Array.isArray(PROGRESSION_PRESETS)).toBe(true);
+    expect(PROGRESSION_PRESETS.length).toBeGreaterThan(0);
+  });
+
+  it("buildAllLayersAsync produces layered events for a resolved preset", async () => {
+    const preset = PROGRESSION_PRESETS.find((p) => p.id === "one-five-six-four")!;
+    const genre = getGenreStyle("pop")!; // use a real genre's pattern ids
+    const steps = preset.steps.map((s, i) => resolveProgressionStep(s, preset.scale, "C", i, false));
+    const layers = await buildAllLayersAsync({
+      steps, tempoBpm: 90, beatsPerBar: 4, swing: genre.swing,
+      chordPatternId: genre.chordPattern, bassPatternId: genre.bassPattern, drumPatternId: genre.drumPattern,
+      drumVariations: genre.drumVariations, chordVariations: genre.chordVariations, bassVariations: genre.bassVariations,
+      loop: true,
+    });
+    expect(layers.chordStrums.length).toBeGreaterThan(0);
+    expect(layers.totalDurationSec).toBeGreaterThan(0);
+    expect(typeof layers.chordStrums[0].time).toBe("number");
+    expect(Array.isArray(layers.chordStrums[0].value.voicing)).toBe(true);
+  });
+});

--- a/packages/fretboard/src/progression-logic.test.ts
+++ b/packages/fretboard/src/progression-logic.test.ts
@@ -20,7 +20,10 @@ describe("progression-logic entry (Tone-free native surface)", () => {
   it("buildAllLayersAsync produces layered events for a resolved preset", async () => {
     const preset = PROGRESSION_PRESETS.find((p) => p.id === "one-five-six-four")!;
     const genre = getGenreStyle("pop")!; // use a real genre's pattern ids
-    const steps = preset.steps.map((s, i) => resolveProgressionStep(s, preset.scale, "C", i, false));
+    // preset.steps is Omit<ProgressionStep,"id"> — ids are assigned on load; supply one here.
+    const steps = preset.steps.map((s, i) =>
+      resolveProgressionStep({ id: `${preset.id}-${i}`, ...s }, preset.scale, "C", i, false),
+    );
     const layers = await buildAllLayersAsync({
       steps, tempoBpm: 90, beatsPerBar: 4, swing: genre.swing,
       chordPatternId: genre.chordPattern, bassPatternId: genre.bassPattern, drumPatternId: genre.drumPattern,

--- a/packages/fretboard/src/progression-logic.ts
+++ b/packages/fretboard/src/progression-logic.ts
@@ -1,0 +1,23 @@
+// Tone-free musical-logic surface for native (React Native) consumers.
+// NONE of these modules import "tone" — safe to import from a RN app where
+// Tone.js cannot run. The web app keeps using the Tone-based engine directly.
+export { buildAllLayersAsync } from "./progressions/audio/buildAllLayers";
+export type {
+  BuildAllLayersInput, BuiltLayers,
+  ChordOnsetEvent, ChordStrumEvent, BassEvent, DrumEvent, MetronomeEvent,
+} from "./progressions/audio/buildAllLayers";
+export {
+  getChordPattern, getBassPattern, getDrumPattern,
+  getChordVariation, getBassVariation, getDrumVariation,
+} from "./progressions/audio/patterns";
+export { getGenreStyle, GENRE_STYLES } from "./progressions/audio/genres";
+export type { GenreStyle } from "./progressions/audio/genres";
+export { getGenreMix } from "./progressions/audio/sound/genreMixPresets";
+export { getBassPatch, getDrumKitPatch } from "./progressions/audio/sound/instrumentPatches";
+export type { BassPatch, DrumKitPatch, PolyChordSpec } from "./progressions/audio/sound/patchTypes";
+export {
+  PROGRESSION_PRESETS, resolveProgressionStep,
+} from "./progressions/progressionDomain";
+export type {
+  ProgressionStep, ResolvedProgressionStep, ProgressionPreset,
+} from "./progressions/progressionDomain";


### PR DESCRIPTION
## What

Additive, web-safe support for a **native** (React Native) audio engine that reuses the package's Tone-free musical logic but cannot import Tone.js.

1. **`@fretflow/fretboard/progression-logic`** — a new re-export entry exposing ONLY the Tone-free modules (`buildAllLayersAsync` + event types, `patterns` getters, `genres`, `genreMixPresets`, `instrumentPatches`/`patchTypes`, `progressionDomain`). Verified none import `tone`, so it's safe to import from a RN app. The web app keeps using the Tone-based engine directly.
2. **`activeProgressionStepIndex?: number`** config-in on `FretboardConfig` — lets a native audio clock drive the board's highlighted chord. Hydrates `setProgressionActiveStepIndexAtom`; `displayedProgressionStepIndexAtom` routes to it while not playing (the in-webview visual clock doesn't run on mobile — `progressionEnabled` stays false).

## Why

The M3 webview-audio approach failed (WKWebView won't unlock an AudioContext from a native button press). Pivoting to a native engine on `react-native-audio-api` — spike-validated (RNAA builds on SDK 56; chord loop plays cleanly). This PR is the package half: expose the reusable logic + accept a host-driven active step.

## Tests
`packages/fretboard/src/contract/` + `progression-logic.test.ts` — 20 tests pass; `tsc --noEmit` clean. No web behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `activeProgressionStepIndex` setting to let host applications control the progression step used for chord highlighting in the fretboard embed.

* **Tests**
  * Added a new suite covering native active-step hydration behavior in the fretboard embed.
  * Added a new suite validating progression logic exports and that chord-layer generation returns well-formed timing and voicing data.

* **Documentation**
  * Exposed progression-logic capabilities via a new React Native/native barrel surface for easier imports (functionality already covered by tests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->