### PR TITLE
docs(agents): lean out AGENTS.md — fix path drift, extract release + architecture detail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,26 +27,19 @@ pnpm run preview               # preview build locally
 - **Commits:** Conventional Commits with scope. `type(scope): message`.
 - **Releases & breaking changes:** Triggered via GitHub Actions (Auto Release). Never tag manually. Breaking changes need a `BREAKING CHANGE:` footer (the Angular preset ignores `!`), and footer placement is fiddly — read [`RELEASING.md`](RELEASING.md) before merging a breaking PR or cutting a release.
 - **Worktrees (preferred isolation):** Before starting multi-step feature work or executing an implementation plan, create a git worktree first — invoke `superpowers:using-git-worktrees`. Run each concurrent/subagent stream that touches files in its own worktree so parallel agents never clobber a shared working tree. Quick single-file doc/config edits on a short-lived branch may skip the worktree. The `.githooks/pre-commit` nudge is only a last-resort reminder when this was missed.
-- **Git hooks:** `.githooks/pre-commit` (plain POSIX shell) hard-blocks direct commits to `main` and prints a non-blocking nudge to use a worktree when committing in the primary checkout while other worktrees exist. Registered via `git config core.hooksPath .githooks` in the `postinstall` script. No husky and no Node-based tooling in hooks — they stay near-zero CPU so concurrent AI agents never thrash or stall on a hung hook.
+- **Git hooks:** `.githooks/pre-commit` (registered via `postinstall`) hard-blocks direct commits to `main` and nudges worktree use. Plain POSIX, no husky/Node — kept near-zero CPU so concurrent agents don't stall.
 - **Instruction files:** `AGENTS.md` is the canonical project guide. `CLAUDE.md` and `GEMINI.md` are `@AGENTS.md` import stubs so Claude Code, Gemini CLI, opencode, Codex, Copilot, and Antigravity all read the same content. Edit `AGENTS.md` only.
 
 ## Architecture
 
