### PR TITLE
feat(fretboard-pkg): add progression-logic subpath export

### DIFF
--- a/packages/fretboard/package.json
+++ b/packages/fretboard/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./progression-logic": "./src/progression-logic.ts",
     "./*": "./src/*"
   },
   "dependencies": {


### PR DESCRIPTION
## What
Adds an explicit `"./progression-logic": "./src/progression-logic.ts"` entry to the package `exports` map.

## Why
The existing `"./*": "./src/*"` wildcard only resolves subpaths that carry an explicit extension, so the extensionless `@fretflow/fretboard/progression-logic` barrel (added in #615) doesn't resolve through Metro/tsc. The FretFlow mobile app currently works around this with a hardcoded alias in `metro.config.js` + `tsconfig.json` pointing at the package's internal `src/`. This explicit export lets consumers import it cleanly; the mobile alias will be removed in a follow-up commit once this lands.

## Verified
- New entry resolves `@fretflow/fretboard/progression-logic` from the mobile app with NO bundler alias (tsc).
- One-line `exports` change only — no source/dep/lockfile changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progression logic is now publicly exported, allowing developers to directly import progression-related utilities. Users can integrate these tools into their applications to leverage chord progression features, enhancing flexibility and accessibility of the package's core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->