### PR TITLE
build(deps): pin jotai to 2.20.0 (2.20.1 type regression)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@radix-ui/react-tooltip": "^1.2.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "jotai": "^2.20.0",
+    "jotai": "2.20.0",
     "lucide-react": "^1.17.0",
     "lz-string": "^1.5.0",
     "motion": "^12.40.0",

--- a/packages/fretboard/package.json
+++ b/packages/fretboard/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@fretflow/core": "workspace:*",
     "clsx": "^2.1.1",
-    "jotai": "^2.20.0",
+    "jotai": "2.20.0",
     "motion": "^12.40.0",
     "tone": "^15.1.22"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       jotai:
-        specifier: ^2.20.0
+        specifier: 2.20.0
         version: 2.20.0(@babel/core@7.29.0)(@babel/template@7.29.7)(@types/react@19.2.16)(react@19.2.7)
       lucide-react:
         specifier: ^1.17.0
@@ -197,7 +197,7 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       jotai:
-        specifier: ^2.20.0
+        specifier: 2.20.0
         version: 2.20.0(@babel/core@7.29.0)(@babel/template@7.29.7)(@types/react@19.2.16)(react@19.2.7)
       motion:
         specifier: ^12.40.0


### PR DESCRIPTION
## Summary

Pin `jotai` to an exact `2.20.0` in both importers (root + `@fretflow/fretboard`) to prevent the lockfile from ever drifting to the broken `2.20.1`.

**Why:** jotai `2.20.1` makes `RESET` a `unique symbol`. Via parameter contravariance, `atomWithReset` / storage-with-reset atoms' write signature (`[SetStateActionWithReset<T>]`) is no longer assignable to `[T]`, so valid `store.set(atom, value)` calls fail to typecheck. Result: **72 `tsc -b` errors** (9 in `src/hooks/useKeyboardShortcuts.ts`, 63 in test files). The app code is correct — this is an upstream type regression rejecting valid usage.

CI passes today only because the frozen lockfile resolves `2.20.0`. The `^2.20.0` range was a latent failure: any lockfile re-resolution (manual `pnpm install`, a dep bump, Dependabot) would pull `2.20.1` and break the **Build** check. Exact-pinning closes that gap.

Unpin when jotai ships `2.20.2+` restoring the valid typing.

## Test Plan
- [x] `tsc -b` → 0 errors (was 72 under 2.20.1)
- [x] `pnpm run lint` → 0 errors
- [x] `pnpm run test` → 2693 passed, 1 skipped
- [x] `pnpm run build` → success
- [x] Lockfile diff is minimal (specifier `^2.20.0` → `2.20.0`, version unchanged at 2.20.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned jotai dependency versions to exact specification for consistent builds across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->