### PR TITLE
feat(progression): keyboard focus + single-tab-stop navigation for the chord controls

### DIFF
--- a/docs/superpowers/plans/2026-06-15-keyboard-shortcut-focus.md
+++ b/docs/superpowers/plans/2026-06-15-keyboard-shortcut-focus.md
@@ -1,0 +1,568 @@
+# Keyboard-Shortcut Focus Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move DOM focus to the tempo stepper (↑/↓) and the chord step list (←/→) after the global arrow-key shortcuts fire, so the existing `:focus-visible` ring highlights the control that changed instead of the whole tab body or a stale chord row.
+
+**Architecture:** The global `useKeyboardShortcuts` hook already mutates atoms but never moves focus. We give the two target controls stable DOM ids and make them programmatically focusable (`tabIndex={-1}`), add `:focus-visible` rings using existing tokens, and have the hook call `getElementById(id)?.focus({ preventScroll: true })` after each relevant mutation — the same pattern already used in `MobilePanel.tsx`. If a target is on the hidden tab, `getElementById` returns `null` and focusing is a silent no-op (state still updates).
+
+**Tech Stack:** React 19 + TypeScript, Jotai, CSS Modules, Vitest + Testing Library (jsdom).
+
+---
+
+## Spec
+
+See [`docs/superpowers/specs/2026-06-15-keyboard-shortcut-focus-design.md`](../specs/2026-06-15-keyboard-shortcut-focus-design.md).
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/components/SongControls/progressionFocusIds.ts` | **New.** Two exported id-string constants shared by the hook and the components, so the ids never drift. |
+| `src/components/StepperControl/StepperControl.tsx` | Accept an optional `groupId`; forward it as `id` + `tabIndex={-1}` to the `StepperShell` group element. |
+| `src/components/StepperShell/StepperShell.module.css` | Add a `:focus-visible` ring on `.shell`. |
+| `src/components/SongControls/ProgressionStepList.tsx` | Give the `.scroll` container the shared id + `tabIndex={-1}`. |
+| `src/components/SongControls/ProgressionStepList.module.css` | Add a `:focus-visible` ring on `.scroll`. |
+| `src/components/SongControls/SongControls.tsx` | Pass `groupId` to the tempo `StepperControl`. |
+| `src/hooks/useKeyboardShortcuts.ts` | Focus the tempo group / chord list after the four arrow shortcuts. |
+| `src/hooks/useKeyboardShortcuts.test.tsx` | New tests for the focus moves + off-tab no-op. |
+| `src/components/StepperControl/StepperControl.test.tsx` | New/extended test: `groupId` renders id + `tabIndex`. |
+| `src/components/SongControls/ProgressionStepList.test.tsx` | New/extended test: scroll container has id + `tabIndex`. |
+
+Notes verified during planning:
+- `StepperShell` extends `HTMLAttributes<HTMLDivElement>` and spreads `{...props}` onto its `div`, so forwarding `id` and `tabIndex` requires no change to `StepperShell.tsx`.
+- `MobilePanels.module.css` `.panel` already sets `outline: none`; **no mobile-panel CSS change is needed.**
+- `.shell` composes `surface--control`, which already rings on `:focus-within`; the new `.shell:focus-visible` rule adds the glow and makes keyboard focus on the group element explicit.
+
+---
+
+## Task 1: Shared focus-target id constants
+
+**Files:**
+- Create: `src/components/SongControls/progressionFocusIds.ts`
+
+- [ ] **Step 1: Create the constants module**
+
+```typescript
+// Stable DOM ids for the controls that global keyboard shortcuts focus after
+// mutating their state (see src/hooks/useKeyboardShortcuts.ts). Shared so the
+// hook and the components can never drift on the id string.
+
+/** The tempo stepper group (↑/↓ shortcuts focus this). */
+export const TEMPO_STEPPER_ID = "progression-tempo-stepper";
+
+/** The chord step list scroll container (←/→ shortcuts focus this). */
+export const PROGRESSION_STEP_LIST_ID = "progression-step-list";
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run: `pnpm exec tsc -b --noEmit`
+Expected: no errors (the file is plain constants).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/SongControls/progressionFocusIds.ts
+git commit -m "feat(shortcuts): add shared focus-target id constants"
+```
+
+---
+
+## Task 2: StepperControl forwards a focusable group id
+
+**Files:**
+- Modify: `src/components/StepperControl/StepperControl.tsx`
+- Modify: `src/components/StepperShell/StepperShell.module.css`
+- Test: `src/components/StepperControl/StepperControl.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+If `StepperControl.test.tsx` already exists, append this `describe` block; otherwise create the file with this content.
+
+```tsx
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { StepperControl } from "./StepperControl";
+
+describe("StepperControl groupId", () => {
+  it("renders the group element with the given id and tabIndex=-1", () => {
+    const { container } = render(
+      <StepperControl
+        value={100}
+        onChange={() => {}}
+        min={40}
+        max={240}
+        groupId="test-stepper"
+        label="Tempo"
+      />,
+    );
+
+    const group = container.querySelector("#test-stepper");
+    expect(group).not.toBeNull();
+    expect(group?.getAttribute("role")).toBe("group");
+    expect(group?.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("does not set a tabIndex when no groupId is given", () => {
+    const { container } = render(
+      <StepperControl value={100} onChange={() => {}} min={40} max={240} label="Tempo" />,
+    );
+
+    const group = container.querySelector('[role="group"]');
+    expect(group).not.toBeNull();
+    expect(group?.getAttribute("tabindex")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run src/components/StepperControl/StepperControl.test.tsx`
+Expected: FAIL — the first test cannot find `#test-stepper` (prop not wired yet).
+
+- [ ] **Step 3: Add the `groupId` prop and forward it**
+
+In `src/components/StepperControl/StepperControl.tsx`, add the prop to the interface (after the `disabled` prop):
+
+```typescript
+  /** When true, both stepper buttons are disabled regardless of value bounds. */
+  disabled?: boolean;
+  /** When set, the stepper group element gets this DOM id and becomes
+   * programmatically focusable (tabIndex=-1) so global keyboard shortcuts can
+   * focus it. Does not add a Tab stop — the +/- buttons remain the tab stops. */
+  groupId?: string;
+```
+
+Add `groupId` to the destructured params:
+
+```typescript
+  testId,
+  width,
+  disabled = false,
+  groupId,
+}: StepperControlProps) {
+```
+
+Forward it to the `StepperShell` group element (the element that already has `role="group"`):
+
+```tsx
+      <StepperShell
+        className={styles["stepper-group"]}
+        role="group"
+        aria-label={label ?? "Stepper control"}
+        data-testid={testId}
+        id={groupId}
+        tabIndex={groupId ? -1 : undefined}
+      >
+```
+
+- [ ] **Step 4: Add the `:focus-visible` ring to the shell**
+
+In `src/components/StepperShell/StepperShell.module.css`, add this rule immediately after the existing `.shell { ... }` block:
+
+```css
+.shell:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-glow);
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run src/components/StepperControl/StepperControl.test.tsx`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/StepperControl/StepperControl.tsx src/components/StepperShell/StepperShell.module.css src/components/StepperControl/StepperControl.test.tsx
+git commit -m "feat(stepper): optional focusable groupId with focus-visible ring"
+```
+
+---
+
+## Task 3: ProgressionStepList scroll container becomes focusable
+
+**Files:**
+- Modify: `src/components/SongControls/ProgressionStepList.tsx`
+- Modify: `src/components/SongControls/ProgressionStepList.module.css`
+- Test: `src/components/SongControls/ProgressionStepList.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+If `ProgressionStepList.test.tsx` already exists, append this `describe` block; otherwise create the file with this content.
+
+```tsx
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { ProgressionStepList } from "./ProgressionStepList";
+import { PROGRESSION_STEP_LIST_ID } from "./progressionFocusIds";
+import type { ResolvedProgressionStep } from "../../progressions/progressionDomain";
+
+const steps = [
+  {
+    id: "s0",
+    degree: "I",
+    duration: 4,
+    resolvedChordLabel: "C",
+    unavailable: false,
+  },
+  {
+    id: "s1",
+    degree: "V",
+    duration: 4,
+    resolvedChordLabel: "G",
+    unavailable: false,
+  },
+] as unknown as ResolvedProgressionStep[];
+
+describe("ProgressionStepList focus target", () => {
+  it("exposes a focusable scroll container with the shared id", () => {
+    const { container } = render(
+      <ProgressionStepList
+        steps={steps}
+        activeIndex={0}
+        onSelect={() => {}}
+        label="Progression"
+        caption="Steps"
+      />,
+    );
+
+    const scroll = container.querySelector(`#${PROGRESSION_STEP_LIST_ID}`);
+    expect(scroll).not.toBeNull();
+    expect(scroll?.getAttribute("tabindex")).toBe("-1");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run src/components/SongControls/ProgressionStepList.test.tsx`
+Expected: FAIL — no element with id `progression-step-list`.
+
+- [ ] **Step 3: Add the id + tabIndex to the scroll container**
+
+In `src/components/SongControls/ProgressionStepList.tsx`, add the import near the top (with the other relative imports):
+
+```typescript
+import { PROGRESSION_STEP_LIST_ID } from "./progressionFocusIds";
+```
+
+Change the `.scroll` wrapper `div` so it carries the id and is focusable:
+
+```tsx
+      <div className={styles.scroll} id={PROGRESSION_STEP_LIST_ID} tabIndex={-1}>
+```
+
+- [ ] **Step 4: Add the `:focus-visible` ring**
+
+In `src/components/SongControls/ProgressionStepList.module.css`, add this rule immediately after the existing `.scroll { ... }` block (around line 46):
+
+```css
+.scroll:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+  border-radius: var(--radius-md);
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run src/components/SongControls/ProgressionStepList.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/SongControls/ProgressionStepList.tsx src/components/SongControls/ProgressionStepList.module.css src/components/SongControls/ProgressionStepList.test.tsx
+git commit -m "feat(progression): focusable chord-list scroll container with ring"
+```
+
+---
+
+## Task 4: Wire the tempo stepper id in SongControls
+
+**Files:**
+- Modify: `src/components/SongControls/SongControls.tsx`
+
+This is a pure wire-up of the prop from Task 2; it is covered end-to-end by the hook test in Task 5 (which renders nothing of SongControls but relies on the id contract) and by manual verification. No separate unit test.
+
+- [ ] **Step 1: Import the constant**
+
+In `src/components/SongControls/SongControls.tsx`, add to the relative imports:
+
+```typescript
+import { TEMPO_STEPPER_ID } from "./progressionFocusIds";
+```
+
+- [ ] **Step 2: Pass `groupId` to the tempo StepperControl**
+
+Find the tempo `StepperControl` (inside the `inspector.meterTempo` `Prop`, around line 304) and add the `groupId` prop:
+
+```tsx
+                <StepperControl
+                  label={t("inspector.meterTempo")}
+                  hideLabel
+                  value={progressionTempoBpm}
+                  min={MIN_PROGRESSION_TEMPO_BPM}
+                  max={MAX_PROGRESSION_TEMPO_BPM}
+                  step={5}
+                  formatValue={(bpm) => `${bpm} BPM`}
+                  onChange={setProgressionTempoBpm}
+                  width="auto"
+                  groupId={TEMPO_STEPPER_ID}
+                />
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `pnpm exec tsc -b --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/SongControls/SongControls.tsx
+git commit -m "feat(song): give the tempo stepper its shortcut focus id"
+```
+
+---
+
+## Task 5: Hook moves focus after the arrow shortcuts
+
+**Files:**
+- Modify: `src/hooks/useKeyboardShortcuts.ts`
+- Test: `src/hooks/useKeyboardShortcuts.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/hooks/useKeyboardShortcuts.test.tsx`, add these imports to the existing import block:
+
+```tsx
+import { activeProgressionStepIndexAtom, progressionTempoBpmAtom } from "../store/progressionAtoms";
+import { TEMPO_STEPPER_ID, PROGRESSION_STEP_LIST_ID } from "../components/SongControls/progressionFocusIds";
+```
+
+(`activeProgressionStepIndexAtom` may already be imported — if so, only add `progressionTempoBpmAtom`.)
+
+Append these tests inside the top-level `describe("useKeyboardShortcuts", ...)` block, before its closing `});`:
+
+```tsx
+  it("ArrowUp moves focus to the tempo stepper when it is present", () => {
+    store.set(progressionTempoBpmAtom, 100);
+    const el = document.createElement("div");
+    el.id = TEMPO_STEPPER_ID;
+    el.tabIndex = -1;
+    document.body.appendChild(el);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowUp" }); });
+
+    expect(store.get(progressionTempoBpmAtom)).toBe(105);
+    expect(document.activeElement).toBe(el);
+    document.body.removeChild(el);
+  });
+
+  it("ArrowDown moves focus to the tempo stepper when it is present", () => {
+    store.set(progressionTempoBpmAtom, 100);
+    const el = document.createElement("div");
+    el.id = TEMPO_STEPPER_ID;
+    el.tabIndex = -1;
+    document.body.appendChild(el);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowDown" }); });
+
+    expect(store.get(progressionTempoBpmAtom)).toBe(95);
+    expect(document.activeElement).toBe(el);
+    document.body.removeChild(el);
+  });
+
+  it("ArrowUp still changes tempo and does not throw when the stepper is absent", () => {
+    store.set(progressionTempoBpmAtom, 100);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowUp" }); });
+
+    expect(store.get(progressionTempoBpmAtom)).toBe(105);
+  });
+
+  it("ArrowRight moves focus to the chord list when not playing", () => {
+    store.set(setProgressionPlayingAtom, false);
+    store.set(activeProgressionStepIndexAtom, 0);
+    const el = document.createElement("div");
+    el.id = PROGRESSION_STEP_LIST_ID;
+    el.tabIndex = -1;
+    document.body.appendChild(el);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowRight" }); });
+
+    expect(document.activeElement).toBe(el);
+    document.body.removeChild(el);
+  });
+
+  it("ArrowLeft moves focus to the chord list when not playing", () => {
+    store.set(setProgressionPlayingAtom, false);
+    store.set(activeProgressionStepIndexAtom, 2);
+    const el = document.createElement("div");
+    el.id = PROGRESSION_STEP_LIST_ID;
+    el.tabIndex = -1;
+    document.body.appendChild(el);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowLeft" }); });
+
+    expect(document.activeElement).toBe(el);
+    document.body.removeChild(el);
+  });
+
+  it("ArrowRight does not move focus to the chord list while playing", () => {
+    store.set(setProgressionPlayingAtom, true);
+    store.set(activeProgressionStepIndexAtom, 0);
+    const el = document.createElement("div");
+    el.id = PROGRESSION_STEP_LIST_ID;
+    el.tabIndex = -1;
+    document.body.appendChild(el);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowRight" }); });
+
+    expect(document.activeElement).not.toBe(el);
+    document.body.removeChild(el);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm exec vitest run src/hooks/useKeyboardShortcuts.test.tsx`
+Expected: FAIL — the new focus assertions fail (`document.activeElement` is `body`, not the target) because the hook does not move focus yet. The "absent" tempo test may already pass.
+
+- [ ] **Step 3: Add focus movement to the hook**
+
+In `src/hooks/useKeyboardShortcuts.ts`, add this import after the existing imports:
+
+```typescript
+import {
+  TEMPO_STEPPER_ID,
+  PROGRESSION_STEP_LIST_ID,
+} from "../components/SongControls/progressionFocusIds";
+```
+
+Add this helper just above `export function useKeyboardShortcuts() {`:
+
+```typescript
+/** Focus a shortcut target by id if it is currently rendered. A no-op when the
+ * element is absent (e.g. its inspector tab is not showing) — the state mutation
+ * has already happened, so we just skip moving focus. `preventScroll` keeps the
+ * page and the list scrollport from jumping. */
+function focusShortcutTarget(id: string) {
+  document.getElementById(id)?.focus({ preventScroll: true });
+}
+```
+
+In the `switch (e.key)`, update the four arrow cases so each focuses its target after the mutation:
+
+```typescript
+        case "ArrowLeft":
+          if (store.get(progressionPlayingAtom)) return;
+          e.preventDefault();
+          store.set(previousProgressionStepAtom);
+          focusShortcutTarget(PROGRESSION_STEP_LIST_ID);
+          break;
+        case "ArrowRight":
+          if (store.get(progressionPlayingAtom)) return;
+          e.preventDefault();
+          store.set(advanceProgressionPlaybackAtom);
+          focusShortcutTarget(PROGRESSION_STEP_LIST_ID);
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          store.set(
+            progressionTempoBpmAtom,
+            Math.min(
+              MAX_PROGRESSION_TEMPO_BPM,
+              store.get(progressionTempoBpmAtom) + 5,
+            ),
+          );
+          focusShortcutTarget(TEMPO_STEPPER_ID);
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          store.set(
+            progressionTempoBpmAtom,
+            Math.max(
+              MIN_PROGRESSION_TEMPO_BPM,
+              store.get(progressionTempoBpmAtom) - 5,
+            ),
+          );
+          focusShortcutTarget(TEMPO_STEPPER_ID);
+          break;
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm exec vitest run src/hooks/useKeyboardShortcuts.test.tsx`
+Expected: PASS (all existing tests plus the six new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useKeyboardShortcuts.ts src/hooks/useKeyboardShortcuts.test.tsx
+git commit -m "feat(shortcuts): focus the changed control after arrow shortcuts"
+```
+
+---
+
+## Task 6: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Lint**
+
+Run: `pnpm run lint`
+Expected: passes (no new errors; the fretboard-boundary and react-compiler rules stay green).
+
+- [ ] **Step 2: Token check**
+
+Run: `pnpm run ui:tokens`
+Expected: no undefined `var(--x)` references — the new rules use `--focus-ring`, `--focus-ring-offset`, `--focus-ring-glow`, `--radius-md`, all already defined.
+
+- [ ] **Step 3: Unit tests**
+
+Run: `pnpm run test`
+Expected: all pass.
+
+- [ ] **Step 4: Build**
+
+Run: `pnpm run build`
+Expected: `tsc -b` + `vite build` succeed.
+
+- [ ] **Step 5: Manual smoke (dev server)**
+
+Run: `pnpm run dev`, open the app, go to the **Song** tab, then:
+- Press ↑/↓ — the **tempo stepper** shows the cyan ring (not the whole tab body), and the value changes by 5 BPM.
+- Press ←/→ (while stopped) — the **chord list** shows the ring as a unit and the active chord advances/retreats.
+- Confirm clicking with the mouse does **not** trigger the ring (keyboard-only `:focus-visible`).
+- On a narrow viewport (mobile dock → Song panel), repeat and confirm the whole-panel highlight is gone.
+
+- [ ] **Step 6: Final commit (if any verification fixups were needed)**
+
+```bash
+git add -A
+git commit -m "test(shortcuts): verification fixups for focus management"
+```
+
+(Skip if steps 1–5 needed no changes.)
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** tempo focus (Tasks 2, 4, 5), chord-list focus (Tasks 3, 5), shared ids to avoid drift (Task 1), off-tab silent no-op (Task 5 "absent" test), no ring-token changes (only consuming existing tokens), mobile panel needs no change (documented). All covered.
+- **Type/name consistency:** `groupId` prop name is identical in Tasks 2 and 4; `TEMPO_STEPPER_ID` / `PROGRESSION_STEP_LIST_ID` defined once in Task 1 and imported everywhere else; `focusShortcutTarget` defined and used only in Task 5.
+- **Known browser caveat:** `:focus-visible` after a programmatic `.focus()` relies on the browser's keyboard-recency heuristic; it resolves to "visible" here because the trigger is a keydown. This is exercised in the manual smoke step (jsdom does not evaluate `:focus-visible`, so unit tests assert `document.activeElement` instead).

--- a/docs/superpowers/plans/2026-06-15-progression-listbox-keyboard-nav.md
+++ b/docs/superpowers/plans/2026-06-15-progression-listbox-keyboard-nav.md
@@ -1,0 +1,406 @@
+# Progression Chord List — Single-Tab-Stop Keyboard Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the progression chord list a single Tab stop that enters on the active row, with `←/→` navigating row-by-row (reusing the chord-nav atoms) while `↑/↓` tempo, `Alt+↑/↓` reorder, and pointer drag stay untouched.
+
+**Architecture:** Apply roving `tabIndex` to the existing `StepSelectButton` rows (active=0, rest=-1) so the list is one Tab stop. A keydown handler on the `.scroll` container turns plain `←/→` into an `onNavigate(direction)` call (wired in `SongControls` to the same `previousProgressionStepAtom`/`advanceProgressionPlaybackAtom` actions as the global shortcut) and bumps a focus counter so a `useLayoutEffect` moves focus onto the active row after re-render. The global `←/→` handler bails when focus is already inside the list to avoid double-advance.
+
+**Tech Stack:** React 19 + TypeScript, Jotai, motion `Reorder`, CSS Modules, Vitest + Testing Library (jsdom).
+
+---
+
+## Spec
+
+See [`docs/superpowers/specs/2026-06-15-progression-listbox-keyboard-nav-design.md`](../specs/2026-06-15-progression-listbox-keyboard-nav-design.md).
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/components/SongControls/ProgressionStepList.tsx` | Roving `tabIndex` on `StepSelectButton`; new required `onNavigate` prop; `onKeyDown` on `.scroll` for plain `←/→`; `useLayoutEffect` focusing the active row on keyboard nav. |
+| `src/components/SongControls/ProgressionStepList.test.tsx` | Add `onNavigate` to existing renders; new tests for roving tabindex + in-list nav + focus follow. |
+| `src/components/SongControls/SongControls.tsx` | Destructure `previousProgressionStep`/`advanceProgressionPlayback`; pass `onNavigate` guarded by play state. |
+| `src/hooks/useKeyboardShortcuts.ts` | Early bail on plain `←/→` when focus is inside the chord list. |
+| `src/hooks/useKeyboardShortcuts.test.tsx` | New test: `←/→` is a no-op when focus is inside the list. |
+
+Verified during planning:
+- `StepSelectButton` (the shared row body) is rendered in both the `Reorder.Group` (drag) and the plain `<ul>` (mobile) branches, so changing it covers both.
+- `useProgressionState()` already returns `previousProgressionStep` and `advanceProgressionPlayback` (both `useSetAtom` of the same atoms the global shortcut uses).
+- `SongControls` already imports `useAtomValue` (jotai) and `progressionPlayingAtom`.
+- The `.scroll` container already has `id={PROGRESSION_STEP_LIST_ID}` and `tabIndex={-1}` (from #619).
+
+---
+
+## Task 1: Roving tabindex + `onNavigate` prop
+
+Makes the list a single Tab stop entering at the active row. (Navigation behavior comes in Task 2.)
+
+**Files:**
+- Modify: `src/components/SongControls/ProgressionStepList.tsx`
+- Test: `src/components/SongControls/ProgressionStepList.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this `describe` block to `ProgressionStepList.test.tsx` (the file already defines `makeStep`, a `steps` array, and imports `vi`):
+
+```tsx
+describe("ProgressionStepList roving tabindex", () => {
+  it("makes only the active row a tab stop (tabIndex 0), others -1", () => {
+    render(
+      <ProgressionStepList
+        steps={steps}
+        activeIndex={1}
+        onSelect={() => {}}
+        onReorder={vi.fn()}
+        onNavigate={vi.fn()}
+        label="Chords"
+        caption="Steps"
+      />,
+    );
+    const rows = screen.getAllByRole("button");
+    expect(rows[0]).toHaveAttribute("tabindex", "-1");
+    expect(rows[1]).toHaveAttribute("tabindex", "0");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run src/components/SongControls/ProgressionStepList.test.tsx -t "roving tabindex"`
+Expected: FAIL — buttons currently have no `tabindex` attribute (it is `null`), and `onNavigate` is not yet a prop (TypeScript error on the render).
+
+- [ ] **Step 3: Add the `onNavigate` prop to the interface**
+
+In `ProgressionStepList.tsx`, add to `ProgressionStepListProps` (right after the `onReorder` member):
+
+```typescript
+  /** Move the active step by one in the list (keyboard ←/→). Wired to the same
+   * actions as the global chord-nav shortcut so behavior is identical. */
+  onNavigate: (direction: -1 | 1) => void;
+```
+
+- [ ] **Step 4: Apply roving tabindex on the row button**
+
+In `StepSelectButton`, add `tabIndex` to the `<button>` (right after the `ref={buttonRef}` line):
+
+```tsx
+      ref={buttonRef}
+      tabIndex={active ? 0 : -1}
+```
+
+- [ ] **Step 5: Keep existing renders compiling**
+
+`onNavigate` is now required. In `ProgressionStepList.test.tsx`, add `onNavigate={vi.fn()}` immediately after the existing `onReorder={vi.fn()}` in **every** `render(<ProgressionStepList … />)` call that does not already have it (including the "focus target" test added earlier and the a11y test). Each call already passes `onReorder={vi.fn()}`; mirror it.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pnpm exec vitest run src/components/SongControls/ProgressionStepList.test.tsx`
+Expected: PASS (all existing tests plus the new roving-tabindex test).
+
+- [ ] **Step 7: Type-check**
+
+Run: `pnpm exec tsc -b --noEmit`
+Expected: errors only in `SongControls.tsx` (it does not pass `onNavigate` yet — fixed in Task 4). If you see errors elsewhere, fix them. It is acceptable to leave only the `SongControls.tsx` "missing onNavigate" error at this point.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/SongControls/ProgressionStepList.tsx src/components/SongControls/ProgressionStepList.test.tsx
+git commit -m "feat(progression): roving tabindex makes the chord list a single tab stop"
+```
+
+---
+
+## Task 2: In-list `←/→` navigation + focus follow
+
+**Files:**
+- Modify: `src/components/SongControls/ProgressionStepList.tsx`
+- Test: `src/components/SongControls/ProgressionStepList.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this `describe` block to `ProgressionStepList.test.tsx`:
+
+```tsx
+describe("ProgressionStepList keyboard navigation", () => {
+  function renderList(activeIndex: number, onNavigate = vi.fn()) {
+    const utils = render(
+      <ProgressionStepList
+        steps={steps}
+        activeIndex={activeIndex}
+        onSelect={() => {}}
+        onReorder={vi.fn()}
+        onNavigate={onNavigate}
+        label="Chords"
+        caption="Steps"
+      />,
+    );
+    return { ...utils, onNavigate };
+  }
+
+  it("calls onNavigate(+1) on plain ArrowRight", () => {
+    const { onNavigate } = renderList(0);
+    fireEvent.keyDown(screen.getAllByRole("button")[0], { key: "ArrowRight" });
+    expect(onNavigate).toHaveBeenCalledWith(1);
+  });
+
+  it("calls onNavigate(-1) on plain ArrowLeft", () => {
+    const { onNavigate } = renderList(1);
+    fireEvent.keyDown(screen.getAllByRole("button")[1], { key: "ArrowLeft" });
+    expect(onNavigate).toHaveBeenCalledWith(-1);
+  });
+
+  it("ignores ArrowRight with Alt (reorder shortcut passes through)", () => {
+    const { onNavigate } = renderList(0);
+    fireEvent.keyDown(screen.getAllByRole("button")[0], { key: "ArrowRight", altKey: true });
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("ignores ArrowUp/ArrowDown (tempo keys pass through)", () => {
+    const { onNavigate } = renderList(0);
+    fireEvent.keyDown(screen.getAllByRole("button")[0], { key: "ArrowUp" });
+    fireEvent.keyDown(screen.getAllByRole("button")[0], { key: "ArrowDown" });
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("moves focus to the new active row after navigation re-renders", () => {
+    const { rerender } = renderList(0);
+    fireEvent.keyDown(screen.getAllByRole("button")[0], { key: "ArrowRight" });
+    // Simulate the atom update that onNavigate would cause:
+    rerender(
+      <ProgressionStepList
+        steps={steps}
+        activeIndex={1}
+        onSelect={() => {}}
+        onReorder={vi.fn()}
+        onNavigate={vi.fn()}
+        label="Chords"
+        caption="Steps"
+      />,
+    );
+    expect(document.activeElement).toBe(screen.getAllByRole("button")[1]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm exec vitest run src/components/SongControls/ProgressionStepList.test.tsx -t "keyboard navigation"`
+Expected: FAIL — no keydown handling yet (`onNavigate` never called; focus never moves).
+
+- [ ] **Step 3: Add imports and the nav state/handlers**
+
+In `ProgressionStepList.tsx`, change the React import to include `useLayoutEffect` and `useState`:
+
+```typescript
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+```
+
+Inside the `ProgressionStepList` component body, after the existing `const draggingRef = useRef(false);`, add the focus counter:
+
+```typescript
+  // Bumped on each in-list ←/→ keystroke so the active row takes focus after the
+  // navigation re-renders. A counter (not a boolean) so it still fires when the
+  // index clamps at an end — focusing the unchanged active row is harmless and
+  // avoids a stale flag stealing focus on a later playback-driven change.
+  const [navFocusTick, setNavFocusTick] = useState(0);
+
+  useLayoutEffect(() => {
+    if (navFocusTick === 0) return;
+    activeRef.current?.focus({ preventScroll: true });
+  }, [navFocusTick]);
+
+  const handleListKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.altKey || event.metaKey || event.ctrlKey || event.shiftKey) return;
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    onNavigate(event.key === "ArrowLeft" ? -1 : 1);
+    setNavFocusTick((tick) => tick + 1);
+  };
+```
+
+Add `onNavigate` to the destructured props in the function signature (it is already in the interface from Task 1):
+
+```typescript
+export function ProgressionStepList({ steps, activeIndex, onSelect, onReorder, onNavigate, label, caption, meta, enableDrag = true }: ProgressionStepListProps) {
+```
+
+- [ ] **Step 4: Attach the handler to the scroll container**
+
+Change the `.scroll` div to add `onKeyDown` (keep the existing `id`/`tabIndex`):
+
+```tsx
+      <div className={styles.scroll} id={PROGRESSION_STEP_LIST_ID} tabIndex={-1} onKeyDown={handleListKeyDown}>
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm exec vitest run src/components/SongControls/ProgressionStepList.test.tsx`
+Expected: PASS (all tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/SongControls/ProgressionStepList.tsx src/components/SongControls/ProgressionStepList.test.tsx
+git commit -m "feat(progression): in-list left/right chord navigation with focus follow"
+```
+
+---
+
+## Task 3: Global `←/→` bails when the list is focused
+
+Prevents the window-level handler from double-advancing while the in-list handler owns navigation.
+
+**Files:**
+- Modify: `src/hooks/useKeyboardShortcuts.ts`
+- Test: `src/hooks/useKeyboardShortcuts.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+In `useKeyboardShortcuts.test.tsx`, append inside the top-level `describe("useKeyboardShortcuts", …)` block:
+
+```tsx
+  it("ArrowRight does not advance the step when focus is inside the chord list", () => {
+    store.set(setProgressionPlayingAtom, false);
+    store.set(activeProgressionStepIndexAtom, 0);
+    const list = document.createElement("div");
+    list.id = PROGRESSION_STEP_LIST_ID;
+    const row = document.createElement("button");
+    list.appendChild(row);
+    document.body.appendChild(list);
+    row.focus();
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowRight" }); });
+
+    expect(store.get(activeProgressionStepIndexAtom)).toBe(0);
+    document.body.removeChild(list);
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run src/hooks/useKeyboardShortcuts.test.tsx -t "focus is inside the chord list"`
+Expected: FAIL — the global handler still advances the step to 1.
+
+- [ ] **Step 3: Add the bail guard**
+
+In `useKeyboardShortcuts.ts`, add a helper just below the existing `focusShortcutTarget` function:
+
+```typescript
+/** True when keyboard focus is currently inside the chord list — in which case
+ * the list's own ←/→ handler owns navigation and the global one must stand down
+ * (the window listener fires regardless of React's stopPropagation). */
+function focusInsideChordList() {
+  const list = document.getElementById(PROGRESSION_STEP_LIST_ID);
+  return !!list && list.contains(document.activeElement);
+}
+```
+
+Update the `ArrowLeft` and `ArrowRight` cases to bail when focus is inside the list. The cases currently start with `if (store.get(progressionPlayingAtom)) return;` — add the list check on the same guard line:
+
+```typescript
+        case "ArrowLeft":
+          if (store.get(progressionPlayingAtom) || focusInsideChordList()) return;
+          e.preventDefault();
+          store.set(previousProgressionStepAtom);
+          focusShortcutTarget(PROGRESSION_STEP_LIST_ID);
+          break;
+        case "ArrowRight":
+          if (store.get(progressionPlayingAtom) || focusInsideChordList()) return;
+          e.preventDefault();
+          store.set(advanceProgressionPlaybackAtom);
+          focusShortcutTarget(PROGRESSION_STEP_LIST_ID);
+          break;
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm exec vitest run src/hooks/useKeyboardShortcuts.test.tsx`
+Expected: PASS (the new test plus all existing ones, including the #619 from-outside focus tests and the #618 `Alt+↑/↓` reorder tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useKeyboardShortcuts.ts src/hooks/useKeyboardShortcuts.test.tsx
+git commit -m "feat(shortcuts): global left/right stands down when the chord list is focused"
+```
+
+---
+
+## Task 4: Wire `onNavigate` in SongControls + verification
+
+**Files:**
+- Modify: `src/components/SongControls/SongControls.tsx`
+
+- [ ] **Step 1: Destructure the nav actions**
+
+In `SongControls.tsx`, add `previousProgressionStep` and `advanceProgressionPlayback` to the object destructured from `useProgressionState()` (the block that already includes `reorderProgressionSteps` and `setActiveProgressionStepIndex`):
+
+```typescript
+    reorderProgressionSteps,
+    previousProgressionStep,
+    advanceProgressionPlayback,
+```
+
+- [ ] **Step 2: Read play state for the guard**
+
+`SongControls` already imports `useAtomValue` and `progressionPlayingAtom`. Add, near the other derived values at the top of the component body (e.g. just after the `useProgressionState()` destructure):
+
+```typescript
+  const isProgressionPlaying = useAtomValue(progressionPlayingAtom);
+```
+
+(If `progressionPlayingAtom` is not already imported in this file, add it to the existing `../../store/progressionAtoms` import alongside `CUSTOM_PRESET_ID`.)
+
+- [ ] **Step 3: Pass `onNavigate` to the list**
+
+In the `<ProgressionStepList … />` usage, add the `onNavigate` prop next to `onReorder` — mirroring the global shortcut: do nothing while playing, otherwise step backward/forward via the same atoms:
+
+```tsx
+                  onReorder={(from, to) => reorderProgressionSteps({ from, to })}
+                  onNavigate={(direction) => {
+                    if (isProgressionPlaying) return;
+                    if (direction < 0) previousProgressionStep();
+                    else advanceProgressionPlayback();
+                  }}
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `pnpm exec tsc -b --noEmit`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/SongControls/SongControls.tsx
+git commit -m "feat(song): wire chord-list keyboard navigation to the chord-nav atoms"
+```
+
+- [ ] **Step 6: Full verification**
+
+Run each and confirm:
+- `pnpm run lint` → 0 errors (a single pre-existing `react-hooks/exhaustive-deps` warning in `packages/fretboard/src/hooks/useFretboardTopologyModel.ts` is expected and unrelated); fretboard boundaries OK.
+- `pnpm run ui:tokens` → no **new** undefined tokens (this change adds no `var(--x)` references).
+- `pnpm run test` → all pass.
+- `pnpm run build` → `tsc -b` + `vite build` succeed.
+
+- [ ] **Step 7: Manual smoke (dev server)**
+
+`pnpm run dev`, open the Song tab:
+- Tab into the chord list — focus lands on the **active** row (not always the first); Tab again leaves the list entirely.
+- With a row focused, `←/→` move chord-by-chord and focus follows the active row; at the ends it clamps (no wrap) just like the global shortcut.
+- `↑/↓` still change tempo and `Alt+↑/↓` still reorder the active step while the list is focused.
+- Mouse click still selects a row; pointer drag (grip handle) still reorders.
+- From outside the list, the first `←/→` still rings the whole list (container) and advances.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** single Tab stop entering at active row (Task 1); in-list `←/→` reusing the nav atoms + focus follow (Tasks 2, 4); `↑/↓`/`Alt+↑/↓`/drag untouched (handler ignores modifiers and non-`←/→` keys — Task 2; nothing else changed); no double-advance (Task 3); from-outside global behavior preserved (Task 3 leaves the non-focused path intact). All covered.
+- **Type/name consistency:** `onNavigate: (direction: -1 | 1) => void` defined in Task 1, consumed in Task 2, supplied in Task 4; `navFocusTick`/`handleListKeyDown`/`focusInsideChordList` each defined and used in one place; `PROGRESSION_STEP_LIST_ID` reused from the existing import in both the component and the hook.
+- **Why a counter, not a boolean flag:** at a clamped end, `onNavigate` may not change `activeIndex`, so an effect keyed on `activeIndex` would not run and a boolean "pending focus" flag could later fire on an unrelated (playback) index change and steal focus. The `navFocusTick` state changes on every keystroke, so the focus effect runs every time and only ever targets the current active row.
+- **jsdom note:** `:focus-visible` is not evaluated in unit tests; tests assert `document.activeElement` and `tabindex` attributes. The visible ring is covered by the manual smoke step.

--- a/docs/superpowers/specs/2026-06-15-keyboard-shortcut-focus-design.md
+++ b/docs/superpowers/specs/2026-06-15-keyboard-shortcut-focus-design.md
@@ -92,17 +92,14 @@ the hidden-tab case.
 interaction was a keydown, so the heuristic resolves to keyboard. The ring shows;
 it does not show for mouse-driven changes.
 
-### Remove the stray mobile-panel outline
+### Mobile panel outline — already suppressed (no change)
 
 [`MobilePanel.tsx`](../../../src/components/MobileShell/MobilePanel.tsx) focuses the
-panel body as a screen-reader landing zone. Because focus now moves to the actual
-control on the next shortcut, the panel no longer retains focus during
-shortcut use. To eliminate the default UA outline on the `tabIndex={-1}` panel
-while it is the landing zone, add `outline: none` for the panel's `:focus` (not
-`:focus-visible`) state in
-[`MobilePanel.module.css`](../../../src/components/MobileShell/MobilePanel.module.css).
-This is safe: the panel is not a keyboard Tab stop and conveys no actionable
-state of its own; its focus exists only to relocate the SR cursor on open.
+panel body as a screen-reader landing zone. Verified during planning: the `.panel`
+rule in `MobilePanels.module.css` already sets `outline: none`, so the panel does
+not draw its own ring. Once focus moves to the actual control on the next
+shortcut, the panel no longer retains focus during shortcut use either. **No CSS
+change to the panel is required.**
 
 ## Components / files touched
 
@@ -114,7 +111,7 @@ state of its own; its focus exists only to relocate the SR cursor on open.
 | `src/components/SongControls/SongControls.tsx` | Pass the tempo stepper `id`. |
 | `src/components/SongControls/ProgressionStepList.tsx` | `id` + `tabIndex={-1}` on the scroll container. |
 | `src/components/SongControls/ProgressionStepList.module.css` | `:focus-visible` ring on the scroll container. |
-| `src/components/MobileShell/MobilePanel.module.css` | Suppress UA outline on the landing-zone panel `:focus`. |
+| `src/components/SongControls/progressionFocusIds.ts` | New: shared id constants for the focus targets (prevents string drift between hook and components). |
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-15-keyboard-shortcut-focus-design.md
+++ b/docs/superpowers/specs/2026-06-15-keyboard-shortcut-focus-design.md
@@ -1,0 +1,141 @@
+# Keyboard-Shortcut Focus Management — Design
+
+**Date:** 2026-06-15
+**Status:** Approved (pending spec review)
+
+## Problem
+
+Global keyboard shortcuts mutate state but never move DOM focus, so the
+`:focus-visible` ring lands in the wrong place:
+
+- **Tempo (↑/↓):** state changes, but focus stays wherever it was. On mobile the
+  panel body holds focus (`tabIndex={-1}`, focused on open), so the browser's
+  default outline wraps the **entire tab body** instead of the tempo control.
+- **Chord navigation (←/→):** the active step changes, but focus does not follow.
+  The chord rows are individual tab stops; the surrounding list is not focusable,
+  so there is no way to "highlight the list" as a unit.
+
+Root cause: [`src/hooks/useKeyboardShortcuts.ts`](../../../src/hooks/useKeyboardShortcuts.ts)
+is a single global `window` keydown handler that sets atoms directly and performs
+no focus management. The ring tokens themselves
+([`src/styles/semantic.css`](../../../src/styles/semantic.css) `--focus-ring`,
+`--focus-ring-glow`) are already correct and are **not** changing.
+
+## Goal
+
+After a shortcut changes a control's value, move focus to that control so the
+existing `:focus-visible` ring highlights exactly what changed:
+
+- ↑/↓ → the **tempo stepper group** is ringed.
+- ←/→ → the **chord step list** (as a single unit) is ringed.
+- The stray "whole tab body" outline on the mobile panel is removed.
+
+This is the standard, accessible behavior: screen readers track the moved focus,
+and a subsequent Tab continues from the affected control.
+
+## Non-goals
+
+- No changes to the ring colors, thickness, glow, or offset tokens.
+- No change to which keys do what, or to the global "works from anywhere" nature
+  of the shortcuts.
+- No roving-focus / ARIA-widget refactor of the stepper or list (rejected
+  Approach C — it would break the global-shortcut UX).
+
+## Approach (chosen: focus-follows-shortcut)
+
+### Focus targets become programmatically focusable
+
+1. **Tempo stepper group** — [`StepperControl.tsx`](../../../src/components/StepperControl/StepperControl.tsx)
+   forwards a stable DOM `id` and `tabIndex={-1}` to the `StepperShell` group
+   element (the `role="group"` wrapper). `tabIndex={-1}` makes it focusable
+   programmatically without adding a Tab stop (the +/− buttons remain the only
+   Tab stops). A `:focus-visible` ring is added to the shell in
+   [`StepperShell.module.css`](../../../src/components/StepperShell/StepperShell.module.css)
+   using the existing `--focus-ring` / `--focus-ring-glow` tokens, so the ring
+   wraps the whole stepper.
+
+   The `id` is passed from the tempo `StepperControl` instance in
+   [`SongControls.tsx`](../../../src/components/SongControls/SongControls.tsx)
+   (e.g. `progression-tempo-stepper`). Other `StepperControl` instances are
+   unaffected because `id`/focusability are opt-in props.
+
+2. **Chord step list** — [`ProgressionStepList.tsx`](../../../src/components/SongControls/ProgressionStepList.tsx)
+   gives the scroll container (`.scroll`) a stable `id` (e.g.
+   `progression-step-list`) and `tabIndex={-1}`, with a `:focus-visible` ring in
+   [`ProgressionStepList.module.css`](../../../src/components/SongControls/ProgressionStepList.module.css).
+   Ringing the scroll container (rather than a single row) matches the requested
+   "highlight the list" behavior. Individual rows keep their own `:focus-visible`
+   rings for direct Tab navigation.
+
+### The hook moves focus after mutating
+
+[`useKeyboardShortcuts.ts`](../../../src/hooks/useKeyboardShortcuts.ts) focuses the
+relevant target immediately after the state mutation, reusing the
+`document.getElementById(...)?.focus({ preventScroll: true })` pattern already
+used in [`MobilePanel.tsx`](../../../src/components/MobileShell/MobilePanel.tsx):
+
+- `ArrowUp` / `ArrowDown`: after setting `progressionTempoBpmAtom`, focus
+  `#progression-tempo-stepper`.
+- `ArrowLeft` / `ArrowRight`: after the chord step change, focus
+  `#progression-step-list`.
+
+`{ preventScroll: true }` avoids the page/list jumping on focus. The existing
+in-list scroll-into-view effect ([`ProgressionStepList.tsx`](../../../src/components/SongControls/ProgressionStepList.tsx)
+lines 41–49) continues to keep the active row visible.
+
+**Off-tab behavior (decided):** if the target element is not in the DOM (its tab
+is not showing), `getElementById` returns `null` and focus is a no-op. The atom
+still updates silently. No auto tab-switch. This preserves today's behavior for
+the hidden-tab case.
+
+`:focus-visible` after a programmatic `.focus()` matches because the triggering
+interaction was a keydown, so the heuristic resolves to keyboard. The ring shows;
+it does not show for mouse-driven changes.
+
+### Remove the stray mobile-panel outline
+
+[`MobilePanel.tsx`](../../../src/components/MobileShell/MobilePanel.tsx) focuses the
+panel body as a screen-reader landing zone. Because focus now moves to the actual
+control on the next shortcut, the panel no longer retains focus during
+shortcut use. To eliminate the default UA outline on the `tabIndex={-1}` panel
+while it is the landing zone, add `outline: none` for the panel's `:focus` (not
+`:focus-visible`) state in
+[`MobilePanel.module.css`](../../../src/components/MobileShell/MobilePanel.module.css).
+This is safe: the panel is not a keyboard Tab stop and conveys no actionable
+state of its own; its focus exists only to relocate the SR cursor on open.
+
+## Components / files touched
+
+| File | Change |
+| --- | --- |
+| `src/hooks/useKeyboardShortcuts.ts` | Focus tempo group / chord list after the four arrow shortcuts. |
+| `src/components/StepperControl/StepperControl.tsx` | Optional `id` + `tabIndex={-1}` forwarded to the group element. |
+| `src/components/StepperShell/StepperShell.module.css` | `:focus-visible` ring on the shell. |
+| `src/components/SongControls/SongControls.tsx` | Pass the tempo stepper `id`. |
+| `src/components/SongControls/ProgressionStepList.tsx` | `id` + `tabIndex={-1}` on the scroll container. |
+| `src/components/SongControls/ProgressionStepList.module.css` | `:focus-visible` ring on the scroll container. |
+| `src/components/MobileShell/MobilePanel.module.css` | Suppress UA outline on the landing-zone panel `:focus`. |
+
+## Testing
+
+- **Unit (vitest + Testing Library):** extend the `useKeyboardShortcuts` tests to
+  assert that, with the targets rendered, `document.activeElement` becomes the
+  tempo group after ↑/↓ and the chord list after ←/→; and that the off-tab case
+  (target absent) is a no-op that still mutates the atom.
+- **A11y:** confirm the focusable group/list keep their accessible names
+  (`role="group"` `aria-label` on the stepper; `aria-label` on the list) and that
+  the new `tabIndex={-1}` does not add Tab stops (Tab order unchanged).
+- **Visual regression:** the existing overlay/mobile suites cover the panel; add
+  or update a snapshot if the panel-outline removal is visible at rest (it should
+  not be, since the panel only shows an outline while focused).
+- Run `pnpm run lint`, `pnpm run ui:tokens`, `pnpm run test`, `pnpm run build`
+  before opening the PR (per AGENTS.md).
+
+## Rejected alternatives
+
+- **B — Transient flash highlight:** paint a temporary ring without moving focus.
+  Not accessible (SR users get no focus change), non-standard, and leaves the
+  wrong "whole body" outline in place.
+- **C — Decentralize into ARIA widgets:** stepper/list handle arrows only when
+  focused. Idiomatic ARIA but removes the global-from-anywhere shortcut UX the
+  user depends on. Larger, behavior-changing refactor.

--- a/docs/superpowers/specs/2026-06-15-progression-listbox-keyboard-nav-design.md
+++ b/docs/superpowers/specs/2026-06-15-progression-listbox-keyboard-nav-design.md
@@ -1,140 +1,164 @@
-# Progression Chord List — Roving-Tabindex Listbox Design
+# Progression Chord List — Single-Tab-Stop Keyboard Navigation Design
 
 **Date:** 2026-06-15
 **Status:** Approved (pending spec review)
-**Builds on:** the focus-management work in PR #619 (shared focus-target ids, `.scroll` container focus, hook ←/→ handling).
+**Builds on:**
+- the focus-management work in PR #619 (shared focus-target ids, `.scroll`
+  container focus, hook `←/→` handling), and
+- the drag-and-drop reorder work merged to main in #618 (the list is now a motion
+  `Reorder.Group` of `<button>` rows, with an `Alt+↑/↓` reorder shortcut).
 
 ## Problem
 
 Tabbing into the chord progression list lands on the **first** row, because every
-row is its own Tab stop (a deliberate choice documented in
-[`ProgressionStepList.tsx`](../../../src/components/SongControls/ProgressionStepList.tsx)).
-For a multi-chord progression this means many Tab stops, and entry is always at
-row 1 even when a later step is the active/selected one. The desired behavior is
-the standard selectable-list pattern: the list is a single Tab stop and entry
+row is its own Tab stop. The rows are `<button>` elements (`StepSelectButton` in
+[`ProgressionStepList.tsx`](../../../src/components/SongControls/ProgressionStepList.tsx)),
+so a multi-chord progression produces many Tab stops, and entry is always at row 1
+even when a later step is the active/selected one. The desired behavior is the
+standard composite-widget pattern: the list is a **single Tab stop** and entry
 lands on the **active** row.
 
 ## Goal
 
-Convert the chord list into a roving-tabindex listbox:
-
-- The list is a **single Tab stop**; Tab enters on the **active** option row and
-  Tab again leaves the whole list.
-- `←/→` navigate between chords; `↑/↓` continue to adjust tempo even while the
-  list is focused (decided: reuse the existing horizontal chord-nav keys, leave
-  the tempo keys global).
+- The list is a **single Tab stop**; Tab enters on the **active** row and Tab
+  again leaves the whole list.
+- `←/→` navigate between chords (matching the existing global chord-nav keys);
+  `↑/↓` continue to adjust tempo and `Alt+↑/↓` continue to reorder, even while the
+  list is focused (decided: reuse the horizontal chord-nav keys, leave the other
+  shortcuts global and untouched).
 - Selection follows focus — moving within the list sets the active step (there is
   already a single piece of state, `activeProgressionStepIndex`), so focus and
   "active" never diverge.
-- Playback-driven active-step changes never steal keyboard focus.
+- Playback-driven and drag-driven active-step changes never steal keyboard focus.
 
 ## Non-goals
 
-- No change to the tempo stepper focus behavior shipped in #619.
-- No change to the `↑/↓` tempo shortcuts or to which keys are global.
-- No visual restyle of the rows beyond what the role/structure change requires
-  (the active row keeps its cyan left-tick + tint; the focus ring tokens are
-  unchanged).
-- No new "activate" affordance (Enter/Space): selection follows focus, and click
+- No change to the tempo `↑/↓` shortcut, the `Alt+↑/↓` reorder shortcut, or the
+  pointer drag-and-drop reorder from #618.
+- No restructure of the list DOM into `role="listbox"`/`role="option"`. Main's
+  rows are `<button>`s nested inside motion `Reorder.Item` (`<li>`) elements;
+  forcing valid `listbox > option` structure would fight the drag library for
+  little gain. We keep the buttons and use **roving tabindex** (the same
+  single-tab-stop composite pattern the repo already uses for the HelpModal
+  tablist). Full listbox/option ARIA semantics are explicitly deferred.
+- No visual restyle of rows; the existing `.row:focus-visible` ring and active
+  styling are reused.
+- No new Enter/Space "activate" affordance: selection follows focus, and click
   still selects.
 
-## Approach (roving-tabindex listbox)
+## Current structure (post-#618, for reference)
 
-### Structure (Part A)
+`ProgressionStepList` renders a `.scroll` container (already
+`id={PROGRESSION_STEP_LIST_ID} tabIndex={-1}` from #619) holding one of two
+branches:
 
-[`ProgressionStepList.tsx`](../../../src/components/SongControls/ProgressionStepList.tsx)
-becomes a valid listbox:
+- `enableDrag` (desktop/tablet-inline): `Reorder.Group as="ul"` whose children are
+  `DraggableStepRow` → `Reorder.Item as="li"` → `StepSelectButton` (`<button>`).
+- otherwise (mobile sheet): a plain `<ul>` of `<li>` → `StepSelectButton`.
 
-- The `<ul>` gets `role="listbox"`, `aria-orientation="horizontal"`, and keeps its
-  `aria-label`.
-- Each row becomes the option itself: `<li role="option" aria-selected={active}
-  tabIndex={active ? 0 : -1} onClick=…>`. The inner `<button>` is dropped —
-  `listbox > option` is the valid ARIA structure, and with selection-following-
-  focus there is no separate activation step. The `.row` class, `aria-label`,
-  `aria-current`/`aria-selected`, and `data-unavailable` move onto the `<li>`.
-- Roving tabindex: exactly one option (the active one) has `tabIndex={0}`; all
-  others have `tabIndex={-1}`. This makes the list a single Tab stop that enters
-  at the active row.
-- The `.scroll` container keeps its `tabIndex={-1}` and shared id from #619 (used
-  as the "ring the whole list" target for the from-outside global shortcut).
+`StepSelectButton` is the shared row body: a `<button>` with `.row`,
+`aria-current`, the accessible name, `onClick={() => onSelect(index)}`, and an
+optional trailing drag handle. The active row's button receives a shared
+`activeRef` (used today for scroll-into-view).
 
-ARIA note: a `<li role="option">` with `tabIndex` is focusable and announced as
-an option with its selected state. The existing per-row `aria-label`
-(position, degree, name, duration, selected) is preserved. `aria-current` is
-replaced by `aria-selected` to match listbox semantics; the visual active styling
-keys off the same `active` flag (a class), not the ARIA attribute.
+## Approach
 
-### Keyboard reconciliation (Part B)
+### Roving tabindex (Part A)
 
-- **In-list `←/→`:** a `keydown` handler on the `.scroll` container (keydown from
-  a focused option bubbles up to it, and the container is itself focusable)
-  handles `ArrowLeft`/`ArrowRight`: `preventDefault`, call a new
-  `onNavigate(direction: -1 | 1)` prop, and flag that the next render should take
-  focus. `↑/↓` and every other key are left alone so tempo keys still work
-  (Home/End support is out of scope).
+- `StepSelectButton` sets `tabIndex={active ? 0 : -1}`. Exactly one button (the
+  active one) is in the Tab order; the rest are reachable only programmatically.
+  Result: the list is a single Tab stop and Tab enters at the active row. This
+  applies to **both** render branches because it lives in the shared
+  `StepSelectButton`.
+- No role/structure changes; the buttons keep `aria-current` and their accessible
+  names. The drag handle and `Reorder.Item` wiring are untouched.
+
+### Keyboard navigation + focus (Part B)
+
+- **In-list `←/→`:** an `onKeyDown` handler on the `.scroll` container (keydown
+  from any focused row button bubbles up to it, and the container is itself
+  focusable) handles **plain** `ArrowLeft`/`ArrowRight` only: it `preventDefault`s,
+  calls a new `onNavigate(direction: -1 | 1)` prop, and sets a "pending focus"
+  ref. It returns early (does nothing) when any of `altKey`/`metaKey`/`ctrlKey`/
+  `shiftKey` is set, so `Alt+↑/↓` reorder and every other shortcut pass through
+  untouched, and it ignores `↑/↓` so tempo keys keep working while the list is
+  focused.
 - **`onNavigate` reuses the global atoms:** `ProgressionStepList` stays
   presentational. `SongControls` wires `onNavigate` to the **same** actions the
-  global shortcut uses — `previousProgressionStepAtom` (−1) and
-  `advanceProgressionPlaybackAtom` (+1) — so in-list navigation is byte-for-byte
-  identical to the `←/→` shortcut: it skips unresolvable steps and clamps at the
-  ends when stopped (those atoms only wrap while playing+looping, which never
-  applies here since navigation is a stopped-state action). Note this is
-  intentionally **not** the wrapping `(i + delta + stepCount) % stepCount`
-  behavior of the SongControls prev/next pips — the list must match the keyboard
-  shortcut, not the pip buttons.
-- **Focusing the new row with correct timing:** the handler records the target
-  index in a ref and a `useLayoutEffect` focuses that row after React re-renders
-  with the new roving tabindex, avoiding the "focus the stale row" race.
+  global `←/→` shortcut uses — `previousProgressionStepAtom` (−1) and
+  `advanceProgressionPlaybackAtom` (+1) — so in-list navigation is identical to
+  the shortcut: it skips unresolvable steps and clamps at the ends when stopped
+  (those atoms only wrap while playing+looping, which never applies here). This is
+  intentionally **not** the wrapping `(i + delta + n) % n` behavior of the
+  SongControls Move pips — the list matches the keyboard shortcut.
+- **Focus follows navigation, with correct timing:** the existing
+  `useEffect([activeIndex])` (scroll-into-view) is extended so that when the
+  "pending focus" ref is set, it focuses `activeRef.current` (the active row
+  button) after React re-renders with the moved roving tabindex, then clears the
+  ref. Because only the in-list `←/→` handler sets that ref, focus never moves on
+  click, drag, playback, or the from-outside global shortcut.
 - **Global `←/→` (from outside the list):** unchanged from #619 — advances the
   step and focuses the `.scroll` container so the whole list shows the ring. Once
-  focus is inside the list, the in-list handler takes over.
-- **No double-advance:** the `ArrowLeft`/`ArrowRight` cases in
+  focus is inside the list (container or a row), the in-list handler owns
+  navigation and focus moves row-to-row.
+- **No double-advance:** the `ArrowLeft`/`ArrowRight` switch cases in
   [`useKeyboardShortcuts.ts`](../../../src/hooks/useKeyboardShortcuts.ts) gain an
-  early bail when `document.activeElement` is inside the list container (looked up
-  by the shared id). When the list is focused, the global handler does nothing and
-  the local handler owns navigation. (The window listener fires regardless of
-  React's `stopPropagation`, so this guard — not propagation — is what prevents
-  the duplicate.)
+  early bail when `document.getElementById(PROGRESSION_STEP_LIST_ID)` contains
+  `document.activeElement`. When the list is focused the global handler does
+  nothing for `←/→` and the local handler owns it. (The window listener fires
+  regardless of React `stopPropagation`, so this guard — not propagation — is what
+  prevents the duplicate.) The `Alt+↑/↓` reorder branch and the tempo `↑/↓` cases
+  are not touched by this guard.
+
+### Net entry behavior
+
+- **Tab** → active row focused (single Tab stop).
+- **First global `←/→` from outside** → step advances, whole-list ring (container).
+- **Subsequent `←/→` inside** → row-by-row, focus follows the active row.
+- **`↑/↓`** → tempo, unaffected. **`Alt+↑/↓`** → reorder, unaffected.
 
 ## Components / files touched
 
 | File | Change |
 | --- | --- |
-| `src/components/SongControls/ProgressionStepList.tsx` | Listbox roles, roving tabindex, `<li role="option">` rows, in-list `←/→` keydown handler (calls `onNavigate`) + focus-after-render effect; new `onNavigate` prop. |
-| `src/components/SongControls/ProgressionStepList.module.css` | Move/keep `.row` styles on the `<li>`; ensure `:focus-visible` ring + active styling still apply. |
+| `src/components/SongControls/ProgressionStepList.tsx` | `tabIndex={active ? 0 : -1}` on `StepSelectButton`; `onKeyDown` on `.scroll` for plain `←/→` → `onNavigate` + pending-focus; extend the active-index effect to focus the active row on keyboard nav; new `onNavigate` prop. |
 | `src/components/SongControls/SongControls.tsx` | Wire `onNavigate` to `previousProgressionStepAtom` / `advanceProgressionPlaybackAtom`. |
-| `src/hooks/useKeyboardShortcuts.ts` | Early bail on `←/→` when focus is inside the chord list (avoid double-advance). |
+| `src/hooks/useKeyboardShortcuts.ts` | Early bail on plain `←/→` when focus is inside the chord list (avoid double-advance). |
 
 ## Testing
 
 - **ProgressionStepList (vitest + Testing Library):**
-  - The list renders as `role="listbox"` with `aria-orientation="horizontal"`.
-  - Exactly one option has `tabIndex=0` (the active one); the rest have `-1`.
-  - Rendering with `activeIndex=2` puts `tabIndex=0` on the third option (Tab
-    enters at the active row, not the first).
-  - `keydown` `ArrowRight`/`ArrowLeft` on a focused option calls `onNavigate`
-    with `+1`/`-1` and (driven by the updated `activeIndex` prop) moves
-    `document.activeElement` to the new active option after render.
-  - `↑`/`↓` on a focused option do **not** call `onNavigate` or `onSelect` (tempo
-    keys pass through).
-  - Click on an option still calls `onSelect`.
-- **useKeyboardShortcuts:** with a list element present and `document.activeElement`
-  inside it, `ArrowRight`/`ArrowLeft` do **not** mutate the step (local handler
-  owns it); with focus outside, they still advance + focus the container (the #619
-  tests stay green).
-- **a11y:** `vitest-axe` on the listbox; confirm option accessible names are
-  intact and Tab order is a single stop.
+  - Exactly one row button has `tabIndex=0` (the active one); the rest are `-1`.
+  - With `activeIndex=2`, the third button has `tabIndex=0` (Tab enters at the
+    active row, not the first).
+  - `keydown` plain `ArrowRight`/`ArrowLeft` on a focused row calls `onNavigate`
+    with `+1`/`-1`; `Alt+ArrowLeft`/`Alt+ArrowRight` and `↑/↓` do **not** call
+    `onNavigate` (they pass through).
+  - After `onNavigate` updates `activeIndex`, `document.activeElement` is the new
+    active row button.
+  - Click on a row still calls `onSelect`.
+  - Covers both `enableDrag` and the static (`enableDrag={false}`) branch.
+- **useKeyboardShortcuts:** with the list element present and `document.activeElement`
+  inside it, plain `ArrowRight`/`ArrowLeft` do **not** mutate the step (local
+  handler owns it); with focus outside, they still advance + focus the container
+  (the #619 tests stay green); the `Alt+↑/↓` reorder tests from #618 stay green.
+- **a11y:** `vitest-axe` on the list; confirm row accessible names are intact and
+  Tab order is a single stop.
 - Run `pnpm run lint`, `pnpm run ui:tokens`, `pnpm run test`, `pnpm run build`.
 - **Manual:** Tab into the list lands on the active row; `←/→` move row-by-row and
-  carry focus; `↑/↓` still change tempo while the list is focused; mouse click
-  still selects; screen reader announces "listbox … option X of N, selected".
+  carry focus; `↑/↓` still change tempo and `Alt+↑/↓` still reorder while the list
+  is focused; mouse click still selects; pointer drag still reorders.
 
 ## Rejected alternatives
 
-- **Keep every row a Tab stop, but enter at the active row:** smaller, but leaves
-  N Tab stops and is a non-standard half-measure (focusable list with no single
-  entry point).
-- **Standard vertical `↑/↓` navigation:** more ARIA-conventional for a visually
-  vertical list, but `↑/↓` are the tempo shortcuts; overloading them while the
-  list is focused changes their meaning contextually. Rejected in favor of
-  reusing the existing horizontal `←/→` chord-nav keys.
+- **Convert to `role="listbox"`/`option`:** cleaner ARIA in the abstract, but
+  invalid/awkward against main's `ul(Reorder.Group) > li(Reorder.Item) > button`
+  structure and the drag library. Roving tabindex over the existing buttons
+  achieves the single-tab-stop goal with far less risk. Full listbox semantics can
+  be a separate follow-up if desired.
+- **Keep every row a Tab stop, enter at the active row:** smaller, but leaves N
+  Tab stops — a non-standard half-measure.
+- **Standard vertical `↑/↓` navigation:** more conventional for a visually
+  vertical list, but `↑/↓` are the tempo shortcut and `Alt+↑/↓` the reorder
+  shortcut; overloading the vertical axis would clash. Reusing the horizontal
+  `←/→` chord-nav keys avoids all of that.

--- a/docs/superpowers/specs/2026-06-15-progression-listbox-keyboard-nav-design.md
+++ b/docs/superpowers/specs/2026-06-15-progression-listbox-keyboard-nav-design.md
@@ -1,0 +1,140 @@
+# Progression Chord List — Roving-Tabindex Listbox Design
+
+**Date:** 2026-06-15
+**Status:** Approved (pending spec review)
+**Builds on:** the focus-management work in PR #619 (shared focus-target ids, `.scroll` container focus, hook ←/→ handling).
+
+## Problem
+
+Tabbing into the chord progression list lands on the **first** row, because every
+row is its own Tab stop (a deliberate choice documented in
+[`ProgressionStepList.tsx`](../../../src/components/SongControls/ProgressionStepList.tsx)).
+For a multi-chord progression this means many Tab stops, and entry is always at
+row 1 even when a later step is the active/selected one. The desired behavior is
+the standard selectable-list pattern: the list is a single Tab stop and entry
+lands on the **active** row.
+
+## Goal
+
+Convert the chord list into a roving-tabindex listbox:
+
+- The list is a **single Tab stop**; Tab enters on the **active** option row and
+  Tab again leaves the whole list.
+- `←/→` navigate between chords; `↑/↓` continue to adjust tempo even while the
+  list is focused (decided: reuse the existing horizontal chord-nav keys, leave
+  the tempo keys global).
+- Selection follows focus — moving within the list sets the active step (there is
+  already a single piece of state, `activeProgressionStepIndex`), so focus and
+  "active" never diverge.
+- Playback-driven active-step changes never steal keyboard focus.
+
+## Non-goals
+
+- No change to the tempo stepper focus behavior shipped in #619.
+- No change to the `↑/↓` tempo shortcuts or to which keys are global.
+- No visual restyle of the rows beyond what the role/structure change requires
+  (the active row keeps its cyan left-tick + tint; the focus ring tokens are
+  unchanged).
+- No new "activate" affordance (Enter/Space): selection follows focus, and click
+  still selects.
+
+## Approach (roving-tabindex listbox)
+
+### Structure (Part A)
+
+[`ProgressionStepList.tsx`](../../../src/components/SongControls/ProgressionStepList.tsx)
+becomes a valid listbox:
+
+- The `<ul>` gets `role="listbox"`, `aria-orientation="horizontal"`, and keeps its
+  `aria-label`.
+- Each row becomes the option itself: `<li role="option" aria-selected={active}
+  tabIndex={active ? 0 : -1} onClick=…>`. The inner `<button>` is dropped —
+  `listbox > option` is the valid ARIA structure, and with selection-following-
+  focus there is no separate activation step. The `.row` class, `aria-label`,
+  `aria-current`/`aria-selected`, and `data-unavailable` move onto the `<li>`.
+- Roving tabindex: exactly one option (the active one) has `tabIndex={0}`; all
+  others have `tabIndex={-1}`. This makes the list a single Tab stop that enters
+  at the active row.
+- The `.scroll` container keeps its `tabIndex={-1}` and shared id from #619 (used
+  as the "ring the whole list" target for the from-outside global shortcut).
+
+ARIA note: a `<li role="option">` with `tabIndex` is focusable and announced as
+an option with its selected state. The existing per-row `aria-label`
+(position, degree, name, duration, selected) is preserved. `aria-current` is
+replaced by `aria-selected` to match listbox semantics; the visual active styling
+keys off the same `active` flag (a class), not the ARIA attribute.
+
+### Keyboard reconciliation (Part B)
+
+- **In-list `←/→`:** a `keydown` handler on the `.scroll` container (keydown from
+  a focused option bubbles up to it, and the container is itself focusable)
+  handles `ArrowLeft`/`ArrowRight`: `preventDefault`, call a new
+  `onNavigate(direction: -1 | 1)` prop, and flag that the next render should take
+  focus. `↑/↓` and every other key are left alone so tempo keys still work
+  (Home/End support is out of scope).
+- **`onNavigate` reuses the global atoms:** `ProgressionStepList` stays
+  presentational. `SongControls` wires `onNavigate` to the **same** actions the
+  global shortcut uses — `previousProgressionStepAtom` (−1) and
+  `advanceProgressionPlaybackAtom` (+1) — so in-list navigation is byte-for-byte
+  identical to the `←/→` shortcut: it skips unresolvable steps and clamps at the
+  ends when stopped (those atoms only wrap while playing+looping, which never
+  applies here since navigation is a stopped-state action). Note this is
+  intentionally **not** the wrapping `(i + delta + stepCount) % stepCount`
+  behavior of the SongControls prev/next pips — the list must match the keyboard
+  shortcut, not the pip buttons.
+- **Focusing the new row with correct timing:** the handler records the target
+  index in a ref and a `useLayoutEffect` focuses that row after React re-renders
+  with the new roving tabindex, avoiding the "focus the stale row" race.
+- **Global `←/→` (from outside the list):** unchanged from #619 — advances the
+  step and focuses the `.scroll` container so the whole list shows the ring. Once
+  focus is inside the list, the in-list handler takes over.
+- **No double-advance:** the `ArrowLeft`/`ArrowRight` cases in
+  [`useKeyboardShortcuts.ts`](../../../src/hooks/useKeyboardShortcuts.ts) gain an
+  early bail when `document.activeElement` is inside the list container (looked up
+  by the shared id). When the list is focused, the global handler does nothing and
+  the local handler owns navigation. (The window listener fires regardless of
+  React's `stopPropagation`, so this guard — not propagation — is what prevents
+  the duplicate.)
+
+## Components / files touched
+
+| File | Change |
+| --- | --- |
+| `src/components/SongControls/ProgressionStepList.tsx` | Listbox roles, roving tabindex, `<li role="option">` rows, in-list `←/→` keydown handler (calls `onNavigate`) + focus-after-render effect; new `onNavigate` prop. |
+| `src/components/SongControls/ProgressionStepList.module.css` | Move/keep `.row` styles on the `<li>`; ensure `:focus-visible` ring + active styling still apply. |
+| `src/components/SongControls/SongControls.tsx` | Wire `onNavigate` to `previousProgressionStepAtom` / `advanceProgressionPlaybackAtom`. |
+| `src/hooks/useKeyboardShortcuts.ts` | Early bail on `←/→` when focus is inside the chord list (avoid double-advance). |
+
+## Testing
+
+- **ProgressionStepList (vitest + Testing Library):**
+  - The list renders as `role="listbox"` with `aria-orientation="horizontal"`.
+  - Exactly one option has `tabIndex=0` (the active one); the rest have `-1`.
+  - Rendering with `activeIndex=2` puts `tabIndex=0` on the third option (Tab
+    enters at the active row, not the first).
+  - `keydown` `ArrowRight`/`ArrowLeft` on a focused option calls `onNavigate`
+    with `+1`/`-1` and (driven by the updated `activeIndex` prop) moves
+    `document.activeElement` to the new active option after render.
+  - `↑`/`↓` on a focused option do **not** call `onNavigate` or `onSelect` (tempo
+    keys pass through).
+  - Click on an option still calls `onSelect`.
+- **useKeyboardShortcuts:** with a list element present and `document.activeElement`
+  inside it, `ArrowRight`/`ArrowLeft` do **not** mutate the step (local handler
+  owns it); with focus outside, they still advance + focus the container (the #619
+  tests stay green).
+- **a11y:** `vitest-axe` on the listbox; confirm option accessible names are
+  intact and Tab order is a single stop.
+- Run `pnpm run lint`, `pnpm run ui:tokens`, `pnpm run test`, `pnpm run build`.
+- **Manual:** Tab into the list lands on the active row; `←/→` move row-by-row and
+  carry focus; `↑/↓` still change tempo while the list is focused; mouse click
+  still selects; screen reader announces "listbox … option X of N, selected".
+
+## Rejected alternatives
+
+- **Keep every row a Tab stop, but enter at the active row:** smaller, but leaves
+  N Tab stops and is a non-standard half-measure (focusable list with no single
+  entry point).
+- **Standard vertical `↑/↓` navigation:** more ARIA-conventional for a visually
+  vertical list, but `↑/↓` are the tempo shortcuts; overloading them while the
+  list is focused changes their meaning contextually. Rejected in favor of
+  reusing the existing horizontal `←/→` chord-nav keys.

--- a/src/components/SongControls/ProgressionStepList.module.css
+++ b/src/components/SongControls/ProgressionStepList.module.css
@@ -47,6 +47,12 @@
   position: relative;
 }
 
+.scroll:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+  border-radius: var(--radius-md);
+}
+
 .list {
   display: flex;
   flex-direction: column;

--- a/src/components/SongControls/ProgressionStepList.test.tsx
+++ b/src/components/SongControls/ProgressionStepList.test.tsx
@@ -37,7 +37,7 @@ const steps: ResolvedProgressionStep[] = [
 
 describe("ProgressionStepList", () => {
   it("renders one row per step with degree, name, and duration in the accessible name", () => {
-    render(<ProgressionStepList steps={steps} activeIndex={0} onSelect={() => {}} onReorder={vi.fn()} label="Chords" caption="Steps" />);
+    render(<ProgressionStepList steps={steps} activeIndex={0} onSelect={() => {}} onReorder={vi.fn()} onNavigate={vi.fn()} label="Chords" caption="Steps" />);
     const rows = screen.getAllByRole("button");
     expect(rows).toHaveLength(2);
     expect(rows[0]).toHaveAccessibleName(/Chord 1, i, A minor, 1 bar/);
@@ -45,7 +45,7 @@ describe("ProgressionStepList", () => {
   });
 
   it("marks the active row with aria-current", () => {
-    render(<ProgressionStepList steps={steps} activeIndex={1} onSelect={() => {}} onReorder={vi.fn()} label="Chords" caption="Steps" />);
+    render(<ProgressionStepList steps={steps} activeIndex={1} onSelect={() => {}} onReorder={vi.fn()} onNavigate={vi.fn()} label="Chords" caption="Steps" />);
     const rows = screen.getAllByRole("button");
     expect(rows[1]).toHaveAttribute("aria-current", "true");
     expect(rows[0]).not.toHaveAttribute("aria-current");
@@ -53,7 +53,7 @@ describe("ProgressionStepList", () => {
 
   it("calls onSelect with the row index on click", () => {
     const onSelect = vi.fn();
-    render(<ProgressionStepList steps={steps} activeIndex={0} onSelect={onSelect} onReorder={vi.fn()} label="Chords" caption="Steps" />);
+    render(<ProgressionStepList steps={steps} activeIndex={0} onSelect={onSelect} onReorder={vi.fn()} onNavigate={vi.fn()} label="Chords" caption="Steps" />);
     fireEvent.click(screen.getAllByRole("button")[1]);
     expect(onSelect).toHaveBeenCalledWith(1);
   });
@@ -65,6 +65,7 @@ describe("ProgressionStepList", () => {
         activeIndex={0}
         onSelect={() => {}}
         onReorder={vi.fn()}
+        onNavigate={vi.fn()}
         label="Chords"
         caption="Steps"
         meta="2 chords · 3 bars"
@@ -76,7 +77,7 @@ describe("ProgressionStepList", () => {
 
   it("has no accessibility violations", async () => {
     const { container } = render(
-      <ProgressionStepList steps={steps} activeIndex={0} onSelect={() => {}} onReorder={vi.fn()} label="Chords" caption="Steps" />,
+      <ProgressionStepList steps={steps} activeIndex={0} onSelect={() => {}} onReorder={vi.fn()} onNavigate={vi.fn()} label="Chords" caption="Steps" />,
     );
     expect(await axe(container)).toHaveNoViolations();
   });
@@ -90,6 +91,7 @@ describe("ProgressionStepList", () => {
         activeIndex={0}
         onSelect={onSelect}
         onReorder={onReorder}
+        onNavigate={vi.fn()}
         label="Chords"
         caption="Steps"
       />,
@@ -106,6 +108,7 @@ describe("ProgressionStepList", () => {
         activeIndex={0}
         onSelect={vi.fn()}
         onReorder={vi.fn()}
+        onNavigate={vi.fn()}
         label="Chords"
         caption="Steps"
       />,
@@ -124,6 +127,7 @@ describe("ProgressionStepList", () => {
         activeIndex={0}
         onSelect={onSelect}
         onReorder={vi.fn()}
+        onNavigate={vi.fn()}
         label="Chords"
         caption="Steps"
       />,
@@ -141,6 +145,7 @@ describe("ProgressionStepList", () => {
         activeIndex={0}
         onSelect={onSelect}
         onReorder={vi.fn()}
+        onNavigate={vi.fn()}
         enableDrag={false}
         label="Chords"
         caption="Steps"
@@ -183,6 +188,7 @@ describe("ProgressionStepList focus target", () => {
         activeIndex={0}
         onSelect={() => {}}
         onReorder={vi.fn()}
+        onNavigate={vi.fn()}
         label="Progression"
         caption="Steps"
       />,
@@ -191,5 +197,24 @@ describe("ProgressionStepList focus target", () => {
     const scroll = container.querySelector(`#${PROGRESSION_STEP_LIST_ID}`);
     expect(scroll).not.toBeNull();
     expect(scroll?.getAttribute("tabindex")).toBe("-1");
+  });
+});
+
+describe("ProgressionStepList roving tabindex", () => {
+  it("makes only the active row a tab stop (tabIndex 0), others -1", () => {
+    render(
+      <ProgressionStepList
+        steps={steps}
+        activeIndex={1}
+        onSelect={() => {}}
+        onReorder={vi.fn()}
+        onNavigate={vi.fn()}
+        label="Chords"
+        caption="Steps"
+      />,
+    );
+    const rows = screen.getAllByRole("button");
+    expect(rows[0]).toHaveAttribute("tabindex", "-1");
+    expect(rows[1]).toHaveAttribute("tabindex", "0");
   });
 });

--- a/src/components/SongControls/ProgressionStepList.test.tsx
+++ b/src/components/SongControls/ProgressionStepList.test.tsx
@@ -218,3 +218,63 @@ describe("ProgressionStepList roving tabindex", () => {
     expect(rows[1]).toHaveAttribute("tabindex", "0");
   });
 });
+
+describe("ProgressionStepList keyboard navigation", () => {
+  function renderList(activeIndex: number, onNavigate = vi.fn()) {
+    const utils = render(
+      <ProgressionStepList
+        steps={steps}
+        activeIndex={activeIndex}
+        onSelect={() => {}}
+        onReorder={vi.fn()}
+        onNavigate={onNavigate}
+        label="Chords"
+        caption="Steps"
+      />,
+    );
+    return { ...utils, onNavigate };
+  }
+
+  it("calls onNavigate(+1) on plain ArrowRight", () => {
+    const { onNavigate } = renderList(0);
+    fireEvent.keyDown(screen.getAllByRole("button")[0], { key: "ArrowRight" });
+    expect(onNavigate).toHaveBeenCalledWith(1);
+  });
+
+  it("calls onNavigate(-1) on plain ArrowLeft", () => {
+    const { onNavigate } = renderList(1);
+    fireEvent.keyDown(screen.getAllByRole("button")[1], { key: "ArrowLeft" });
+    expect(onNavigate).toHaveBeenCalledWith(-1);
+  });
+
+  it("ignores ArrowRight with Alt (reorder shortcut passes through)", () => {
+    const { onNavigate } = renderList(0);
+    fireEvent.keyDown(screen.getAllByRole("button")[0], { key: "ArrowRight", altKey: true });
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("ignores ArrowUp/ArrowDown (tempo keys pass through)", () => {
+    const { onNavigate } = renderList(0);
+    fireEvent.keyDown(screen.getAllByRole("button")[0], { key: "ArrowUp" });
+    fireEvent.keyDown(screen.getAllByRole("button")[0], { key: "ArrowDown" });
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("moves focus to the new active row after navigation re-renders", () => {
+    const { rerender } = renderList(0);
+    fireEvent.keyDown(screen.getAllByRole("button")[0], { key: "ArrowRight" });
+    // Simulate the atom update that onNavigate would cause:
+    rerender(
+      <ProgressionStepList
+        steps={steps}
+        activeIndex={1}
+        onSelect={() => {}}
+        onReorder={vi.fn()}
+        onNavigate={vi.fn()}
+        label="Chords"
+        caption="Steps"
+      />,
+    );
+    expect(document.activeElement).toBe(screen.getAllByRole("button")[1]);
+  });
+});

--- a/src/components/SongControls/ProgressionStepList.test.tsx
+++ b/src/components/SongControls/ProgressionStepList.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { useState } from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { axe } from "../../test-utils/a11y";
 import { ProgressionStepList } from "./ProgressionStepList";
 import { PROGRESSION_STEP_LIST_ID } from "./progressionFocusIds";
@@ -260,21 +261,23 @@ describe("ProgressionStepList keyboard navigation", () => {
     expect(onNavigate).not.toHaveBeenCalled();
   });
 
-  it("moves focus to the new active row after navigation re-renders", () => {
-    const { rerender } = renderList(0);
+  it("moves focus to the active row after keyboard navigation", async () => {
+    function Harness() {
+      const [idx, setIdx] = useState(0);
+      return (
+        <ProgressionStepList
+          steps={steps}
+          activeIndex={idx}
+          onSelect={() => {}}
+          onReorder={vi.fn()}
+          onNavigate={(direction) => setIdx((i) => i + direction)}
+          label="Chords"
+          caption="Steps"
+        />
+      );
+    }
+    render(<Harness />);
     fireEvent.keyDown(screen.getAllByRole("button")[0], { key: "ArrowRight" });
-    // Simulate the atom update that onNavigate would cause:
-    rerender(
-      <ProgressionStepList
-        steps={steps}
-        activeIndex={1}
-        onSelect={() => {}}
-        onReorder={vi.fn()}
-        onNavigate={vi.fn()}
-        label="Chords"
-        caption="Steps"
-      />,
-    );
-    expect(document.activeElement).toBe(screen.getAllByRole("button")[1]);
+    await waitFor(() => expect(document.activeElement).toBe(screen.getAllByRole("button")[1]));
   });
 });

--- a/src/components/SongControls/ProgressionStepList.test.tsx
+++ b/src/components/SongControls/ProgressionStepList.test.tsx
@@ -1,7 +1,9 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { axe } from "../../test-utils/a11y";
 import { ProgressionStepList } from "./ProgressionStepList";
+import { PROGRESSION_STEP_LIST_ID } from "./progressionFocusIds";
 import type { ResolvedProgressionStep } from "../../progressions/progressionDomain";
 
 function makeStep(
@@ -75,5 +77,23 @@ describe("ProgressionStepList", () => {
       <ProgressionStepList steps={steps} activeIndex={0} onSelect={() => {}} label="Chords" caption="Steps" />,
     );
     expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe("ProgressionStepList focus target", () => {
+  it("exposes a focusable scroll container with the shared id", () => {
+    const { container } = render(
+      <ProgressionStepList
+        steps={steps}
+        activeIndex={0}
+        onSelect={() => {}}
+        label="Progression"
+        caption="Steps"
+      />,
+    );
+
+    const scroll = container.querySelector(`#${PROGRESSION_STEP_LIST_ID}`);
+    expect(scroll).not.toBeNull();
+    expect(scroll?.getAttribute("tabindex")).toBe("-1");
   });
 });

--- a/src/components/SongControls/ProgressionStepList.tsx
+++ b/src/components/SongControls/ProgressionStepList.tsx
@@ -178,6 +178,7 @@ export function ProgressionStepList({ steps, activeIndex, onSelect, onReorder, o
         <span className={styles.captionTitle}>{caption}</span>
         {meta ? <span className={styles.captionMeta}>{meta}</span> : null}
       </div>
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
       <div className={styles.scroll} id={PROGRESSION_STEP_LIST_ID} tabIndex={-1} onKeyDown={handleListKeyDown}>
         {enableDrag ? (
           <Reorder.Group

--- a/src/components/SongControls/ProgressionStepList.tsx
+++ b/src/components/SongControls/ProgressionStepList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { ReactNode, Ref } from "react";
 import clsx from "clsx";
 import { Reorder, useDragControls } from "motion/react";
@@ -128,10 +128,29 @@ function DraggableStepRow({ step, index, active, onSelect, buttonRef, onDragActi
  * for drag-to-reorder. The active row carries a cyan left-tick + tint. Top/bottom
  * fade hints appear only when the list overflows.
  */
-export function ProgressionStepList({ steps, activeIndex, onSelect, onReorder, label, caption, meta, enableDrag = true }: ProgressionStepListProps) {
+export function ProgressionStepList({ steps, activeIndex, onSelect, onReorder, onNavigate, label, caption, meta, enableDrag = true }: ProgressionStepListProps) {
   const listRef = useRef<HTMLUListElement>(null);
   const activeRef = useRef<HTMLButtonElement>(null);
   const draggingRef = useRef(false);
+
+  // Bumped on each in-list ←/→ keystroke so the active row takes focus after the
+  // navigation re-renders. A counter (not a boolean) so it still fires when the
+  // index clamps at an end — focusing the unchanged active row is harmless and
+  // avoids a stale flag stealing focus on a later playback-driven change.
+  const [navFocusTick, setNavFocusTick] = useState(0);
+
+  useLayoutEffect(() => {
+    if (navFocusTick === 0) return;
+    activeRef.current?.focus({ preventScroll: true });
+  }, [navFocusTick, activeIndex]);
+
+  const handleListKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.altKey || event.metaKey || event.ctrlKey || event.shiftKey) return;
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    onNavigate(event.key === "ArrowLeft" ? -1 : 1);
+    setNavFocusTick((tick) => tick + 1);
+  };
 
   // Keep the active row visible *within the list's own scrollport* only. Skip
   // while a drag is in flight — the reorder action retargets the active index on
@@ -159,7 +178,7 @@ export function ProgressionStepList({ steps, activeIndex, onSelect, onReorder, l
         <span className={styles.captionTitle}>{caption}</span>
         {meta ? <span className={styles.captionMeta}>{meta}</span> : null}
       </div>
-      <div className={styles.scroll} id={PROGRESSION_STEP_LIST_ID} tabIndex={-1}>
+      <div className={styles.scroll} id={PROGRESSION_STEP_LIST_ID} tabIndex={-1} onKeyDown={handleListKeyDown}>
         {enableDrag ? (
           <Reorder.Group
             as="ul"

--- a/src/components/SongControls/ProgressionStepList.tsx
+++ b/src/components/SongControls/ProgressionStepList.tsx
@@ -12,6 +12,12 @@ import { PROGRESSION_STEP_LIST_ID } from "./progressionFocusIds";
 import { singleMoveDiff } from "./progressionStepListUtils";
 import styles from "./ProgressionStepList.module.css";
 
+// Id of the inner list, used to give the focusable scroll container its
+// accessible name via `aria-labelledby` without duplicating the literal
+// `aria-label` (two elements with the same `aria-label` break strict-mode
+// e2e selectors that target the list by name).
+const STEP_LIST_LABEL_ID = "progression-step-list-label";
+
 interface ProgressionStepListProps {
   steps: ResolvedProgressionStep[];
   activeIndex: number;
@@ -172,7 +178,7 @@ export function ProgressionStepList({ steps, activeIndex, onSelect, onReorder, o
         {meta ? <span className={styles.captionMeta}>{meta}</span> : null}
       </div>
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-      <div className={styles.scroll} id={PROGRESSION_STEP_LIST_ID} role="group" aria-label={label} tabIndex={-1} onKeyDown={handleListKeyDown}>
+      <div className={styles.scroll} id={PROGRESSION_STEP_LIST_ID} role="group" aria-labelledby={STEP_LIST_LABEL_ID} tabIndex={-1} onKeyDown={handleListKeyDown}>
         {enableDrag ? (
           <Reorder.Group
             as="ul"
@@ -180,6 +186,7 @@ export function ProgressionStepList({ steps, activeIndex, onSelect, onReorder, o
             values={ids}
             onReorder={handleReorder}
             className={styles.list}
+            id={STEP_LIST_LABEL_ID}
             aria-label={label}
             ref={listRef}
           >
@@ -198,7 +205,7 @@ export function ProgressionStepList({ steps, activeIndex, onSelect, onReorder, o
             ))}
           </Reorder.Group>
         ) : (
-          <ul className={styles.list} aria-label={label} ref={listRef}>
+          <ul className={styles.list} id={STEP_LIST_LABEL_ID} aria-label={label} ref={listRef}>
             {steps.map((step, index) => (
               <li key={step.id} className={styles.item}>
                 <StepSelectButton

--- a/src/components/SongControls/ProgressionStepList.tsx
+++ b/src/components/SongControls/ProgressionStepList.tsx
@@ -18,6 +18,9 @@ interface ProgressionStepListProps {
   onSelect: (index: number) => void;
   /** Reorder a step from one index to another (pointer drag). */
   onReorder: (from: number, to: number) => void;
+  /** Move the active step by one in the list (keyboard ←/→). Wired to the same
+   * actions as the global chord-nav shortcut so behavior is identical. */
+  onNavigate: (direction: -1 | 1) => void;
   /** Accessible label for the list container. */
   label: string;
   /** Visible mono caption above the list (e.g. "Steps"). */
@@ -55,6 +58,7 @@ function StepSelectButton({ step, index, active, onSelect, buttonRef, trailing }
     <button
       type="button"
       ref={buttonRef}
+      tabIndex={active ? 0 : -1}
       className={clsx(styles.row, { [styles.active]: active })}
       aria-current={active ? "true" : undefined}
       data-unavailable={step.unavailable || undefined}

--- a/src/components/SongControls/ProgressionStepList.tsx
+++ b/src/components/SongControls/ProgressionStepList.tsx
@@ -171,8 +171,8 @@ export function ProgressionStepList({ steps, activeIndex, onSelect, onReorder, o
         <span className={styles.captionTitle}>{caption}</span>
         {meta ? <span className={styles.captionMeta}>{meta}</span> : null}
       </div>
-      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
-      <div className={styles.scroll} id={PROGRESSION_STEP_LIST_ID} tabIndex={-1} onKeyDown={handleListKeyDown}>
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+      <div className={styles.scroll} id={PROGRESSION_STEP_LIST_ID} role="group" aria-label={label} tabIndex={-1} onKeyDown={handleListKeyDown}>
         {enableDrag ? (
           <Reorder.Group
             as="ul"

--- a/src/components/SongControls/ProgressionStepList.tsx
+++ b/src/components/SongControls/ProgressionStepList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import type { ReactNode, Ref } from "react";
 import clsx from "clsx";
 import { Reorder, useDragControls } from "motion/react";
@@ -133,23 +133,16 @@ export function ProgressionStepList({ steps, activeIndex, onSelect, onReorder, o
   const activeRef = useRef<HTMLButtonElement>(null);
   const draggingRef = useRef(false);
 
-  // Bumped on each in-list ←/→ keystroke so the active row takes focus after the
-  // navigation re-renders. A counter (not a boolean) so it still fires when the
-  // index clamps at an end — focusing the unchanged active row is harmless and
-  // avoids a stale flag stealing focus on a later playback-driven change.
-  const [navFocusTick, setNavFocusTick] = useState(0);
-
-  useLayoutEffect(() => {
-    if (navFocusTick === 0) return;
-    activeRef.current?.focus({ preventScroll: true });
-  }, [navFocusTick, activeIndex]);
-
   const handleListKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.altKey || event.metaKey || event.ctrlKey || event.shiftKey) return;
     if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
     event.preventDefault();
     onNavigate(event.key === "ArrowLeft" ? -1 : 1);
-    setNavFocusTick((tick) => tick + 1);
+    // Focus the active row after the navigation re-render commits. rAF runs after
+    // React has flushed the atom-driven update, so activeRef points at the new
+    // active row (or the same row if the index clamped at an end). Scheduling only
+    // here means playback/click/drag never steal focus.
+    requestAnimationFrame(() => activeRef.current?.focus({ preventScroll: true }));
   };
 
   // Keep the active row visible *within the list's own scrollport* only. Skip

--- a/src/components/SongControls/ProgressionStepList.tsx
+++ b/src/components/SongControls/ProgressionStepList.tsx
@@ -5,6 +5,7 @@ import {
   type ResolvedProgressionStep,
 } from "../../progressions/progressionDomain";
 import { useTranslation } from "../../hooks/useTranslation";
+import { PROGRESSION_STEP_LIST_ID } from "./progressionFocusIds";
 import styles from "./ProgressionStepList.module.css";
 
 interface ProgressionStepListProps {
@@ -54,7 +55,7 @@ export function ProgressionStepList({ steps, activeIndex, onSelect, label, capti
         <span className={styles.captionTitle}>{caption}</span>
         {meta ? <span className={styles.captionMeta}>{meta}</span> : null}
       </div>
-      <div className={styles.scroll}>
+      <div className={styles.scroll} id={PROGRESSION_STEP_LIST_ID} tabIndex={-1}>
         <ul className={styles.list} aria-label={label} ref={listRef}>
           {steps.map((step, index) => {
             const active = index === activeIndex;

--- a/src/components/SongControls/SongControls.tsx
+++ b/src/components/SongControls/SongControls.tsx
@@ -116,6 +116,8 @@ export function SongControls() {
     removeProgressionStep,
     moveProgressionStep,
     reorderProgressionSteps,
+    previousProgressionStep,
+    advanceProgressionPlayback,
     updateProgressionStepDuration,
     updateProgressionStepQuality,
     selectProgressionStepRoot,
@@ -126,6 +128,8 @@ export function SongControls() {
     currentProgressionPresetId,
     setActiveProgressionStepIndex,
   } = useProgressionState();
+
+  const isProgressionPlaying = useAtomValue(progressionPlayingAtom);
 
   const activeRoot = activeResolvedProgressionStep?.root ?? rootNote;
   const qualityGroups: LabeledSelectGroup[] = buildQualityGroupsWithDiatonic(
@@ -395,6 +399,11 @@ export function SongControls() {
                   activeIndex={activeProgressionStepIndex}
                   onSelect={setActiveProgressionStepIndex}
                   onReorder={(from, to) => reorderProgressionSteps({ from, to })}
+                  onNavigate={(direction) => {
+                    if (isProgressionPlaying) return;
+                    if (direction < 0) previousProgressionStep();
+                    else advanceProgressionPlayback();
+                  }}
                   enableDrag={!useSheetShell}
                   label={t("controls.progressionNavigation")}
                   caption={t("controls.stepsLabel")}

--- a/src/components/SongControls/SongControls.tsx
+++ b/src/components/SongControls/SongControls.tsx
@@ -31,6 +31,7 @@ import { buildChordRootGroups, classifyRoot } from "./chordRootOptions";
 import { buildQualityGroupsWithDiatonic } from "./qualityGroups";
 import { ProgressionStepList } from "./ProgressionStepList";
 import { ChordTonesReadout } from "./ChordTonesReadout";
+import { TEMPO_STEPPER_ID } from "./progressionFocusIds";
 import shared from "../shared/shared.module.css";
 import { CUSTOM_PRESET_ID, progressionPlayingAtom } from "../../store/progressionAtoms";
 import styles from "./SongControls.module.css";
@@ -311,6 +312,7 @@ export function SongControls() {
                   formatValue={(bpm) => `${bpm} BPM`}
                   onChange={setProgressionTempoBpm}
                   width="auto"
+                  groupId={TEMPO_STEPPER_ID}
                 />
               </Prop>
             </PropGrid>

--- a/src/components/SongControls/SongControls.tsx
+++ b/src/components/SongControls/SongControls.tsx
@@ -33,7 +33,8 @@ import { ProgressionStepList } from "./ProgressionStepList";
 import { ChordTonesReadout } from "./ChordTonesReadout";
 import { TEMPO_STEPPER_ID } from "./progressionFocusIds";
 import shared from "../shared/shared.module.css";
-import { CUSTOM_PRESET_ID, progressionPlayingAtom } from "../../store/progressionAtoms";
+import { CUSTOM_PRESET_ID } from "../../store/progressionAtoms";
+import { progressionPlayingAtom } from "@fretflow/fretboard/store/progressionAtoms";
 import styles from "./SongControls.module.css";
 
 // Look up a scale family by id; fail loudly at module init if the catalog id

--- a/src/components/SongControls/progressionFocusIds.ts
+++ b/src/components/SongControls/progressionFocusIds.ts
@@ -1,0 +1,9 @@
+// Stable DOM ids for the controls that global keyboard shortcuts focus after
+// mutating their state (see src/hooks/useKeyboardShortcuts.ts). Shared so the
+// hook and the components can never drift on the id string.
+
+/** The tempo stepper group (↑/↓ shortcuts focus this). */
+export const TEMPO_STEPPER_ID = "progression-tempo-stepper";
+
+/** The chord step list scroll container (←/→ shortcuts focus this). */
+export const PROGRESSION_STEP_LIST_ID = "progression-step-list";

--- a/src/components/StepperControl/StepperControl.test.tsx
+++ b/src/components/StepperControl/StepperControl.test.tsx
@@ -171,3 +171,33 @@ describe("StepperControl/StepperControl", () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 });
+
+describe("StepperControl groupId", () => {
+  it("renders the group element with the given id and tabIndex=-1", () => {
+    const { container } = render(
+      <StepperControl
+        value={100}
+        onChange={() => {}}
+        min={40}
+        max={240}
+        groupId="test-stepper"
+        label="Tempo"
+      />,
+    );
+
+    const group = container.querySelector("#test-stepper");
+    expect(group).not.toBeNull();
+    expect(group?.getAttribute("role")).toBe("group");
+    expect(group?.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("does not set a tabIndex when no groupId is given", () => {
+    const { container } = render(
+      <StepperControl value={100} onChange={() => {}} min={40} max={240} label="Tempo" />,
+    );
+
+    const group = container.querySelector('[role="group"]');
+    expect(group).not.toBeNull();
+    expect(group?.getAttribute("tabindex")).toBeNull();
+  });
+});

--- a/src/components/StepperControl/StepperControl.tsx
+++ b/src/components/StepperControl/StepperControl.tsx
@@ -44,6 +44,10 @@ export interface StepperControlProps {
   width?: "fill" | "auto";
   /** When true, both stepper buttons are disabled regardless of value bounds. */
   disabled?: boolean;
+  /** When set, the stepper group element gets this DOM id and becomes
+   * programmatically focusable (tabIndex=-1) so global keyboard shortcuts can
+   * focus it. Does not add a Tab stop — the +/- buttons remain the tab stops. */
+  groupId?: string;
 }
 
 export function StepperControl({
@@ -59,6 +63,7 @@ export function StepperControl({
   testId,
   width,
   disabled = false,
+  groupId,
 }: StepperControlProps) {
   return (
     <div
@@ -73,6 +78,8 @@ export function StepperControl({
         role="group"
         aria-label={label ?? "Stepper control"}
         data-testid={testId}
+        id={groupId}
+        tabIndex={groupId ? -1 : undefined}
       >
         <motion.button
           type="button"

--- a/src/components/StepperShell/StepperShell.module.css
+++ b/src/components/StepperShell/StepperShell.module.css
@@ -8,6 +8,12 @@
   padding: 2px;
 }
 
+.shell:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-glow);
+}
+
 .button {
   appearance: none;
   border: none;

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -16,8 +16,13 @@ import {
   progressionBassEnabledAtom,
   progressionDrumsEnabledAtom,
   progressionMetronomeEnabledAtom,
+  progressionTempoBpmAtom,
 } from "../store/progressionAtoms";
 import { isMutedAtom } from "../store/audioAtoms";
+import {
+  TEMPO_STEPPER_ID,
+  PROGRESSION_STEP_LIST_ID,
+} from "../components/SongControls/progressionFocusIds";
 
 function makeWrapper(store: ReturnType<typeof createStore>) {
   return function Wrapper({ children }: { children: React.ReactNode }) {
@@ -297,5 +302,89 @@ describe("useKeyboardShortcuts", () => {
     act(() => { fireEvent.keyDown(document, { key: "ArrowLeft" }); });
 
     expect(store.get(activeProgressionStepIndexAtom)).toBe(2);
+  });
+
+  it("ArrowUp moves focus to the tempo stepper when it is present", () => {
+    store.set(progressionTempoBpmAtom, 100);
+    const el = document.createElement("div");
+    el.id = TEMPO_STEPPER_ID;
+    el.tabIndex = -1;
+    document.body.appendChild(el);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowUp" }); });
+
+    expect(store.get(progressionTempoBpmAtom)).toBe(105);
+    expect(document.activeElement).toBe(el);
+    document.body.removeChild(el);
+  });
+
+  it("ArrowDown moves focus to the tempo stepper when it is present", () => {
+    store.set(progressionTempoBpmAtom, 100);
+    const el = document.createElement("div");
+    el.id = TEMPO_STEPPER_ID;
+    el.tabIndex = -1;
+    document.body.appendChild(el);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowDown" }); });
+
+    expect(store.get(progressionTempoBpmAtom)).toBe(95);
+    expect(document.activeElement).toBe(el);
+    document.body.removeChild(el);
+  });
+
+  it("ArrowUp still changes tempo and does not throw when the stepper is absent", () => {
+    store.set(progressionTempoBpmAtom, 100);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowUp" }); });
+
+    expect(store.get(progressionTempoBpmAtom)).toBe(105);
+  });
+
+  it("ArrowRight moves focus to the chord list when not playing", () => {
+    store.set(setProgressionPlayingAtom, false);
+    store.set(activeProgressionStepIndexAtom, 0);
+    const el = document.createElement("div");
+    el.id = PROGRESSION_STEP_LIST_ID;
+    el.tabIndex = -1;
+    document.body.appendChild(el);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowRight" }); });
+
+    expect(document.activeElement).toBe(el);
+    document.body.removeChild(el);
+  });
+
+  it("ArrowLeft moves focus to the chord list when not playing", () => {
+    store.set(setProgressionPlayingAtom, false);
+    store.set(activeProgressionStepIndexAtom, 2);
+    const el = document.createElement("div");
+    el.id = PROGRESSION_STEP_LIST_ID;
+    el.tabIndex = -1;
+    document.body.appendChild(el);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowLeft" }); });
+
+    expect(document.activeElement).toBe(el);
+    document.body.removeChild(el);
+  });
+
+  it("ArrowRight does not move focus to the chord list while playing", () => {
+    store.set(setProgressionPlayingAtom, true);
+    store.set(activeProgressionStepIndexAtom, 0);
+    const el = document.createElement("div");
+    el.id = PROGRESSION_STEP_LIST_ID;
+    el.tabIndex = -1;
+    document.body.appendChild(el);
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowRight" }); });
+
+    expect(document.activeElement).not.toBe(el);
+    document.body.removeChild(el);
   });
 });

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -441,4 +441,21 @@ describe("useKeyboardShortcuts", () => {
     // Order is unchanged: unmodified arrows never reorder.
     expect(store.get(progressionStepsAtom).map((s) => s.id)).toEqual(["a", "b", "c"]);
   });
+
+  it("ArrowRight does not advance the step when focus is inside the chord list", () => {
+    store.set(setProgressionPlayingAtom, false);
+    store.set(activeProgressionStepIndexAtom, 0);
+    const list = document.createElement("div");
+    list.id = PROGRESSION_STEP_LIST_ID;
+    const row = document.createElement("button");
+    list.appendChild(row);
+    document.body.appendChild(list);
+    row.focus();
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowRight" }); });
+
+    expect(store.get(activeProgressionStepIndexAtom)).toBe(0);
+    document.body.removeChild(list);
+  });
 });

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -458,4 +458,21 @@ describe("useKeyboardShortcuts", () => {
     expect(store.get(activeProgressionStepIndexAtom)).toBe(0);
     document.body.removeChild(list);
   });
+
+  it("ArrowLeft does not change the step when focus is inside the chord list", () => {
+    store.set(setProgressionPlayingAtom, false);
+    store.set(activeProgressionStepIndexAtom, 1);
+    const list = document.createElement("div");
+    list.id = PROGRESSION_STEP_LIST_ID;
+    const row = document.createElement("button");
+    list.appendChild(row);
+    document.body.appendChild(list);
+    row.focus();
+    renderHook(() => useKeyboardShortcuts(), { wrapper: makeWrapper(store) });
+
+    act(() => { fireEvent.keyDown(document, { key: "ArrowLeft" }); });
+
+    expect(store.get(activeProgressionStepIndexAtom)).toBe(1);
+    document.body.removeChild(list);
+  });
 });

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -21,6 +21,18 @@ import {
   MIN_PROGRESSION_TEMPO_BPM,
   MAX_PROGRESSION_TEMPO_BPM,
 } from "../progressions/progressionDomain";
+import {
+  TEMPO_STEPPER_ID,
+  PROGRESSION_STEP_LIST_ID,
+} from "../components/SongControls/progressionFocusIds";
+
+/** Focus a shortcut target by id if it is currently rendered. A no-op when the
+ * element is absent (e.g. its inspector tab is not showing) — the state mutation
+ * has already happened, so we just skip moving focus. `preventScroll` keeps the
+ * page and the list scrollport from jumping. */
+function focusShortcutTarget(id: string) {
+  document.getElementById(id)?.focus({ preventScroll: true });
+}
 
 export function useKeyboardShortcuts() {
   const store = useStore();
@@ -88,11 +100,13 @@ export function useKeyboardShortcuts() {
           if (store.get(progressionPlayingAtom)) return;
           e.preventDefault();
           store.set(previousProgressionStepAtom);
+          focusShortcutTarget(PROGRESSION_STEP_LIST_ID);
           break;
         case "ArrowRight":
           if (store.get(progressionPlayingAtom)) return;
           e.preventDefault();
           store.set(advanceProgressionPlaybackAtom);
+          focusShortcutTarget(PROGRESSION_STEP_LIST_ID);
           break;
         case "ArrowUp":
           e.preventDefault();
@@ -103,6 +117,7 @@ export function useKeyboardShortcuts() {
               store.get(progressionTempoBpmAtom) + 5,
             ),
           );
+          focusShortcutTarget(TEMPO_STEPPER_ID);
           break;
         case "ArrowDown":
           e.preventDefault();
@@ -113,6 +128,7 @@ export function useKeyboardShortcuts() {
               store.get(progressionTempoBpmAtom) - 5,
             ),
           );
+          focusShortcutTarget(TEMPO_STEPPER_ID);
           break;
         case "t":
         case "T":

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -41,6 +41,14 @@ function focusShortcutTarget(id: string) {
   document.getElementById(id)?.focus({ preventScroll: true });
 }
 
+/** True when keyboard focus is currently inside the chord list — in which case
+ * the list's own ←/→ handler owns navigation and the global one must stand down
+ * (the window listener fires regardless of React's stopPropagation). */
+function focusInsideChordList() {
+  const list = document.getElementById(PROGRESSION_STEP_LIST_ID);
+  return !!list && list.contains(document.activeElement);
+}
+
 export function useKeyboardShortcuts() {
   const store = useStore();
 
@@ -120,13 +128,13 @@ export function useKeyboardShortcuts() {
           );
           break;
         case "ArrowLeft":
-          if (store.get(progressionPlayingAtom)) return;
+          if (store.get(progressionPlayingAtom) || focusInsideChordList()) return;
           e.preventDefault();
           store.set(previousProgressionStepAtom);
           focusShortcutTarget(PROGRESSION_STEP_LIST_ID);
           break;
         case "ArrowRight":
-          if (store.get(progressionPlayingAtom)) return;
+          if (store.get(progressionPlayingAtom) || focusInsideChordList()) return;
           e.preventDefault();
           store.set(advanceProgressionPlaybackAtom);
           focusShortcutTarget(PROGRESSION_STEP_LIST_ID);


### PR DESCRIPTION
## Summary

Improves keyboard focus and navigation for the progression (Song) controls. Two related changes plus a merge of main.

**1. Focus follows the global arrow shortcuts.** Tempo ↑/↓ and chord ←/→ mutated state but never moved DOM focus, so the `:focus-visible` ring landed in the wrong place (the whole tab body, or a stale row). Now ↑/↓ ring the tempo stepper and the global ←/→ (from outside the list) ring the chord list, via shared focus-target ids and the existing focus-ring tokens (no ring restyle). Off-tab presses stay a silent no-op.

**2. The chord list is a single Tab stop.** Tabbing in used to land on the first row (every row was a Tab stop). The list now uses roving `tabIndex` over the existing `<button>` rows — Tab enters on the **active** row; `←/→` navigate row-by-row (reusing the same chord-nav atoms as the global shortcut, no-op while playing) and move focus to the active row via `requestAnimationFrame`. The global ←/→ handler stands down when focus is already inside the list, so there's no double-advance. `↑/↓` (tempo), `Alt+↑/↓` (reorder, from #618), and pointer drag-and-drop are untouched. Full listbox/option ARIA is deliberately deferred — it would fight the motion `Reorder.Group` structure; roving tabindex over buttons matches the repo's HelpModal tablist precedent.

**3. Merge of `main`.** Resolved conflicts from #618 (drag-and-drop reorder + `Alt+↑/↓`), preserving all of main's shortcuts.

Design + plans under `docs/superpowers/specs/` and `docs/superpowers/plans/` (`2026-06-15-keyboard-shortcut-focus*`, `2026-06-15-progression-listbox-keyboard-nav*`).

## Test Plan

- [x] `pnpm run lint` — 0 errors; fretboard boundaries OK
- [x] `pnpm run test` — 2724 passed (focus-target, roving-tabindex, in-list nav + focus-follow, global-handler bail both directions; #618/#619 tests stay green)
- [x] `pnpm exec tsc -b --noEmit` — clean
- [x] `pnpm run build` — succeeds
- [x] `pnpm run ui:tokens` — no new undefined tokens
- [ ] Manual: Tab into the list lands on the active row; ←/→ move row-by-row with focus following; ↑/↓ still change tempo and Alt+↑/↓ still reorder while the list is focused; mouse click still selects; pointer drag still reorders; the global ←/→ from outside rings the whole list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard navigation now moves focus to the tempo and progression controls after ArrowUp/ArrowDown and ArrowLeft/ArrowRight actions.
  * Progression step navigation now uses roving keyboard focus (only the active row is tabbable) and disables progression navigation while playback is active.

* **Bug Fixes**
  * ArrowLeft/ArrowRight no longer trigger step changes when focus is inside the chord list area.

* **Style**
  * Improved keyboard focus-ring visuals for the progression scroll region and stepper shells via consistent `:focus-visible` styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->