-### State & Logic
+- **State:** Jotai atoms — atomic reactivity, no prop drilling. Domain atoms live in `@fretflow/fretboard` (`packages/fretboard/src/store/`); app-shell atoms (`inspectorAtoms`, `languageAtom`, `urlOverrideAtoms`) in `src/store/`. Old `src/store/*` and `src/progressions/` paths are re-export stubs — import from `@fretflow/fretboard/...` in new code.
+- **Domain (pure):** `@fretflow/core` (`packages/core/src/`) — theory, guitar, degrees, `shapes/`. Theory functions are backed by [Tonal.js](https://github.com/tonaljs/tonal); naming translation in `packages/core/src/lib/tonal.ts`.
+- **Rendering:** `packages/fretboard/src/components/FretboardSVG/FretboardSVG.tsx` is the primary SVG renderer; `FretboardEmbed` is the package's serializable public contract (`config` in, `FretboardEvent`s out).
+- **Controls:** `components/Inspector/` — two tabs (Overlay = scale + chord cards; Song = key/scale, progression, tempo, backing track).
+- **Layout:** `useLayoutMode` → `MainLayoutWrapper` emits `data-layout-tier` + `data-layout-variant`; **both gate responsive CSS — always consider both.**
+- **Rendering domains:** Scale and chord rendering are independent — **do not cross-wire their visibility or color state.** (Loading a progression preset is the one intentional exception: it sets the active *scale* but does not couple the color domains.)
 
-- **State:** Jotai atoms live in `@fretflow/fretboard` (`packages/fretboard/src/store/`), domain-split across `scaleAtoms`, `chordOverlayAtoms`, `practiceLensAtoms`, `fingeringAtoms`, `shapeAtoms`, `layoutAtoms`, `audioAtoms`, `uiAtoms`, `progressionAtoms`, `songStateAtoms`, `voicingFallbackAtoms`, `voicingStringSets`, `composableSelectors`, `actions`. App-shell atoms (`inspectorAtoms`, `languageAtom`, `urlOverrideAtoms`) remain in `src/store/`. Old `src/store/*` paths are thin re-export stubs — new code should import from `@fretflow/fretboard/store/<module>` (or the package's public surface) directly. Components subscribe directly to the atoms they consume (atomic reactivity — no prop drilling).
-- **Domain (pure):** `@fretflow/core` workspace package at `packages/core/src/` — `theory.ts`, `theoryCatalog.ts`, `guitar.ts`, `degrees.ts`, `circleOfFifthsUtils.ts`, `diatonicNotes.ts`, `constants.ts`. Includes the `shapes/` package (`templates`, `fullChordShapes`, `voicings`, `helpers`, `polygons`, `threeNPS`, `analytics`, `practicePatterns`).
-- **Music theory:** `@fretflow/core`'s theory functions (`getNoteDisplay`, `getChordNotes`, `getScaleNotes`, `getDiatonicChord`, `getKeySignature`, etc.) are backed by [Tonal.js](https://github.com/tonaljs/tonal) (`@tonaljs/note`, `@tonaljs/chord`, `@tonaljs/scale`, `@tonaljs/key`, `@tonaljs/interval`, `@tonaljs/roman-numeral`, `@tonaljs/progression`). Naming translation lives in `packages/core/src/lib/tonal.ts`.
-- **Audio:** `GuitarSynth` singleton in `packages/fretboard/src/core/audio.ts` (Web Audio API). Tone.js progression playback in `packages/fretboard/src/progressions/` + `packages/fretboard/src/hooks/useProgressionAudioPlayback.ts`. The matching `src/` paths (`src/progressions/`, `src/hooks/useProgressionAudioPlayback.ts`) are thin re-export stubs — import from `@fretflow/fretboard/...` in new code.
-- **Persistence:** `atomWithStorage` with keys prefixed via `src/utils/storage.ts`.
-
-### Components & Layout
-
-- **Orchestration:** `src/App.tsx` wires atoms to `MainLayoutWrapper`.
-- **Rendering:** `packages/fretboard/src/components/Fretboard/Fretboard.tsx` wraps `packages/fretboard/src/components/FretboardSVG/FretboardSVG.tsx` (the primary SVG renderer — large, direct atom subscriptions). The package's public contract is `FretboardEmbed` (serializable `config` in, `FretboardEvent`s out via `onEvent`, `audio: "builtin" | "events"`) — an additive surface that does not change how the web app renders `<Fretboard/>`.
-- **Controls:** `components/Inspector/` is the control surface — a two-tab Inspector (`tabs.tsx`: `view` → "Overlay", `song` → "Song"). The **Overlay** tab (`ViewTab.tsx`) stacks two `InspectorCard`s: a Scale card hosting `FingeringPatternControls` (pattern / shape / position) and a Chord card hosting `ChordOverlayControls` (voicing + close-mode string set). The **Song** tab (`SongControls/SongControls.tsx`) owns key + scale (root/scale dropdowns), progression preset + sequence, time signature + tempo, and the backing track. On mobile the Inspector renders as a bottom tab bar; on larger screens as side-by-side cards.
-- **Layout:** `useLayoutMode` (in `src/hooks/`) measures viewport via `src/layout/responsive.ts` → returns `{ tier, variant, … }`. `MainLayoutWrapper` emits `data-layout-tier` (mobile/tablet/desktop) and `data-layout-variant` (mobile/landscape-mobile/tablet-split/tablet-stacked/desktop-split/desktop-stacked/desktop-3col) attributes. **Both gate responsive CSS — always consider both.**
-- **Primitives:** `ToggleBar`, `StepperControl` (+ `StepperSelect`, `StepperShell`), `LabeledSelect`, `NotePill`, `Switch`, `Tooltip` / `SettingsTooltip`, and `InspectorCard`.
+Full module inventory, component wiring, the CAGED/3NPS pipeline, and Note Roles → [`docs/design/architecture.md`](docs/design/architecture.md).
 
 ## File Layout
 
@@ -88,25 +81,10 @@ src/
 - **Tuning:** Arrays ordered high string (index 0) to low string.
 - **Coordinates:** `"string-fret"` keys (e.g., `"0-12"`).
 - **Tests:** Co-located with source — `components/<Name>/<Name>.test.tsx`, `core/<name>.test.ts`, `store/<name>.test.ts`. Shared helpers in `src/test-utils/`.
-- **CSS:**
-  - CSS Modules (`*.module.css`) for all component-scoped styles.
-  - Global foundations under `src/styles/` (`tokens.css`, `semantic.css`, `App.css`, `index.css`) — imported via `src/styles/index.css`.
-  - Shared module CSS in `src/components/shared/shared.module.css`.
-  - Use `clsx` for conditional classes, `cva` for variant class systems, `motion` (from `motion/react`) for animations.
-  - Linting is **ESLint only** (`pnpm run lint` → `eslint .`); there is no stylelint or lint-staged. Package manager is **pnpm** (workspace defined in `pnpm-workspace.yaml`).
-  - **Tokens must resolve.** Every `var(--x)` must point at a defined token (a CSS `--x: …` declaration or a React inline-style key). Run `pnpm run ui:tokens` (or `/ui-review`) before finishing any mobile/tablet UI change — see `docs/design/mobile-ui-contract.md`.
+- **CSS:** CSS Modules (`*.module.css`) for components; global foundations in `src/styles/` (imported via `src/styles/index.css`); shared module CSS in `src/components/shared/`. Use `clsx` (conditional classes), `cva` (variants), `motion` from `motion/react` (animations). **Tokens must resolve** — every `var(--x)` must point at a defined token; run `pnpm run ui:tokens` (or `/ui-review`) before finishing mobile/tablet UI changes (see `docs/design/mobile-ui-contract.md`).
+- **Tooling:** Package manager **pnpm** (workspace in `pnpm-workspace.yaml`); linting is **ESLint only** — no stylelint, no lint-staged.
 - **React Compiler:** Enabled via `babel-plugin-react-compiler` in `vite.config.ts` with `compilationMode: 'infer'`. Every component and hook in `src/` and `packages/core/src/` is auto-memoized — manual `useMemo` / `useCallback` / `React.memo` is rarely needed for render-perf and should be added only when profiling proves it. The `react-compiler/react-compiler` ESLint rule runs at `error` and guards Rules-of-React compliance. To opt a single component out, add `'use no memo'` as the first statement of the function body with a `// TODO(react-compiler): <reason>` comment.
 - **A11y:** ARIA labels + semantic HTML + `:focus-visible` styles required. `vitest-axe` available for component tests.
-
-## CAGED / 3NPS System
-
-1. `packages/core/src/shapes/` finds note positions via `SHAPE_CONFIGS` and generates polygon vertices (fixed templates for pentatonic, dynamic for 7-note scales). `fullChordShapes.ts` + `voicings.ts` provide full-chord and close-voicing pickers.
-2. Orchestrator merges adjacent boundaries with buffer.
-3. `FretboardSVG.tsx` renders pixel SVG polygons; `useChordConnectorPolylines` draws the connector polylines linking voicing notes.
-
-## Note Roles
-
-Notes carry a semantic role (`root-active`, `chord-tone`, `note-blue`, `note-active`, `note-scale-only`, `chord-outside`, `note-inactive`). The **emphasis layer** in `src/components/FretboardSVG/utils/semantics.ts#getEmphasis` adds voice-leading cues (anticipation, hold, departing) when a progression is active, falling back to guide-tone emphasis when there's no progression. **Scale and chord rendering are independent domains** — do not cross-wire their visibility or color state. (Loading a progression preset is the one intentional exception: it sets the active *scale* — a one-time user action establishing harmonic context — but it does not couple the rendering/color domains.)
 
 ## Testing
 
@@ -115,17 +93,12 @@ Notes carry a semantic role (`root-active`, `chord-tone`, `note-blue`, `note-act
 - **Visual regression suites** under `e2e/`: `app-components`, `app-layout`, `app-mobile`, `app-overlays`, `fretboard-svg` — each with committed darwin + linux snapshots. Update via `pnpm run test:visual:update` (darwin) or `pnpm run test:visual:update:linux` (cross-platform).
 - **a11y:** `vitest-axe` + `eslint-plugin-jsx-a11y`.
 
-## CI / Release
+## Reference docs (read on demand — do not preload)
 
-- `ci.yml`: `changes` (paths-filter) → parallel `test` + `build` → `e2e` (downloads `dist`, production config) → `quality-gate` (skipped-aware PR comment). Docs-only PRs report `skipped` without breaking required checks.
-- `deploy.yml`: GitHub Pages.
-- `auto-release.yml`: manual trigger, semver from Conventional Commits.
-- Dependabot weekly for npm + github-actions.
+Durable docs live in `docs/design/` (index: `docs/design/README.md`) plus `RELEASING.md`. They are **not** preloaded — pull the relevant one only when working in its domain, cite it, and add new sources back:
 
-## Design Rationale (read on demand — do not preload)
-
-Durable "why" docs live in `docs/design/` (index: `docs/design/README.md`). They are **not** preloaded — pull the relevant one only when making a decision in its domain, cite it, and add new sources back:
-
+- module inventory / component wiring / CAGED-3NPS pipeline / note roles / CI shape → `docs/design/architecture.md`
+- releases / breaking-change footer rules → `RELEASING.md`
 - markers / color / marker shape / connectors / voice-leading motion → `docs/design/fretboard-visual-language.md`
 - voicing / strum / close-voicing fallback / audio playback → `docs/design/audio-voicing-engine.md`
 - chord qualities / scales / guide tones / improvisation lenses / modes → `docs/design/music-theory-pedagogy.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,33 +19,13 @@ pnpm run ui:tokens             # flag undefined CSS token (var(--x)) references 
 pnpm run preview               # preview build locally
 ```
 
-**MANDATORY:** Run `lint`, `test`, and `build` locally before opening a PR. Git hooks do **not** run these checks — `.githooks/pre-commit` only blocks direct commits to `main`. CI is the real gate, but running them locally first avoids burning a CI cycle.
+**MANDATORY:** Run `lint` and `test` locally before opening a PR; run `build` too when the change touches types, imports, or the build graph (it's the slow one). Git hooks do **not** run these checks — `.githooks/pre-commit` only blocks direct commits to `main`. CI is the real gate, but running them locally first avoids burning a CI cycle.
 
 ## Development Workflow
 
 - **Branching:** Trunk-based. `main` = trunk. PRs required.
 - **Commits:** Conventional Commits with scope. `type(scope): message`.
-- **Breaking changes:** The Auto Release workflow uses the Angular preset, which does **not** recognize the `!` shorthand (e.g. `feat!:`). To trigger a major version bump you **must** include a `BREAKING CHANGE:` footer in the commit body:
-
-  ```text
-  feat(scope): short subject
-
-  Optional body.
-
-  BREAKING CHANGE: explanation of what breaks and how to migrate.
-  ```
-
-  When merging a PR via squash, ensure the squash commit body (not just the title) carries the footer — GitHub does not append PR body to the commit by default. Without the footer, breaking PRs will be released as a minor bump.
-
-  **Footer placement matters.** `conventional-commits-parser` only promotes `BREAKING CHANGE:` to a breaking-change note when it lives in the **footer section** — the final paragraph block of the commit. Things that displace it out of the footer block (and silently demote the release to a minor bump):
-  - Markdown horizontal rules (`---`, `---------`) in the body.
-  - A trailing `Co-authored-by:` / `Signed-off-by:` / "Generated with Claude Code" paragraph after the `BREAKING CHANGE:` line.
-  - Any "token: value" paragraph that comes after `BREAKING CHANGE:`.
-
-  Keep the body plain text and put `BREAKING CHANGE:` as the last paragraph. If the squash UI appends trailers, use **Rebase and merge** instead to preserve the body verbatim. After merging, dispatch Auto Release and confirm the dry-run prints `Type: major` before the tag step runs.
-
-  When squashing, GitHub fills the squash body from the PR description by default. Confirmed failure mode: PR #463 and PR #465 both squashed with a PR description that contained markdown rules and ended with a `Co-authored-by:` paragraph, and the analyzer scored both as non-breaking. The safe path for any breaking PR is to use **Rebase and merge** so the branch commit body lands on `main` verbatim.
-- **Releases:** Triggered via GitHub Actions (Auto Release). Never tag manually.
+- **Releases & breaking changes:** Triggered via GitHub Actions (Auto Release). Never tag manually. Breaking changes need a `BREAKING CHANGE:` footer (the Angular preset ignores `!`), and footer placement is fiddly — read [`RELEASING.md`](RELEASING.md) before merging a breaking PR or cutting a release.
 - **Worktrees (preferred isolation):** Before starting multi-step feature work or executing an implementation plan, create a git worktree first — invoke `superpowers:using-git-worktrees`. Run each concurrent/subagent stream that touches files in its own worktree so parallel agents never clobber a shared working tree. Quick single-file doc/config edits on a short-lived branch may skip the worktree. The `.githooks/pre-commit` nudge is only a last-resort reminder when this was missed.
 - **Git hooks:** `.githooks/pre-commit` (plain POSIX shell) hard-blocks direct commits to `main` and prints a non-blocking nudge to use a worktree when committing in the primary checkout while other worktrees exist. Registered via `git config core.hooksPath .githooks` in the `postinstall` script. No husky and no Node-based tooling in hooks — they stay near-zero CPU so concurrent AI agents never thrash or stall on a hung hook.
 - **Instruction files:** `AGENTS.md` is the canonical project guide. `CLAUDE.md` and `GEMINI.md` are `@AGENTS.md` import stubs so Claude Code, Gemini CLI, opencode, Codex, Copilot, and Antigravity all read the same content. Edit `AGENTS.md` only.
@@ -57,7 +37,7 @@ pnpm run preview               # preview build locally
 - **State:** Jotai atoms live in `@fretflow/fretboard` (`packages/fretboard/src/store/`), domain-split across `scaleAtoms`, `chordOverlayAtoms`, `practiceLensAtoms`, `fingeringAtoms`, `shapeAtoms`, `layoutAtoms`, `audioAtoms`, `uiAtoms`, `progressionAtoms`, `songStateAtoms`, `voicingFallbackAtoms`, `voicingStringSets`, `composableSelectors`, `actions`. App-shell atoms (`inspectorAtoms`, `languageAtom`, `urlOverrideAtoms`) remain in `src/store/`. Old `src/store/*` paths are thin re-export stubs — new code should import from `@fretflow/fretboard/store/<module>` (or the package's public surface) directly. Components subscribe directly to the atoms they consume (atomic reactivity — no prop drilling).
 - **Domain (pure):** `@fretflow/core` workspace package at `packages/core/src/` — `theory.ts`, `theoryCatalog.ts`, `guitar.ts`, `degrees.ts`, `circleOfFifthsUtils.ts`, `diatonicNotes.ts`, `constants.ts`. Includes the `shapes/` package (`templates`, `fullChordShapes`, `voicings`, `helpers`, `polygons`, `threeNPS`, `analytics`, `practicePatterns`).
 - **Music theory:** `@fretflow/core`'s theory functions (`getNoteDisplay`, `getChordNotes`, `getScaleNotes`, `getDiatonicChord`, `getKeySignature`, etc.) are backed by [Tonal.js](https://github.com/tonaljs/tonal) (`@tonaljs/note`, `@tonaljs/chord`, `@tonaljs/scale`, `@tonaljs/key`, `@tonaljs/interval`, `@tonaljs/roman-numeral`, `@tonaljs/progression`). Naming translation lives in `packages/core/src/lib/tonal.ts`.
-- **Audio:** `GuitarSynth` singleton in `src/core/audio.ts` (Web Audio API). Tone.js progression playback in `src/progressions/` + `src/hooks/useProgressionAudioPlayback.ts`.
+- **Audio:** `GuitarSynth` singleton in `packages/fretboard/src/core/audio.ts` (Web Audio API). Tone.js progression playback in `packages/fretboard/src/progressions/` + `packages/fretboard/src/hooks/useProgressionAudioPlayback.ts`. The matching `src/` paths (`src/progressions/`, `src/hooks/useProgressionAudioPlayback.ts`) are thin re-export stubs — import from `@fretflow/fretboard/...` in new code.
 - **Persistence:** `atomWithStorage` with keys prefixed via `src/utils/storage.ts`.
 
 ### Components & Layout
@@ -82,7 +62,7 @@ packages/
                               # (enforced by scripts/check-fretboard-boundaries.mjs in `pnpm run lint`).
 
 src/
-├── App.tsx                   # orchestrator (~260 lines)
+├── App.tsx                   # orchestrator
 ├── main.tsx
 ├── core/                     # app-side runtime (audio, lazyGuitarAudio, toneInit,
 │                             # fretboardLayoutCache, polygonCoverage)
@@ -109,7 +89,7 @@ src/
 - **Coordinates:** `"string-fret"` keys (e.g., `"0-12"`).
 - **Tests:** Co-located with source — `components/<Name>/<Name>.test.tsx`, `core/<name>.test.ts`, `store/<name>.test.ts`. Shared helpers in `src/test-utils/`.
 - **CSS:**
-  - CSS Modules (`*.module.css`) for all component-scoped styles (38 modules).
+  - CSS Modules (`*.module.css`) for all component-scoped styles.
   - Global foundations under `src/styles/` (`tokens.css`, `semantic.css`, `App.css`, `index.css`) — imported via `src/styles/index.css`.
   - Shared module CSS in `src/components/shared/shared.module.css`.
   - Use `clsx` for conditional classes, `cva` for variant class systems, `motion` (from `motion/react`) for animations.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,33 @@
+# Releasing FretFlow
+
+Release mechanics — **read on demand**, when cutting a release or merging a breaking change. Not preloaded into agent context. The day-to-day workflow lives in [`AGENTS.md`](AGENTS.md); this doc holds the detail that only matters at release time.
+
+## Trigger
+
+Releases are triggered via GitHub Actions (**Auto Release**, `auto-release.yml`). It is a manual dispatch and computes the semver bump from Conventional Commits. **Never tag manually.**
+
+## Breaking changes
+
+The Auto Release workflow uses the Angular preset, which does **not** recognize the `!` shorthand (e.g. `feat!:`). To trigger a major version bump you **must** include a `BREAKING CHANGE:` footer in the commit body:
+
+```text
+feat(scope): short subject
+
+Optional body.
+
+BREAKING CHANGE: explanation of what breaks and how to migrate.
+```
+
+When merging a PR via squash, ensure the squash commit body (not just the title) carries the footer — GitHub does not append the PR body to the commit by default. Without the footer, breaking PRs will be released as a minor bump.
+
+### Footer placement matters
+
+`conventional-commits-parser` only promotes `BREAKING CHANGE:` to a breaking-change note when it lives in the **footer section** — the final paragraph block of the commit. Things that displace it out of the footer block (and silently demote the release to a minor bump):
+
+- Markdown horizontal rules (`---`, `---------`) in the body.
+- A trailing `Co-authored-by:` / `Signed-off-by:` / "Generated with Claude Code" paragraph after the `BREAKING CHANGE:` line.
+- Any "token: value" paragraph that comes after `BREAKING CHANGE:`.
+
+Keep the body plain text and put `BREAKING CHANGE:` as the last paragraph. If the squash UI appends trailers, use **Rebase and merge** instead to preserve the body verbatim. After merging, dispatch Auto Release and confirm the dry-run prints `Type: major` before the tag step runs.
+
+When squashing, GitHub fills the squash body from the PR description by default. Confirmed failure mode: PR #463 and PR #465 both squashed with a PR description that contained markdown rules and ended with a `Co-authored-by:` paragraph, and the analyzer scored both as non-breaking. The safe path for any breaking PR is to use **Rebase and merge** so the branch commit body lands on `main` verbatim.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -8,6 +8,7 @@ than re-deriving the grounding, and add any new sources back into it.
 
 | Doc | Consult before changing… |
 |---|---|
+| [`architecture.md`](./architecture.md) | module inventory, component wiring, state/atom layout, CAGED/3NPS rendering pipeline, note roles, CI shape — *where the code lives* (structural map, not rationale) |
 | [`fretboard-visual-language.md`](./fretboard-visual-language.md) | markers, color, marker shape/size/fill, connectors, voice-leading motion, contrast/OKLCH tokens — *how notes are drawn* |
 | [`audio-voicing-engine.md`](./audio-voicing-engine.md) | voicing selection, inversion-based strum, close-voicing fallback, audio / Tone.js playback |
 | [`music-theory-pedagogy.md`](./music-theory-pedagogy.md) | chord qualities & extensions, scales, guide tones, improvisation lenses, modal characteristic tones — *what notes mean* |

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -1,0 +1,40 @@
+# Architecture Reference
+
+The detailed structural map of FretFlow — module inventory, component wiring, rendering pipeline, and CI shape. **Read on demand** when you're about to touch a subsystem; not preloaded into agent context. [`AGENTS.md`](../../AGENTS.md) keeps only the one-line orientation and points here.
+
+## State & Logic
+
+- **State:** Jotai atoms live in `@fretflow/fretboard` (`packages/fretboard/src/store/`), domain-split across `scaleAtoms`, `chordOverlayAtoms`, `practiceLensAtoms`, `fingeringAtoms`, `shapeAtoms`, `layoutAtoms`, `audioAtoms`, `uiAtoms`, `progressionAtoms`, `songStateAtoms`, `voicingFallbackAtoms`, `voicingStringSets`, `composableSelectors`, `actions`. App-shell atoms (`inspectorAtoms`, `languageAtom`, `urlOverrideAtoms`) remain in `src/store/`. Old `src/store/*` paths are thin re-export stubs — new code should import from `@fretflow/fretboard/store/<module>` (or the package's public surface) directly. Components subscribe directly to the atoms they consume (atomic reactivity — no prop drilling).
+- **Domain (pure):** `@fretflow/core` workspace package at `packages/core/src/` — `theory.ts`, `theoryCatalog.ts`, `guitar.ts`, `degrees.ts`, `circleOfFifthsUtils.ts`, `diatonicNotes.ts`, `constants.ts`. Includes the `shapes/` package (`templates`, `fullChordShapes`, `voicings`, `helpers`, `polygons`, `threeNPS`, `analytics`, `practicePatterns`).
+- **Music theory:** `@fretflow/core`'s theory functions (`getNoteDisplay`, `getChordNotes`, `getScaleNotes`, `getDiatonicChord`, `getKeySignature`, etc.) are backed by [Tonal.js](https://github.com/tonaljs/tonal) (`@tonaljs/note`, `@tonaljs/chord`, `@tonaljs/scale`, `@tonaljs/key`, `@tonaljs/interval`, `@tonaljs/roman-numeral`, `@tonaljs/progression`). Naming translation lives in `packages/core/src/lib/tonal.ts`.
+- **Audio:** `GuitarSynth` singleton in `packages/fretboard/src/core/audio.ts` (Web Audio API). Tone.js progression playback in `packages/fretboard/src/progressions/` + `packages/fretboard/src/hooks/useProgressionAudioPlayback.ts`. The matching `src/` paths (`src/progressions/`, `src/hooks/useProgressionAudioPlayback.ts`) are thin re-export stubs — import from `@fretflow/fretboard/...` in new code.
+- **Persistence:** `atomWithStorage` with keys prefixed via `src/utils/storage.ts`.
+
+## Components & Layout
+
+- **Orchestration:** `src/App.tsx` wires atoms to `MainLayoutWrapper`.
+- **Rendering:** `packages/fretboard/src/components/Fretboard/Fretboard.tsx` wraps `packages/fretboard/src/components/FretboardSVG/FretboardSVG.tsx` (the primary SVG renderer — large, direct atom subscriptions). The package's public contract is `FretboardEmbed` (serializable `config` in, `FretboardEvent`s out via `onEvent`, `audio: "builtin" | "events"`) — an additive surface that does not change how the web app renders `<Fretboard/>`.
+- **Controls:** `components/Inspector/` is the control surface — a two-tab Inspector (`tabs.tsx`: `view` → "Overlay", `song` → "Song"). The **Overlay** tab (`ViewTab.tsx`) stacks two `InspectorCard`s: a Scale card hosting `FingeringPatternControls` (pattern / shape / position) and a Chord card hosting `ChordOverlayControls` (voicing + close-mode string set). The **Song** tab (`SongControls/SongControls.tsx`) owns key + scale (root/scale dropdowns), progression preset + sequence, time signature + tempo, and the backing track. On mobile the Inspector renders as a bottom tab bar; on larger screens as side-by-side cards.
+- **Layout:** `useLayoutMode` (in `src/hooks/`) measures viewport via `src/layout/responsive.ts` → returns `{ tier, variant, … }`. `MainLayoutWrapper` emits `data-layout-tier` (mobile/tablet/desktop) and `data-layout-variant` (mobile/landscape-mobile/tablet-split/tablet-stacked/desktop-split/desktop-stacked/desktop-3col) attributes. **Both gate responsive CSS — always consider both.**
+- **Primitives:** `ToggleBar`, `StepperControl` (+ `StepperSelect`, `StepperShell`), `LabeledSelect`, `NotePill`, `Switch`, `Tooltip` / `SettingsTooltip`, and `InspectorCard`.
+
+## CAGED / 3NPS Rendering Pipeline
+
+1. `packages/core/src/shapes/` finds note positions via `SHAPE_CONFIGS` and generates polygon vertices (fixed templates for pentatonic, dynamic for 7-note scales). `fullChordShapes.ts` + `voicings.ts` provide full-chord and close-voicing pickers.
+2. Orchestrator merges adjacent boundaries with buffer.
+3. `FretboardSVG.tsx` renders pixel SVG polygons; `useChordConnectorPolylines` draws the connector polylines linking voicing notes.
+
+See [`fretboard-visual-language.md`](./fretboard-visual-language.md) for the *why* behind markers, color, and connectors.
+
+## Note Roles
+
+Notes carry a semantic role (`root-active`, `chord-tone`, `note-blue`, `note-active`, `note-scale-only`, `chord-outside`, `note-inactive`). The **emphasis layer** in `src/components/FretboardSVG/utils/semantics.ts#getEmphasis` adds voice-leading cues (anticipation, hold, departing) when a progression is active, falling back to guide-tone emphasis when there's no progression.
+
+**Scale and chord rendering are independent domains** — do not cross-wire their visibility or color state. (Loading a progression preset is the one intentional exception: it sets the active *scale* — a one-time user action establishing harmonic context — but it does not couple the rendering/color domains.) This guardrail is also stated in `AGENTS.md` because it's easy to violate.
+
+## CI / Release Pipeline
+
+- `ci.yml`: `changes` (paths-filter) → parallel `test` + `build` → `e2e` (downloads `dist`, production config) → `quality-gate` (skipped-aware PR comment). Docs-only PRs report `skipped` without breaking required checks.
+- `deploy.yml`: GitHub Pages.
+- `auto-release.yml`: manual trigger, semver from Conventional Commits. Release mechanics and the breaking-change footer rules live in [`RELEASING.md`](../../RELEASING.md).
+- Dependabot weekly for npm + github-actions.


### PR DESCRIPTION
## Why

`AGENTS.md` is preloaded into **every** agent's context, every session. It should hold only what an agent needs *before it knows its task*; anything domain-specific should sit behind a pointer. This PR challenges the file against the actual codebase, fixes the drift, and leans it out.

**Net: AGENTS.md ~13.9KB → ~9.9KB (~29% less preloaded context per agent).**

## Verified path drift (was actively misleading agents)
- `GuitarSynth` → corrected from `src/core/audio.ts` (doesn't exist) to `packages/fretboard/src/core/audio.ts`.
- Tone.js progression playback → corrected from `src/progressions/` to `packages/fretboard/src/progressions/`; the `src/` paths are re-export stubs, now noted explicitly. (The Audio section and File Layout block previously contradicted each other.)
- Dropped hardcoded counts — "~260 lines" (actually 310) and "38 modules" (actually 49); both had already drifted.

## Extracted to referenced docs (the lean-out)
- **`RELEASING.md`** (repo root — `docs/*` is gitignored except `docs/superpowers/` and `docs/design/`): the ~20-line `BREAKING CHANGE` footer mechanics, which were always-preloaded despite being release-time-only.
- **`docs/design/architecture.md`** (new, tracked): full atom/module inventory, component wiring, CAGED/3NPS rendering pipeline, note roles, and CI pipeline shape. Indexed in `docs/design/README.md`.
- AGENTS.md `Architecture` collapsed to a 6-bullet summary + pointer; `CAGED/3NPS`, `Note Roles`, and `CI/Release` sections removed (now referenced). Load-bearing guardrails kept inline: the stub-import rule, "both attrs gate responsive CSS", and "scale/chord rendering are independent domains".
- Trimmed the git-hooks rationale and the CSS convention block; split tooling (pnpm/ESLint) into its own bullet.

## Best-practice
- Softened mandatory local `build` — `lint`+`test` stay mandatory; `build` is conditional on changes touching types/imports/the build graph (CI gates it regardless).

## Scope

Docs only. No code touched — nothing to lint/test/build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)