### PR TITLE
feat(progression): match step list height to editor + conditional overflow fade

### DIFF
--- a/src/components/SongControls/ProgressionStepList.module.css
+++ b/src/components/SongControls/ProgressionStepList.module.css
@@ -7,7 +7,7 @@
   min-width: 12rem;
   display: flex;
   flex-direction: column;
-  min-height: 0;
+  min-height: 17rem;
 }
 
 /* Caption: mono "STEPS" title + right-aligned summary meta. */
@@ -45,6 +45,8 @@
    degrades gracefully. */
 .scroll {
   position: relative;
+  flex: 1 1 0;
+  min-height: 0;
 }
 
 .scroll:focus-visible {
@@ -60,7 +62,7 @@
   margin: 0;
   padding: 0 0.35rem 0 0;
   list-style: none;
-  max-height: 17rem;
+  height: 100%;
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--faceplate-divider) transparent;
@@ -92,7 +94,7 @@
     timeline-scope: --chord-list-scroll;
   }
 
-  .list {
+  .list[data-overflows] {
     scroll-timeline: --chord-list-scroll block;
     mask-image: linear-gradient(
       to bottom,
@@ -303,6 +305,7 @@
   flex: 0 0 auto;
   width: 100%;
   min-width: 0;
+  min-height: 0;
 }
 
 :global([data-layout-tier="mobile"]) .scroll {
@@ -312,6 +315,7 @@
 :global([data-layout-tier="mobile"]) .list {
   max-height: none;
   overflow-y: visible;
+  height: auto;
 }
 
 :global([data-layout-tier="mobile"]) .list {

--- a/src/components/SongControls/ProgressionStepList.tsx
+++ b/src/components/SongControls/ProgressionStepList.tsx
@@ -165,6 +165,24 @@ export function ProgressionStepList({ steps, activeIndex, onSelect, onReorder, o
     else if (rr.bottom > lr.bottom) listEl.scrollTop += rr.bottom - lr.bottom;
   }, [activeIndex]);
 
+  // Mark the list when its content overflows so the CSS mask fade only shows
+  // when there is actually something to scroll to.
+  useEffect(() => {
+    const el = listRef.current;
+    if (!el) return;
+    const update = () => {
+      if (el.scrollHeight > el.clientHeight) {
+        el.setAttribute("data-overflows", "");
+      } else {
+        el.removeAttribute("data-overflows");
+      }
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [steps]);
+
   const ids = steps.map((step) => step.id);
   const handleReorder = (nextIds: string[]) => {
     const move = singleMoveDiff(ids, nextIds);

--- a/src/components/SongControls/SongControls.module.css
+++ b/src/components/SongControls/SongControls.module.css
@@ -233,7 +233,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 1rem 1.25rem;
-  align-items: flex-start;
+  align-items: stretch;
 }
 
 /* Right pane: the bordered cyan-glow editor card. */


### PR DESCRIPTION
## Summary

- **Height matching:** The step list column now stretches to match the editor panel height. Previously the list was capped at max-height: 17rem while the editor panel grew freely.
- **Conditional overflow fade:** The scroll-driven bottom fade now only appears when the list actually has scrollable content. Previously the fade was always visible even with short progressions.

## Changes

**SongControls.module.css** — align-items: flex-start → align-items: stretch on .progression-master-detail.

**ProgressionStepList.module.css** — .col gets min-height: 17rem; .scroll gets flex: 1 1 0 + min-height: 0; .list swaps max-height: 17rem for height: 100%; mobile overrides reset both; mask selector narrowed to .list[data-overflows].

**ProgressionStepList.tsx** — new useEffect with ResizeObserver toggles data-overflows on the ul when scrollHeight > clientHeight, re-runs on steps changes.

## Test plan

- At desktop width, step list column height matches the editor panel height
- With a short progression (fits without scrolling): no bottom fade visible, data-overflows absent on the ul
- With a long progression (overflows): bottom fade appears, data-overflows present; scrolling to bottom fades it out
- Mobile: list flows at natural height, editor stacks below, no fade

Generated with [Claude Code](https://claude.com/claude-code)